### PR TITLE
Added "CCPImage" to Restored Deployment Created when Performing pgBackRest Restore

### DIFF
--- a/operator/backrest/restore.go
+++ b/operator/backrest/restore.go
@@ -407,6 +407,7 @@ func CreateRestoredDeployment(restclient *rest.RESTClient, cluster *crv1.Pgclust
 		LogStatement:            operator.Pgo.Cluster.LogStatement,
 		LogMinDurationStatement: operator.Pgo.Cluster.LogMinDurationStatement,
 		CCPImagePrefix:          operator.Pgo.Cluster.CCPImagePrefix,
+		CCPImage:                cluster.Spec.CCPImage,
 		CCPImageTag:             cluster.Spec.CCPImageTag,
 		PVCName:                 util.CreatePVCSnippet(cluster.Spec.PrimaryStorage.StorageType, restoreToName),
 		DeploymentLabels:        operator.GetLabelsFromMap(primaryLabels),


### PR DESCRIPTION
Added **CCPImage** to the new (i.e. restored) deployment that is created when performing a pgBackRest restore.  Specifically, the **CCPImage** value that was defined for the original pgcluster (e.g. the default value of **crunchy-postgres** or the value provided using the `--ccp-image` flag) will be applied to the new (i.e. restored) deployment.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The restored pod fails with an `InvalidImageName` error.

[ch2186]

**What is the new behavior (if this is a feature change)?**
**CCPImage** is populated on the restored deployment, allowing the restored pod to deploy as expected.


**Other information**:
N/A