### PR TITLE
Replacing credentials with secret for backup

### DIFF
--- a/apis/cr/v1/backup.go
+++ b/apis/cr/v1/backup.go
@@ -24,15 +24,14 @@ const PgbackupResourcePlural = "pgbackups"
 
 // PgbackupSpec ...
 type PgbackupSpec struct {
-	Name         string        `json:"name"`
-	StorageSpec  PgStorageSpec `json:"storagespec"`
-	CCPImageTag  string        `json:"ccpimagetag"`
-	BackupHost   string        `json:"backuphost"`
-	BackupUser   string        `json:"backupuser"`
-	BackupPass   string        `json:"backuppass"`
-	BackupPort   string        `json:"backupport"`
-	BackupStatus string        `json:"backupstatus"`
-	BackupPVC    string        `json:"backuppvc"`
+	Name             string        `json:"name"`
+	StorageSpec      PgStorageSpec `json:"storagespec"`
+	CCPImageTag      string        `json:"ccpimagetag"`
+	BackupHost       string        `json:"backuphost"`
+	BackupUserSecret string        `json:"backupusersecret"`
+	BackupPort       string        `json:"backupport"`
+	BackupStatus     string        `json:"backupstatus"`
+	BackupPVC        string        `json:"backuppvc"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/apis/cr/v1/deepcopy.go
+++ b/apis/cr/v1/deepcopy.go
@@ -8,15 +8,14 @@ func (in *Pgbackup) DeepCopyInto(out *Pgbackup) {
 	out.TypeMeta = in.TypeMeta
 	out.ObjectMeta = in.ObjectMeta
 	out.Spec = PgbackupSpec{
-		Name:         in.Spec.Name,
-		StorageSpec:  in.Spec.StorageSpec,
-		CCPImageTag:  in.Spec.CCPImageTag,
-		BackupHost:   in.Spec.BackupHost,
-		BackupUser:   in.Spec.BackupUser,
-		BackupPass:   in.Spec.BackupPass,
-		BackupPort:   in.Spec.BackupPort,
-		BackupStatus: in.Spec.BackupStatus,
-		BackupPVC:    in.Spec.BackupPVC,
+		Name:             in.Spec.Name,
+		StorageSpec:      in.Spec.StorageSpec,
+		CCPImageTag:      in.Spec.CCPImageTag,
+		BackupHost:       in.Spec.BackupHost,
+		BackupUserSecret: in.Spec.BackupUserSecret,
+		BackupPort:       in.Spec.BackupPort,
+		BackupStatus:     in.Spec.BackupStatus,
+		BackupPVC:        in.Spec.BackupPVC,
 	}
 	out.Status = in.Status
 }

--- a/apiserver/backupservice/backupimpl.go
+++ b/apiserver/backupservice/backupimpl.go
@@ -223,15 +223,15 @@ func getBackupParams(name, storageConfig string) (*crv1.Pgbackup, error) {
 	spec.CCPImageTag = apiserver.Pgo.Cluster.CCPImageTag
 	spec.BackupStatus = "initial"
 	spec.BackupHost = "basic"
-	spec.BackupUser = "primaryuser"
-	spec.BackupPass = "password"
+	spec.BackupUserSecret = "primaryuser"
 	spec.BackupPort = "5432"
 
 	cluster := crv1.Pgcluster{}
 	_, err = kubeapi.Getpgcluster(apiserver.RESTClient, &cluster, name, apiserver.Namespace)
 	if err == nil {
 		spec.BackupHost = cluster.Spec.Name
-		spec.BackupPass, err = util.GetSecretPassword(apiserver.Clientset, cluster.Spec.Name, crv1.PrimarySecretSuffix, apiserver.Namespace)
+		spec.BackupUserSecret = cluster.Spec.Name + crv1.PrimarySecretSuffix
+		_, err = util.GetSecretPassword(apiserver.Clientset, cluster.Spec.Name, crv1.PrimarySecretSuffix, apiserver.Namespace)
 		if err != nil {
 			return newInstance, err
 		}

--- a/conf/postgres-operator/backup-job.json
+++ b/conf/postgres-operator/backup-job.json
@@ -41,10 +41,20 @@
                         "value": "{{.BackupHost}}"
                     }, {
                         "name": "BACKUP_USER",
-                        "value": "{{.BackupUser}}"
+                        "valueFrom": {
+                            "secretKeyRef": {
+                                "name": "{{.BackupUserSecret}}",
+                                "key": "username"
+                            }
+                        }
                     }, {
                         "name": "BACKUP_PASS",
-                        "value": "{{.BackupPass}}"
+                        "valueFrom": {
+                            "secretKeyRef": {
+                                "name": "{{.BackupUserSecret}}",
+                                "key": "password"
+                            }
+                        }
                     }, {
                         "name": "BACKUP_PORT",
                         "value": "{{.BackupPort}}"

--- a/operator/backup/backup.go
+++ b/operator/backup/backup.go
@@ -18,6 +18,9 @@ package backup
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/kubeapi"
@@ -27,20 +30,17 @@ import (
 	v1batch "k8s.io/api/batch/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"os"
-	"time"
 )
 
 type jobTemplateFields struct {
-	Name            string
-	PvcName         string
-	CCPImagePrefix  string
-	CCPImageTag     string
-	SecurityContext string
-	BackupHost      string
-	BackupUser      string
-	BackupPass      string
-	BackupPort      string
+	Name             string
+	PvcName          string
+	CCPImagePrefix   string
+	CCPImageTag      string
+	SecurityContext  string
+	BackupHost       string
+	BackupUserSecret string
+	BackupPort       string
 }
 
 // AddBackupBase creates a backup job and its pvc
@@ -73,15 +73,14 @@ func AddBackupBase(clientset *kubernetes.Clientset, client *rest.RESTClient, job
 
 	//create the job -
 	jobFields := jobTemplateFields{
-		Name:            job.Spec.Name,
-		PvcName:         util.CreatePVCSnippet(job.Spec.StorageSpec.StorageType, pvcName),
-		CCPImagePrefix:  operator.Pgo.Cluster.CCPImagePrefix,
-		CCPImageTag:     job.Spec.CCPImageTag,
-		SecurityContext: util.CreateSecContext(job.Spec.StorageSpec.Fsgroup, job.Spec.StorageSpec.SupplementalGroups),
-		BackupHost:      job.Spec.BackupHost,
-		BackupUser:      job.Spec.BackupUser,
-		BackupPass:      job.Spec.BackupPass,
-		BackupPort:      job.Spec.BackupPort,
+		Name:             job.Spec.Name,
+		PvcName:          util.CreatePVCSnippet(job.Spec.StorageSpec.StorageType, pvcName),
+		CCPImagePrefix:   operator.Pgo.Cluster.CCPImagePrefix,
+		CCPImageTag:      job.Spec.CCPImageTag,
+		SecurityContext:  util.CreateSecContext(job.Spec.StorageSpec.Fsgroup, job.Spec.StorageSpec.SupplementalGroups),
+		BackupHost:       job.Spec.BackupHost,
+		BackupUserSecret: job.Spec.BackupUserSecret,
+		BackupPort:       job.Spec.BackupPort,
 	}
 
 	var doc2 bytes.Buffer

--- a/pgo/cmd/backup.go
+++ b/pgo/cmd/backup.go
@@ -18,13 +18,14 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	log "github.com/Sirupsen/logrus"
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"github.com/crunchydata/postgres-operator/pgo/api"
 	labelutil "github.com/crunchydata/postgres-operator/util"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var PVCName string
@@ -113,7 +114,7 @@ func printBackupCRD(result *crv1.Pgbackup) {
 	fmt.Printf("%s%s\n", TreeBranch, "CCPImageTag:\t"+result.Spec.CCPImageTag)
 	fmt.Printf("%s%s\n", TreeBranch, "Backup Status:\t"+result.Spec.BackupStatus)
 	fmt.Printf("%s%s\n", TreeBranch, "Backup Host:\t"+result.Spec.BackupHost)
-	fmt.Printf("%s%s\n", TreeBranch, "Backup User:\t"+result.Spec.BackupUser)
+	fmt.Printf("%s%s\n", TreeBranch, "Backup User Secret:\t"+result.Spec.BackupUserSecret)
 	fmt.Printf("%s%s\n", TreeTrunk, "Backup Port:\t"+result.Spec.BackupPort)
 
 }


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
Fixes #390 


**What is the current behavior? (link to any open issues here)**
pgbackup spec is using BackupUser and BackupPass and the jobs created uses thoses informations ine the container's env spec. It is possible to display the password in cleartext using:
```
kubectl get jobs <job-name> -o yaml
```
or 
```
kubectl get pgbackups.cr.client-go.k8s.io <pgbackup-name> -o yaml
```

**What is the new behavior (if this is a feature change)?**
pgbackup spec is now using a BackupUserSecret spec which refers to a Secret which wil then be used by the job. Passwords are no longer available in cleartext.
```
$ kubectl get pgbackups.cr.client-go.k8s.io $NS retest -o yaml
apiVersion: cr.client-go.k8s.io/v1
kind: Pgbackup
metadata:
  creationTimestamp: 2018-10-15T14:00:25Z
  generation: 1
  name: retest
  namespace: demo
  resourceVersion: "43622"
  selfLink: /apis/cr.client-go.k8s.io/v1/namespaces/demo/pgbackups/retest
  uid: aa84e4fc-d082-11e8-8ac6-080027567e6e
spec:
  backuphost: retest
  backupport: "5432"
  backuppvc: ""
  backupstatus: completed
  backupusersecret: retest-primaryuser-secret
  ccpimagetag: centos7-10.5-2.1.0
  name: retest
  storagespec:
    accessmode: ReadWriteMany
    fsgroup: ""
    matchLabels: ""
    name: retest-backup
    size: 1G
    storageclass: ""
    storagetype: create
    supplementalgroups: "65534"
status:
  message: Successfully processed Pgbackup by controller
  state: Processed
```
```
$ kubectl get jobs $NS backup-retest -o yamlapiVersion: batch/v1
kind: Job
metadata:
  creationTimestamp: 2018-10-15T14:00:26Z
  labels:
    pg-cluster: retest
    pgbackup: "true"
    vendor: crunchydata
  name: backup-retest
  namespace: demo
  resourceVersion: "43621"
  selfLink: /apis/batch/v1/namespaces/demo/jobs/backup-retest
  uid: aad744d5-d082-11e8-8ac6-080027567e6e
spec:
  backoffLimit: 0
  completions: 1
  parallelism: 1
  selector:
    matchLabels:
      controller-uid: aad744d5-d082-11e8-8ac6-080027567e6e
  template:
    metadata:
      creationTimestamp: null
      labels:
        controller-uid: aad744d5-d082-11e8-8ac6-080027567e6e
        job-name: backup-retest
        pg-cluster: retest
        pgbackup: "true"
        vendor: crunchydata
      name: retest
    spec:
      containers:
      - env:
        - name: BACKUP_HOST
          value: retest
        - name: BACKUP_USER
          valueFrom:
            secretKeyRef:
              key: username
              name: retest-primaryuser-secret
        - name: BACKUP_PASS
          valueFrom:
            secretKeyRef:
              key: password
              name: retest-primaryuser-secret
        - name: BACKUP_PORT
          value: "5432"
        image: crunchydata/crunchy-backup:centos7-10.5-2.1.0
        imagePullPolicy: IfNotPresent
        name: backup
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /pgdata
          name: pgdata
      dnsPolicy: ClusterFirst
      restartPolicy: Never
      schedulerName: default-scheduler
      securityContext:
        supplementalGroups:
        - 65534
      terminationGracePeriodSeconds: 30
      volumes:
      - name: pgdata
        persistentVolumeClaim:
          claimName: retest-backup
status:
  completionTime: 2018-10-15T14:01:37Z
  conditions:
  - lastProbeTime: 2018-10-15T14:01:37Z
    lastTransitionTime: 2018-10-15T14:01:37Z
    status: "True"
    type: Complete
  startTime: 2018-10-15T14:00:26Z
  succeeded: 1
```
**Other information**:
Can later be used to specify a user when creating a backup.