### PR TITLE
Add Scheduler Deployment & RBAC to PGO Helm Chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 public
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 public
-.vscode

--- a/chart/postgres-operator/files/postgres-operator/pgo.yaml
+++ b/chart/postgres-operator/files/postgres-operator/pgo.yaml
@@ -4,7 +4,7 @@ Cluster:
   CCPImagePrefix:  crunchydata
   Metrics:  false
   Badger:  false
-  CCPImageTag:  rhel7-10.6-2.2.0-rc8
+  CCPImageTag:  centos7-10.6-2.2.0
   Port:  5432
   User:  testuser
   Database:  userdb
@@ -62,4 +62,4 @@ Pgo:
   LSPVCTemplate:  /pgo-config/pgo.lspvc-template.json
   LoadTemplate:  /pgo-config/pgo.load-template.json
   COImagePrefix:  crunchydata
-  COImageTag:  rhel7-3.4.0-rc2
+  COImageTag:  centos7-3.4.0

--- a/chart/postgres-operator/templates/scheduler-sa.yml
+++ b/chart/postgres-operator/templates/scheduler-sa.yml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scheduler-sa
+  namespace: "{{ .Release.Namespace }}"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: scheduler-sa
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  - pods
+  - configmaps
+  - deployments
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  - extensions
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - "/apis"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - pods/exec
+  verbs:
+  - create
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: scheduler-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scheduler-sa
+subjects:
+- kind: ServiceAccount
+  name: scheduler-sa
+  namespace: "{{ .Release.Namespace }}"

--- a/chart/postgres-operator/templates/scheduler.yml
+++ b/chart/postgres-operator/templates/scheduler.yml
@@ -1,0 +1,32 @@
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: crunchy-scheduler
+  labels:
+    name: crunchy-scheduler
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: crunchy-scheduler
+    spec:
+      serviceAccountName: scheduler-sa
+      containers:
+      - name: scheduler
+        image: "{{ .Values.env.ccp_image_prefix }}/crunchy-scheduler:{{ .Values.env.ccp_image_tag }}"
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: TIMEOUT
+          value: '3600'
+        volumeMounts: []
+        resources: {}
+        imagePullPolicy: IfNotPresent
+      volumes: []
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst

--- a/chart/postgres-operator/values.yaml
+++ b/chart/postgres-operator/values.yaml
@@ -11,6 +11,7 @@ image:
 env:
   debug: "true"
   ccp_image_prefix: "crunchydata"
+  ccp_image_tag: "centos7-10.6-2.2.0"
   co_image_prefix: "crunchydata"
   co_image_tag: "centos7-3.4.0"
   tls_no_verify: false


### PR DESCRIPTION
Add the crunchy-scheduler deployment and associated RBAC to the postgres-operator Helm chart.  This enables PGO scheduler functionality when deploying the postgres-operator using Helm. 

Closes CrunchyData/postgres-operator-test#122

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
When the postgres-operator is deployed using Helm, the pgo `schedule` command does not work without first manually deploying a crunchy-scheduler container (i.e. deploying crunchy-scheduler separately from the postgres-operator itself).


**What is the new behavior (if this is a feature change)?**
The postgres-operator Helm chart now creates a crunchy-scheduler deployment, deploying the crunchy-scheduler pod needed to fully enable scheduler functionality for the postgres-operator.


**Other information**:
N/A