### PR TITLE
Fix bug dropping error when loading TLS

### DIFF
--- a/pgo/cmd/auth.go
+++ b/pgo/cmd/auth.go
@@ -181,7 +181,7 @@ func GetCredentials() {
 	}
 	cert, err = tls.LoadX509KeyPair(clientCertPath, clientKeyPath)
 	if err != nil {
-		fmt.Println("Error: could not load example.com.crt and example.com.key")
+		fmt.Printf("Error loading client certificate/key: %s\n", err)
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
Important error feedback loading client TLS files was being discarded in `pgo`.  Added the error to the error message.