### PR TITLE
Update to new Rhel base image (7.5)

### DIFF
--- a/rhel7/Dockerfile.pgo-apiserver.rhel7
+++ b/rhel7/Dockerfile.pgo-apiserver.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7.4
+FROM registry.access.redhat.com/rhel7
 
 
 LABEL Release="2.6" Vendor="Crunchy Data Solutions" 

--- a/rhel7/Dockerfile.pgo-load.rhel7
+++ b/rhel7/Dockerfile.pgo-load.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7.4
+FROM registry.access.redhat.com/rhel7
 
 LABEL name="crunchydata/pgo-load" \
         vendor="crunchy data" \

--- a/rhel7/Dockerfile.pgo-lspvc.rhel7
+++ b/rhel7/Dockerfile.pgo-lspvc.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7.4
+FROM registry.access.redhat.com/rhel7
 
 LABEL Release="2.6" Vendor="Crunchy Data Solutions" 
 

--- a/rhel7/Dockerfile.pgo-rmdata.rhel7
+++ b/rhel7/Dockerfile.pgo-rmdata.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7.4
+FROM registry.access.redhat.com/rhel7
 
 LABEL Release="2.6" Vendor="Crunchy Data Solutions" 
 

--- a/rhel7/Dockerfile.postgres-operator.rhel7
+++ b/rhel7/Dockerfile.postgres-operator.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7.4
+FROM registry.access.redhat.com/rhel7
 
 LABEL Release="2.6" Vendor="Crunchy Data Solutions" 
 


### PR DESCRIPTION
It appears that a rhel7.5 base image has become available.

I'd like to suggest that we move from a hardcoded 7.4 image to the "floating" image:
https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/rhel7
As you can see, this new image uses 7.5 as a default.

I do not believe this to be a breaking change, as it is a patch to the underlying container packages.