### PR TITLE
Add timeout to scheduler deployment

### DIFF
--- a/deploy/scheduler.json
+++ b/deploy/scheduler.json
@@ -29,6 +29,10 @@
                                         "fieldPath": "metadata.namespace"
                                     }
                                 }
+                            },
+                            {
+                                "name": "TIMEOUT",
+                                "value": "3600"
                             }
                         ],
                         "volumeMounts": [],


### PR DESCRIPTION
Adding a default timeout of 1 hour for backup jobs.