### PR TITLE
Add resources and storage information to pgo show cluster cmd

### DIFF
--- a/pgo/cmd/cluster.go
+++ b/pgo/cmd/cluster.go
@@ -125,6 +125,13 @@ func printCluster(detail *msgs.ShowClusterDetail) {
 		}
 	}
 
+	resources := detail.Cluster.Spec.ContainerResources
+	resourceStr := fmt.Sprintf("%sresources : CPU Limit=%s Memory Limit=%s, CPU Request=%s Memory Request=%s", TreeBranch, resources.LimitsCPU, resources.LimitsMemory, resources.RequestsCPU, resources.RequestsMemory)
+	fmt.Println(resourceStr)
+
+	storageStr := fmt.Sprintf("%sstorage : Primary=%s Replica=%s", TreeBranch, detail.Cluster.Spec.PrimaryStorage.Size, detail.Cluster.Spec.ReplicaStorage.Size)
+	fmt.Println(storageStr)
+
 	for _, d := range detail.Deployments {
 		fmt.Println(TreeBranch + "deployment : " + d.Name)
 	}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
```
$ pgo show cluster test

cluster : test (centos7-10.5-2.1.0)
	pod : test-578cd54d99-cbzqg (Running) on minikube (1/1) (primary)
	pvc : test
	deployment : test
	service : test - ClusterIP (10.96.126.121)
	labels : archive=false archive-timeout=60 name=test pgo-version=3.3.0-rc4 primary=true crunchy-pgbadger=false crunchy_collect=false pg-cluster=test pgo-backrest=false
```


**What is the new behavior (if this is a feature change)?**
Adds information about resources and storage (fixes #261)

```
$ pgo show cluster test

cluster : test (centos7-10.5-2.1.0)
	pod : test-578cd54d99-cbzqg (Running) on minikube (1/1) (primary)
	pvc : test
	resources : CPU Limit=0.1 Memory Limit=512Mi, CPU Request=0.1 Memory Request=512Mi
	storage : Primary=1G Replica=1G
	deployment : test
	service : test - ClusterIP (10.96.126.121)
	labels : archive=false crunchy_collect=false archive-timeout=60 crunchy-pgbadger=false name=test pg-cluster=test pgo-backrest=false pgo-version=3.3.0-rc4 primary=true
```

**Other information**: