### PR TITLE
Getting namespace properly when there is multiple context on kube config

### DIFF
--- a/examples/quickstart.sh
+++ b/examples/quickstart.sh
@@ -103,7 +103,13 @@ echo ""
 case $CO_CMD in
 kubectl)
 $CO_CMD get namespaces
-export CO_NAMESPACE=`$CO_CMD config view -o "jsonpath={.contexts[?(@.name==\"$($CO_CMD config current-context 2>/dev/null)\")].context.namespace}"`
+
+export CO_CURRENT_CONTEXT=`$CO_CMD config current-context 2>/dev/null`
+echo ""
+echo "Using current context "$CO_CURRENT_CONTEXT | tee -a $LOG
+echo ""
+
+export CO_NAMESPACE=`$CO_CMD config view -o "jsonpath={.contexts[?(@.name==\"$CO_CURRENT_CONTEXT\")].context.namespace}"`
 	;;
 oc)
 $CO_CMD project

--- a/examples/quickstart.sh
+++ b/examples/quickstart.sh
@@ -103,7 +103,7 @@ echo ""
 case $CO_CMD in
 kubectl)
 $CO_CMD get namespaces
-export CO_NAMESPACE=`$CO_CMD config view | grep namespace:| cut -f2 -d':' | cut -f2 -d' '`
+export CO_NAMESPACE=`$CO_CMD config view -o "jsonpath={.contexts[?(@.name==\"$($CO_CMD config current-context 2>/dev/null)\")].context.namespace}"`
 	;;
 oc)
 $CO_CMD project

--- a/hugo/content/installation/manual-installation.adoc
+++ b/hugo/content/installation/manual-installation.adoc
@@ -67,7 +67,7 @@ To run the operator and the *pgo* client, you will need the following -
 ....
 kubectl create -f examples/demo-namespace.json
 kubectl config set-context $(kubectl config current-context) --namespace=demo
-kubectl config view | grep namespace
+kubectl config view -o "jsonpath={.contexts[?(@.name==\"$(kubectl config current-context 2>/dev/null)\")].context.namespace}"
 ....
 
 Run the Makefile `setup` target to install depedencies and also


### PR DESCRIPTION
When there is multiple context on kube config file, namespace could not have been detected properly. This fix allow us to get the namespace of current-context.

* [x]  Have you added an explanation of what your changes do and why you'd like them to be included?
* [x]  Have you updated or added documentation for the change, as applicable?
* [x]  Have you tested your changes on all related environments with successful results, as applicable?


 - [x] Bug fix (non-breaking change which fixes an issue)

**What is the current behavior? (link to any open issues here)**
Current behaviour gets multiple nampspaces when there is more than 1 context; 

```sh
$ ./quickstart.sh                                                                                                                                                                                   (gpukube/gitlab)
CO_VERSION is set to  3.3.0
Which Operator version do you want to install? [3.3.0]
3.3.0 is the version entered
Is this a 'kube' install or an 'ocp' install?[kube]
user has selected a kube install
use centos7 or rhel7 based images?[centos7], NOTE:  rhel images available only to crunchy customers)
user has selected centos images
enter operator image prefix [crunchydata]
setting CO_IMAGE_PREFIX to  crunchydata
user has entered crunchydata  for the operator image prefix
enter container-suite image prefix []
setting CCP_IMAGE_PREFIX to
user has entered   for the container-suite image prefix
Testing for dependencies...

Testing kubectl connection...

NAME            STATUS   AGE
default         Active   49d
namespace1      Active   48d
namespace2      Active   22h
kube-public     Active   49d
kube-system     Active   49d
Connected to cluster

The postgres-operator will be installed into the current namespace which is [demo namespace1 ns2].
Do you want to continue the installation? [Yn]
```
The namespace `[demo namespace1 ns2]` is not valid namespace.

**What is the new behavior (if this is a feature change)?**

Only the namespace of current context is going to be used.

```
✗ ./quickstart.sh                                                                                                                                                                     (gpukube/gitlab)
CO_VERSION is set to  3.3.0
Which Operator version do you want to install? [3.3.0]
3.3.0 is the version entered
Is this a 'kube' install or an 'ocp' install?[kube]
user has selected a kube install
use centos7 or rhel7 based images?[centos7], NOTE:  rhel images available only to crunchy customers)
user has selected centos images
enter operator image prefix [crunchydata]
setting CO_IMAGE_PREFIX to  crunchydata
user has entered crunchydata  for the operator image prefix
enter container-suite image prefix []
setting CCP_IMAGE_PREFIX to
user has entered   for the container-suite image prefix
Testing for dependencies...

Testing kubectl connection...

```sh
NAME            STATUS   AGE
default         Active   49d
namespace1      Active   48d
namespace2      Active   22h
kube-public     Active   49d
kube-system     Active   49d

Using current context minikube

Connected to cluster

The postgres-operator will be installed into the current namespace which is [namespace1].
Do you want to continue the installation? [Yn]
```
