### PR TITLE
Part 1: Issue #279 Revise & Cleanup pgo CLI help text

### DIFF
--- a/hugo/content/getting-started/_index.adoc
+++ b/hugo/content/getting-started/_index.adoc
@@ -292,7 +292,7 @@ without having to shutdown the currently attached PostgreSQL cluster.
 
 === Delete Cluster
 
-The *delete cluster* command will by default delete all associated components of
+The `delete cluster` command will by default delete all associated components of
 the selected cluster, but will not delete the data or the backups unless specified.
 
 ==== Syntax
@@ -523,6 +523,9 @@ The selector to use for cluster filtering.
 
 |`--pvc-name` |N/A |String |
 The PVC name to use for the backup instead of the default.
+
+|`--backup-type` |N/A |String |
+The backup type to perform. Default is pgbasebackup, and both pgbasebackup and pgbackrest are valid backup types.
 
 |`--storage-config` |N/A |String |
 The name of a Storage config in pgo.yaml to use for the cluster storage.

--- a/pgo/cmd/auth.go
+++ b/pgo/cmd/auth.go
@@ -107,7 +107,7 @@ func GetCredentials() {
 		}
 
 		fullPath = pgoUser
-		log.Debug(pgouserenvvar + " env var is being used at " + fullPath)
+		log.Debug(pgouserenvvar + " environment variable is being used at " + fullPath)
 		dat, err = ioutil.ReadFile(fullPath)
 		if err != nil {
 			fmt.Println("Error: " + fullPath + " file not found")

--- a/pgo/cmd/backrest.go
+++ b/pgo/cmd/backrest.go
@@ -30,9 +30,10 @@ import (
 
 var backRestCmd = &cobra.Command{
 	Use:   "backrest",
-	Short: "perform a pgbackrest action",
-	Long: `BACKREST performs a pgbackrest action, for example:
-		pgo backrest mycluster`,
+	Short: "Perform a pgBackRest action",
+	Long: `BACKREST performs a pgBackRest action. For example:
+
+	pgo backrest mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("backup called")
 		if len(args) == 0 && Selector == "" {
@@ -51,8 +52,8 @@ var backRestCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(backRestCmd)
 
-	backRestCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
-	backRestCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "--no-prompt causes there to be no command line confirmation when doing a pgbackrest command")
+	backRestCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	backRestCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "No command line confirmation.")
 
 }
 
@@ -108,7 +109,7 @@ func createBackrestBackup(args []string) {
 	}
 
 	if len(response.Results) == 0 {
-		fmt.Println("no clusters found")
+		fmt.Println("No clusters found.")
 		return
 	}
 
@@ -156,7 +157,7 @@ func showBackrest(args []string) {
 		}
 
 		if len(response.Items) == 0 {
-			fmt.Println("no backrest found")
+			fmt.Println("No pgBackRest found.")
 			return
 		}
 

--- a/pgo/cmd/backup.go
+++ b/pgo/cmd/backup.go
@@ -36,7 +36,8 @@ var backupCmd = &cobra.Command{
 	Use:   "backup",
 	Short: "perform a Backup",
 	Long: `BACKUP performs a Backup, for example:
-				                        pgo backup mycluster`,
+
+  pgo backup mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("backup called")
 		if len(args) == 0 && Selector == "" {
@@ -48,7 +49,7 @@ var backupCmd = &cobra.Command{
 				} else if BackupType == labelutil.LABEL_BACKUP_TYPE_BASEBACKUP {
 					createBackup(args)
 				} else {
-					fmt.Println("Error: You must specify either pgbasebackup or pgbackrest for the --backup-type")
+					fmt.Println("Error: You must specify either pgbasebackup or pgbackrest for the --backup-type.")
 				}
 			} else {
 				fmt.Println("Aborting...")
@@ -61,11 +62,11 @@ var backupCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(backupCmd)
 
-	backupCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
-	backupCmd.Flags().StringVarP(&PVCName, "pvc-name", "", "", "The PVC name to use for the backup instead of the default backup PVC ")
-	backupCmd.Flags().StringVarP(&BackupType, "backup-type", "", "", "The backup type to perform, default is pgbasebackup, pgbasebackup and pgbackrest are valid backup types")
-	backupCmd.Flags().StringVarP(&StorageConfig, "storage-config", "", "", "The storage config to use for the backup volume ")
-	backupCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "--no-prompt causes there to be no command line confirmation when doing a backup command")
+	backupCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	backupCmd.Flags().StringVarP(&PVCName, "pvc-name", "", "", "The PVC name to use for the backup instead of the default.")
+	backupCmd.Flags().StringVarP(&StorageConfig, "storage-config", "", "", "The name of a Storage config in pgo.yaml to use for the cluster storage.")
+	backupCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "No command line confirmation.")
+	backupCmd.Flags().StringVarP(&BackupType, "backup-type", "", "", "The backup type to perform. Default is pgbasebackup, and both pgbasebackup and pgbackrest are valid backup types.")
 
 }
 
@@ -112,7 +113,7 @@ func showBackup(args []string) {
 		}
 
 		if len(response.BackupList.Items) == 0 {
-			fmt.Println("no backups found")
+			fmt.Println("No backups found.")
 			return
 		}
 
@@ -183,11 +184,11 @@ func deleteBackup(args []string) {
 
 		if response.Status.Code == msgs.Ok {
 			if len(response.Results) == 0 {
-				fmt.Println("no backups found")
+				fmt.Println("No backups found.")
 				return
 			}
 			for k := range response.Results {
-				fmt.Println("deleted backup " + response.Results[k])
+				fmt.Println("Deleted backup " + response.Results[k])
 			}
 		} else {
 			fmt.Println("Error: " + response.Status.Msg)
@@ -252,7 +253,7 @@ func createBackup(args []string) {
 	}
 
 	if len(response.Results) == 0 {
-		fmt.Println("no clusters found")
+		fmt.Println("No clusters found.")
 		return
 	}
 

--- a/pgo/cmd/cluster.go
+++ b/pgo/cmd/cluster.go
@@ -141,7 +141,7 @@ func showCluster(args []string) {
 		}
 
 		if len(response.Results) == 0 {
-			fmt.Println("no clusters found")
+			fmt.Println("No clusters found.")
 			return
 		}
 
@@ -205,7 +205,7 @@ func createCluster(args []string) {
 	var err error
 
 	if len(args) == 0 {
-		fmt.Println("Error: cluster name argument is required")
+		fmt.Println("Error: Cluster name argument is required.")
 		return
 	}
 

--- a/pgo/cmd/create.go
+++ b/pgo/cmd/create.go
@@ -40,13 +40,11 @@ var Series int
 var CreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a Cluster, Policy, or User",
-	Long: `CREATE allows you to create a new Cluster, Policy, User
-For example:
+	Long: `CREATE allows you to create a new Cluster, Policy, or User. For example:
 
-pgo create cluster
-pgo create policy
-pgo create user
-.`,
+	pgo create cluster
+	pgo create policy
+	pgo create user`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("create called")
 		if len(args) == 0 || (args[0] != "cluster" && args[0] != "policy") && args[0] != "user" {
@@ -61,22 +59,21 @@ pgo create user
 // createClusterCmd ...
 var createClusterCmd = &cobra.Command{
 	Use:   "cluster",
-	Short: "Create a database cluster",
-	Long: `Create a crunchy cluster which consist of a
-primary and a number of replica backends. For example:
+	Short: "Create a PostgreSQL cluster",
+	Long: `Create a PostgreSQL cluster consisting of a primary and a number of replica backends. For example:
 
-pgo create cluster mycluster`,
+	pgo create cluster mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("create cluster called")
 		if BackupPath != "" || BackupPVC != "" {
 			if SecretFrom == "" || BackupPath == "" || BackupPVC == "" {
-				fmt.Println(`Error: secret-from, backup-path, backup-pvc are all required to perform a restore`)
+				fmt.Println(`Error: The --secret-from, --backup-path, and --backup-pvc flags are all required to perform a restore.`)
 				return
 			}
 		}
 
 		if len(args) == 0 {
-			fmt.Println(`Error: a cluster name is required for this command`)
+			fmt.Println(`Error: A cluster name is required for this command.`)
 		} else {
 			createCluster(args)
 		}
@@ -86,19 +83,20 @@ pgo create cluster mycluster`,
 // createPolicyCmd ...
 var createPolicyCmd = &cobra.Command{
 	Use:   "policy",
-	Short: "Create a policy",
+	Short: "Create a SQL policy",
 	Long: `Create a policy. For example:
-pgo create policy mypolicy --in-file=/tmp/mypolicy.sql`,
+
+	pgo create policy mypolicy --in-file=/tmp/mypolicy.sql`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("create policy called ")
 		if PolicyFile == "" && PolicyURL == "" {
 			//log.Error("--in-file or --url is required to create a policy")
-			fmt.Println(`Error: --in-file or --url is required to create a policy`)
+			fmt.Println(`Error: The --in-file or --url flags are required to create a policy.`)
 			return
 		}
 
 		if len(args) == 0 {
-			fmt.Println(`Error: a policy name is required for this command`)
+			fmt.Println(`Error: A policy name is required for this command.`)
 		} else {
 			createPolicy(args)
 		}
@@ -110,15 +108,16 @@ var createIngestCmd = &cobra.Command{
 	Use:   "ingest",
 	Short: "Create an ingest",
 	Long: `Create an ingest. For example:
-pgo create ingest myingest --ingest-config=./ingest.json`,
+
+	pgo create ingest myingest --ingest-config=./ingest.json`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("create ingest called ")
 
 		if len(args) == 0 {
-			fmt.Println(`Error: an ingest name is required for this command`)
+			fmt.Println(`Error: An ingest name is required for this command.`)
 		} else {
 			if IngestConfig == "" {
-				fmt.Println("Error: You must specify the ingest-config flag")
+				fmt.Println("Error: You must specify the ingest-config flag.")
 				return
 			}
 			createIngest(args)
@@ -129,18 +128,19 @@ pgo create ingest myingest --ingest-config=./ingest.json`,
 // createUserCmd ...
 var createUserCmd = &cobra.Command{
 	Use:   "user",
-	Short: "Create a postgres user",
+	Short: "Create a PostgreSQL user",
 	Long: `Create a postgres user. For example:
-pgo create user user1 --selector=name=mycluster`,
+
+	pgo create user user1 --selector=name=mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("create user called ")
 		if Selector == "" {
-			fmt.Println(`Error: --selector is required to create a user`)
+			fmt.Println(`Error: The --selector flag is required to create a user.`)
 			return
 		}
 
 		if len(args) == 0 {
-			fmt.Println(`Error: a user name is required for this command`)
+			fmt.Println(`Error: A user name is required for this command.`)
 		} else {
 			createUser(args)
 		}
@@ -154,32 +154,33 @@ func init() {
 	CreateCmd.AddCommand(createIngestCmd)
 	CreateCmd.AddCommand(createUserCmd)
 
-	createIngestCmd.Flags().StringVarP(&IngestConfig, "ingest-config", "i", "", "The path of an ingest configuration file")
-	createClusterCmd.Flags().BoolVarP(&PgpoolFlag, "pgpool", "", false, "If set, will cause the crunchy-pgpool container to be added to the database cluster")
-	createClusterCmd.Flags().BoolVarP(&BackrestFlag, "pgbackrest", "", false, "If set, will cause a pgbackrest volume to be enabled for the database cluster")
-	createClusterCmd.Flags().BoolVarP(&ArchiveFlag, "archive", "", false, "If set, will cause archive logging to be enabled for the database cluster")
+	createClusterCmd.Flags().BoolVarP(&BackrestFlag, "pgbackrest", "", false, "Enables a pgBackRest volume for the database pod.")
+	createClusterCmd.Flags().BoolVarP(&BadgerFlag, "pgbadger", "", false, "Adds the crunchy-pgbadger container to the database pod.")
+	createIngestCmd.Flags().StringVarP(&IngestConfig, "ingest-config", "i", "", "Defines the path of an ingest configuration file.")
+	createClusterCmd.Flags().BoolVarP(&PgpoolFlag, "pgpool", "", false, "Adds the crunchy-pgpool container to the database pod.")
+	createClusterCmd.Flags().BoolVarP(&ArchiveFlag, "archive", "", false, "Enables archive logging for the database cluster.")
 	createClusterCmd.Flags().StringVarP(&PgpoolSecret, "pgpool-secret", "", "", "The name of a pgpool secret to use for the pgpool configuration.")
-	createClusterCmd.Flags().BoolVarP(&MetricsFlag, "metrics", "m", false, "If set, will cause the crunchy-collect container to be added to the database pod")
-	createClusterCmd.Flags().BoolVarP(&BadgerFlag, "pgbadger", "", false, "If set, will cause the crunchy-pgbadger container to be added to the database pod")
-	createClusterCmd.Flags().BoolVarP(&AutofailFlag, "autofail", "", false, "If set, will cause the autofailover to be enabled on this cluster")
-	createClusterCmd.Flags().StringVarP(&CustomConfig, "custom-config", "g", "", "The name of a configMap that holds custom PG config files used to override the defaults")
+	createClusterCmd.Flags().BoolVarP(&MetricsFlag, "metrics", "m", false, "Adds the crunchy-collect container to the database pod.")
+	createClusterCmd.Flags().BoolVarP(&AutofailFlag, "autofail", "", false, "If set, will cause autofailover to be enabled on this cluster.")
+	createClusterCmd.Flags().StringVarP(&CustomConfig, "custom-config", "g", "", "The name of a configMap that holds custom PostgreSQL configuration files used to override defaults.")
 	createClusterCmd.Flags().StringVarP(&StorageConfig, "storage-config", "", "", "The name of a Storage config in pgo.yaml to use for the cluster storage.")
 	createClusterCmd.Flags().StringVarP(&ReplicaStorageConfig, "replica-storage-config", "", "", "The name of a Storage config in pgo.yaml to use for the cluster replica storage.")
-	createClusterCmd.Flags().StringVarP(&NodeLabel, "node-label", "", "", "The node label (key=value) to use in placing the primary database, if not set any node is used")
-	createClusterCmd.Flags().StringVarP(&ServiceType, "service-type", "", "", "The service type to use in the Service for the PG cluster, if not set the pgo.yaml default will be used.")
-	createClusterCmd.Flags().StringVarP(&Password, "password", "w", "", "The password to use for initial database users")
-	createClusterCmd.Flags().StringVarP(&SecretFrom, "secret-from", "s", "", "The cluster name to use when restoring secrets")
-	createClusterCmd.Flags().StringVarP(&BackupPVC, "backup-pvc", "p", "", "The backup archive PVC to restore from")
-	createClusterCmd.Flags().StringVarP(&UserLabels, "labels", "l", "", "The labels to apply to this cluster")
-	createClusterCmd.Flags().StringVarP(&BackupPath, "backup-path", "x", "", "The backup archive path to restore from")
-	createClusterCmd.Flags().StringVarP(&PoliciesFlag, "policies", "z", "", "The policies to apply when creating a cluster, comma separated")
-	createClusterCmd.Flags().StringVarP(&CCPImageTag, "ccp-image-tag", "c", "", "The CCPImageTag to use for cluster creation, if specified overrides the .pgo.yaml setting")
-	createClusterCmd.Flags().IntVarP(&Series, "series", "e", 1, "The number of clusters to create in a series, defaults to 1")
-	createClusterCmd.Flags().StringVarP(&ContainerResources, "resources-config", "r", "", "The name of a container resource configuration in pgo.yaml that holds CPU and memory requests and limits")
-	createPolicyCmd.Flags().StringVarP(&PolicyURL, "url", "u", "", "The url to use for adding a policy")
-	createPolicyCmd.Flags().StringVarP(&PolicyFile, "in-file", "i", "", "The policy file path to use for adding a policy")
-	createUserCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to filter on clusters")
-	createUserCmd.Flags().BoolVarP(&ManagedUser, "managed", "m", false, "--managed creates a user with secrets")
-	createUserCmd.Flags().StringVarP(&UserDBAccess, "db", "b", "", "--db=userdb grants the user access to a database")
-	createUserCmd.Flags().IntVarP(&PasswordAgeDays, "valid-days", "v", 30, "--valid-days=7 sets passwords for new users to 7 days")
+	createClusterCmd.Flags().StringVarP(&NodeLabel, "node-label", "", "", "The node label (key=value) to use in placing the primary database. If not set, any node is used.")
+	createClusterCmd.Flags().StringVarP(&ServiceType, "service-type", "", "", "The Service type to use for the PostgreSQL cluster. If not set, the pgo.yaml default will be used.")
+	createClusterCmd.Flags().StringVarP(&Password, "password", "w", "", "The password to use for initial database users.")
+	createClusterCmd.Flags().StringVarP(&SecretFrom, "secret-from", "s", "", "The cluster name to use when restoring secrets.")
+	createClusterCmd.Flags().StringVarP(&BackupPVC, "backup-pvc", "p", "", "The backup archive PVC to restore from.")
+	createClusterCmd.Flags().StringVarP(&UserLabels, "labels", "l", "", "The labels to apply to this cluster.")
+	createClusterCmd.Flags().StringVarP(&BackupPath, "backup-path", "x", "", "The backup archive path to restore from.")
+	createClusterCmd.Flags().StringVarP(&PoliciesFlag, "policies", "z", "", "The policies to apply when creating a cluster, comma separated.")
+	createClusterCmd.Flags().StringVarP(&CCPImageTag, "ccp-image-tag", "c", "", "The CCPImageTag to use for cluster creation. If specified, overrides the pgo.yaml setting.")
+	createClusterCmd.Flags().IntVarP(&Series, "series", "e", 1, "The number of clusters to create in a series.")
+	createClusterCmd.Flags().StringVarP(&ContainerResources, "resources-config", "r", "", "The name of a container resource configuration in pgo.yaml that holds CPU and memory requests and limits.")
+	createPolicyCmd.Flags().StringVarP(&PolicyURL, "url", "u", "", "The url to use for adding a policy.")
+	createPolicyCmd.Flags().StringVarP(&PolicyFile, "in-file", "i", "", "The policy file path to use for adding a policy.")
+	createUserCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	createUserCmd.Flags().BoolVarP(&ManagedUser, "managed", "m", false, "Creates a user with secrets that can be managed by the Operator.")
+	createUserCmd.Flags().StringVarP(&UserDBAccess, "db", "b", "", "Grants the user access to a database.")
+	createUserCmd.Flags().IntVarP(&PasswordAgeDays, "valid-days", "v", 30, "Sets passwords for new users to X days.")
+
 }

--- a/pgo/cmd/delete.go
+++ b/pgo/cmd/delete.go
@@ -25,16 +25,15 @@ import (
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete a user, policy, cluster, backup, or upgrade",
-	Long: `delete allows you to delete a user, policy, cluster, backup, or upgrade
-For example:
+	Long: `The delete command allows you to delete a user, policy, cluster, backup, or upgrade. For example:
 
-pgo delete user jeffmc --selector=name=mycluster
-pgo delete policy mypolicy
-pgo delete cluster mycluster
-pgo delete cluster mycluster --delete-data
-pgo delete cluster mycluster --delete-data --delete-backups
-pgo delete backup mycluster
-pgo delete upgrade mycluster`,
+	pgo delete user testuser --selector=name=mycluster
+	pgo delete policy mypolicy
+	pgo delete cluster mycluster
+	pgo delete cluster mycluster --delete-data
+	pgo delete cluster mycluster --delete-data --delete-backups
+	pgo delete backup mycluster
+	pgo delete upgrade mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		if len(args) == 0 {
@@ -55,7 +54,7 @@ pgo delete upgrade mycluster`,
 			case "upgrade":
 				break
 			default:
-				fmt.Println(`Error: You must specify the type of resource to delete.  Valid resource types include: 
+				fmt.Println(`Error: You must specify the type of resource to delete.  Valid resource types include:
 	* policy
 	* user
 	* cluster
@@ -77,13 +76,12 @@ func init() {
 	deleteCmd.AddCommand(deletePolicyCmd)
 	deleteCmd.AddCommand(deleteIngestCmd)
 	deleteCmd.AddCommand(deleteClusterCmd)
-	deletePolicyCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "--no-prompt causes there to be no command line confirmation when doing a delete command")
-	deleteClusterCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "--no-prompt causes there to be no command line confirmation when doing a delete command")
-	deleteClusterCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
-	deleteUserCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
-	deleteClusterCmd.Flags().BoolVarP(&DeleteData, "delete-data", "d", false, "--delete-data causes the data for this cluster to be removed permanently ")
-	deleteClusterCmd.Flags().BoolVarP(&DeleteBackups, "delete-backups", "b", false, "--delete-backups causes the backups for this cluster to be removed permanently ")
-
+	deletePolicyCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "No command line confirmation.")
+	deleteClusterCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "No command line confirmation.")
+	deleteClusterCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	deleteUserCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	deleteClusterCmd.Flags().BoolVarP(&DeleteData, "delete-data", "d", false, "Causes the data for this cluster to be removed permanently.")
+	deleteClusterCmd.Flags().BoolVarP(&DeleteBackups, "delete-backups", "b", false, "Causes the backups for this cluster to be removed permanently.")
 	deleteCmd.AddCommand(deleteBackupCmd)
 	deleteCmd.AddCommand(deleteUpgradeCmd)
 
@@ -91,12 +89,13 @@ func init() {
 
 var deleteIngestCmd = &cobra.Command{
 	Use:   "ingest",
-	Short: "delete an ingest",
-	Long: `delete an ingest. For example:
+	Short: "Delete an ingest",
+	Long: `Delete an ingest. For example:
+
 	pgo delete ingest myingest`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Println("Error: a ingest name is required for this command")
+			fmt.Println("Error: A ingest name is required for this command.")
 		} else {
 			if util.AskForConfirmation(NoPrompt, "") {
 				deleteIngest(args)
@@ -109,12 +108,13 @@ var deleteIngestCmd = &cobra.Command{
 
 var deleteUpgradeCmd = &cobra.Command{
 	Use:   "upgrade",
-	Short: "delete an upgrade",
-	Long: `delete an upgrade. For example:
+	Short: "Delete an upgrade",
+	Long: `Delete an upgrade. For example:
+
 	pgo delete upgrade mydatabase`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Println("Error: a database or cluster name is required for this command")
+			fmt.Println("Error: A database or cluster name is required for this command.")
 		} else {
 			if util.AskForConfirmation(NoPrompt, "") {
 				deleteUpgrade(args)
@@ -127,12 +127,13 @@ var deleteUpgradeCmd = &cobra.Command{
 
 var deleteBackupCmd = &cobra.Command{
 	Use:   "backup",
-	Short: "delete a backup",
-	Long: `delete a backup. For example:
+	Short: "Delete a backup",
+	Long: `Delete a backup. For example:
+
 	pgo delete backup mydatabase`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Println("Error: a database or cluster name is required for this command")
+			fmt.Println("Error: A database or cluster name is required for this command.")
 		} else {
 			if util.AskForConfirmation(NoPrompt, "") {
 				deleteBackup(args)
@@ -146,15 +147,16 @@ var deleteBackupCmd = &cobra.Command{
 // deleteUserCmd ...
 var deleteUserCmd = &cobra.Command{
 	Use:   "user",
-	Short: "delete a user",
-	Long: `delete a user. For example:
+	Short: "Delete a user",
+	Long: `Delete a user. For example:
+
 	pgo delete user someuser --selector=name=mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		if len(args) == 0 {
-			fmt.Println("Error: a user name is required for this command")
+			fmt.Println("Error: A user name is required for this command.")
 		} else if Selector == "" {
-			fmt.Println("Error: a selector is required for this command")
+			fmt.Println("Error: A selector is required for this command.")
 		} else {
 			if util.AskForConfirmation(NoPrompt, "") {
 				deleteUser(args[0])
@@ -169,12 +171,13 @@ var deleteUserCmd = &cobra.Command{
 // deleteClusterCmd ...
 var deleteClusterCmd = &cobra.Command{
 	Use:   "cluster",
-	Short: "delete a cluster",
-	Long: `delete a crunchy cluster. For example:
+	Short: "Delete a PostgreSQL cluster",
+	Long: `Delete a PostgreSQL cluster. For example:
+
 	pgo delete cluster mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 && Selector == "" {
-			fmt.Println("Error: a cluster name or selector is required for this command")
+			fmt.Println("Error: A cluster name or selector is required for this command.")
 		} else {
 			if util.AskForConfirmation(NoPrompt, "") {
 				deleteCluster(args)
@@ -188,12 +191,13 @@ var deleteClusterCmd = &cobra.Command{
 
 var deletePolicyCmd = &cobra.Command{
 	Use:   "policy",
-	Short: "delete a policy",
-	Long: `delete a policy. For example:
+	Short: "Delete a SQL policy",
+	Long: `Delete a policy. For example:
+
 	pgo delete policy mypolicy`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Println("Error: a policy name is required for this command")
+			fmt.Println("Error: A policy name is required for this command.")
 		} else {
 			if util.AskForConfirmation(NoPrompt, "") {
 				deletePolicy(args)

--- a/pgo/cmd/df.go
+++ b/pgo/cmd/df.go
@@ -30,13 +30,11 @@ const CAPMAX = 50
 
 var dfCmd = &cobra.Command{
 	Use:   "df",
-	Short: "df on Clusters",
-	Long: `df displays disk status of Clusters
-				For example:
+	Short: "Display disk space for clusters",
+	Long: `Displays the disk status for PostgreSQL clusters. For example:
 
-				pgo df mycluster
-				pgo df --selector=env=research
-				.`,
+	pgo df mycluster
+	pgo df --selector=env=research`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("df called")
 		if Selector == "" && len(args) == 0 {
@@ -49,7 +47,9 @@ var dfCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(dfCmd)
-	dfCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
+	
+	dfCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+
 }
 
 func showDf(args []string) {
@@ -109,7 +109,7 @@ func showDf(args []string) {
 		}
 
 		if len(response.Results) == 0 {
-			fmt.Println("nothing found")
+			fmt.Println("Nothing found.")
 			return
 		}
 

--- a/pgo/cmd/failover.go
+++ b/pgo/cmd/failover.go
@@ -30,9 +30,10 @@ import (
 
 var failoverCmd = &cobra.Command{
 	Use:   "failover",
-	Short: "perform a failover",
-	Long: `performs a failover, for example:
-		pgo failover mycluster`,
+	Short: "Performs a manual failover",
+	Long: `Performs a manual failover. For example:
+
+	pgo failover mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("failover called")
 		if len(args) == 0 {
@@ -42,7 +43,7 @@ var failoverCmd = &cobra.Command{
 				queryFailover(args)
 			} else if util.AskForConfirmation(NoPrompt, "") {
 				if Target == "" {
-					fmt.Println(`Error: --target is required for failover.`)
+					fmt.Println(`Error: The --target flag is required for failover.`)
 					return
 				}
 				createFailover(args)
@@ -57,10 +58,10 @@ var failoverCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(failoverCmd)
 
-	failoverCmd.Flags().BoolVarP(&Query, "query", "", false, "--query prints the list of failover candidates")
-	failoverCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "--no-prompt causes there to be no command line confirmation when doing a failover command")
-	failoverCmd.Flags().StringVarP(&Target, "target", "", "", "--target is the replica target which the failover will occur on.")
-
+	failoverCmd.Flags().BoolVarP(&Query, "query", "", false, "Prints the list of failover candidates.")
+	failoverCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "No command line confirmation.")
+	failoverCmd.Flags().StringVarP(&Target, "target", "", "", "The replica target which the failover will occur on.")
+	
 }
 
 // createFailover ....

--- a/pgo/cmd/ingest.go
+++ b/pgo/cmd/ingest.go
@@ -42,13 +42,13 @@ type IngestConfigFile struct {
 func createIngest(args []string) {
 
 	if len(args) == 0 {
-		fmt.Println("Error: ingest name argument is required")
+		fmt.Println("Error: An ingest name argument is required.")
 		return
 	}
 
 	r, err := parseRequest(IngestConfig, args[0])
 	if err != nil {
-		fmt.Println("Error: problem parsing ingest config file")
+		fmt.Println("Error: Problem parsing ingest configuration file.")
 		fmt.Println("Error: ", err)
 		return
 	}
@@ -86,7 +86,7 @@ func createIngest(args []string) {
 	}
 
 	if response.Status.Code == msgs.Ok {
-		fmt.Println("created ingest")
+		fmt.Println("Created ingest.")
 	} else {
 		fmt.Println("Error: ", response.Status.Msg)
 		os.Exit(2)
@@ -130,11 +130,11 @@ func deleteIngest(args []string) {
 
 		if response.Status.Code == msgs.Ok {
 			if len(response.Results) == 0 {
-				fmt.Println("no ingests found")
+				fmt.Println("No ingests found.")
 				return
 			}
 			for k := range response.Results {
-				fmt.Println("deleted ingest " + response.Results[k])
+				fmt.Println("Deleted ingest " + response.Results[k])
 			}
 		} else {
 			fmt.Println("Error: ", response.Status.Msg)

--- a/pgo/cmd/label.go
+++ b/pgo/cmd/label.go
@@ -32,19 +32,17 @@ var DeleteLabel bool
 
 var labelCmd = &cobra.Command{
 	Use:   "label",
-	Short: "label a set of clusters",
-	Long: `LABEL allows you to add or remove a label on a set of clusters
-For example:
+	Short: "Label a set of clusters",
+	Long: `LABEL allows you to add or remove a label on a set of clusters. For example:
 
-pgo label mycluster yourcluster --label=environment=prod 
-pgo label mycluster yourcluster --label=environment=prod  --delete-label
-pgo label --label=environment=prod --selector=name=mycluster
-pgo label --label=environment=prod --selector=status=final --dry-run
-.`,
+	pgo label mycluster yourcluster --label=environment=prod
+	pgo label mycluster yourcluster --label=environment=prod  --delete-label
+	pgo label --label=environment=prod --selector=name=mycluster
+	pgo label --label=environment=prod --selector=status=final --dry-run`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("label called")
 		if len(args) == 0 && Selector == "" {
-			fmt.Println("Error: selector or list of clusters is required to label a policy")
+			fmt.Println("Error: A selector or list of clusters is required to label a policy.")
 			return
 		}
 		if LabelCmdLabel == "" {
@@ -58,18 +56,18 @@ pgo label --label=environment=prod --selector=status=final --dry-run
 func init() {
 	RootCmd.AddCommand(labelCmd)
 
-	labelCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
-	labelCmd.Flags().StringVarP(&LabelCmdLabel, "label", "l", "", "The new label to apply for any selected or specified clusters")
-	labelCmd.Flags().BoolVarP(&DryRun, "dry-run", "d", false, "--dry-run shows clusters that label would be applied to but does not actually label them")
-	labelCmd.Flags().BoolVarP(&DeleteLabel, "delete-label", "x", false, "--delete-label deletes a label from matching clusters")
-
+	labelCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	labelCmd.Flags().StringVarP(&LabelCmdLabel, "label", "l", "", "The new label to apply for any selected or specified clusters.")
+	labelCmd.Flags().BoolVarP(&DryRun, "dry-run", "d", false, "Shows the clusters that the label would be applied to, without labelling them.")
+	labelCmd.Flags().BoolVarP(&DeleteLabel, "delete-label", "x", false, "Deletes a label from specified clusters.")
+	
 }
 
 func labelClusters(clusters []string) {
 	var err error
 
 	if len(clusters) == 0 && Selector == "" {
-		fmt.Println("no clusters specified")
+		fmt.Println("No clusters specified.")
 		return
 	}
 
@@ -109,7 +107,7 @@ func labelClusters(clusters []string) {
 	log.Debugf("response is %v\n", resp)
 
 	if DryRun {
-		fmt.Println("DRY RUN....would have applied label on ...")
+		fmt.Println("The label would have been applied on the following:")
 	}
 	var response msgs.LabelResponse
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {

--- a/pgo/cmd/load.go
+++ b/pgo/cmd/load.go
@@ -33,16 +33,17 @@ var LoadConfig string
 
 var loadCmd = &cobra.Command{
 	Use:   "load",
-	Short: "perform a data load",
-	Long: `LOAD performs a load, for example:
-			pgo load --load-config=./load.json --selector=project=xray`,
+	Short: "Perform a data load",
+	Long: `LOAD performs a load. For example:
+
+	pgo load --load-config=./load.json --selector=project=xray`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("load called")
 		if len(args) == 0 && Selector == "" {
 			fmt.Println(`Error: You must specify the cluster to load or a selector flag.`)
 		} else {
 			if LoadConfig == "" {
-				fmt.Println("Error: You must specify the load-config ")
+				fmt.Println("Error: You must specify the load-config.")
 				return
 			}
 
@@ -55,23 +56,24 @@ var loadCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(loadCmd)
 
-	loadCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
-	loadCmd.Flags().StringVarP(&LoadConfig, "load-config", "l", "", "The load configuration to use that defines the load job")
-	loadCmd.Flags().StringVarP(&PoliciesFlag, "policies", "z", "", "The policies to apply before loading a file, comma separated")
+	loadCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	loadCmd.Flags().StringVarP(&LoadConfig, "load-config", "l", "", "The load configuration to use that defines the load job.")
+	loadCmd.Flags().StringVarP(&PoliciesFlag, "policies", "z", "", "The policies to apply before loading a file, comma separated.")
+	
 }
 
 func createLoad(args []string) {
 	if PoliciesFlag != "" {
 		log.Debug("policies=" + PoliciesFlag)
 	} else {
-		log.Debug("policies is blank")
+		log.Debug("The --policies flag requires a value.")
 	}
 	if Selector != "" {
 		//use the selector instead of an argument list to filter on
 
 		_, err := labels.Parse(Selector)
 		if err != nil {
-			fmt.Println("Error: could not parse selector flag")
+			fmt.Println("Error: Could not parse selector flag.")
 			return
 		}
 	}
@@ -120,7 +122,7 @@ func createLoad(args []string) {
 
 	//get the response
 	if response.Status.Code == msgs.Error {
-		fmt.Println("Error: error in loading...")
+		fmt.Println("Error: Error in loading...")
 		fmt.Println("Error: " + response.Status.Msg)
 		os.Exit(2)
 	}

--- a/pgo/cmd/policy.go
+++ b/pgo/cmd/policy.go
@@ -29,18 +29,16 @@ import (
 
 var applyCmd = &cobra.Command{
 	Use:   "apply",
-	Short: "apply a Policy",
-	Long: `APPLY allows you to apply a Policy to a set of clusters
-For example:
+	Short: "Apply a policy",
+	Long: `APPLY allows you to apply a Policy to a set of clusters. For example:
 
-pgo apply mypolicy1 --selector=name=mycluster
-pgo apply mypolicy1 --selector=someotherpolicy
-pgo apply mypolicy1 --selector=someotherpolicy --dry-run
-.`,
+	pgo apply mypolicy1 --selector=name=mycluster
+	pgo apply mypolicy1 --selector=someotherpolicy
+	pgo apply mypolicy1 --selector=someotherpolicy --dry-run`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("apply called")
 		if Selector == "" {
-			fmt.Println("Error: selector is required to apply a policy")
+			fmt.Println("Error: Selector is required to apply a policy.")
 			return
 		}
 		if len(args) == 0 {
@@ -54,8 +52,8 @@ pgo apply mypolicy1 --selector=someotherpolicy --dry-run
 func init() {
 	RootCmd.AddCommand(applyCmd)
 
-	applyCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
-	applyCmd.Flags().BoolVarP(&DryRun, "dry-run", "d", false, "--dry-run shows clusters that policy would be applied to but does not actually apply them")
+	applyCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	applyCmd.Flags().BoolVarP(&DryRun, "dry-run", "d", false, "Shows the clusters that the label would be applied to, without labelling them.")
 
 }
 
@@ -63,12 +61,12 @@ func applyPolicy(args []string) {
 	var err error
 
 	if len(args) == 0 {
-		fmt.Println("Error: policy name argument is required")
+		fmt.Println("Error: A policy name argument is required.")
 		return
 	}
 
 	if Selector == "" {
-		fmt.Println("Error: --selector flag is required")
+		fmt.Println("Error: The --selector flag is required.")
 		return
 	}
 
@@ -114,15 +112,15 @@ func applyPolicy(args []string) {
 	}
 
 	if DryRun {
-		fmt.Println("would have applied policy on " + "something")
+		fmt.Println("The label would have been applied on the following:")
 	}
 
 	if response.Status.Code == msgs.Ok {
 		if len(response.Name) == 0 {
-			fmt.Println("no clusters found")
+			fmt.Println("No clusters found.")
 		} else {
 			for _, v := range response.Name {
-				fmt.Println("applied policy on " + v)
+				fmt.Println("Applied policy on " + v)
 			}
 		}
 	} else {
@@ -172,7 +170,7 @@ func showPolicy(args []string) {
 		}
 
 		if len(response.PolicyList.Items) == 0 {
-			fmt.Println("no policies found")
+			fmt.Println("No policies found.")
 			return
 		}
 
@@ -192,7 +190,7 @@ func showPolicy(args []string) {
 func createPolicy(args []string) {
 
 	if len(args) == 0 {
-		fmt.Println("Error: poliicy name argument is required")
+		fmt.Println("Error: A poliicy name argument is required.")
 		return
 	}
 	var err error
@@ -249,7 +247,7 @@ func createPolicy(args []string) {
 	}
 
 	if response.Status.Code == msgs.Ok {
-		fmt.Println("created policy")
+		fmt.Println("Created policy.")
 	} else {
 		fmt.Println("Error: " + response.Status.Msg)
 		os.Exit(2)
@@ -306,7 +304,7 @@ func deletePolicy(args []string) {
 		}
 
 		if response.Status.Code == msgs.Ok {
-			fmt.Println("policy deleted")
+			fmt.Println("Policy deleted.")
 		} else {
 			fmt.Println("Error: " + response.Status.Msg)
 		}

--- a/pgo/cmd/pvc.go
+++ b/pgo/cmd/pvc.go
@@ -75,7 +75,7 @@ func printPVC(pvcName, pvcRoot string) {
 	}
 
 	if len(response.Results) == 0 {
-		fmt.Println("no PVC Results")
+		fmt.Println("No PVC Results")
 		return
 	}
 	log.Debugf("response = %v\n", response)

--- a/pgo/cmd/reload.go
+++ b/pgo/cmd/reload.go
@@ -33,13 +33,14 @@ var ConfigMapName string
 
 var reloadCmd = &cobra.Command{
 	Use:   "reload",
-	Short: "perform a reload",
-	Long: `RELOAD performs a PG reload on a set of clusters, for example:
-		pgo reload mycluster`,
+	Short: "Perform a cluster reload",
+	Long: `RELOAD performs a PostgreSQL reload on a cluster or set of clusters. For example:
+
+	pgo reload mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("reload called")
 		if len(args) == 0 && Selector == "" {
-			fmt.Println(`Error: You must specify the cluster to reload or a selector flag.`)
+			fmt.Println(`Error: You must specify the cluster to reload or specify a selector flag.`)
 		} else {
 			if util.AskForConfirmation(NoPrompt, "") {
 				reload(args)
@@ -54,8 +55,8 @@ var reloadCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(reloadCmd)
 
-	reloadCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
-	reloadCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "--no-prompt causes there to be no command line confirmation when doing a reload command")
+	reloadCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	reloadCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "No command line confirmation.")
 
 }
 
@@ -111,7 +112,7 @@ func reload(args []string) {
 	}
 
 	if len(response.Results) == 0 {
-		fmt.Println("no clusters found")
+		fmt.Println("No clusters found.")
 		return
 	}
 

--- a/pgo/cmd/restore.go
+++ b/pgo/cmd/restore.go
@@ -34,11 +34,11 @@ var PITRTarget string
 
 var restoreCmd = &cobra.Command{
 	Use:   "restore",
-	Short: "perform a restore",
-	Long: `RELOAD performs a pgbackrest restore to a new PG cluster, for example:
-		pgo restore mycluster --to-cluster=restoredcluster
-		pgo restore mycluster --restore-opts="--delta" --to-cluster=restoredcluster
-		pgo restore mycluster --restore-opts="--delta --type=time --target='2018-08-16 10:34:19.247526-04'" --to-cluster=restoredcluster`,
+	Short: "Perform a pgBackRest restore",
+	Long: `RESTORE performs a pgBackRest restore to a new PostgreSQL cluster. For example:
+
+	pgo restore withbr --to-cluster=restored
+	pgo create cluster restored --custom-config=backrest-restore-withbr-to-restored --secret-from=withbr --pgbackrest`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("restore called")
 		if len(args) == 0 {
@@ -49,7 +49,7 @@ var restoreCmd = &cobra.Command{
 				os.Exit(2)
 			}
 			if RestoreOpts == "" {
-				fmt.Println("Error: You must specify --restore-opts flag")
+				fmt.Println("Error: You must specify the --restore-opts flag.")
 				os.Exit(2)
 			}
 			restore(args)
@@ -61,9 +61,9 @@ var restoreCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(restoreCmd)
 
-	restoreCmd.Flags().StringVarP(&ToCluster, "to-cluster", "", "", "The name of the new cluster to restore to ")
-	restoreCmd.Flags().StringVarP(&RestoreOpts, "restore-opts", "", "", "default is full, other values are entered free form")
-	restoreCmd.Flags().StringVarP(&PITRTarget, "pitr-target", "", "", "the PITR target which is a PG timestamp such as '2018-08-13 11:25:42.582117-04'")
+	restoreCmd.Flags().StringVarP(&ToCluster, "to-cluster", "", "", "The name of the new cluster to restore to.")
+	restoreCmd.Flags().StringVarP(&RestoreOpts, "restore-opts", "", "full", "The options for the restore.")
+	restoreCmd.Flags().StringVarP(&PITRTarget, "pitr-target", "", "", "The PITR target, being a PostgreSQL timestamp such as '2018-08-13 11:25:42.582117-04'.")
 
 }
 
@@ -120,7 +120,7 @@ func restore(args []string) {
 	}
 
 	if len(response.Results) == 0 {
-		fmt.Println("no clusters found")
+		fmt.Println("No clusters found.")
 		return
 	}
 

--- a/pgo/cmd/root.go
+++ b/pgo/cmd/root.go
@@ -27,8 +27,7 @@ import (
 var RootCmd = &cobra.Command{
 	Use:   "pgo",
 	Short: "The pgo command line interface.",
-	Long: `The pgo command line interface lets you
-create and manage PostgreSQL clusters.`,
+	Long: `The pgo command line interface lets you create and manage PostgreSQL clusters.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	//	Run: func(cmd *cobra.Command, args []string) { },
@@ -53,8 +52,8 @@ func init() {
 	GREEN = color.New(color.FgGreen).SprintFunc()
 	RED = color.New(color.FgRed).SprintFunc()
 
-	RootCmd.PersistentFlags().StringVar(&APIServerURL, "apiserver-url", "", "postgres operator apiserver URL")
-	RootCmd.PersistentFlags().BoolVar(&DebugFlag, "debug", false, "enable debug with true")
+	RootCmd.PersistentFlags().StringVar(&APIServerURL, "apiserver-url", "", "The URL for the PostgreSQL Operator apiserver.")
+	RootCmd.PersistentFlags().BoolVar(&DebugFlag, "debug", false, "Enable debugging when true.")
 
 }
 
@@ -67,7 +66,7 @@ func initConfig() {
 	if APIServerURL == "" {
 		APIServerURL = os.Getenv("CO_APISERVER_URL")
 		if APIServerURL == "" {
-			fmt.Println("Error: CO_APISERVER_URL env var or --apiserver-url flag needs to be supplied")
+			fmt.Println("Error: The CO_APISERVER_URL environment variable or the --apiserver-url flag needs to be supplied.")
 			os.Exit(-1)
 		}
 	}

--- a/pgo/cmd/scale.go
+++ b/pgo/cmd/scale.go
@@ -33,18 +33,16 @@ var ScaleDownTarget string
 
 var scaleCmd = &cobra.Command{
 	Use:   "scale",
-	Short: "Scale a Cluster",
-	Long: `scale allows you to adjust a Cluster's replica configuration
-For example:
+	Short: "Scale a PostgreSQL cluster",
+	Long: `The scale command allows you to adjust a Cluster's replica configuration. For example:
 
-pgo scale mycluster --replica-count=1
+	pgo scale mycluster --replica-count=1
 
-to list replicas:
-pgo scale mycluster --query
+	To list targetable replicas:
+	pgo scale mycluster --query
 
-to scale down a specific replica:
-pgo scale mycluster --scale-down-target=mycluster-replica-xxxx
-.`,
+	To scale down a specific replica:
+	pgo scale mycluster --scale-down-target=mycluster-replica-xxxx`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("scale called")
 
@@ -75,17 +73,17 @@ pgo scale mycluster --scale-down-target=mycluster-replica-xxxx
 func init() {
 	RootCmd.AddCommand(scaleCmd)
 
-	scaleCmd.Flags().IntVarP(&ReplicaCount, "replica-count", "r", 1, "The replica count to apply to the clusters, defaults to 1")
-	scaleCmd.Flags().StringVarP(&ContainerResources, "resources-config", "", "", "The name of a container resource configuration in pgo.yaml that holds CPU and memory requests and limits")
-	scaleCmd.Flags().StringVarP(&ScaleDownTarget, "scale-down-target", "", "", "The name of a replica to delete")
+	scaleCmd.Flags().StringVarP(&ScaleDownTarget, "scale-down-target", "", "", "The name of a replica to delete.")
+	scaleCmd.Flags().StringVarP(&ServiceType, "service-type", "", "", "The service type to use in the replica Service. If not set, the default in pgo.yaml will be used.")
+	scaleCmd.Flags().StringVarP(&CCPImageTag, "ccp-image-tag", "c", "", "The CCPImageTag to use for cluster creation. If specified, overrides the .pgo.yaml setting.")
+	scaleCmd.Flags().BoolVarP(&Query, "query", "", false, "Prints the list of targetable replica candidates.")
+	scaleCmd.Flags().BoolVarP(&DeleteData, "delete-data", "", false, "Causes the data for the scaled down replica to be removed permanently.")
+	scaleCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "No command line confirmation.")
+	scaleCmd.Flags().StringVarP(&Target, "target", "", "", "The replica target which the scaling will occur on. Only applies when --replica-count=-1.")
+	scaleCmd.Flags().IntVarP(&ReplicaCount, "replica-count", "r", 1, "The replica count to apply to the clusters.")
+	scaleCmd.Flags().StringVarP(&ContainerResources, "resources-config", "", "", "he name of a container resource configuration in pgo.yaml that holds CPU and memory requests and limits.")
 	scaleCmd.Flags().StringVarP(&StorageConfig, "storage-config", "", "", "The name of a Storage config in pgo.yaml to use for the replica storage.")
-	scaleCmd.Flags().StringVarP(&NodeLabel, "node-label", "", "", "The node label (key=value) to use in placing the replica pod, if not set any node is used")
-	scaleCmd.Flags().StringVarP(&ServiceType, "service-type", "", "", "The service type to use in the replica Service, if not set the default in pgo.yaml will be used")
-	scaleCmd.Flags().StringVarP(&CCPImageTag, "ccp-image-tag", "c", "", "The CCPImageTag to use for cluster creation, if specified overrides the .pgo.yaml setting")
-	scaleCmd.Flags().BoolVarP(&Query, "query", "", false, "--query prints the list of replica candidates")
-	scaleCmd.Flags().BoolVarP(&DeleteData, "delete-data", "", false, "--delete-data deletes the data of the scaled down replica ")
-	scaleCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "--no-prompt causes there to be no command line confirmation when doing a scale command")
-	scaleCmd.Flags().StringVarP(&Target, "target", "", "", "--target is the replica target which the scale will occur on. Only applies when --replica-cound=-1")
+	scaleCmd.Flags().StringVarP(&NodeLabel, "node-label", "", "", "The node label (key) to use in placing the primary database. If not set, any node is used.")
 
 }
 

--- a/pgo/cmd/show.go
+++ b/pgo/cmd/show.go
@@ -30,9 +30,8 @@ var PVCRoot string
 
 var ShowCmd = &cobra.Command{
 	Use:   "show",
-	Short: "show a description of a cluster",
-	Long: `show allows you to show the details of a policy, backup, pvc, or cluster.
-For example:
+	Short: "Show the description of a cluster",
+	Long: `Show allows you to show the details of a policy, backup, pvc, or cluster. For example:
 
 	pgo show policy policy1
 	pgo show pvc mycluster
@@ -44,7 +43,7 @@ For example:
 	pgo show cluster mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Println(`Error: You must specify the type of resource to show.  
+			fmt.Println(`Error: You must specify the type of resource to show.
 Valid resource types include:
 	* cluster
 	* pvc
@@ -66,7 +65,7 @@ Valid resource types include:
 			case "backup":
 				break
 			default:
-				fmt.Println(`Error: You must specify the type of resource to show.  
+				fmt.Println(`Error: You must specify the type of resource to show.
 Valid resource types include:
 	* cluster
 	* pvc
@@ -93,21 +92,22 @@ func init() {
 	ShowCmd.AddCommand(ShowUpgradeCmd)
 	ShowCmd.AddCommand(ShowUserCmd)
 
-	ShowClusterCmd.Flags().StringVarP(&PostgresVersion, "version", "v", "", "The postgres version to filter on")
-	ShowClusterCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
-	ShowUserCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
-	ShowPVCCmd.Flags().StringVarP(&PVCRoot, "pvc-root", "r", "", "The PVC directory to list")
-	ShowBackupCmd.Flags().StringVarP(&BackupType, "backup-type", "", "", "The backup type output to list, valid choices are pgbasebackup or pgbackrest")
-	ShowClusterCmd.Flags().StringVarP(&OutputFormat, "output", "o", "", "The output format, json is currently supported")
+	ShowBackupCmd.Flags().StringVarP(&BackupType, "backup-type", "", "", "The backup type output to list. Valid choices are pgbasebackup or pgbackrest.")
+	ShowClusterCmd.Flags().StringVarP(&PostgresVersion, "version", "v", "", "Filter the results based on the PostgreSQL version of the cluster.")
+	ShowClusterCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	ShowBackrestCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	ShowUserCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	ShowPVCCmd.Flags().StringVarP(&PVCRoot, "pvc-root", "r", "", "The PVC directory to list.")
+	ShowClusterCmd.Flags().StringVarP(&OutputFormat, "output", "o", "", "The output format. Currently, JSON is supported.")
 
 }
 
 var ShowConfigCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Show config information",
-	Long: `Show config information. For example:
+	Short: "Show configuration information",
+	Long: `Show configuration information for the Operator. For example:
 
-				pgo show config`,
+	pgo show config`,
 	Run: func(cmd *cobra.Command, args []string) {
 		showConfig(args)
 	},
@@ -118,10 +118,10 @@ var ShowPolicyCmd = &cobra.Command{
 	Short: "Show policy information",
 	Long: `Show policy information. For example:
 
-				pgo show policy policy1`,
+	pgo show policy policy1`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Println("Error: policy name(s) required for this command")
+			fmt.Println("Error: Policy name(s) required for this command.")
 		} else {
 			showPolicy(args)
 		}
@@ -130,16 +130,16 @@ var ShowPolicyCmd = &cobra.Command{
 
 var ShowPVCCmd = &cobra.Command{
 	Use:   "pvc",
-	Short: "Show pvc information",
-	Long: `Show pvc information. For example:
+	Short: "Show PVC information",
+	Long: `Show PVC information. For example:
 
-				pgo show pvc all
-				pgo show pvc mycluster-backup
-				pgo show pvc mycluster-xlog
-				pgo show pvc mycluster`,
+	pgo show pvc all
+	pgo show pvc mycluster-backup
+	pgo show pvc mycluster-xlog
+	pgo show pvc mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Println("Error: PVC name(s) required for this command")
+			fmt.Println("Error: PVC name(s) required for this command.")
 		} else {
 			showPVC(args)
 		}
@@ -151,10 +151,10 @@ var ShowUpgradeCmd = &cobra.Command{
 	Short: "Show upgrade information",
 	Long: `Show upgrade information. For example:
 
-				pgo show upgrade mycluster`,
+	pgo show upgrade mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Println("Error: cluster name(s) required for this command")
+			fmt.Println("Error: cluster name(s) required for this command.")
 		} else {
 			showUpgrade(args)
 		}
@@ -167,10 +167,10 @@ var ShowBackupCmd = &cobra.Command{
 	Short: "Show backup information",
 	Long: `Show backup information. For example:
 
-				pgo show backup mycluser`,
+	pgo show backup mycluser`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Println("Error: cluster name(s) required for this command")
+			fmt.Println("Error: cluster name(s) required for this command.")
 		} else {
 			if BackupType == util.LABEL_BACKUP_TYPE_BACKREST {
 
@@ -178,7 +178,7 @@ var ShowBackupCmd = &cobra.Command{
 			} else if BackupType == util.LABEL_BACKUP_TYPE_BASEBACKUP {
 				showBackup(args)
 			} else {
-				fmt.Println("Error: valid backup-type values are pgbasebackup and pgbackrest, pgbasebackup is the default if not supplied")
+				fmt.Println("Error: Valid backup-type values are pgbasebackup and pgbackrest. The default if not supplied is pgbasebackup.")
 			}
 		}
 	},
@@ -188,12 +188,12 @@ var ShowBackupCmd = &cobra.Command{
 var ShowClusterCmd = &cobra.Command{
 	Use:   "cluster",
 	Short: "Show cluster information",
-	Long: `Show a crunchy cluster. For example:
+	Long: `Show a PostgreSQL cluster. For example:
 
-				pgo show cluster mycluster`,
+	pgo show cluster mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if Selector == "" && len(args) == 0 {
-			fmt.Println("Error: cluster name(s) required for this command")
+			fmt.Println("Error: Cluster name(s) required for this command.")
 		} else {
 			showCluster(args)
 		}
@@ -204,12 +204,12 @@ var ShowClusterCmd = &cobra.Command{
 var ShowIngestCmd = &cobra.Command{
 	Use:   "ingest",
 	Short: "Show ingest information",
-	Long: `Show a crunchy ingest. For example:
+	Long: `Show an ingest. For example:
 
-				pgo show ingest myingest`,
+	pgo show ingest myingest`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if Selector == "" && len(args) == 0 {
-			fmt.Println("Error: ingest name(s) required for this command")
+			fmt.Println("Error: Ingest name(s) required for this command.")
 		} else {
 			showIngest(args)
 		}
@@ -222,10 +222,10 @@ var ShowUserCmd = &cobra.Command{
 	Short: "Show user information",
 	Long: `Show users on a cluster. For example:
 
-				pgo show user mycluster`,
+	pgo show user mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if Selector == "" && len(args) == 0 {
-			fmt.Println("Error: cluster name(s) required for this command")
+			fmt.Println("Error: Cluster name(s) required for this command.")
 		} else {
 			showUser(args)
 		}

--- a/pgo/cmd/status.go
+++ b/pgo/cmd/status.go
@@ -28,12 +28,10 @@ import (
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "status Clusters",
-	Long: `status displays namespace wide info on Clusters
-				For example:
+	Short: "Display PostgreSQL cluster status",
+	Long: `Display namespace wide information for PostgreSQL clusters.	For example:
 
-				pgo status 
-				.`,
+	pgo status`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("status called")
 		showStatus(args)
@@ -44,7 +42,9 @@ var Summary bool
 
 func init() {
 	RootCmd.AddCommand(statusCmd)
-	statusCmd.Flags().StringVarP(&OutputFormat, "output", "o", "", "The output format, json is currently supported")
+	
+	statusCmd.Flags().StringVarP(&OutputFormat, "output", "o", "", "The output format. Currently, JSON is supported.")
+
 }
 
 func showStatus(args []string) {

--- a/pgo/cmd/test.go
+++ b/pgo/cmd/test.go
@@ -27,19 +27,17 @@ import (
 
 var testCmd = &cobra.Command{
 	Use:   "test",
-	Short: "test a Cluster",
-	Long: `TEST allows you to test a new Cluster
-				For example:
+	Short: "Test cluster connectivity",
+	Long: `TEST allows you to test the connectivity for a cluster. For example:
 
-				pgo test mycluster
-				.`,
+	pgo test mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("test called")
 		if Selector == "" && len(args) == 0 {
 			fmt.Println(`Error: You must specify the name of the clusters to test.`)
 		} else {
 			if OutputFormat != "" && OutputFormat != "json" {
-				fmt.Println("Error: only json is supported for output flag value")
+				fmt.Println("Error: Only JSON is currently supported for the --output flag value.")
 				os.Exit(2)
 			}
 			showTest(args)
@@ -49,8 +47,8 @@ var testCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(testCmd)
-	testCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
-	testCmd.Flags().StringVarP(&OutputFormat, "output", "o", "", "The output format, json is currently supported")
+	testCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	testCmd.Flags().StringVarP(&OutputFormat, "output", "o", "", "The output format. Currently, JSON is supported.")
 }
 
 func showTest(args []string) {
@@ -110,7 +108,7 @@ func showTest(args []string) {
 		}
 
 		if len(response.Results) == 0 {
-			fmt.Println("nothing found")
+			fmt.Println("Nothing found.")
 			return
 		}
 
@@ -120,7 +118,7 @@ func showTest(args []string) {
 			for _, v := range result.Items {
 				fmt.Printf("%s%s is ", TreeBranch, v.PsqlString)
 				if v.Working {
-					fmt.Printf("%s\n", GREEN("working"))
+					fmt.Printf("%s\n", GREEN("Working"))
 				} else {
 					fmt.Printf("%s\n", RED("NOT working"))
 				}

--- a/pgo/cmd/upgrade.go
+++ b/pgo/cmd/upgrade.go
@@ -38,9 +38,10 @@ var UpgradeType string
 
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
-	Short: "perform an upgrade",
-	Long: `UPGRADE performs an upgrade, for example:
-				                pgo upgrade mycluster`,
+	Short: "Perform an upgrade",
+	Long: `UPGRADE performs an upgrade on a PostgreSQL cluster. For example:
+
+  pgo upgrade mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("upgrade called")
 		if len(args) == 0 && Selector == "" {
@@ -59,8 +60,10 @@ var upgradeCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(upgradeCmd)
-	upgradeCmd.Flags().StringVarP(&UpgradeType, "upgrade-type", "t", "minor", "The upgrade type to perform either minor or major, default is minor ")
-	upgradeCmd.Flags().StringVarP(&CCPImageTag, "ccp-image-tag", "c", "", "The CCP_IMAGE_TAG to use for the upgrade target")
+
+	upgradeCmd.Flags().StringVarP(&UpgradeType, "upgrade-type", "t", "minor", "The upgrade type. Accepted values are either 'minor' or 'major'.")
+	upgradeCmd.Flags().StringVarP(&CCPImageTag, "ccp-image-tag", "c", "", "The CCPImageTag to use for cluster creation. If specified, overrides the pgo.yaml setting.")
+
 }
 
 func showUpgrade(args []string) {
@@ -105,7 +108,7 @@ func showUpgrade(args []string) {
 		}
 
 		if len(response.UpgradeList.Items) == 0 {
-			fmt.Println("no upgrades found")
+			fmt.Println("no upgrades found.")
 			return
 		}
 
@@ -175,7 +178,7 @@ func deleteUpgrade(args []string) {
 
 		if response.Status.Code == msgs.Ok {
 			if len(response.Results) == 0 {
-				fmt.Println("no upgrades found")
+				fmt.Println("no upgrades found.")
 				return
 			}
 			for k := range response.Results {
@@ -203,7 +206,7 @@ func validateCreateUpdate(args []string) error {
 	}
 	if UpgradeType == MajorUpgrade || UpgradeType == MinorUpgrade {
 	} else {
-		return errors.New("upgrade-type requires either a value of major or minor, if not specified, minor is the default value")
+		return errors.New("The --upgrade-type flag requires either a value of major or minor. If not specified, minor is the default value.")
 	}
 	return err
 }
@@ -212,7 +215,7 @@ func createUpgrade(args []string) {
 	log.Debugf("createUpgrade called %v\n", args)
 
 	if len(args) == 0 && Selector == "" {
-		fmt.Println("Error: cluster names or a selector flag is required")
+		fmt.Println("Error: Cluster name(s) or a selector flag is required.")
 		os.Exit(2)
 	}
 

--- a/pgo/cmd/user.go
+++ b/pgo/cmd/user.go
@@ -52,14 +52,12 @@ var ManagedUser bool
 
 var userCmd = &cobra.Command{
 	Use:   "user",
-	Short: "manage users",
-	Long: `USER allows you to manage users and passwords across a set of clusters
-For example:
+	Short: "Manage PostgreSQL users",
+	Long: `USER allows you to manage users and passwords across a set of clusters. For example:
 
-pgo user --selector=name=mycluster --update-passwords
-pgo user --expired=7 --selector=name=mycluster
-pgo user --change-password=bob --selector=name=mycluster
-.`,
+	pgo user --selector=name=mycluster --update-passwords
+	pgo user --expired=7 --selector=name=mycluster
+	pgo user --change-password=bob --selector=name=mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("user called")
 		userManager()
@@ -69,13 +67,13 @@ pgo user --change-password=bob --selector=name=mycluster
 func init() {
 	RootCmd.AddCommand(userCmd)
 
-	userCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering ")
-	userCmd.Flags().StringVarP(&Expired, "expired", "e", "", "--expired=7 shows passwords that will expired in 7 days")
-	userCmd.Flags().IntVarP(&PasswordAgeDays, "valid-days", "v", 30, "--valid-days=7 sets passwords for new users to 7 days")
-	userCmd.Flags().StringVarP(&ChangePasswordForUser, "change-password", "c", "", "--change-password=bob updates the password for a user on selective clusters")
-	userCmd.Flags().StringVarP(&UserDBAccess, "db", "b", "", "--db=userdb grants the user access to a database")
-	userCmd.Flags().BoolVarP(&UpdatePasswords, "update-passwords", "u", false, "--update-passwords performs password updating on expired passwords")
-	userCmd.Flags().BoolVarP(&ManagedUser, "managed", "m", false, "--managed creates a user with secrets")
+	userCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	userCmd.Flags().StringVarP(&Expired, "expired", "e", "", "Shows passwords that will expire in X days.")
+	userCmd.Flags().IntVarP(&PasswordAgeDays, "valid-days", "v", 30, "Sets passwords for new users to X days.")
+	userCmd.Flags().StringVarP(&ChangePasswordForUser, "change-password", "c", "", "Updates the password for a user on selective clusters.")
+	userCmd.Flags().StringVarP(&UserDBAccess, "db", "b", "", "Grants the user access to a database.")
+	userCmd.Flags().BoolVarP(&UpdatePasswords, "update-passwords", "u", false, "Performs password updating on expired passwords.")
+	userCmd.Flags().BoolVarP(&ManagedUser, "managed", "m", false, "Creates a user with secrets that can be managed by the Operator.")
 
 }
 
@@ -140,12 +138,12 @@ func userManager() {
 func createUser(args []string) {
 
 	if Selector == "" {
-		fmt.Println("Error: selector flag is required")
+		fmt.Println("Error: The --selector flag is required.")
 		return
 	}
 
 	if len(args) == 0 {
-		fmt.Println("Error: user name argument is required")
+		fmt.Println("Error: A user name argument is required.")
 		return
 	}
 
@@ -304,7 +302,7 @@ func showUser(args []string) {
 			os.Exit(2)
 		}
 		if len(response.Results) == 0 {
-			fmt.Println("no clusters found")
+			fmt.Println("No clusters found.")
 			return
 		}
 

--- a/pgo/cmd/version.go
+++ b/pgo/cmd/version.go
@@ -27,12 +27,10 @@ import (
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "print version information for the postgres-operator",
-	Long: `VERSION allows you to print version information for the postgres-operator
-				For example:
+	Short: "Print version information for the PostgreSQL Operator",
+	Long: `VERSION allows you to print version information for the postgres-operator. For example:
 
-				pgo version
-				.`,
+	pgo version`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debug("version called")
 		showVersion()


### PR DESCRIPTION
- There was a merge conflict in the getting-started documentation. This has been fixed and the documentation re-generated to fix the error in the public documentation.
- Command line help text has been rewritten to match the updated phrasing in the documentation.
- Phrasing and punctuation has been addressed for consistency in output.
- Detail has been added to command descriptions where necessary.

It is of note that issue #279 cannot yet be closed. Much more needs to be done to improve the consistency of formatting and output in both the help and debugging output and continue along the lines of this PR. This was tested in an environment running 3.1 after rebuilding with the following commands:

```
make clean
make pgo
```