### PR TITLE
Use User & UserSecretName in Pgcluster

### DIFF
--- a/apis/cr/v1/common.go
+++ b/apis/cr/v1/common.go
@@ -15,13 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import ()
+import (
+	"fmt"
+)
 
 // RootSecretSuffix ...
 const RootSecretSuffix = "-postgres-secret"
-
-// UserSecretSuffix ...
-const UserSecretSuffix = "-testuser-secret"
 
 // PrimarySecretSuffix ...
 const PrimarySecretSuffix = "-primaryuser-secret"
@@ -55,4 +54,12 @@ type PgContainerResources struct {
 	RequestsCPU    string `json:"requestscpu"`
 	LimitsMemory   string `json:"limitsmemory"`
 	LimitsCPU      string `json:"limitscpu"`
+}
+
+// UserSecretSuffix ...
+func UserSecretSuffix(user string) string {
+	if user == "" {
+		user = "testuser"
+	}
+	return fmt.Sprintf("-%s-secret", user)
 }

--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -724,30 +724,35 @@ func validateSecretFrom(secretname string) error {
 		return err
 	}
 
-	log.Debug("secrets for " + secretname)
+	log.Debugf("secrets for %s", secretname)
 	pgprimaryFound := false
 	pgrootFound := false
 	pguserFound := false
 
+	primarySecretname := secretname + crv1.PrimarySecretSuffix
+	rootSecretname := secretname + crv1.RootSecretSuffix
+	userSecretname := secretname + crv1.UserSecretSuffix("")
+
 	for _, s := range secrets.Items {
-		//fmt.Println("")
-		//fmt.Println("secret : " + s.ObjectMeta.Name)
-		if s.ObjectMeta.Name == secretname+crv1.PrimarySecretSuffix {
+		if s.ObjectMeta.Name == primarySecretname {
 			pgprimaryFound = true
-		} else if s.ObjectMeta.Name == secretname+crv1.RootSecretSuffix {
+		} else if s.ObjectMeta.Name == rootSecretname {
 			pgrootFound = true
-		} else if s.ObjectMeta.Name == secretname+crv1.UserSecretSuffix {
+		} else if s.ObjectMeta.Name == userSecretname {
 			pguserFound = true
+		}
+		if pgprimaryFound && pgrootFound && pguserFound {
+			return nil
 		}
 	}
 	if !pgprimaryFound {
-		return errors.New(secretname + crv1.PrimarySecretSuffix + " not found")
+		return fmt.Errorf("%s not found", primarySecretname)
 	}
 	if !pgrootFound {
-		return errors.New(secretname + crv1.RootSecretSuffix + " not found")
+		return fmt.Errorf("%s not found", rootSecretname)
 	}
 	if !pguserFound {
-		return errors.New(secretname + crv1.UserSecretSuffix + " not found")
+		return fmt.Errorf("%s not found", userSecretname)
 	}
 
 	return err

--- a/operator/cluster/cluster.go
+++ b/operator/cluster/cluster.go
@@ -128,8 +128,8 @@ func AddClusterBase(clientset *kubernetes.Clientset, client *rest.RESTClient, cl
 	var err1, err2, err3 error
 	if cl.Spec.SecretFrom != "" {
 		_, cl.Spec.RootPassword, err1 = util.GetPasswordFromSecret(clientset, namespace, cl.Spec.SecretFrom+crv1.RootSecretSuffix)
-		_, cl.Spec.Password, err2 = util.GetPasswordFromSecret(clientset, namespace, cl.Spec.SecretFrom+crv1.UserSecretSuffix)
 		_, cl.Spec.PrimaryPassword, err3 = util.GetPasswordFromSecret(clientset, namespace, cl.Spec.SecretFrom+crv1.PrimarySecretSuffix)
+		_, cl.Spec.Password, err2 = util.GetPasswordFromSecret(clientset, namespace, cl.Spec.SecretFrom+crv1.UserSecretSuffix(cl.Spec.User))
 		if err1 != nil || err2 != nil || err3 != nil {
 			log.Error("error getting secrets using SecretFrom " + cl.Spec.SecretFrom)
 			return

--- a/operator/cluster/cluster.go
+++ b/operator/cluster/cluster.go
@@ -136,8 +136,8 @@ func AddClusterBase(clientset *kubernetes.Clientset, client *rest.RESTClient, cl
 		}
 	}
 
-	var testPassword string
-	_, _, testPassword, err = util.CreateDatabaseSecrets(clientset, client, cl, namespace)
+	var userPassword string
+	_, _, userPassword, err = util.CreateDatabaseSecrets(clientset, client, cl, namespace)
 	if err != nil {
 		log.Error("error in create secrets " + err.Error())
 		return
@@ -158,11 +158,15 @@ func AddClusterBase(clientset *kubernetes.Clientset, client *rest.RESTClient, cl
 
 	//add pgpool deployment if requested
 	if cl.Spec.UserLabels["crunchy-pgpool"] == "true" {
-		//generate a secret for pgpool using the testuser credential
+		//generate a secret for pgpool using the user credential
 		secretName := cl.Spec.Name + "-pgpool-secret"
 		primaryName := cl.Spec.Name
 		replicaName := cl.Spec.Name + "-replica"
-		err = CreatePgpoolSecret(clientset, primaryName, replicaName, primaryName, secretName, "testuser", testPassword, namespace)
+		user := "testuser"
+		if cl.Spec.User != "" {
+			user = cl.Spec.User
+		}
+		err = CreatePgpoolSecret(clientset, primaryName, replicaName, primaryName, secretName, user, userPassword, namespace)
 		if err != nil {
 			log.Error(err)
 			return

--- a/util/secrets.go
+++ b/util/secrets.go
@@ -90,7 +90,7 @@ func CreateDatabaseSecrets(clientset *kubernetes.Clientset, restclient *rest.RES
 	if cl.Spec.User != "" {
 		username = cl.Spec.User
 	}
-	suffix = crv1.UserSecretSuffix
+	suffix = crv1.UserSecretSuffix(username)
 
 	secretName = cl.Spec.Name + suffix
 	if cl.Spec.UserSecretName != "" {


### PR DESCRIPTION
There are User and UserSecretName fields in the Pgclusterspec but they are being ignored for cluster creation.

Admittedly, User is being set to "testuser" by the API server on cluster creation anyway, but the Pgcluster CR should be source of truth for the operator.