### PR TITLE
This will add a prompt for all deletes

### DIFF
--- a/pgo/cmd/delete.go
+++ b/pgo/cmd/delete.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
+	"github.com/crunchydata/postgres-operator/pgo/util"
 	"github.com/spf13/cobra"
 )
 
@@ -85,7 +86,12 @@ var deleteUpgradeCmd = &cobra.Command{
 		if len(args) == 0 {
 			log.Error("a database or cluster name is required for this command")
 		} else {
-			deleteUpgrade(args)
+		   fmt.Print("WARNING - This is destructive: Are you sure? (yes/no): ")
+		   if util.AskForConfirmation() {
+			   deleteUpgrade(args)
+			} else {
+			   fmt.Println(`Aborting...`)
+			}
 		}
 	},
 }
@@ -99,7 +105,12 @@ var deleteBackupCmd = &cobra.Command{
 		if len(args) == 0 {
 			log.Error("a database or cluster name is required for this command")
 		} else {
-			deleteBackup(args)
+         fmt.Print("WARNING - This is destructive: Are you sure? (yes/no): ")
+		   if util.AskForConfirmation() {
+			   deleteBackup(args)
+         } else {
+            fmt.Println(`Aborting...`)
+         }
 		}
 	},
 }
@@ -114,7 +125,12 @@ var deleteClusterCmd = &cobra.Command{
 		if len(args) == 0 && Selector == "" {
 			log.Error("a cluster name or selector is required for this command")
 		} else {
-			deleteCluster(args)
+			fmt.Print("WARNING - This is destructive: Are you sure? (yes/no): ")
+		   if util.AskForConfirmation() {
+			   deleteCluster(args)
+         } else {
+            fmt.Println(`Aborting...`)
+         }
 		}
 	},
 }
@@ -128,7 +144,12 @@ var deletePolicyCmd = &cobra.Command{
 		if len(args) == 0 {
 			log.Error("a policy name is required for this command")
 		} else {
-			deletePolicy(args)
+			fmt.Print("WARNING - This is destructive: Are you sure? (yes/no): ")
+		   if util.AskForConfirmation() {
+			   deletePolicy(args)
+         } else {
+            fmt.Println(`Aborting...`)
+         }
 		}
 	},
 }

--- a/pgo/util/confirmation.go
+++ b/pgo/util/confirmation.go
@@ -1,0 +1,61 @@
+package util
+
+/*
+ Copyright 2017 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import (
+	"fmt"
+)
+
+// Mostly copied from https://gist.github.com/albrow/5882501
+// AskForConfirmation uses Scanln to parse user input. A user must type in "yes" or "no" and
+// then press enter. It has fuzzy matching, so "y", "Y", "yes", "YES", and "Yes" all count as
+// confirmations. If the input is not recognized, it will ask again. The function does not return
+// until it gets a valid response from the user. Typically, you should use fmt to print out a question
+// before calling AskForConfirmation. E.g. fmt.Println("WARNING: Are you sure? (yes/no)")
+func AskForConfirmation() bool {
+	var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		fmt.Println("Please type yes or no and then press enter:")
+		return AskForConfirmation()
+	}
+	okayResponses := []string{"y", "Y", "yes", "Yes", "YES"}
+	nokayResponses := []string{"n", "N", "no", "No", "NO", ""}
+	if containsString(okayResponses, response) {
+		return true
+	} else if containsString(nokayResponses, response) {
+		return false
+	} else {
+		fmt.Println("Please type yes or no and then press enter:")
+		return AskForConfirmation()
+	}
+}
+
+// posString returns the first index of element in slice.
+// If slice does not contain element, returns -1.
+func posString(slice []string, element string) int {
+	for index, elem := range slice {
+		if elem == element {
+			return index
+		}
+	}
+	return -1
+}
+
+// containsString returns true iff slice contains element
+func containsString(slice []string, element string) bool {
+	return !(posString(slice, element) == -1)
+}


### PR DESCRIPTION
```
$ pgo delete cluster pgo-test2
WARNING - This is destructive: Are you sure? (yes/no):
```

It forces a response if enter hit without a valid one.

fixes https://github.com/CrunchyData/postgres-operator/issues/108