### PR TITLE
Update pgBackRest Version to v2.10 for Compatibility with Crunchy Container Suite v2.3.1

### DIFF
--- a/centos7/Dockerfile.pgo-backrest-repo.centos7
+++ b/centos7/Dockerfile.pgo-backrest-repo.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - Apiserver" \
 	description="Crunchy Data PostgreSQL Operator - Apiserver"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.08"
+ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
 
 # PGDG PostgreSQL Repository
 

--- a/centos7/Dockerfile.pgo-backrest-restore.centos7
+++ b/centos7/Dockerfile.pgo-backrest-restore.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.08"
+ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/Dockerfile.pgo-backrest.centos7
+++ b/centos7/Dockerfile.pgo-backrest.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.08"
+ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/Dockerfile.repo-client.centos7
+++ b/centos7/Dockerfile.repo-client.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - Apiserver" \
 	description="Crunchy Data PostgreSQL Operator - Apiserver"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.08"
+ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
 
 # PGDG PostgreSQL Repository
 

--- a/rhel7/Dockerfile.pgo-backrest-repo.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-repo.rhel7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgo-backrest-repo" \
 	description="Crunchy Data PostgreSQL Operator - pgo-backrest-repo"
 
-ENV PGVERSION="11" BACKREST_VERSION="2.08"
+ENV PGVERSION="11" BACKREST_VERSION="2.10"
 ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata

--- a/rhel7/Dockerfile.pgo-backrest-restore.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-restore.rhel7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgo-backrest-restore" \
 	description="pgBackRest backrest restore"
 
-ENV PGVERSION="11" BACKREST_VERSION="2.08"
+ENV PGVERSION="11" BACKREST_VERSION="2.10"
 
 ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/

--- a/rhel7/Dockerfile.pgo-backrest.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest.rhel7
@@ -12,7 +12,7 @@ LABEL name="crunchydata/pgo-backrest-" \
     summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
     description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" BACKREST_VERSION="2.08"
+ENV PGVERSION="11" BACKREST_VERSION="2.10"
 
 # Crunchy Postgres repo
 ADD conf/RPM-GPG-KEY-crunchydata  /


### PR DESCRIPTION
Updated pgBackRest version to **2.10** to ensure PGO v3.5.1 is compatible with Crunchy Container Suite v2.3.1  (specifically to ensure both utilize the same version of pgBackRest [v2.10], therefore ensuring all pgBackRest functionality works as expected).

[ch2198]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
N/A


**What is the new behavior (if this is a feature change)?**
N/A


**Other information**:
N/A