### PR TITLE
Updated the Invalid Cluster Deployment Spec in the PGO Helm Chart

### DIFF
--- a/chart/postgres-operator/files/postgres-operator/cluster/1/cluster-deployment-1.json
+++ b/chart/postgres-operator/files/postgres-operator/cluster/1/cluster-deployment-1.json
@@ -68,12 +68,10 @@
                         "name": "PGDATA_PATH_OVERRIDE",
                         "value": "{{.DataPathOverride}}"
                     }, {
+			{{.PgmonitorEnvVars}}
 			{{.PgbackrestEnvVars}}
                         "name": "PG_DATABASE",
                         "value": "{{.Database}}"
-                    }, {
-                        "name": "PGMONITOR_PASSWORD",
-                        "value": "password"
                     }, {
                         "name": "ARCHIVE_MODE",
                         "value": "{{.ArchiveMode}}"
@@ -177,7 +175,7 @@
             "emptyDir": { "medium": "Memory" }
                     }, {
                         "name": "backrestrepo",
-			{{.BackrestPVCName}}
+            "emptyDir": { "medium": "Memory" }
                     }, {
                         "name": "pgconf-volume",
             {{.ConfVolume}}


### PR DESCRIPTION
Updated the invalid cluster deployment spec in the PGO Helm chart, specifically updating `chart/postgres-operator/files/postgres-operator/cluster/1/cluster-deployment-1.json` according to the latest changes found in `conf\postgres-operator\cluster\1\cluster-deployment-1.json`.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
An error is thrown when creating a new cluster, and the cluster is not created.

[ch2074]

**What is the new behavior (if this is a feature change)?**
The cluster is created as expected due to the valid deployment specification.


**Other information**:
N/A