### PR TITLE
Added Multi-zone Guidance to the PGO Design Documentation

### DIFF
--- a/hugo/content/Design/_index.md
+++ b/hugo/content/Design/_index.md
@@ -244,3 +244,112 @@ are captured in a unique pgcluster resource for that Postgres cluster
  * pgbackup - when you run a pgbasebackup, a pgbackup is created to hold the workflow and status of the last backup job, this CRD will eventually be deprecated in favor of a more general pgtask resource
  * pgreplica - when you create a Postgres replica, a pgreplica CRD is created to define that replica
 
+
+## Considerations for Multi-zone Cloud Environments
+
+#### Overview
+When using the Operator in a Kubernetes cluster consisting of nodes that span multiple zones, special consideration must be
+taken to ensure all pods and the volumes they require are scheduled and provisioned within the same zone.  Specifically,
+being that a pod is unable mount a volume that is located in another zone, any volumes that are dynamically provisioned must
+be provisioned in a topology-aware manner according to the specific scheduling requirements for the pod. For instance, this
+means ensuring that the volume containing the database files for the primary DB in a new PG cluster is provisioned in the
+same zone as the node containing the PG primary pod that will be using it.
+
+#### Default Behavior
+By default, the Kubernetes scheduler will ensure any pods created that claim a specific volume via a PVC are scheduled on a
+node in the same zone as that volume.  This is part of the
+[multi-zone support](https://kubernetes.io/docs/setup/multiple-zones/) that is included in Kubernetes by default. However,
+when using dynamic provisioning, volumes are not provisioned in a topology-aware manner by default, which means a volume
+will not be provisioned according to the same scheduling requirements that will be placed on the pod that will be using it
+(e.g. it will not consider node selectors, resource requirements, pod affinity/anti-affinity, and various other scheduling
+requirements).  Rather, PVC's are immediately bound as soon as they are requested, which means volumes are provisioned 
+without knowledge of these scheduling requirements. This behavior is the result of the `volumeBindingMode` defined on the
+Storage Class being utilized to dynamically provision the volume, which is set to `Immediate` by default.  This can be seen
+in the following Storage Class definition, which defines a Storage Class for a Google Cloud Engine Persistent Disk (GCE PD)
+that uses the default value of `Immediate` for its `volumeBindingMode`:
+
+```bash
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: example-sc
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+volumeBindingMode: Immediate
+```
+
+Unfortunately, using `Immediate` for the `volumeBindingMode` in a multi-zone cluster can result in undesired behavior when
+using the Operator, being that the scheduler will ignore any requested _(but not mandatory)_ scheduling requirements if
+necessary to ensure the pod can be scheduled. Specifically, the scheduler will ultimately schedule the pod on a node in the
+same zone as the volume, even if another node was requested for scheduling that pod. For instance, a node label might be
+specified using the `--node-label` option when creating a cluster using the `pgo create cluster` command in order target a 
+specific node (or nodes) for the deployment of that cluster. Within the Operator, a **node label** is implemented as a 
+`preferredDuringSchedulingIgnoredDuringExecution` node affinity rule, which is an affinity rule that Kubernetes will attempt
+to adhere to when scheduling any pods for the cluster, but _will not guarantee_ (more information on node affinity rules can
+be found [here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)). Therefore,
+if the volume ends up in a zone other than the zone containing the node (or nodes) defined by the node label, the node label
+will be ignored, and the pod will be scheduled according to the zone containing the volume.  
+
+#### Topology Aware Volumes
+In order to overcome the behavior described above in a multi-zone cluster, volumes must be made topology aware.  This is
+accomplished by setting the `volumeBindingMode` for the storage class to `WaitForFirstConsumer`, which delays the dynamic
+provisioning of a volume until a pod using it is created. In other words, the PVC is no longer bound as soon as it is 
+requested, but rather waits for a pod utilizing it to be creating prior to binding.  This change ensures that volume can
+take into account the scheduling requirements for the pod, which in the case of a multi-zone cluster means ensuring the
+volume is provisioned in the same zone containing the node where the pod has be scheduled.  This also means the scheduler
+should no longer ignore a node label in order to follow a volume to another zone when scheduling a pod, since the volume
+will now follow the pod according to the pod's specificscheduling requirements.  The following is an example of the the same
+Storage Class defined above, only with `volumeBindingMode` now set to `WaitForFirstConsumer`:
+
+```bash
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: example-sc
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+volumeBindingMode: WaitForFirstConsumer
+```
+
+#### Additional Solutions
+If you are using a version of Kubernetes that does not support `WaitForFirstConsumer`, an alternate _(and now deprecated)_
+solution exists in the form of parameters that can be defined on the Storage Class definition to ensure volumes are
+provisioned in a specific zone (or zones).  For instance, when defining a Storage Class for a GCE PD for use in Google 
+Kubernetes Engine (GKE) cluster, the **zone** parameter can be used to ensure any volumes dynamically provisioned using that
+Storage Class are located in that specific zone.  The following is an example of a Storage Class for a GKE cluster that will
+provision volumes in the **us-east1** zone:
+
+```bash
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: example-sc
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+  replication-type: none
+  zone: us-east1
+```
+
+Once storage classes have been defined for one or more zones, they can then be defined as one or more storage configurations
+within the pgo.yaml configuration file (as described in the 
+[PGO YAML configuration guide](/configuration/pgo-yaml-configuration)).  From there those storage configurations can then be
+selected when creating a new cluster, as shown in the following example:
+
+```bash
+pgo create cluster mycluster --storage-config=example-sc
+```
+
+With this approach, the pod will once again be scheduled according to the zone in which the volume was provisioned. However,
+the zone parameters defined on the Storage Class bring consistency to scheduling by guaranteeing that the volume, and
+therefore also the pod using that volume, are scheduled in a specific zone as defined by the user, bringing consistency
+and predictability to volume provisioning and pod scheduling in multi-zone clusters.
+
+For more information regarding the specific parameters available for the Storage Classes being utilizing in your cloud 
+environment, please see the
+[Kubernetes documentation for Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/).
+
+Lastly, while the above applies to the dynamic provisioning of volumes, it should be noted that volumes can also be manually
+provisioned in desired zones in order to achieve the desired topology requirements for any pods and their volumes.


### PR DESCRIPTION
Added guidance to the PGO design documentation for users utilizing the PGO in Kubernetes clusters consisting of nodes that span multiple zones (e.g. when using the PGO in multi-zone cloud environments such as GCE, AWS, etc.).

[ch2546]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Guidance does not exist for PGO users in multi-zone cloud environments.


**What is the new behavior (if this is a feature change)?**
Guidance now exists for PGO users in multi-zone cloud environments.


**Other information**:
N/A