### PR TITLE
update the documentation for pgBackrest

### DIFF
--- a/hugo/content/getting-started/_index.adoc
+++ b/hugo/content/getting-started/_index.adoc
@@ -309,8 +309,10 @@ pgo create cluster restored --custom-config=backrest-restore-withbr-to-restored 
 ....
 
 The pgBackRest backrestrepo PVCs are created using the pgo.yaml `BackupStorage` setting.
-Typically, this will be a RWX file system which will allow you to restore from this PVC
-without having to shutdown the currently attached PostgreSQL cluster.
+Typically, this will be a RWX file system but if the file system is RWO the PVCs will be 
+created without having write access and a backup and restore will fail. The RWX file
+system setup will allow you to restore from this PVC without having to shutdown the currently
+attached PostgreSQL cluster.
 
 === Delete Cluster
 


### PR DESCRIPTION
Updated the documentation for pgBackrest to add information that a pvc with RWO access will not let the user successfully do a back and restore

https://github.com/CrunchyData/postgres-operator-test/issues/72

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
update dated documentation with stronger verb-age about pvc's access mode
