### PR TITLE
Added "--secret-from" option to "Restore from pgbasebackup" example

### DIFF
--- a/hugo/content/Operator CLI/_index.md
+++ b/hugo/content/Operator CLI/_index.md
@@ -176,7 +176,7 @@ before you do a restore.
 
 #### Restore from pgbasebackup
 
-    pgo create cluster restoredcluster --backup-path=/somebackup/path --backup-pvc=somebackuppvc
+    pgo create cluster restoredcluster --backup-path=/somebackup/path --backup-pvc=somebackuppvc --secret-from=mycluster
 
 ### Fail-over Operations
 


### PR DESCRIPTION
Added the **--secret-from** option to the 'Restore from pgbasebackup' example, since this option is needed in order to perform a pgbasebackup restore using the Operator.

[ch1932]