### PR TITLE
minor doc updates

### DIFF
--- a/hugo/content/how-it-works/_index.adoc
+++ b/hugo/content/how-it-works/_index.adoc
@@ -385,13 +385,7 @@ Postgres cluster.
 That container requires you run the *crunchy-metrics* containers
 as defined within the *crunchy-containers* project.
 
-The *prometheus push gateway* that is deployed as part of the
-*crunchy-metrics* example is a current requirement for the
-metrics solution.  This will change in an upcoming
-release of the *crunchy-containers* project and there will
-no longer be a requirement for the push gateway to be deployed.
-
-See link:https://github.com/CrunchyData/crunchy-containers/blob/master/docs/examples.adoc#metrics-collection[the crunchy-containers Metrics example] for more details on setting up the *crunchy-metrics* solution.
+See link:https://crunchydata.github.io/crunchy-containers/getting-started/kubernetes-and-openshift/#_metrics_and_performance[the crunchy-containers Metrics example] for more details on setting up the *crunchy-metrics* solution.
 
 === Manual Failover
 


### PR DESCRIPTION
Removed outdated section referring to the Prometheus Promgateway as well as replaced outdated link to the crunchy-containers documentation.