### PR TITLE
Added "--node-label" Flag to the "pgo restore" Command & Locked in pgBackRest Version

### DIFF
--- a/apiserver/backrestservice/backrestimpl.go
+++ b/apiserver/backrestservice/backrestimpl.go
@@ -404,7 +404,7 @@ func Restore(request *msgs.RestoreRequest, ns string) msgs.RestoreResponse {
 		return resp
 	}
 
-	pgtask, err := getRestoreParams(request, ns, cluster, &resp)
+	pgtask, err := getRestoreParams(request, ns, cluster)
 	if err != nil {
 		resp.Status.Code = msgs.Error
 		resp.Status.Msg = err.Error()
@@ -428,7 +428,7 @@ func Restore(request *msgs.RestoreRequest, ns string) msgs.RestoreResponse {
 	return resp
 }
 
-func getRestoreParams(request *msgs.RestoreRequest, ns string, cluster crv1.Pgcluster, resp *msgs.RestoreResponse) (*crv1.Pgtask, error) {
+func getRestoreParams(request *msgs.RestoreRequest, ns string, cluster crv1.Pgcluster) (*crv1.Pgtask, error) {
 	var newInstance *crv1.Pgtask
 
 	spec := crv1.PgtaskSpec{}
@@ -448,8 +448,6 @@ func getRestoreParams(request *msgs.RestoreRequest, ns string, cluster crv1.Pgcl
 	if request.NodeLabel != "" {
 		parts := strings.Split(request.NodeLabel, "=")
 		if len(parts) != 2 {
-			resp.Status.Code = msgs.Error
-			resp.Status.Msg = request.NodeLabel + " node label does not follow key=value format"
 			return nil, errors.New(request.NodeLabel + " node label does not follow key=value format")
 		}
 

--- a/apiservermsgs/backrestmsgs.go
+++ b/apiservermsgs/backrestmsgs.go
@@ -15,10 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import (
-//crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
-)
-
 // CreateBackrestBackupResponse ...
 type CreateBackrestBackupResponse struct {
 	Results []string
@@ -57,4 +53,5 @@ type RestoreRequest struct {
 	ToPVC       string
 	RestoreOpts string
 	PITRTarget  string
+	NodeLabel   string
 }

--- a/centos7/Dockerfile.pgo-backrest-repo.centos7
+++ b/centos7/Dockerfile.pgo-backrest-repo.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - Apiserver" \
 	description="Crunchy Data PostgreSQL Operator - Apiserver"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.08"
 
 # PGDG PostgreSQL Repository
 
@@ -16,7 +16,7 @@ RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/r
 
 RUN yum -y update && \
 #yum -y install epel-release && \
-yum -y install psmisc openssh-server openssh-clients pgbackrest hostname pgocps-ng && \
+yum -y install psmisc openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
 yum -y clean all
 
 RUN groupadd pgbackrest -g 2000 && useradd pgbackrest -u 2000 -g 2000

--- a/centos7/Dockerfile.pgo-backrest-restore.centos7
+++ b/centos7/Dockerfile.pgo-backrest-restore.centos7
@@ -8,11 +8,11 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
-RUN yum -y update && yum -y install psmisc openssh-server openssh-clients pgbackrest postgresql11-server procps-ng && yum -y clean all
+RUN yum -y update && yum -y install psmisc openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" postgresql11-server procps-ng && yum -y clean all
 
 VOLUME ["/sshd", "/pgdata"]
 

--- a/centos7/Dockerfile.pgo-backrest.centos7
+++ b/centos7/Dockerfile.pgo-backrest.centos7
@@ -8,11 +8,11 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.08"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
-RUN yum -y update && yum -y install postgresql11-server && yum -y install pgbackrest && yum -y clean all
+RUN yum -y update && yum -y install postgresql11-server && yum -y install pgbackrest-"${BACKREST_VERSION}" && yum -y clean all
 
 RUN mkdir -p /opt/cpm/bin /pgdata /backrestrepo && chown -R 26:26 /opt/cpm
 ADD bin/pgo-backrest/ /opt/cpm/bin

--- a/centos7/Dockerfile.repo-client.centos7
+++ b/centos7/Dockerfile.repo-client.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - Apiserver" \
 	description="Crunchy Data PostgreSQL Operator - Apiserver"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.08"
 
 # PGDG PostgreSQL Repository
 
@@ -16,7 +16,7 @@ RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/r
 
 RUN yum -y update && \
 #yum -y install epel-release && \
-yum -y install openssh-server openssh-clients pgbackrest hostname pgocps-ng && \
+yum -y install openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
 yum -y clean all
 
 RUN useradd pgbackrest

--- a/chart/postgres-operator/files/postgres-operator/backrest-restore-job.json
+++ b/chart/postgres-operator/files/postgres-operator/backrest-restore-job.json
@@ -82,6 +82,7 @@
                         }
                     }]
                 }],
+        {{.NodeSelector}}
                 "restartPolicy": "Never"
             }
         }

--- a/conf/postgres-operator/backrest-restore-job.json
+++ b/conf/postgres-operator/backrest-restore-job.json
@@ -82,6 +82,7 @@
                         }
                     }]
                 }],
+        {{.NodeSelector}}
                 "restartPolicy": "Never"
             }
         }

--- a/controller/jobcontroller.go
+++ b/controller/jobcontroller.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -141,21 +140,9 @@ func (c *JobController) onUpdate(oldObj, newObj interface{}) {
 				log.Error("error in patching pgtask " + labels[util.LABEL_JOB_NAME] + err.Error())
 			}
 
-			affinity := job.Spec.Template.Spec.Affinity
-			var affinityJSON string
-			if affinity != nil {
-				log.Debugf("Affinity found on restore job, and will applied to the restored deployment")
-				affinityBytes, err := json.MarshalIndent(affinity, "", "  ")
-				if err != nil {
-					log.Error("unable to marshall affinity obtained from restore job spec")
-				}
-				affinityJSON = "\"affinity\":" + string(affinityBytes) + ","
-				log.Debug("Affinity string: " + affinityJSON)
-			}
-
 			backrestoperator.UpdateRestoreWorkflow(c.JobClient, c.JobClientset, labels[util.LABEL_PG_CLUSTER],
 				crv1.PgtaskWorkflowBackrestRestorePVCCreatedStatus, job.ObjectMeta.Namespace, labels[crv1.PgtaskWorkflowID],
-				labels[util.LABEL_BACKREST_RESTORE_TO_PVC], affinityJSON)
+				labels[util.LABEL_BACKREST_RESTORE_TO_PVC], job.Spec.Template.Spec.Affinity)
 		}
 
 		return

--- a/hugo/content/Design/_index.md
+++ b/hugo/content/Design/_index.md
@@ -176,6 +176,7 @@ on PG 9.6/9.5 systems, the command you will use is *select pg_xlog_replay_resume
  * there is currently no Operator validation of user entered pgBackRest command options, you will need to make sure to enter these correctly, if not the pgBackRest restore command can fail.
  * the restore workflow does not perform a backup after the restore nor does it verify that any replicas are in a working status after the restore, it is possible you might have to take actions on the replica to get them back to replicating with the new restored primary.
  * pgbackrest.org suggests running a pgbackrest backup after a restore, this needs to be done by the DBA as part of a restore
+ * when performing a restore, the **node-label** option can be utilized to target a specific node for both the pgBackRest restore job and the new (i.e. restored) primary deployment that is then created for the cluster.  If a node label is not specified, the restore job will not target any specific node, and the restored primary deployment will inherit any node label's defined for the original primary deployment.
 
 ## PGO Scheduler
 

--- a/hugo/content/Operator CLI/_index.md
+++ b/hugo/content/Operator CLI/_index.md
@@ -172,6 +172,10 @@ Or perform a restore based on a point in time:
 
     pgo restore mycluster --pitr-target="2019-01-14 00:02:14.921404+00" --backup-opts="--type=time"
 
+You can also target specific nodes when performing a restore:
+
+    pgo restore mycluster --node-label=failure-domain.beta.kubernetes.io/zone=us-central1-a
+
 Here are some steps to test PITR:
 
  * pgo create cluster mycluster --pgbackrest

--- a/pgo/cmd/create.go
+++ b/pgo/cmd/create.go
@@ -35,7 +35,6 @@ var CCPImageTag string
 var Password string
 var SecretFrom, BackupPath, BackupPVC string
 var PoliciesFlag, PolicyFile, PolicyURL string
-var NodeLabel string
 var UserLabels string
 var ServiceType string
 var Schedule string

--- a/pgo/cmd/flags.go
+++ b/pgo/cmd/flags.go
@@ -26,6 +26,7 @@ var DebugFlag bool
 var Selector string
 var DryRun bool
 var ScheduleName string
+var NodeLabel string
 
 var BackupType string
 var RestoreType string

--- a/pgo/cmd/restore.go
+++ b/pgo/cmd/restore.go
@@ -18,13 +18,14 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	log "github.com/Sirupsen/logrus"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"github.com/crunchydata/postgres-operator/pgo/api"
 	"github.com/crunchydata/postgres-operator/pgo/util"
 	otherutil "github.com/crunchydata/postgres-operator/util"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var PITRTarget string
@@ -56,6 +57,7 @@ func init() {
 
 	restoreCmd.Flags().StringVarP(&BackupOpts, "backup-opts", "", "", "The restore options for pgbackrest or pgdump.")
 	restoreCmd.Flags().StringVarP(&PITRTarget, "pitr-target", "", "", "The PITR target, being a PostgreSQL timestamp such as '2018-08-13 11:25:42.582117-04'.")
+	restoreCmd.Flags().StringVarP(&NodeLabel, "node-label", "", "", "The node label (key=value) to use when scheduling the pgBackRest restore job and the new (i.e. restored) primary deployment. If not set, any node is used.")
 	restoreCmd.Flags().BoolVarP(&NoPrompt, "no-prompt", "n", false, "No command line confirmation.")
 	restoreCmd.Flags().StringVarP(&BackupPVC, "backup-pvc", "", "", "The PVC containing the pgdump directory to restore from.")
 	restoreCmd.Flags().StringVarP(&BackupType, "backup-type", "", "", "The type of backup to restore from, default is pgbackrest. Valid types are pgbackrest or pgdump.")
@@ -87,6 +89,7 @@ func restore(args []string, ns string) {
 		request.ToPVC = request.FromCluster + "-" + otherutil.RandStringBytesRmndr(4)
 		request.RestoreOpts = BackupOpts
 		request.PITRTarget = PITRTarget
+		request.NodeLabel = NodeLabel
 
 		response, err = api.Restore(httpclient, &SessionCredentials, request)
 	}

--- a/rhel7/Dockerfile.pgo-backrest-repo.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-repo.rhel7
@@ -8,13 +8,13 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgo-backrest-repo" \
 	description="Crunchy Data PostgreSQL Operator - pgo-backrest-repo"
 
-ENV PGVERSION="11" 
+ENV PGVERSION="11" BACKREST_VERSION="2.08"
 ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 RUN yum -y update && \
-yum -y install psmisc openssh-server openssh-clients crunchy-backrest hostname pgocps-ng && \
+yum -y install psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
 yum -y clean all
 
 RUN groupadd pgbackrest -g 2000 && useradd pgbackrest -u 2000 -g 2000

--- a/rhel7/Dockerfile.pgo-backrest-restore.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-restore.rhel7
@@ -8,13 +8,13 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgo-backrest-restore" \
 	description="pgBackRest backrest restore"
 
-ENV PGVERSION="11" 
+ENV PGVERSION="11" BACKREST_VERSION="2.08"
 
 ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-RUN yum -y update && yum -y install psmisc openssh-server openssh-clients crunchy-backrest postgresql11-server procps-ng && yum -y clean all
+RUN yum -y update && yum -y install psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" postgresql11-server procps-ng && yum -y clean all
 
 VOLUME ["/sshd", "/pgdata"]
 

--- a/rhel7/Dockerfile.pgo-backrest.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest.rhel7
@@ -12,7 +12,7 @@ LABEL name="crunchydata/pgo-backrest-" \
     summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
     description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" 
+ENV PGVERSION="11" BACKREST_VERSION="2.08"
 
 # Crunchy Postgres repo
 ADD conf/RPM-GPG-KEY-crunchydata  /
@@ -23,7 +23,7 @@ COPY redhat/atomic/pgo_backrest/help.1 /help.1
 COPY redhat/atomic/pgo_backrest/help.md /help.md
 COPY redhat/licenses /licenses
 
-RUN yum -y update && yum -y install postgresql11-server && yum -y install crunchy-backrest && yum -y clean all
+RUN yum -y update && yum -y install postgresql11-server && yum -y install crunchy-backrest-"${BACKREST_VERSION}" && yum -y clean all
 
 #RUN mkdir -p /opt/cpm/bin /pgdata /backrestrepo && chown -R 26:26 /opt/cpm && chmod -R g=u /pgdata 
 RUN mkdir -p /opt/cpm/bin /pgdata /backrestrepo && chown -R 26:26 /opt/cpm 


### PR DESCRIPTION
Added the `--node-label` flag to the `pgo restore` command.  With this flag the PGO user can now specify/request a specific node for the pgBackRest restore job and the new (i.e. restored) primary deployment that will then be created. 

[ch2002]

This PR also locks the version of pgBackRest utilized by the Operator in at v2.08 in order to maintain compatibility with the version of pgBackRest utilized in the Crunchy Container Suite.

[ch2150]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The user is unable to specify a specific node when performing a pgBackRest restore using the `pgo restore` command.

Also, the Dockerfile's do not specify a specific version of pgBackRest, which can lead to version mismatch errors when performing various pgBackRest commands (e.g. creating a stanza).


**What is the new behavior (if this is a feature change)?**
The user is able to specify a specific node when performing a pgBackRest restore using by using the `--node-label` flag with the `pgo restore` command.

Also, the Dockerfile's now specify a specific version of pgBackRest, which will ensure compatibility with the version of pgBackRest utilized in the Crunchy Container Suite.

**Other information**:
N/A