### PR TITLE
fix pod type detection

### DIFF
--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -1108,7 +1108,13 @@ func createWorkflowTask(clusterName, ns string) (string, error) {
 func getType(pod *v1.Pod, clusterName string) string {
 
 	//log.Debugf("%v\n", pod.ObjectMeta.Labels)
-	if pod.ObjectMeta.Labels[config.LABEL_PGO_BACKREST_REPO] != "" {
+	if primary, found := pod.ObjectMeta.Labels[config.LABEL_PRIMARY]; found {
+		if primary == "true" {
+			return msgs.PodTypePrimary
+		} else {
+			return msgs.PodTypeReplica
+		}
+	} else if pod.ObjectMeta.Labels[config.LABEL_PGO_BACKREST_REPO] != "" {
 		return msgs.PodTypePgbackrest
 	} else if pod.ObjectMeta.Labels[config.LABEL_PGBOUNCER] != "" {
 		return msgs.PodTypePgbouncer
@@ -1116,10 +1122,6 @@ func getType(pod *v1.Pod, clusterName string) string {
 		return msgs.PodTypePgpool
 	} else if pod.ObjectMeta.Labels[config.LABEL_PGBACKUP] == "true" {
 		return msgs.PodTypeBackup
-	} else if pod.ObjectMeta.Labels[config.LABEL_SERVICE_NAME] == clusterName {
-		return msgs.PodTypePrimary
-	} else {
-		return msgs.PodTypeReplica
 	}
 	return msgs.PodTypeUnknown
 

--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -1108,8 +1108,8 @@ func createWorkflowTask(clusterName, ns string) (string, error) {
 func getType(pod *v1.Pod, clusterName string) string {
 
 	//log.Debugf("%v\n", pod.ObjectMeta.Labels)
-	if primary, found := pod.ObjectMeta.Labels[config.LABEL_PRIMARY]; found {
-		if primary == "true" {
+	if _, found := pod.ObjectMeta.Labels[config.LABEL_PRIMARY]; found {
+		if pod.ObjectMeta.Labels[config.LABEL_SERVICE_NAME] == clusterName {
 			return msgs.PodTypePrimary
 		} else {
 			return msgs.PodTypeReplica

--- a/controller/podcontroller.go
+++ b/controller/podcontroller.go
@@ -292,13 +292,15 @@ func isPostgresPod(newpod *apiv1.Pod) bool {
 		log.Debugf("pgo-backrest-repo pod found [%s]", newpod.Name)
 		return false
 	}
-	if newpod.ObjectMeta.Labels[config.LABEL_PGPOOL] == "true" {
-		log.Debugf("pgpool pod found [%s]", newpod.Name)
-		return false
-	}
-	if newpod.ObjectMeta.Labels[config.LABEL_PGBOUNCER] == "true" {
-		log.Debugf("pgbouncer pod found [%s]", newpod.Name)
-		return false
+	if _, ok := newpod.ObjectMeta.Labels[config.LABEL_PRIMARY]; !ok {
+		if newpod.ObjectMeta.Labels[config.LABEL_PGPOOL] == "true" {
+			log.Debugf("pgpool pod found [%s]", newpod.Name)
+			return false
+		}
+		if newpod.ObjectMeta.Labels[config.LABEL_PGBOUNCER] == "true" {
+			log.Debugf("pgbouncer pod found [%s]", newpod.Name)
+			return false
+		}
 	}
 	return true
 }


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
#637 #641 

Everything is detected as a pgpool or a pgbouncer if one of them is on your cluster.

```
cluster : a-type-cluster (crunchy-postgres:centos7-11.2-2.3.1)
	pod : a-type-cluster-545559d9cf-ss5h9 (Running) on node-6 (1/1) (pgbouncer)
	pvc : a-type-cluster
	pvc : a-type-cluster-xlog
	pod : a-type-cluster-ceho-555c78cdcd-4frf6 (Running) on node-7 (1/1) (pgbouncer)
	pvc : a-type-cluster-ceho
	pvc : a-type-cluster-ceho-xlog
	pod : a-type-cluster-pgbouncer-8bb9cd499-v47vm (Running) on node-6 (1/1) (pgbouncer)
	pod : a-type-cluster-pgpool-54c6579f47-r5zkb (Running) on node-7 (1/1) (pgpool)
	pod : a-type-cluster-qhbh-67cd6fc7cd-qc5p5 (Running) on node-6 (1/1) (pgbouncer)
	pvc : a-type-cluster-qhbh
	pvc : a-type-cluster-qhbh-xlog
```



**What is the new behavior (if this is a feature change)?**
`show cluster` returns the right pod type
```
	pod : a-type-cluster-545559d9cf-ss5h9 (Running) on node-6 (1/1) (primary)
	pvc : a-type-cluster
	pvc : a-type-cluster-xlog
	pod : a-type-cluster-ceho-555c78cdcd-4frf6 (Running) on node-7 (1/1) (replica)
	pvc : a-type-cluster-ceho
	pvc : a-type-cluster-ceho-xlog
	pod : a-type-cluster-pgbouncer-8bb9cd499-v47vm (Running) on node-6 (1/1) (pgbouncer)
	pod : a-type-cluster-pgpool-54c6579f47-r5zkb (Running) on node-7 (1/1) (pgpool)
	pod : a-type-cluster-qhbh-67cd6fc7cd-qc5p5 (Running) on node-6 (1/1) (replica)
	pvc : a-type-cluster-qhbh
	pvc : a-type-cluster-qhbh-xlog
```
`service-name` is correctly assigned when using one of these two as it doesn't return early by detecting that it is a pgpool/pgbouncer pod. Hence it is possible to deploy a cluster

**Other information**:
I am using the LABEL_PRIMARY as it is the once used by `checkPostgresPods` before assigning a `service-name` but we might as well use the `service-name` itself as it is the current implementation.