### PR TITLE
Fix golang-examples/

### DIFF
--- a/golang-examples/addlabel.go
+++ b/golang-examples/addlabel.go
@@ -1,25 +1,16 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
-	jsonpatch "github.com/evanphx/json-patch"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/client-go/kubernetes"
-	//"k8s.io/client-go/pkg/api"
-	"k8s.io/apimachinery/pkg/types"
-	//"k8s.io/client-go/pkg/api/errors"
-	"encoding/json"
+	"github.com/evanphx/json-patch"
 	"k8s.io/api/extensions/v1beta1"
-	//"k8s.io/client-go/pkg/runtime"
-	//"k8s.io/client-go/pkg/runtime/serializer"
-
-	//"k8s.io/client-go/pkg/api/unversioned"
-	//"k8s.io/client-go/pkg/api/v1"
-	//"k8s.io/client-go/rest"
 	"k8s.io/apimachinery/pkg/api/meta"
-
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 

--- a/golang-examples/addlabeltopod.go
+++ b/golang-examples/addlabeltopod.go
@@ -1,27 +1,16 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
-	jsonpatch "github.com/evanphx/json-patch"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/client-go/kubernetes"
-	//"k8s.io/client-go/pkg/api"
-	"k8s.io/apimachinery/pkg/types"
-	//"k8s.io/client-go/pkg/api/errors"
-	"encoding/json"
-	//"k8s.io/api/extensions/v1beta1"
+	"github.com/evanphx/json-patch"
 	"k8s.io/api/core/v1"
-
-	//"k8s.io/client-go/pkg/runtime"
-	//"k8s.io/client-go/pkg/runtime/serializer"
-
-	//"k8s.io/client-go/pkg/api/unversioned"
-	//"k8s.io/client-go/pkg/api/v1"
-	//"k8s.io/client-go/rest"
 	"k8s.io/apimachinery/pkg/api/meta"
-
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 

--- a/golang-examples/addreplica.go
+++ b/golang-examples/addreplica.go
@@ -1,18 +1,15 @@
 package main
 
-import "fmt"
-import "flag"
-import "encoding/json"
-import log "github.com/Sirupsen/logrus"
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
 
-//import "k8s.io/client-go/pkg/api/v1"
-
-//import "github.com/crunchydata/postgres-operator/operator/util"
-import "k8s.io/client-go/tools/clientcmd"
-import "k8s.io/client-go/kubernetes"
-
-//import v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
-import api "k8s.io/client-go/pkg/api"
+	log "github.com/Sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
 
 type ThingSpec struct {
 	Op    string `json:"op"`
@@ -51,7 +48,7 @@ func main() {
 	}
 	log.Debug(string(patchBytes))
 
-	_, err = clientset.Deployments("default").Patch(deploymentName, api.JSONPatchType, patchBytes)
+	_, err = clientset.AppsV1beta1().Deployments("default").Patch(deploymentName, types.JSONPatchType, patchBytes)
 	if err != nil {
 		log.Error("error creating master Deployment " + err.Error())
 		panic(err.Error())

--- a/golang-examples/config.go
+++ b/golang-examples/config.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"encoding/json"
-	log "github.com/Sirupsen/logrus"
 	"io/ioutil"
 	"os"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 type ContainerResource struct {

--- a/golang-examples/crdread.go
+++ b/golang-examples/crdread.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+
 	log "github.com/Sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	clientset "github.com/crunchydata/postgres-operator/client"

--- a/golang-examples/createsecret.go
+++ b/golang-examples/createsecret.go
@@ -20,16 +20,8 @@ import (
 	"flag"
 	"fmt"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
-	//"k8s.io/client-go/pkg/api"
-	//"k8s.io/client-go/pkg/api/errors"
-
-	//"k8s.io/client-go/pkg/runtime"
-	//"k8s.io/client-go/pkg/runtime/serializer"
-
-	//"k8s.io/client-go/pkg/api/unversioned"
-	"k8s.io/client-go/pkg/api/v1"
-	//"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -58,7 +50,7 @@ func main() {
 	secret.Data["username"] = []byte("testuser")
 	secret.Data["password"] = []byte("mypassword")
 
-	_, err = clientset.Secrets(namespace).Create(&secret)
+	_, err = clientset.CoreV1().Secrets(namespace).Create(&secret)
 	if err != nil {
 		fmt.Println(err.Error())
 	} else {

--- a/golang-examples/dfcalc.go
+++ b/golang-examples/dfcalc.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 

--- a/golang-examples/exec.go
+++ b/golang-examples/exec.go
@@ -4,20 +4,17 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"github.com/gorilla/websocket"
 	"io"
-	//"io/ioutil"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"net/http"
 	"net/url"
-	//"k8s.io/client-go/pkg/api/errors"
 
-	"k8s.io/client-go/pkg/runtime"
-	"k8s.io/client-go/pkg/runtime/serializer"
-
-	"k8s.io/client-go/pkg/api/unversioned"
-	//"k8s.io/client-go/pkg/api/v1"
+	"github.com/gorilla/websocket"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -103,26 +100,25 @@ func getCommandString(cmd string) string {
 }
 
 func configureClient(config *rest.Config) {
-	groupversion := unversioned.GroupVersion{
+	groupversion := schema.GroupVersion{
 		Group:   "k8s.io",
 		Version: "v1",
 	}
 
 	config.GroupVersion = &groupversion
-	//config.APIPath = "/apis"
 	config.ContentType = runtime.ContentTypeJSON
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: api.Codecs}
+	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
 
 	schemeBuilder := runtime.NewSchemeBuilder(
 		func(scheme *runtime.Scheme) error {
 			scheme.AddKnownTypes(
 				groupversion,
-				&api.ListOptions{},
-				&api.DeleteOptions{},
+				&v1.ListOptions{},
+				&v1.DeleteOptions{},
 			)
 			return nil
 		})
-	schemeBuilder.AddToScheme(api.Scheme)
+	schemeBuilder.AddToScheme(scheme.Scheme)
 }
 
 type RoundTripCallback func(conn *websocket.Conn, resp *http.Response, err error) error

--- a/golang-examples/failoverevent.go
+++ b/golang-examples/failoverevent.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // StateMachine holds a state machine that is created when

--- a/golang-examples/gen-pgpool-pass.go
+++ b/golang-examples/gen-pgpool-pass.go
@@ -20,9 +20,10 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"golang.org/x/crypto/ssh/terminal"
 	"os"
 	"strings"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 func main() {

--- a/golang-examples/listlog.go
+++ b/golang-examples/listlog.go
@@ -1,15 +1,18 @@
 package main
 
-import "fmt"
-import "os"
-import "flag"
-import "bytes"
-import "io"
-import "time"
-import "k8s.io/client-go/pkg/api/v1"
-import "github.com/crunchydata/postgres-operator/operator/util"
-import "k8s.io/client-go/tools/clientcmd"
-import "k8s.io/client-go/kubernetes"
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/crunchydata/postgres-operator/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
 
 func main() {
 
@@ -29,13 +32,13 @@ func main() {
 	}
 
 	timeout := time.Duration(2 * time.Second)
-	lo := v1.ListOptions{LabelSelector: "name=" + "lspvc"}
-	podPhase := v1.PodSucceeded
+	lo := metav1.ListOptions{LabelSelector: "name=" + "lspvc"}
+	podPhase := corev1.PodSucceeded
 	err = util.WaitUntilPod(clientset, lo, podPhase, timeout, "default")
 	if err != nil {
 		fmt.Println("error waiting on lspvc pod to complete" + err.Error())
 	}
-	logOptions := v1.PodLogOptions{}
+	logOptions := corev1.PodLogOptions{}
 	podName := "lspvc-donut"
 	req := clientset.Core().Pods("default").GetLogs(podName, &logOptions)
 	if req == nil {

--- a/golang-examples/listpods.go
+++ b/golang-examples/listpods.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"

--- a/golang-examples/readyaml.go
+++ b/golang-examples/readyaml.go
@@ -3,9 +3,10 @@ package main
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
+
+	"gopkg.in/yaml.v2"
 )
 
 type ClusterStruct struct {

--- a/util/waituntil.go
+++ b/util/waituntil.go
@@ -20,7 +20,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
-	//"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/api/core/v1"
 	"time"
 )


### PR DESCRIPTION
The examples were referring to packages that didn't exist and so could not be built.
Notably, there seemed to be confusion between usages of client-go and apimachinery.

Commented imports were also removed and goimports was run on the files.