### PR TITLE
Add a password-length parameter for user creation and update

### DIFF
--- a/apiserver/userservice/userimpl.go
+++ b/apiserver/userservice/userimpl.go
@@ -20,6 +20,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/apiserver"
@@ -29,9 +33,6 @@ import (
 	_ "github.com/lib/pq"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // connInfo ....
@@ -120,7 +121,7 @@ func User(request *msgs.UserRequest) msgs.UserResponse {
 				msg := "changing password of user " + request.ChangePasswordForUser + " on " + d.ObjectMeta.Name
 				log.Debug(msg)
 				resp.Results = append(resp.Results, msg)
-				newPassword := util.GeneratePassword(defaultPasswordLength)
+				newPassword := util.GeneratePassword(request.PasswordLength)
 				if request.Password != "" {
 					parts := strings.Split(request.Password, " ")
 					if len(parts) > 1 {
@@ -134,7 +135,7 @@ func User(request *msgs.UserRequest) msgs.UserResponse {
 				pgbouncer := cluster.Spec.UserLabels[util.LABEL_PGBOUNCER] == "true"
 				pgpool := cluster.Spec.UserLabels[util.LABEL_PGPOOL] == "true"
 
-				err = updatePassword(cluster.Spec.Name, info, request.ChangePasswordForUser, newPassword, newExpireDate, apiserver.Namespace, pgpool, pgbouncer)
+				err = updatePassword(cluster.Spec.Name, info, request.ChangePasswordForUser, newPassword, newExpireDate, apiserver.Namespace, pgpool, pgbouncer, request.PasswordLength)
 				if err != nil {
 					log.Error(err.Error())
 					resp.Status.Code = msgs.Error
@@ -151,11 +152,11 @@ func User(request *msgs.UserRequest) msgs.UserResponse {
 					for _, v := range results {
 						log.Debug("RoleName " + v.Rolname + " Role Valid Until " + v.Rolvaliduntil)
 						if request.UpdatePasswords {
-							newPassword := util.GeneratePassword(defaultPasswordLength)
+							newPassword := util.GeneratePassword(request.PasswordLength)
 							newExpireDate := GeneratePasswordExpireDate(request.PasswordAgeDays)
 							pgbouncer := cluster.Spec.UserLabels[util.LABEL_PGBOUNCER] == "true"
 							pgpool := cluster.Spec.UserLabels[util.LABEL_PGPOOL] == "true"
-							err = updatePassword(cluster.Spec.Name, v.ConnDetails, v.Rolname, newPassword, newExpireDate, apiserver.Namespace, pgpool, pgbouncer)
+							err = updatePassword(cluster.Spec.Name, v.ConnDetails, v.Rolname, newPassword, newExpireDate, apiserver.Namespace, pgpool, pgbouncer, request.PasswordLength)
 							if err != nil {
 								log.Error("error in updating password")
 							}
@@ -221,7 +222,7 @@ func callDB(info connInfo, clusterName, maxdays string) []pswResult {
 }
 
 // updatePassword ...
-func updatePassword(clusterName string, p connInfo, username, newPassword, passwordExpireDate, namespace string, pgpool bool, pgbouncer bool) error {
+func updatePassword(clusterName string, p connInfo, username, newPassword, passwordExpireDate, namespace string, pgpool bool, pgbouncer bool, passwordLength int) error {
 	var err error
 	var conn *sql.DB
 
@@ -265,7 +266,7 @@ func updatePassword(clusterName string, p connInfo, username, newPassword, passw
 		return nil
 	}
 
-	err = util.UpdateUserSecret(apiserver.Clientset, clusterName, username, newPassword, namespace)
+	err = util.UpdateUserSecret(apiserver.Clientset, clusterName, username, newPassword, namespace, passwordLength)
 	if err != nil {
 		log.Debug(err.Error())
 		return err
@@ -443,7 +444,7 @@ func addUser(request *msgs.CreateUserRequest, namespace, clusterName string, inf
 		if request.Password != "" {
 			info.Password = request.Password
 		}
-		err = util.CreateUserSecret(apiserver.Clientset, clusterName, request.Name, info.Password, namespace)
+		err = util.CreateUserSecret(apiserver.Clientset, clusterName, request.Name, info.Password, namespace, request.PasswordLength)
 		if err != nil {
 			log.Error(err.Error())
 			return err
@@ -554,7 +555,7 @@ func CreateUser(request *msgs.CreateUserRequest) msgs.CreateUserResponse {
 			log.Debug(msg)
 			resp.Results = append(resp.Results, msg)
 		}
-		newPassword := util.GeneratePassword(defaultPasswordLength)
+		newPassword := util.GeneratePassword(request.PasswordLength)
 		if request.Password != "" {
 			newPassword = request.Password
 		}
@@ -562,7 +563,7 @@ func CreateUser(request *msgs.CreateUserRequest) msgs.CreateUserResponse {
 
 		pgbouncer := c.Spec.UserLabels[util.LABEL_PGBOUNCER] == "true"
 		pgpool := c.Spec.UserLabels[util.LABEL_PGPOOL] == "true"
-		err = updatePassword(c.Name, info, request.Name, newPassword, newExpireDate, apiserver.Namespace, pgpool, pgbouncer)
+		err = updatePassword(c.Name, info, request.Name, newPassword, newExpireDate, apiserver.Namespace, pgpool, pgbouncer, request.PasswordLength)
 		if err != nil {
 			log.Error(err.Error())
 			resp.Status.Code = msgs.Error

--- a/apiservermsgs/usermsgs.go
+++ b/apiservermsgs/usermsgs.go
@@ -35,6 +35,7 @@ type UserRequest struct {
 	UpdatePasswords       bool
 	ManagedUser           bool
 	ClientVersion         string
+	PasswordLength        int
 }
 
 // DeleteUserResponse ...
@@ -58,6 +59,7 @@ type CreateUserRequest struct {
 	UserDBAccess    string
 	PasswordAgeDays int
 	ClientVersion   string
+	PasswordLength  int
 }
 
 // CreateUserResponse ...

--- a/hugo/content/getting-started/_index.adoc
+++ b/hugo/content/getting-started/_index.adoc
@@ -1278,13 +1278,16 @@ Allows user to specify a password instead of using a generated password.
 
 |`--valid-days` |N/A |Int |
 Sets passwords for new users to X days (default 30).
+
+|`--password-length` |N/A |Int |
+When no password is provided, generates a password with this number of characters (default 12).
 |=========================================================
 
 ==== Examples
 
 ===== Basic User Creation
 
-To create a new Postgres user assigned to the *mycluster* cluster, execute:
+To create a new Postgres user assigned to the *mycluster* cluster, execute (password will be auto generated and 12 characters long):
 ....
 pgo create user sally --selector=name=mycluster
 ....
@@ -1325,7 +1328,7 @@ will cause pgpool to be reconfigured to pick up the user deletion.
 
 ===== Change Password
 
-To change the password for a user in the *mycluster* cluster:
+To change the password for a user in the *mycluster* cluster (password will be auto generated and 12 characters long):
 ....
 pgo user --change-password=sally --selector=name=mycluster
 ....

--- a/pgo/cmd/create.go
+++ b/pgo/cmd/create.go
@@ -268,4 +268,5 @@ func init() {
 	createUserCmd.Flags().BoolVarP(&ManagedUser, "managed", "", false, "Creates a user with secrets that can be managed by the Operator.")
 	createUserCmd.Flags().StringVarP(&UserDBAccess, "db", "", "", "Grants the user access to a database.")
 	createUserCmd.Flags().IntVarP(&PasswordAgeDays, "valid-days", "", 30, "Sets passwords for new users to X days.")
+	createUserCmd.Flags().IntVarP(&PasswordLength, "password-length", "", 12, "If no password is supplied, this is the length of the auto generated password")
 }

--- a/pgo/cmd/user.go
+++ b/pgo/cmd/user.go
@@ -18,11 +18,12 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+
 	log "github.com/Sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"github.com/crunchydata/postgres-operator/pgo/api"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // PasswordAgeDays password age flag
@@ -45,6 +46,9 @@ var Expired string
 
 // UpdatePasswords update passwords flag
 var UpdatePasswords bool
+
+// PasswordLength password length flag
+var PasswordLength int
 
 var userCmd = &cobra.Command{
 	Use:   "user",
@@ -69,6 +73,7 @@ func init() {
 	userCmd.Flags().StringVarP(&UserDBAccess, "db", "", "", "Grants the user access to a database.")
 	userCmd.Flags().StringVarP(&Password, "password", "", "", "Specifies the user password when updating a user password or creating a new user.")
 	userCmd.Flags().BoolVarP(&UpdatePasswords, "update-passwords", "", false, "Performs password updating on expired passwords.")
+	userCmd.Flags().IntVarP(&PasswordLength, "password-length", "", 12, "If no password is supplied, this is the length of the auto generated password")
 
 }
 
@@ -87,6 +92,7 @@ func userManager() {
 	request.UpdatePasswords = UpdatePasswords
 	request.ManagedUser = ManagedUser
 	request.ClientVersion = msgs.PGO_VERSION
+	request.PasswordLength = PasswordLength
 
 	response, err := api.UserManager(httpclient, &SessionCredentials, &request)
 
@@ -126,6 +132,7 @@ func createUser(args []string) {
 	r.UserDBAccess = UserDBAccess
 	r.PasswordAgeDays = PasswordAgeDays
 	r.ClientVersion = msgs.PGO_VERSION
+	r.PasswordLength = PasswordLength
 
 	response, err := api.CreateUser(httpclient, &SessionCredentials, r)
 	if err != nil {

--- a/util/secrets.go
+++ b/util/secrets.go
@@ -22,6 +22,7 @@ import (
 	"github.com/crunchydata/postgres-operator/kubeapi"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+
 	//"k8s.io/client-go/rest"
 	"math/rand"
 	"strings"
@@ -122,12 +123,12 @@ func CopySecrets(clientset *kubernetes.Clientset, namespace string, fromCluster,
 }
 
 // CreateUserSecret will create a new secret holding a user credential
-func CreateUserSecret(clientset *kubernetes.Clientset, clustername, username, password, namespace string) error {
+func CreateUserSecret(clientset *kubernetes.Clientset, clustername, username, password, namespace string, passwordLength int) error {
 
 	var err error
 
 	secretName := clustername + "-" + username + "-secret"
-	var enPassword = GeneratePassword(10)
+	var enPassword = GeneratePassword(passwordLength)
 	if password != "" {
 		log.Debug("using user specified password for secret " + secretName)
 		enPassword = password
@@ -141,7 +142,7 @@ func CreateUserSecret(clientset *kubernetes.Clientset, clustername, username, pa
 }
 
 // UpdateUserSecret updates a user secret with a new password
-func UpdateUserSecret(clientset *kubernetes.Clientset, clustername, username, password, namespace string) error {
+func UpdateUserSecret(clientset *kubernetes.Clientset, clustername, username, password, namespace string, passwordLength int) error {
 
 	var err error
 
@@ -151,7 +152,7 @@ func UpdateUserSecret(clientset *kubernetes.Clientset, clustername, username, pa
 	err = kubeapi.DeleteSecret(clientset, secretName, namespace)
 	if err == nil {
 		//create secret with updated password
-		err = CreateUserSecret(clientset, clustername, username, password, namespace)
+		err = CreateUserSecret(clientset, clustername, username, password, namespace, passwordLength)
 		if err != nil {
 			log.Error("UpdateUserSecret error creating secret" + err.Error())
 		} else {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable? Tested using minikube with latest 3.3.0-rc4



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Auto-generated passwords have a defined size.

```
$ pgo create user --help
Create a postgres user. For example:

    pgo create user manageduser --managed --selector=name=mycluster
    pgo create user user1 --selector=name=mycluster

Usage:
  pgo create user [flags]

Flags:
      --db string         Grants the user access to a database.
  -h, --help              help for user
      --managed           Creates a user with secrets that can be managed by the Operator.
      --password string   The password to use for creating a new user which overrides a generated password.
  -s, --selector string   The selector to use for cluster filtering.
      --valid-days int    Sets passwords for new users to X days. (default 30)

Global Flags:
      --apiserver-url string   The URL for the PostgreSQL Operator apiserver.
      --debug                  Enable debugging when true.
```


**What is the new behavior (if this is a feature change)?**
Fixes #357 
```
$ pgo create user --help
Create a postgres user. For example:

    pgo create user manageduser --managed --selector=name=mycluster
    pgo create user user1 --selector=name=mycluster

Usage:
  pgo create user [flags]

Flags:
      --db string             Grants the user access to a database.
  -h, --help                  help for user
      --managed               Creates a user with secrets that can be managed by the Operator.
      --password string       The password to use for creating a new user which overrides a generated password.
      --password-length int   If no password is supplied, this is the length of the auto generated password (default 12)
  -s, --selector string       The selector to use for cluster filtering.
      --valid-days int        Sets passwords for new users to X days. (default 30)

Global Flags:
      --apiserver-url string   The URL for the PostgreSQL Operator apiserver.
      --debug                  Enable debugging when true.
```

User creation:
```
$ pgo create user manageduser --managed -s name=newtest --password-length 32
adding new user manageduser to newtest

$ kubectl get secret newtest-manageduser-secret $NS -o jsonpath='{.data.password}' | base64 --decode | awk '{print length}'
32
```

User update:
```
$ pgo user -s name=newtest --change-password manageduser --password-length 16
changing password of user manageduser on newtest

$ kubectl get secret newtest-manageduser-secret $NS -o jsonpath='{.data.password}' | base64 --decode | awk '{print length}'
16
```

**Other information**:
