### PR TITLE
Add Missing pgbackrest Config & RBAC to PGO Helm Chart

### DIFF
--- a/chart/postgres-operator/files/postgres-operator/pgbackrest.conf
+++ b/chart/postgres-operator/files/postgres-operator/pgbackrest.conf
@@ -1,0 +1,6 @@
+[db]
+db-path=/pgdata/HOSTNAME
+
+[global]
+repo-path=/backrestrepo/HOSTNAME-backups
+log-path=/tmp

--- a/chart/postgres-operator/templates/rbac.yaml
+++ b/chart/postgres-operator/templates/rbac.yaml
@@ -62,5 +62,43 @@ roleRef:
   name: pgo-role
   apiGroup: rbac.authorization.k8s.io
 
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pgo-backrest
+  namespace: "{{ .Release.Namespace }}"
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: pgo-backrest-role
+  namespace: "{{ .Release.Namespace }}"
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: pgo-backrest-role-binding
+  namespace: "{{ .Release.Namespace }}"
+subjects:
+- kind: ServiceAccount
+  name: pgo-backrest
+  namespace: "{{ .Release.Namespace }}"
+roleRef:
+  kind: Role
+  name: pgo-backrest-role
+  apiGroup: rbac.authorization.k8s.io
 
 {{ end }}


### PR DESCRIPTION
Added missing **pgbackrest.conf** file to directory **files\postgres-operator** within the postgres-operator Helm chart.  Also added the proper pgbackrest service account, role and role binding to template file **rbac.yaml** within the Helm chart. 

Closes CrunchyData/postgres-operator-test#105

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
pgbackrest is not properly configured due to a missing **pgbackrest.conf** file.  Additionally, the pgbackrest backup and restore jobs are unsuccessful due to missing a pgbackrest service account, role and role binding.


**What is the new behavior (if this is a feature change)?**
pgbackrest is properly configured for the cluster, and pgbackrest backup and restore jobs complete successfully.


**Other information**:
N/A