### PR TITLE
Add minimum TLS 1.1 requirement

### DIFF
--- a/apiserver.go
+++ b/apiserver.go
@@ -155,6 +155,7 @@ func main() {
 		ServerName:         "pgo-apiserver",
 		InsecureSkipVerify: tlsNoVerify,
 		ClientCAs:          caCertPool,
+		MinVersion:         tls.VersionTLS11,
 	}
 
 	log.Info("listening on port " + PORT)

--- a/pgo/cmd/auth.go
+++ b/pgo/cmd/auth.go
@@ -194,6 +194,7 @@ func GetCredentials() {
 				RootCAs:            caCertPool,
 				InsecureSkipVerify: true,
 				Certificates:       []tls.Certificate{cert},
+				MinVersion:         tls.VersionTLS11,
 			},
 		},
 	}


### PR DESCRIPTION
This adds a minimum TLS requirement of 1.1 for both `pgo` CLI and the API.

[CH2173]