### PR TITLE
Remove scheduler sa from install RBAC

### DIFF
--- a/deploy/install-rbac.sh
+++ b/deploy/install-rbac.sh
@@ -33,9 +33,6 @@ expenv -f $DIR/cluster-rbac.yaml | $CO_CMD create -f -
 # create the service account, role, role-binding and add to the service account
 expenv -f $DIR/rbac.yaml | $CO_CMD create -f -
 
-# create the rbac for the scheduler
-expenv -f $DIR/scheduler-sa.json | $CO_CMD $NS create -f -
-
 # create the sshd keys for pgbackrest repo functionality
 source $DIR/gen-sshd-keys.sh
 


### PR DESCRIPTION
Removing `scheduler-sa.json` reference from `install-rbac.sh` because it no longer exists.

[CH1831]