### PR TITLE
Replace "kubectl" with variable defined and add env vars for default admin and clustername 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,11 @@ installrbac:
 setup:
 	./bin/get-deps.sh
 setupnamespace:
-	kubectl create -f ./examples/demo-namespace.json
-	kubectl config set-context demo --cluster=kubernetes --namespace=demo --user=kubernetes-admin
-	kubectl config use-context demo
+	$(CO_CMD) create -f ./examples/demo-namespace.json
+	$(CO_CMD) config set-context demo --cluster=$(CO_DEFAULT_CLUSTER) --namespace=demo --user=$(CO_ADMIN_USER)
+	$(CO_CMD) config use-context demo
 bounce:
-	kubectl get pod --selector=name=postgres-operator -o=jsonpath="{.items[0].metadata.name}" | xargs kubectl delete pod
+	$(CO_CMD) get pod --selector=name=postgres-operator -o=jsonpath="{.items[0].metadata.name}" | xargs $(CO_CMD) delete pod
 deployoperator:
 	cd deploy && ./deploy.sh
 main:	check-go-vars

--- a/examples/envs.sh
+++ b/examples/envs.sh
@@ -8,6 +8,8 @@ export CO_IMAGE_PREFIX=crunchydata
 export CO_BASEOS=centos7
 export CO_VERSION=3.5.1
 export CO_IMAGE_TAG=$CO_BASEOS-$CO_VERSION
+export CO_DEFAULT_CLUSTER=kubernetes
+export CO_ADMIN_USER=kubernetes-admin
 
 # for the pgo CLI auth
 export PGO_CA_CERT=$COROOT/conf/postgres-operator/server.crt
@@ -20,13 +22,13 @@ setip() {
 }
 
 alog() {
-	kubectl  -n "$CO_NAMESPACE" logs `kubectl  -n "$CO_NAMESPACE" get pod --selector=name=postgres-operator -o jsonpath="{.items[0].metadata.name}"` -c apiserver
+	$CO_CMD  -n "$CO_NAMESPACE" logs `$CO_CMD  -n "$CO_NAMESPACE" get pod --selector=name=postgres-operator -o jsonpath="{.items[0].metadata.name}"` -c apiserver
 }
 
 olog() {
-	kubectl  -n "$CO_NAMESPACE" logs `kubectl  -n "$CO_NAMESPACE" get pod --selector=name=postgres-operator -o jsonpath="{.items[0].metadata.name}"` -c operator
+	$CO_CMD  -n "$CO_NAMESPACE" logs `$CO_CMD  -n "$CO_NAMESPACE" get pod --selector=name=postgres-operator -o jsonpath="{.items[0].metadata.name}"` -c operator
 }
 
 slog() {
-	kubectl  -n "$CO_NAMESPACE" logs `kubectl  -n "$CO_NAMESPACE" get pod --selector=name=postgres-operator -o jsonpath="{.items[0].metadata.name}"` -c scheduler
+	$CO_CMD  -n "$CO_NAMESPACE" logs `$CO_CMD  -n "$CO_NAMESPACE" get pod --selector=name=postgres-operator -o jsonpath="{.items[0].metadata.name}"` -c scheduler
 }


### PR DESCRIPTION
**Description**
  Even though already defined `CO_CMD=kubectl` but not used it in the script and `Makefile`, so I replace hard coded `kubectl` with the env variable, additonally add `CO_DEFAULT_CLUSTER` and `CO_ADMIN_USER` env variable for enhancement to make change easily the names on each user system. 

  For instance, `OpenShift` use usually `oc` cli instead of `kubectl` and the `default cluster name` is based on the cluster entry `API URL` and default `system admin` name is `system:admin`.

**Checklist:**
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

When install on `OpenShift`, I should edit the `cli` command name, `system admin`, `cluster name` manually for installation.

**What is the new behavior (if this is a feature change)?**

I can start to install as specifying the `cli`, `admin name`, `cluster name` in the `.bashrc` initially.
And it's not feature changes.

**Other information**:

I've verified `OpenShift v3.11`(`Kubernetes v1.11`) about this changes.