### PR TITLE
If failover target replica has a metrics sidecar, failover will fail

### DIFF
--- a/util/failover.go
+++ b/util/failover.go
@@ -86,7 +86,7 @@ func GetPod(clientset *kubernetes.Clientset, deploymentName, namespace string) (
 	for _, v := range pods.Items {
 		pod = &v
 	}
-	if len(pod.Spec.Containers) != 1 {
+	if len(pod.Spec.Containers) != 1 && pod.Labels["crunchy_collect"] == "false" {
 		return pod, errors.New("could not find a container in the pod")
 	}
 


### PR DESCRIPTION
If the failover target replica has a metrics sidecar `len(pod.Spec.Containers)` will return `2` instead of `1`.

To fix this, I added onto the if statement to also check if the `pod.Lables["crunchy_collect"] == false`.

This is to fix #241 