### PR TITLE
quickstart fixes

### DIFF
--- a/examples/quickstart-for-gke.sh
+++ b/examples/quickstart-for-gke.sh
@@ -17,32 +17,32 @@ LOG="pgo-installer.log"
 
 export PGORELEASE=2.6
 
-echo "testing for dependencies " | tee -a $LOG
+echo "Testing for dependencies..." | tee -a $LOG
 
 which wget > /dev/null 2> /dev/null
 if [[ $? -ne 0 ]]; then
-	echo "wget is missing on your system, a required dependency" | tee -a $LOG
+	echo "The required dependency wget is missing on your system." | tee -a $LOG
 	exit 1
 fi
 which kubectl > /dev/null 2> /dev/null
 if [[ $? -ne 0 ]]; then
-	echo "kubectl is missing on your system, a required dependency" | tee -a $LOG
+	echo "The required dependency kubectl is missing on your system." | tee -a $LOG
 	exit 1
 fi
 
 echo ""
-echo "testing kubectl connection" | tee -a $LOG
+echo "Testing kubectl connection..." | tee -a $LOG
 echo ""
-kubectl get namespaces 
+kubectl get namespaces
 if [[ $? -ne 0 ]]; then
-	echo "kubectl is not connecting to your Kube Cluster, required to proceed" | tee -a $LOG
+	echo "kubectl is not able to connect to your Kube Cluster." | tee -a $LOG
 	exit 1
 fi
 
 NAMESPACE=`kubectl config current-context`
-echo "will install postgres-operator into the current namespace which is ["$NAMESPACE"]"
+echo "The postgres-operator tool will be installed into the current namespace which is ["$NAMESPACE"]."
 
-echo -n "do you want to continue the installation? [yes no] "
+echo -n "Do you want to continue the installation? [yes no] "
 read REPLY
 if [[ "$REPLY" != "yes" ]]; then
 	echo "aborting installation"
@@ -61,7 +61,7 @@ export PGO_CA_CERT=$COROOT/conf/apiserver/server.crt
 export PGO_CLIENT_CERT=$COROOT/conf/apiserver/server.crt
 export PGO_CLIENT_KEY=$COROOT/conf/apiserver/server.key
 
-echo "setting environment variables in $HOME/.bashrc" | tee -a $LOG
+echo "Setting environment variables in $HOME/.bashrc..." | tee -a $LOG
 
 cat <<'EOF' >> $HOME/.bashrc
 
@@ -73,28 +73,28 @@ export PGO_CLIENT_KEY=$HOME/odev/src/github.com/crunchydata/postgres-operator/co
 #
 EOF
 
-echo "setting up installation directory " | tee -a $LOG
+echo "Setting up installation directory..." | tee -a $LOG
 
 mkdir -p $HOME/odev/src $HOME/odev/bin $HOME/odev/pkg
 mkdir -p $GOPATH/src/github.com/crunchydata/postgres-operator
 
 echo ""
-echo "installing pgo server config" | tee -a $LOG
+echo "Installing the pgo server config..." | tee -a $LOG
 wget --quiet https://github.com/CrunchyData/postgres-operator/releases/download/$PGORELEASE/postgres-operator.$PGORELEASE.tar.gz -O /tmp/postgres-operator.$PGORELEASE.tar.gz
 if [[ $? -ne 0 ]]; then
-	echo "problem getting pgo server config"
+	echo "Error: pgo server config not found."
 	exit 1
 fi
 
 cd $COROOT
 tar xzf /tmp/postgres-operator.$PGORELEASE.tar.gz
 if [[ $? -ne 0 ]]; then
-	echo "problem getting 2.5 release"
+	echo "Error: problem with unpackaging the $PGORELEASE release."
 	exit 1
 fi
 
 echo ""
-echo "installing pgo client" | tee -a $LOG
+echo "Installing pgo client..." | tee -a $LOG
 
 mv pgo $GOBIN
 mv pgo-mac $GOBIN
@@ -103,46 +103,44 @@ mv expenv.exe $GOBIN
 mv expenv-mac $GOBIN
 mv expenv $GOBIN
 
-echo "storage classes on your system..."
+echo "Storage classes on your system:"
 kubectl get sc
 echo ""
-echo -n "enter the name of the storage class to use: "
+echo -n "Enter the name of the storage class to use: "
 read STORAGE_CLASS
 
 echo ""
-echo "setting up pgo storage configuration for storageclass" | tee -a $LOG
+echo "Setting up pgo storage configuration for the selected storageclass..." | tee -a $LOG
 cp $COROOT/examples/pgo.yaml.storageclass $COROOT/conf/apiserver/pgo.yaml
 sed --in-place=.bak 's/standard/'"$STORAGE_CLASS"'/' $COROOT/conf/apiserver/pgo.yaml
 sed --in-place=.bak 's/demo/'"$PROJECT"'/' $COROOT/deploy/service-account.yaml
 sed --in-place=.bak 's/demo/'"$PROJECT"'/' $COROOT/deploy/rbac.yaml
 
 echo ""
-echo "setting up pgo client auth" | tee -a $LOG
+echo "Setting up pgo client authentication..." | tee -a $LOG
 echo "username:password" > $HOME/.pgouser
 
-echo "for pgo bash completion you will need to install the bash-completion package" | tee -a $LOG
+echo "For pgo bash completion you will need to install the bash-completion package." | tee -a $LOG
 
 cp $COROOT/examples/pgo-bash-completion $HOME/.bash_completion
 
-echo -n "do you want to deploy the operator? [yes no] "
+echo -n "Do you want to deploy the operator? [yes no] "
 read REPLY
 if [[ "$REPLY" == "yes" ]]; then
-	echo "deploy the operator to the Kube cluster" | tee -a $LOG
+	echo "Deploying the operator to the Kubernetes cluster..." | tee -a $LOG
 	$COROOT/deploy/deploy.sh | tee -a $LOG
 fi
 
-echo "install complete" | tee -a $LOG
+echo "Installation complete." | tee -a $LOG
 echo ""
 
 echo "At this point you can access the operator by using a port-forward command similar to:"
 podname=`kubectl get pod --selector=name=postgres-operator -o jsonpath={..metadata.name}`
 echo "kubectl port-forward " $podname " 18443:8443"
-echo "do this in another terminal or run in the background"
+echo "Do this in another terminal or run in the background."
 
 echo ""
-echo "WARNING:  for the postgres-operator settings to take effect, log out of your session and back in, or reload your .bashrc file"
+echo "WARNING: for the postgres-operator settings to take effect, it will be necessary to log out of your session and back in or reload your .bashrc file."
 
 echo ""
-echo "NOTE:  to access the pgo CLI, place it within your PATH, it is located in $HOME/odev/bin/pgo"
-
-
+echo "NOTE: In order to access the pgo CLI, it will be necessary to place it within your PATH. The default location after installing is within $HOME/odev/bin/pgo"

--- a/examples/quickstart-for-ocp.sh
+++ b/examples/quickstart-for-ocp.sh
@@ -17,38 +17,38 @@ LOG="pgo-installer.log"
 
 export PGORELEASE=2.6
 
-echo "testing for dependencies " | tee -a $LOG
+echo "Testing for dependencies..." | tee -a $LOG
 
 which wget > /dev/null 2> /dev/null
 if [[ $? -ne 0 ]]; then
-	echo "wget is missing on your system, a required dependency" | tee -a $LOG
+	echo "The required dependency wget is missing on your system." | tee -a $LOG
 	exit 1
 fi
 which oc > /dev/null 2> /dev/null
 if [[ $? -ne 0 ]]; then
-	echo "oc is missing on your system, a required dependency" | tee -a $LOG
+	echo "The required dependency oc is missing on your system." | tee -a $LOG
 	exit 1
 fi
 
 echo ""
-echo "testing oc connection" | tee -a $LOG
+echo "Testing oc connection..." | tee -a $LOG
 echo ""
 oc project
 if [[ $? -ne 0 ]]; then
-	echo "oc is not connecting to your Openshift Cluster, required to proceed" | tee -a $LOG
+	echo "oc is not able to connect to your OpenShift Cluster." | tee -a $LOG
 	exit 1
 fi
 
-echo "connected to project" | tee -a $LOG
+echo "Connected to project." | tee -a $LOG
 echo ""
-echo "this script will install the postgres operator into the project listed below...."
+echo "This script will install the postgres operator into the project listed below."
 oc project
 echo ""
 
 PROJECT=`oc project -q`
-echo "installing into project ["$PROJECT"]"
+echo "Installing into project ["$PROJECT"]."
 echo ""
-echo -n "do you want to continue the installation? [yes no] "
+echo -n "Do you want to continue the installation? [yes no] "
 read REPLY
 if [[ "$REPLY" == "no" ]]; then
 	exit 0
@@ -67,7 +67,7 @@ export PGO_CLIENT_CERT=$COROOT/conf/apiserver/server.crt
 export PGO_CLIENT_KEY=$COROOT/conf/apiserver/server.key
 
 echo ""
-echo "setting environment variables in $HOME/.bashrc" | tee -a $LOG
+echo "Setting environment variables in $HOME/.bashrc..." | tee -a $LOG
 echo ""
 
 cat <<'EOF' >> $HOME/.bashrc
@@ -77,18 +77,18 @@ export CO_APISERVER_URL=https://127.0.0.1:18443
 export PGO_CA_CERT=$HOME/odev/src/github.com/crunchydata/postgres-operator/conf/apiserver/server.crt
 export PGO_CLIENT_CERT=$HOME/odev/src/github.com/crunchydata/postgres-operator/conf/apiserver/server.crt
 export PGO_CLIENT_KEY=$HOME/odev/src/github.com/crunchydata/postgres-operator/conf/apiserver/server.key
-# 
+#
 
 EOF
 
 echo ""
-echo "setting up installation directory" | tee -a $LOG
+echo "Setting up installation directory..." | tee -a $LOG
 
 mkdir -p $HOME/odev/src $HOME/odev/bin $HOME/odev/pkg
 mkdir -p $GOPATH/src/github.com/crunchydata/postgres-operator
 
 echo ""
-echo "installing pgo server config" | tee -a $LOG
+echo "Installing the pgo server config..." | tee -a $LOG
 wget --quiet https://github.com/CrunchyData/postgres-operator/releases/download/$PGORELEASE/postgres-operator.$PGORELEASE.tar.gz -O /tmp/postgres-operator.$PGORELEASE.tar.gz
 #if [[ $? -ne 0 ]]; then
 #	echo "problem getting pgo server config"
@@ -97,12 +97,12 @@ wget --quiet https://github.com/CrunchyData/postgres-operator/releases/download/
 cd $COROOT
 tar xzf /tmp/postgres-operator.$PGORELEASE.tar.gz
 if [[ $? -ne 0 ]]; then
-	echo "problem getting 2.6 release"
+	echo "Error: problem with unpackaging the $PGORELEASE release."
 	exit 1
 fi
 
 echo ""
-echo "installing pgo client" | tee -a $LOG
+echo "Installing pgo client..." | tee -a $LOG
 
 mv pgo $GOBIN
 mv pgo-mac $GOBIN
@@ -111,51 +111,51 @@ mv expenv.exe $GOBIN
 mv expenv-mac $GOBIN
 mv expenv $GOBIN
 
-echo "storage classes on your system..."
+echo "Storage classes on your system:"
 oc get sc
 echo ""
-echo -n "enter the name of the storage class to use: "
+echo -n "Enter the name of the storage class to use: "
 read STORAGE_CLASS
 
 echo ""
-echo "setting up pgo storage configuration for storageclass" | tee -a $LOG
+echo "Setting up pgo storage configuration for the selected storageclass..." | tee -a $LOG
 cp $COROOT/examples/pgo.yaml.storageclass $COROOT/conf/apiserver/pgo.yaml
-sed --in-place=.bak 's/standard/'"$STORAGE_CLASS"'/' $COROOT/conf/apiserver/pgo.yaml 
-sed --in-place=.bak 's/demo/'"$PROJECT"'/' $COROOT/deploy/service-account.yaml 
-sed --in-place=.bak 's/demo/'"$PROJECT"'/' $COROOT/deploy/rbac.yaml 
+sed --in-place=.bak 's/standard/'"$STORAGE_CLASS"'/' $COROOT/conf/apiserver/pgo.yaml
+sed --in-place=.bak 's/demo/'"$PROJECT"'/' $COROOT/deploy/service-account.yaml
+sed --in-place=.bak 's/demo/'"$PROJECT"'/' $COROOT/deploy/rbac.yaml
 
 echo ""
-echo -n "storage classes can require a fsgroup setting to be specified in the security context of your pods, typically this value is 26 but on some storage providers, this value is blank, enter your fsgroup setting if required or blank if not required: "
+echo -n "Storage classes can require a fsgroup setting to be specified in the security context of your pods. Typically, this value is 26, but on some storage providers this value is blank. Enter your fsgroup setting if required or leave blank if not required: "
 read FSGROUP
-sed --in-place=.bak 's/26/'"$FSGROUP"'/' $COROOT/conf/apiserver/pgo.yaml 
+sed --in-place=.bak 's/26/'"$FSGROUP"'/' $COROOT/conf/apiserver/pgo.yaml
 
 echo ""
-echo "setting up pgo client auth" | tee -a $LOG
+echo "Setting up pgo client authentication..." | tee -a $LOG
 echo "username:password" > $HOME/.pgouser
 
 echo ""
-echo "for pgo bash completion you will need to install the bash-completion package" | tee -a $LOG
+echo "For pgo bash completion you will need to install the bash-completion package." | tee -a $LOG
 
 cp $COROOT/examples/pgo-bash-completion $HOME/.bash_completion
 echo ""
-echo -n "do you want to deploy the operator? [yes no] "
+echo -n "Do you want to deploy the operator? [yes no] "
 read REPLY
 if [[ "$REPLY" == "yes" ]]; then
-	echo "deploy the operator to the OCP cluster" | tee -a $LOG
+	echo "Deploying the operator to the OCP cluster..." | tee -a $LOG
 #	$COROOT/deploy/deploy.sh > /dev/null 2> /dev/null | tee -a $LOG
 	$COROOT/deploy/deploy.sh | tee -a $LOG
 fi
 
-echo "install complete" | tee -a $LOG
+echo "Installation complete." | tee -a $LOG
 echo ""
 
 echo "At this point you can access the operator by using a port-forward command similar to:"
 podname=`oc get pod --selector=name=postgres-operator -o jsonpath={..metadata.name}`
 echo "oc port-forward " $podname " 18443:8443"
-echo "do this in another terminal or run in the background"
+echo "Do this in another terminal or run in the background."
 
 echo ""
-echo "WARNING:  for the postgres-operator settings to take effect, log out of your session and back in, or reload your .bashrc file"
+echo "WARNING: for the postgres-operator settings to take effect, it will be necessary to log out of your session and back in or reload your .bashrc file."
 
 echo ""
-echo "NOTE:  to access the pgo CLI, place it within your PATH, it is located in $HOME/odev/bin/pgo"
+echo "NOTE: In order to access the pgo CLI, it will be necessary to place it within your PATH. The default location after installing is within $HOME/odev/bin/pgo"


### PR DESCRIPTION
- Updated all comments to use grammar & punctuation within the OCP and GKE scripts.
- One error comment - "problem with the X release" - used a hardcoded release name. Replaced with $PGORELEASE