### PR TITLE
Update docker image tag to match correct version

### DIFF
--- a/examples/operator/deployment.json
+++ b/examples/operator/deployment.json
@@ -17,7 +17,7 @@
 	        "securityContext": {
 		},
                     "name": "postgres-operator",
-                    "image": "crunchydata/postgres-operator:centos7-1.2.0",
+                    "image": "crunchydata/postgres-operator:centos7-1.3.0",
                     "imagePullPolicy": "IfNotPresent",
                     "env": [{
                         "name": "DOCKER_API_VERSION",


### PR DESCRIPTION
This is to update the `examples/operator/deployment.json` to match the version of the operator image.