### PR TITLE
Add a new way to access postgres-operator apiserver using Kubernetes ingress

### DIFF
--- a/deploy/ingress.yml
+++ b/deploy/ingress.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: postgres-operator
+  namespace: demo
+  annotations:
+    ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/secure-backends: "true"
+spec:
+  backend:
+    serviceName: postgres-operator
+    servicePort: 8443

--- a/hugo/content/installation/deployment.adoc
+++ b/hugo/content/installation/deployment.adoc
@@ -116,6 +116,8 @@ This alias (`setip`) will set the `CO_APISERVER_URL` IP address for you.
 
 ==== Running Kubernetes Remotely
 
+===== Port forwarding
+
 Set up a port-forward tunnel from your host to the Kube remote host, specifying the operator pod -
 ....
 kubectl get pod --selector=name=postgres-operator
@@ -130,6 +132,41 @@ In another terminal -
 export CO_APISERVER_URL=https://127.0.0.1:8443
 pgo version
 ....
+
+===== Using an ingress
+
+Ingresses allows you to access Kubernetes services throught a controller.
+
+First you will need to ensure a NGINX Ingress Controller is available in your Kubernetes cluster.
+
+If you are using Minikube, you can easily deploy one using
+....
+minikube addons enable ingress
+....
+If not, please refer to the https://kubernetes.github.io/ingress-nginx/deploy/#bare-metal[Nginx Ingress Controller's official documentation] for its installation.
+
+Once your controller is running, just deploy the ingress using
+....
+kubectl create -f $COROOT/deploy/ingress.yml
+....
+Due to the annotations used, please note this ingress is currently usable only with Nginx Ingress Controller.
+
+Now you can use the adress IP of the host where the nginx-ingress-controller pod is to connect to the pgo apiserver. The port will be 443 (and not 8443).
+
+To retrieve the address ip:
+....
+kubectl get ingress postgres-operator -o jsonpath="{.status.loadBalancer.ingress[0].ip}"
+
+export CO_APISERVER_URL=https://`kubectl get ingress postgres-operator -o jsonpath="{.status.loadBalancer.ingress[0].ip}"`
+....
+
+If you are using minikube, the address IP displayed is incorrect, just use:
+....
+minikube ip
+
+export CO_APISERVER_URL=https://`minikube ip`
+....
+
 
 {{% /expand%}}
 


### PR DESCRIPTION
…ingress

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Informations**:
This PR adds information on how to remotely access the postgres-operator apiserver using an Ingress. I think this way is simpler to connect the pgo client and its apiserver than the port forwarding.