### PR TITLE
Add 'name' label to the PGO Deployment & Update Cluster Role Bindings in PGO Helm Chart

### DIFF
--- a/chart/postgres-operator/templates/cluster-role-binding.yaml
+++ b/chart/postgres-operator/templates/cluster-role-binding.yaml
@@ -10,7 +10,7 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: postgres-operator
+  name: system:serviceaccount:{{ .Release.Namespace }}:postgres-operator
 
 ---
 
@@ -25,6 +25,6 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: postgres-operator
+  name: system:serviceaccount:{{ .Release.Namespace }}:postgres-operator
 
 {{ end }}

--- a/chart/postgres-operator/templates/deployment.yaml
+++ b/chart/postgres-operator/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: {{ template "postgres-operator.name" . }}
         release: {{ .Release.Name }}
+        name: "postgres-operator"
     spec:
       serviceAccountName: postgres-operator
       containers:


### PR DESCRIPTION
Added a 'name' label to the PGO pod and updated the cluster role bindings for the PGO service account.  The name label will ensure an error is not thrown in the **apiserver** container logs when attempting to find a running **postgres-operator** within the cluster, while assigning the proper cluster role bindings to the PGO service account will ensure that the account is able to properly display node information when using the `pgo status` command.

Closes CrunchyData/postgres-operator-test#98

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The PGO service account is unable to obtain node information when the `pgo status` command is utilized.  Additionally, the **apiserver** container logs display an error on startup due to in the inability to locate the running PGO pod.  

Additional details and specific error messages can be found in ticket CrunchyData/postgres-operator-test#98


**What is the new behavior (if this is a feature change)?**
The `pgo status` command now properly displays node information, and an error is no longer seen in the **apiserver** logs since the container is now able to properly locate the PGO pod during initialization. 


**Other information**:
N/A