### PR TITLE
postgres-operator-apiserver -> apiserver

### DIFF
--- a/docs/build.asciidoc
+++ b/docs/build.asciidoc
@@ -200,7 +200,7 @@ from source, you can pull down the Docker images as follows:
 docker pull crunchydata/lspvc:centos7-2.1
 docker pull crunchydata/csvload:centos7-2.1
 docker pull crunchydata/postgres-operator:centos7-2.1
-docker pull crunchydata/postgres-operator-apiserver:centos7-2.1
+docker pull crunchydata/apiserver:centos7-2.1
 ....
 
 Next get the *pgo* client, go to the Releases page and download the tar ball, uncompress it into your $HOME directory:


### PR DESCRIPTION
The "docker pull crunchydata/postgres-operator-apiserver:centos7-2.1" command fails because postgres-operator-apiserver doesn't exist. The image is actually apiserver:centos7-2.1