### PR TITLE
bring Dockerfiles to pg10, update descriptions

### DIFF
--- a/centos7/Dockerfile.pgo-apiserver.centos7
+++ b/centos7/Dockerfile.pgo-apiserver.centos7
@@ -14,7 +14,7 @@ ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
-RUN yum -y update && yum -y install postgresql96 hostname && yum -y clean all
+RUN yum -y update && yum -y install postgresql10 hostname && yum -y clean all
 
 ADD bin/apiserver /usr/local/bin
 ADD bin/postgres-operator/runpsql.sh /usr/local/bin

--- a/centos7/Dockerfile.pgo-backrest.centos7
+++ b/centos7/Dockerfile.pgo-backrest.centos7
@@ -1,6 +1,9 @@
 FROM centos:7
 
 LABEL Vendor="Crunchy Data Solutions" \
+		PostgresVersion="10" \
+		PostgresFullVersion="10.5" \
+		Version="7.5" \
 		Release="3.2.0" \
 		summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 		description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."

--- a/centos7/Dockerfile.postgres-operator.centos7
+++ b/centos7/Dockerfile.postgres-operator.centos7
@@ -14,7 +14,7 @@ ENV PGVERSION="10" PGDG_REPO="pgdg-centos10-10-2.noarch.rpm"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
-RUN yum -y update && yum -y install hostname postgresql96  && yum -y clean all
+RUN yum -y update && yum -y install hostname postgresql10  && yum -y clean all
 
 ADD bin/postgres-operator /usr/local/bin
 

--- a/rhel7/Dockerfile.pgo-backrest.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest.rhel7
@@ -4,13 +4,13 @@ MAINTAINER jeff.mccormick@crunchydata.com
 
 LABEL name="crunchydata/pgo-backrest-" \
     vendor="crunchydata.com" \
-        PostgresVersion="10" \
-        PostgresFullVersion="10.5" \
-        Version="7.5" \
-        Release="3.2.0" \
+    PostgresVersion="10" \
+    PostgresFullVersion="10.5" \
+    Version="7.5" \
+    Release="3.2.0" \
     run='docker run -d -p 8080:80 --name=web-app web-app' \
-    summary="Crunchy Data PostgreSQL Operator - pgo-backrest" \
-    description="performs pgbackrest commands."
+    summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
+    description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
 ENV PGVERSION="10"
 


### PR DESCRIPTION
- update rhel7 pgBackRest description to be consistent with the centos7 Dockerfile
- add missing version strings to rhel7, centos7 pgBackRest Dockerfiles
- bring all postgresql96 instances to postgresql10