### PR TITLE
Refactored scheduler-sa to use a role

### DIFF
--- a/deploy/cleanup-rbac.sh
+++ b/deploy/cleanup-rbac.sh
@@ -31,7 +31,7 @@ $CO_CMD $NS delete serviceaccount pgo-backrest
 $CO_CMD $NS delete role pgo-backrest-role
 $CO_CMD $NS delete rolebinding pgo-backrest-role-binding
 
-$CO_CMD $NS delete clusterrolebinding,clusterrole,sa,rolebinding scheduler-sa scheduler-sa
+$CO_CMD $NS delete clusterrolebinding,clusterrole,sa,role,rolebinding scheduler-sa scheduler-sa
 
 sleep 5
 

--- a/deploy/scheduler-sa.json
+++ b/deploy/scheduler-sa.json
@@ -1,8 +1,9 @@
 {
     "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-    "kind": "ClusterRole",
+    "kind": "Role",
     "metadata": {
-        "name": "scheduler-sa"
+        "name": "scheduler-sa",
+        "namespace": "$CO_NAMESPACE"
     },
     "rules": [
         {
@@ -10,7 +11,6 @@
                 ""
             ],
             "resources": [
-                "namespaces",
                 "pods",
                 "configmaps",
                 "deployments",
@@ -35,8 +35,6 @@
                 "list",
                 "watch",
                 "create",
-                "update",
-                "patch",
                 "delete"
             ]
         },
@@ -47,16 +45,6 @@
             ],
             "resources": [
                 "deployments"
-            ],
-            "verbs": [
-                "get",
-                "list",
-                "watch"
-            ]
-        },
-        {
-            "nonResourceURLs": [
-                "/apis"
             ],
             "verbs": [
                 "get",
@@ -89,13 +77,13 @@
 
 {
     "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-    "kind": "ClusterRoleBinding",
+    "kind": "RoleBinding",
     "metadata": {
         "name": "scheduler-sa"
     },
     "roleRef": {
         "apiGroup": "rbac.authorization.k8s.io",
-        "kind": "ClusterRole",
+        "kind": "Role",
         "name": "scheduler-sa"
     },
     "subjects": [


### PR DESCRIPTION
As per https://github.com/CrunchyData/crunchy-containers/issues/942, I've reduced the Scheduler service account to use a Role/RoleBinding instead of ClusterRole/ClusterRoleBinding.  Since scheduler only operates within a namespace, it doesn't require cluster privileges at this time.