### PR TITLE
Fix gofmt warnings

### DIFF
--- a/apis/cr/v1/common.go
+++ b/apis/cr/v1/common.go
@@ -15,8 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import ()
-
 // RootSecretSuffix ...
 const RootSecretSuffix = "-root-secret"
 

--- a/rpgo/cmd/backup.go
+++ b/rpgo/cmd/backup.go
@@ -130,7 +130,7 @@ func showBackupInfo(name string) {
 
 	if ShowPVC {
 		//print pvc information for all jobs
-		for key, _ := range pvcMap {
+		for key := range pvcMap {
 			PrintPVCListing(key)
 		}
 	}


### PR DESCRIPTION
Corrections from `gofmt -s`:
* Blank import, not needed
* Only first values require a blank variable if you want to skip, proceeding can be dropped