### PR TITLE
"hostPath" is local storage and not considering to share with other pods

### DIFF
--- a/conf/postgres-operator/pgo.yaml
+++ b/conf/postgres-operator/pgo.yaml
@@ -28,7 +28,7 @@ ReplicaStorage: hostpathstorage
 BackrestStorage: hostpathstorage
 Storage:
   hostpathstorage:
-    AccessMode:  ReadWriteMany
+    AccessMode:  ReadWriteOnce
     Size:  1G
     StorageType:  create
   replicastorage:

--- a/pv/crunchy-pv.json
+++ b/pv/crunchy-pv.json
@@ -8,11 +8,10 @@
     "capacity": {
         "storage": "1Gi"
     },
-    "accessModes": [ "ReadWriteMany" ],
+    "accessModes": [ "ReadWriteOnce" ],
     "hostPath": {
         "path": "/data"
     },
     "persistentVolumeReclaimPolicy": "Retain"
   }
 }
-


### PR DESCRIPTION
`hostPath` can not share with other pods, and `Postgresql`'s `HA` is working through own replication storage, not sharing storage. Even though it's just suggestion for testing `PV`/`PVC` definition, you had better to be more accurate details for clarification, because `database`'s `storage` is more important section than other software.

Refer [Types of Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes) for more details.
~~~
HostPath (Single node testing only – local storage is not supported in any way and WILL NOT WORK in a multi-node cluster)
~~~

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Current `hostPath` `PV`/`PVC`'s `accessMode` is not correct, and it allows to bind on `PV` with multiple `PVC` potentially.
 
**What is the new behavior (if this is a feature change)?**

It would be more clarification for user's usage of `hostPath`.

**Other information**:
