### PR TITLE
Update README and Index pages for accurate relative links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,25 +7,62 @@
 
 Latest Release: 3.3.0 {docdate}
 
-== General
-
-The *postgres-operator* is a controller that runs within a Kubernetes cluster that provides a means to deploy and manage PostgreSQL clusters.
+== Documentation
 
 Please view the official Crunchy Data PostgreSQL Operator documentation link:https://crunchydata.github.io/postgres-operator/stable/[here]. If you are
 interested in contributing or making an update to the documentation, please view the link:https://crunchydata.github.io/postgres-operator/stable/contributing/[Contributing Guidelines].
 
-[link=https://crunchydata.github.io/postgres-operator/stable/]
-image::btn.png[Official Documentation]
+== What is the Operator?
 
-If you are looking for the latest documentation, please see the develop branch which is considered unstable. The development documentation can be reviewed  link:https://crunchydata.github.io/postgres-operator/latest/[here]
+The *postgres-operator* is a controller that runs within a Kubernetes cluster that provides a means to deploy and manage PostgreSQL clusters.
+
+Use the postgres-operator to -
+
+ * deploy PostgreSQL containers including streaming replication clusters
+ * scale up PostgreSQL clusters with extra replicas
+ * add pgpool and metrics sidecars to PostgreSQL clusters
+ * apply SQL policies to PostgreSQL clusters
+ * assign metadata tags to PostgreSQL clusters
+ * maintain PostgreSQL users and passwords
+ * perform minor and major upgrades to PostgreSQL clusters
+ * load simple CSV and JSON files into PostgreSQL clusters
+ * perform database backups
+
+== Design
+
+The *postgres-operator* design incorporates the following concepts -
+
+ * adds Custom Resource Definitions for PostgreSQL to Kubernetes
+ * adds controller logic that watches events on PostgreSQL resources
+ * provides a command line client (*pgo*) and REST API for interfacing with the postgres-operator
+ * provides for very customized deployments including container resources, storage configurations, and PostgreSQL custom configurations
+
+More design information is found on the link:https://crunchydata.github.io/postgres-operator/stable/how-it-works/[How It Works] page.
+
+== Requirements
+
+The postgres-operator runs on any Kubernetes and Openshift platform that supports
+Custom Resource Definitions.
+
+The Operator project builds and operates with the following containers -
+
+* link:https://hub.docker.com/r/crunchydata/pgo-lspvc/[PVC Listing Container]
+* link:https://hub.docker.com/r/crunchydata/pgo-rmdata/[Remove Data Container]
+* link:https://hub.docker.com/r/crunchydata/postgres-operator/[postgres-operator Container]
+* link:https://hub.docker.com/r/crunchydata/pgo-apiserver/[apiserver Container]
+* link:https://hub.docker.com/r/crunchydata/pgo-load/[file load Container]
+* link:https://hub.docker.com/r/crunchydata/pgo-backrest/[backrest interface Container]
+
+This Operator is developed and tested on the following operating systems but is known to run on other operating systems -
+
+* *CentOS 7*
+* *RHEL 7*
 
 == Installation
 
 To build and deploy the Operator on your Kubernetes system, follow the instructions documented on the link:https://crunchydata.github.io/postgres-operator/stable/installation/[Installation] page.
 
-If you're seeking to upgrade your existing Operator installation, please visit the link:https://crunchydata.github.io/postgres-operator/stable/installation/upgrading-the-operator/[Upgrading the Operator] page.  Also read the Release Notes as to details on recent changes to the Operator.
-
-More design information is found on the link:https://crunchydata.github.io/postgres-operator/stable/how-it-works/[How It Works] page.
+If you're seeking to upgrade your existing Operator installation, please visit the link:https://crunchydata.github.io/postgres-operator/installation/upgrading-the-operator/[Upgrading the Operator] page.
 
 == Configuration
 

--- a/hugo/content/_index.adoc
+++ b/hugo/content/_index.adoc
@@ -10,8 +10,8 @@ Latest Release: 3.3.0 {docdate}
 
 == Documentation
 
-Please view the official Crunchy Data PostgreSQL Operator documentation link:https://crunchydata.github.io/postgres-operator/[here]. If you are
-interested in contributing or making an update to the documentation, please view the link:https://crunchydata.github.io/postgres-operator/contributing/[Contributing Guidelines].
+Please view the official Crunchy Data PostgreSQL Operator documentation link:https://crunchydata.github.io/postgres-operator/stable/[here]. If you are
+interested in contributing or making an update to the documentation, please view the link:/contributing/[Contributing Guidelines].
 
 == What is the Operator?
 
@@ -38,7 +38,7 @@ The *postgres-operator* design incorporates the following concepts -
  * provides a command line client (*pgo*) and REST API for interfacing with the postgres-operator
  * provides for very customized deployments including container resources, storage configurations, and PostgreSQL custom configurations
 
-More design information is found on the link:https://crunchydata.github.io/postgres-operator/how-it-works/[How It Works] page.
+More design information is found on the link:/how-it-works/[How It Works] page.
 
 == Requirements
 
@@ -61,14 +61,14 @@ This Operator is developed and tested on the following operating systems but is 
 
 == Installation
 
-To build and deploy the Operator on your Kubernetes system, follow the instructions documented on the link:https://crunchydata.github.io/postgres-operator/installation/[Installation] page.
+To build and deploy the Operator on your Kubernetes system, follow the instructions documented on the link:/installation/[Installation] page.
 
-If you're seeking to upgrade your existing Operator installation, please visit the link:https://crunchydata.github.io/postgres-operator/installation/upgrading-the-operator/[Upgrading the Operator] page.
+If you're seeking to upgrade your existing Operator installation, please visit the link:/installation/upgrading-the-operator/[Upgrading the Operator] page.
 
 == Configuration
 
-The operator is template-driven; this makes it simple to configure both the client and the operator. The configuration options are documented on the link:https://crunchydata.github.io/postgres-operator/installation/configuration/[Configuration] page.
+The operator is template-driven; this makes it simple to configure both the client and the operator. The configuration options are documented on the link:/installation/configuration/[Configuration] page.
 
 == Getting Started
 
-*postgres-operator* commands are documented on the link:https://crunchydata.github.io/postgres-operator/getting-started/[Getting Started] page.
+*postgres-operator* commands are documented on the link:/getting-started/[Getting Started] page.


### PR DESCRIPTION
This PR addresses the currently-broken absolute links found in the README and the Index page.