### PR TITLE
fix example/envs.sh: use CO_NAMESPACE

### DIFF
--- a/examples/envs.sh
+++ b/examples/envs.sh
@@ -6,7 +6,7 @@ export CO_CMD=kubectl
 export COROOT=$GOPATH/src/github.com/crunchydata/postgres-operator
 export CO_IMAGE_PREFIX=crunchydata
 export CO_BASEOS=centos7
-export CO_VERSION=3.5.0
+export CO_VERSION=3.5.1
 export CO_IMAGE_TAG=$CO_BASEOS-$CO_VERSION
 
 # for the pgo CLI auth
@@ -14,9 +14,19 @@ export PGO_CA_CERT=$COROOT/conf/postgres-operator/server.crt
 export PGO_CLIENT_CERT=$COROOT/conf/postgres-operator/server.crt
 export PGO_CLIENT_KEY=$COROOT/conf/postgres-operator/server.key
 
-# useful aliases
-alias setip='export CO_APISERVER_URL=https://`kubectl get service postgres-operator -o=jsonpath="{.spec.clusterIP}"`:8443'
-alias alog='kubectl logs `kubectl get pod --selector=name=postgres-operator -o jsonpath="{.items[0].metadata.name}"` -c apiserver'
-alias olog='kubectl logs `kubectl get pod --selector=name=postgres-operator -o jsonpath="{.items[0].metadata.name}"` -c operator'
-alias slog='kubectl logs `kubectl get pod --selector=name=postgres-operator -o jsonpath="{.items[0].metadata.name}"` -c scheduler'
+# useful functions
+setip() {
+	export CO_APISERVER_URL=https://`kubectl -n "$CO_NAMESPACE" get service postgres-operator -o=jsonpath="{.spec.clusterIP}"`:8443
+}
 
+alog() {
+	kubectl  -n "$CO_NAMESPACE" logs `kubectl  -n "$CO_NAMESPACE" get pod --selector=name=postgres-operator -o jsonpath="{.items[0].metadata.name}"` -c apiserver
+}
+
+olog() {
+	kubectl  -n "$CO_NAMESPACE" logs `kubectl  -n "$CO_NAMESPACE" get pod --selector=name=postgres-operator -o jsonpath="{.items[0].metadata.name}"` -c operator
+}
+
+slog() {
+	kubectl  -n "$CO_NAMESPACE" logs `kubectl  -n "$CO_NAMESPACE" get pod --selector=name=postgres-operator -o jsonpath="{.items[0].metadata.name}"` -c scheduler
+}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The example `envs.sh` use neither CO_NAMESPACE nor demo.
The example `envs.sh` use an outdated CO_VERSION which does not support the `CreateDump`, `RestoreDump` and `ScaleCluster`. This will cause the installation tutorial to fail because `CreateDump` is not a valid permission in 3.5.0.


**What is the new behavior (if this is a feature change)?**
The example envs.sh now use CO_NAMESPACE which is by default demo.
The example envs.sh now use 3.5.1 which supports these three permissions.

**Other information**:
As a new user, having a broken example `envs.sh` is confusing. Your deployment will fail even if you follow the installation tutorial. The error is not obvious until you read the code or the changelog.