### PR TITLE
Removed dash so PV name matches correctly

### DIFF
--- a/examples/operator/delete-pv.sh
+++ b/examples/operator/delete-pv.sh
@@ -17,6 +17,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 for i in {1..15}
 do
-   	echo "deleting PV crunchy-pv-$i"
-	kubectl delete pv crunchy-pv-$i
+   	echo "deleting PV crunchy-pv$i"
+	kubectl delete pv crunchy-pv$i
 done


### PR DESCRIPTION
The `create-pv.sh` uses name format `crunchy-pv$i`.  This fixes the `delete-pv.sh` to match that name format.