### PR TITLE
Added Validation for Options that can be Provided to Backup & Restore Utilities

### DIFF
--- a/apiserver/backrestservice/backrestimpl.go
+++ b/apiserver/backrestservice/backrestimpl.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crunchydata/postgres-operator/apiserver/backupoptions"
 	"github.com/crunchydata/postgres-operator/operator"
 
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
@@ -46,6 +47,15 @@ func CreateBackup(request *msgs.CreateBackrestBackupRequest, ns string) msgs.Cre
 	resp.Status.Code = msgs.Ok
 	resp.Status.Msg = ""
 	resp.Results = make([]string, 0)
+
+	if request.BackupOpts != "" {
+		err := backupoptions.ValidateBackupOpts(request.BackupOpts, request)
+		if err != nil {
+			resp.Status.Code = msgs.Error
+			resp.Status.Msg = err.Error()
+			return resp
+		}
+	}
 
 	if request.Selector != "" {
 		//use the selector instead of an argument list to filter on
@@ -392,6 +402,15 @@ func Restore(request *msgs.RestoreRequest, ns string) msgs.RestoreResponse {
 	resp.Results = make([]string, 0)
 
 	log.Debugf("Restore %v\n", request)
+
+	if request.RestoreOpts != "" {
+		err := backupoptions.ValidateBackupOpts(request.RestoreOpts, request)
+		if err != nil {
+			resp.Status.Code = msgs.Error
+			resp.Status.Msg = err.Error()
+			return resp
+		}
+	}
 
 	cluster := crv1.Pgcluster{}
 	found, err := kubeapi.Getpgcluster(apiserver.RESTClient, &cluster, request.FromCluster, ns)

--- a/apiserver/backupoptions/backupoptionsutil.go
+++ b/apiserver/backupoptions/backupoptionsutil.go
@@ -1,0 +1,216 @@
+package backupoptions
+
+/*
+Copyright 2019 Crunchy Data Solutions, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
+	"github.com/spf13/pflag"
+)
+
+type backupOptions interface {
+	validate([]string) error
+	getBlacklistFlags() ([]string, []string)
+}
+
+// ValidateBackupOpts validates the backup/restore options that can be provided to the various backup
+// and restore utilities supported by pgo (e.g. pg_basebackup, pg_dump, pg_restore, pgBackRest, etc.)
+func ValidateBackupOpts(backupOpts string, request interface{}) error {
+
+	// some quick checks to make sure backup opts string is valid and should be processed and validated
+	if strings.TrimSpace(backupOpts) == "" {
+		return nil
+	} else if !strings.HasPrefix(strings.TrimSpace(backupOpts), "-") &&
+		!strings.HasPrefix(strings.TrimSpace(backupOpts), "--") {
+		return errors.New("bad flag syntax. Backup options must start with '-' or '--'")
+	} else if strings.TrimSpace(strings.Replace(backupOpts, "-", "", -1)) == "" {
+		return errors.New("bad flag syntax. No backup options provided")
+	}
+
+	// validate backup opts
+	backupOptions, setFlagFieldNames, err := convertBackupOptsToStruct(backupOpts, request)
+	if err != nil {
+		return err
+	} else {
+		err := backupOptions.validate(setFlagFieldNames)
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func convertBackupOptsToStruct(backupOpts string, request interface{}) (backupOptions, []string, error) {
+
+	parsedBackupOpts := parseBackupOpts(backupOpts)
+
+	optsStruct, utilityName, err := createBackupOptionsStruct(backupOpts, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	structValue := reflect.Indirect(reflect.ValueOf(optsStruct))
+	structType := structValue.Type()
+
+	commandLine := pflag.NewFlagSet(utilityName+" backup-opts", pflag.ContinueOnError)
+	usage := new(bytes.Buffer)
+	commandLine.SetOutput(usage)
+
+	for i := 0; i < structValue.NumField(); i++ {
+		fieldVal := structValue.Field(i)
+
+		flag, _ := structType.Field(i).Tag.Lookup("flag")
+		flagShort, _ := structType.Field(i).Tag.Lookup("flag-short")
+
+		if flag != "" || flagShort != "" {
+			switch fieldVal.Kind() {
+			case reflect.String:
+				commandLine.StringVarP(fieldVal.Addr().Interface().(*string), flag, flagShort, "", "")
+			case reflect.Int:
+				commandLine.IntVarP(fieldVal.Addr().Interface().(*int), flag, flagShort, 0, "")
+			case reflect.Bool:
+				commandLine.BoolVarP(fieldVal.Addr().Interface().(*bool), flag, flagShort, false, "")
+			case reflect.Slice:
+				commandLine.StringArrayVarP(fieldVal.Addr().Interface().(*[]string), flag, flagShort, nil, "")
+			}
+		}
+	}
+
+	err = commandLine.Parse(parsedBackupOpts)
+	if err != nil {
+		return nil, nil, handleCustomParseErrors(err, usage, optsStruct)
+	}
+
+	setFlagFieldNames := obtainSetFlagFieldNames(commandLine, structType)
+
+	return optsStruct, setFlagFieldNames, nil
+}
+
+func parseBackupOpts(backupOpts string) []string {
+
+	newFields := []string{}
+	var newField string
+	for i, c := range backupOpts {
+		// if another option is found, add current option to newFields array
+		if !(c == ' ' && backupOpts[i+1] == '-') {
+			newField = newField + string(c)
+		}
+
+		// append if at the end of the flag (i.e. if another new flag was found) or if at the end of the string
+		if i == len(backupOpts)-1 || c == ' ' && backupOpts[i+1] == '-' {
+			if len(strings.Split(newField, " ")) > 1 && !strings.Contains(strings.Split(newField, " ")[0], "=") {
+				splitFlagNoEqualsSign := strings.SplitN(newField, " ", 2)
+				if (len(splitFlagNoEqualsSign)) > 1 {
+					newFields = append(newFields, strings.TrimSpace(splitFlagNoEqualsSign[0]))
+					newFields = append(newFields, strings.TrimSpace(splitFlagNoEqualsSign[1]))
+				}
+			} else {
+				newFields = append(newFields, strings.TrimSpace(newField))
+			}
+			newField = ""
+		}
+	}
+
+	return newFields
+}
+
+func createBackupOptionsStruct(backupOpts string, request interface{}) (backupOptions, string, error) {
+
+	switch request.(type) {
+	case *msgs.CreateBackrestBackupRequest:
+		return &pgBackRestBackupOptions{}, "pgBackRest", nil
+	case *msgs.RestoreRequest:
+		return &pgBackRestRestoreOptions{}, "pgBackRest", nil
+	case *msgs.CreateBackupRequest:
+		return &pgBaseBackupOptions{}, "pg_basebackup", nil
+	case *msgs.CreatepgDumpBackupRequest:
+		if strings.Contains(backupOpts, "--dump-all") {
+			return &pgDumpAllOptions{}, "pg_dumpall", nil
+		} else {
+			return &pgDumpOptions{}, "pg_dump", nil
+		}
+	case *msgs.PgRestoreRequest:
+		return &pgRestoreOptions{}, "pg_restore", nil
+	}
+	return nil, "", errors.New("Request type not recognized. Unable to create struct for backup opts")
+}
+
+func isValidCompressLevel(compressLevel int) bool {
+	if compressLevel >= 0 && compressLevel <= 9 {
+		return true
+	} else {
+		return false
+	}
+}
+
+func isValidValue(vals []string, val string) bool {
+	isValid := false
+	for _, currVal := range vals {
+		if val == currVal {
+			isValid = true
+			return isValid
+		}
+	}
+	return isValid
+}
+
+func handleCustomParseErrors(err error, usage *bytes.Buffer, optsStruct backupOptions) error {
+	blacklistFlags, blacklistFlagsShort := optsStruct.getBlacklistFlags()
+	if err.Error() == "pflag: help requested" {
+		pflag.Usage()
+		return errors.New(usage.String())
+	} else if strings.Contains(err.Error(), "unknown flag") {
+		for _, blacklistFlag := range blacklistFlags {
+			flagMatch, err := regexp.MatchString("\\B"+blacklistFlag+"$", err.Error())
+			if err != nil {
+				return err
+			} else if flagMatch {
+				return fmt.Errorf("Flag %s is not supported for use with PGO", blacklistFlag)
+			}
+		}
+	} else if strings.Contains(err.Error(), "unknown shorthand flag") {
+		for _, blacklistFlagShort := range blacklistFlagsShort {
+			blacklistFlagQuotes := "'" + strings.TrimPrefix(blacklistFlagShort, "-") + "'"
+			if strings.Contains(err.Error(), blacklistFlagQuotes) {
+				return fmt.Errorf("Shorthand flag %s is not supported for use with PGO", blacklistFlagShort)
+			}
+		}
+	}
+	return err
+}
+
+func obtainSetFlagFieldNames(commandLine *pflag.FlagSet, structType reflect.Type) []string {
+	var setFlagFieldNames []string
+	var visitBackupOptFlags = func(flag *pflag.Flag) {
+		for i := 0; i < structType.NumField(); i++ {
+			field := structType.Field(i)
+			flagName, _ := field.Tag.Lookup("flag")
+			flagNameShort, _ := field.Tag.Lookup("flag-short")
+			if flag.Name == flagName || flag.Name == flagNameShort {
+				setFlagFieldNames = append(setFlagFieldNames, field.Name)
+			}
+		}
+	}
+	commandLine.Visit(visitBackupOptFlags)
+	return setFlagFieldNames
+}

--- a/apiserver/backupoptions/pgbackrestoptions.go
+++ b/apiserver/backupoptions/pgbackrestoptions.go
@@ -1,0 +1,208 @@
+package backupoptions
+
+/*
+Copyright 2019 Crunchy Data Solutions, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"errors"
+	"strings"
+)
+
+var pgBackRestOptsBlacklist = []string{"--archive-check", "--no-archive-check", "--online", "--no-online", "--link-all",
+	"--link-map", "--tablespace-map", "--tablespace-map-all", "--cmd-ssh", "--config", "--config-include-path",
+	"--config-path", "--lock-path", "--neutral-umask", "--no-neutral-umask", "--stanza", "--log-timestamp",
+	"--repo-cipher-type", "--repo-host", "--repo-host-cmd", "--repo-host-config", "--repo-host-config-include-path",
+	"--repo-host-config-path", "--repo-host-port", "--repo-host-user", "--repo-path", "--repo-s3-bucket",
+	"--repo-s3-ca-file", "--repo-s3-ca-path", "--repo-s3-endpoint", "--repo-s3-host", "--repo-s3-region",
+	"--repo-s3-verify-ssl", "--repo-type", "--pg-host", "--pg-host-cmd", "--pg-host-config",
+	"--pg-host-config-include-path", "--pg-host-config-path", "--pg-host-port", "--pg-host-user", "--pg-path", "--pg-port"}
+
+type pgBackRestBackupOptions struct {
+	ArchiveCopy           bool   `flag:"archive-copy"`
+	NoArchiveCopy         bool   `flag:"no-archive-copy"`
+	ArchiveTimeout        int    `flag:"archive-timeout"`
+	BackupStandby         bool   `flag:"backup-standby"`
+	NoBackupStandby       bool   `flag:"no-backup-standby"`
+	ChecksumPage          bool   `flag:"checksum-page"`
+	NoChecksumPage        bool   `flag:"no-checksum-page"`
+	Exclude               string `flag:"exclude"`
+	Force                 bool   `flag:"force"`
+	ManifestSaveThreshold string `flag:"manifest-save-threshold"`
+	Resume                bool   `flag:"resume"`
+	NoResume              bool   `flag:"no-resume"`
+	StartFast             bool   `flag:"start-fast"`
+	NoStartFast           bool   `flag:"no-start-fast"`
+	StopAuto              bool   `flag:"stop-auto"`
+	NoStopAuto            bool   `flag:"no-stop-auto"`
+	BackupType            string `flag:"type"`
+	BufferSize            string `flag:"buffer-size"`
+	Compress              bool   `flag:"compress"`
+	NoCompress            bool   `flag:"no-compress"`
+	CompressLevel         int    `flag:"compress-level"`
+	CompressLevelNetwork  int    `flag:"compress-level-network"`
+	DBTimeout             int    `flag:"db-timeout"`
+	Delta                 bool   `flag:"no-delta"`
+	ProcessMax            int    `flag:"process-max"`
+	ProtocolTimeout       int    `flag:"protocol-timeout"`
+	LogLevelConsole       string `flag:"log-level-console"`
+	LogLevelFile          string `flag:"log-level-file"`
+	LogLevelStderr        string `flag:"log-level-stderr"`
+	LogSubprocess         bool   `flag:"log-subprocess"`
+}
+
+type pgBackRestRestoreOptions struct {
+	DBInclude            string `flag:"db-include"`
+	Force                bool   `flag:"force"`
+	RecoveryOption       string `flag:"recovery-option"`
+	Set                  string `flag:"set"`
+	Target               string `flag:"target"`
+	TargetAction         string `flag:"target-action"`
+	TargetExclusive      bool   `flag:"target-exclusive"`
+	NoTargetExclusive    bool   `flag:"no-target-exclusive"`
+	TargetTimeline       int    `flag:"target-timeline"`
+	RestoreType          string `flag:"type"`
+	BufferSize           string `flag:"buffer-size"`
+	Compress             bool   `flag:"compress"`
+	NoCompress           bool   `flag:"no-compress"`
+	CompressLevel        int    `flag:"compress-level"`
+	CompressLevelNetwork int    `flag:"compress-level-network"`
+	DBTimeout            int    `flag:"db-timeout"`
+	Delta                bool   `flag:"no-delta"`
+	ProcessMax           int    `flag:"process-max"`
+	ProtocolTimeout      int    `flag:"protocol-timeout"`
+	LogLevelConsole      string `flag:"log-level-console"`
+	LogLevelFile         string `flag:"log-level-file"`
+	LogLevelStderr       string `flag:"log-level-stderr"`
+	LogSubprocess        bool   `flag:"log-subprocess"`
+}
+
+func (backRestBackupOpts pgBackRestBackupOptions) validate(setFlagFieldNames []string) error {
+
+	var errstrings []string
+
+	for _, setFlag := range setFlagFieldNames {
+
+		switch setFlag {
+		case "BackupType":
+			if !isValidValue([]string{"full", "diff", "incr"}, backRestBackupOpts.BackupType) {
+				err := errors.New("Invalid type provided for pgBackRest backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "CompressLevel":
+			if !isValidCompressLevel(backRestBackupOpts.CompressLevel) {
+				err := errors.New("Invalid compress level for pgBackRest backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "CompressLevelNetwork":
+			if !isValidCompressLevel(backRestBackupOpts.CompressLevelNetwork) {
+				err := errors.New("Invalid network compress level for pgBackRest backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "LogLevelConsole":
+			if !isValidBackrestLogLevel(backRestBackupOpts.LogLevelConsole) {
+				err := errors.New("Invalid log level for pgBackRest backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "LogLevelFile":
+			if !isValidBackrestLogLevel(backRestBackupOpts.LogLevelFile) {
+				err := errors.New("Invalid log level for pgBackRest backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "LogLevelStdErr":
+			if !isValidBackrestLogLevel(backRestBackupOpts.LogLevelStderr) {
+				err := errors.New("Invalid log level for pgBackRest backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		}
+	}
+
+	if len(errstrings) > 0 {
+		return errors.New(strings.Join(errstrings, "\n"))
+	}
+
+	return nil
+}
+
+func (backRestRestoreOpts pgBackRestRestoreOptions) validate(setFlagFieldNames []string) error {
+
+	var errstrings []string
+
+	for _, setFlag := range setFlagFieldNames {
+
+		switch setFlag {
+		case "TargetAction":
+			if !isValidValue([]string{"pause", "promote", "shutdown"}, backRestRestoreOpts.TargetAction) {
+				err := errors.New("Invalid target action provided for pgBackRest restore")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "TargetExclusive":
+			if backRestRestoreOpts.RestoreType != "time" && backRestRestoreOpts.RestoreType != "xid" {
+				err := errors.New("The target exclusive option is only applicable for a pgBackRest restore " +
+					"when type is 'time' or 'xid' ")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "RestoreType":
+			validRestoreTypes := []string{"default", "immediate ", "name ", "xid", "time", "preserve", "none"}
+			if !isValidValue(validRestoreTypes, backRestRestoreOpts.RestoreType) {
+				err := errors.New("Invalid type provided for pgBackRest restore")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "CompressLevel":
+			if !isValidCompressLevel(backRestRestoreOpts.CompressLevel) {
+				err := errors.New("Invalid compress level for pgBackRest restore")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "CompressLevelNetwork":
+			if !isValidCompressLevel(backRestRestoreOpts.CompressLevelNetwork) {
+				err := errors.New("Invalid network compress level for pgBackRest restore")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "LogLevelConsole":
+			if !isValidBackrestLogLevel(backRestRestoreOpts.LogLevelConsole) {
+				err := errors.New("Invalid log level for pgBackRest restore")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "LogLevelFile":
+			if !isValidBackrestLogLevel(backRestRestoreOpts.LogLevelFile) {
+				err := errors.New("Invalid log level for pgBackRest restore")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "LogLevelStdErr":
+			if !isValidBackrestLogLevel(backRestRestoreOpts.LogLevelStderr) {
+				err := errors.New("Invalid log level for pgBackRest restore")
+				errstrings = append(errstrings, err.Error())
+			}
+		}
+	}
+
+	if len(errstrings) > 0 {
+		return errors.New(strings.Join(errstrings, "\n"))
+	}
+
+	return nil
+}
+
+func isValidBackrestLogLevel(logLevel string) bool {
+	logLevels := []string{"off", "error", "warn", "info", "detail", "debug", "trace"}
+	return isValidValue(logLevels, logLevel)
+}
+
+func (backRestBackupOpts pgBackRestBackupOptions) getBlacklistFlags() ([]string, []string) {
+	return pgBackRestOptsBlacklist, nil
+}
+
+func (backRestRestoreOpts pgBackRestRestoreOptions) getBlacklistFlags() ([]string, []string) {
+	return pgBackRestOptsBlacklist, nil
+}

--- a/apiserver/backupoptions/pgbasebackupoptions.go
+++ b/apiserver/backupoptions/pgbasebackupoptions.go
@@ -1,0 +1,113 @@
+package backupoptions
+
+/*
+Copyright 2019 Crunchy Data Solutions, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+var pgBasebackupOptsBlacklist = []string{"--pgdata", "--slot", "--wal-method", "--label", "--dbname", "--host", "--port",
+	"--username", "--no-password", "--password", "--version"}
+
+var pgBasebackupOptsBlacklistShort = []string{"-D", "-S", "-X", "-l", "-d", "-h", "-p", "-U", "-w", "-W", "-V"}
+
+type pgBaseBackupOptions struct {
+	Format            string `flag:"format" flag-short:"F"`
+	MaxRate           string `flag:"max-rate" flag-short:"r"`
+	WriteRecover      bool   `flag:"write-recovery" flag-short:"R"`
+	NoSlot            bool   `flag:"no-slot"`
+	TablespaceMapping string `flag:"tablespace-mapping" flag-short:"T"`
+	WalDir            string `flag:"waldir"`
+	Gzip              bool   `flag:"gzip" flag-short:"z"`
+	Compress          int    `flag:"compress" flag-short:"Z"`
+	Checkpoint        string `flag:"checkpoint" flag-short:"c"`
+	NoClean           bool   `flag:"no-clean" flag-short:"n"`
+	Progress          bool   `flag:"progress" flag-short:"P"`
+	NoSync            bool   `flag:"no-sync"`
+	Verbose           bool   `flag:"verbose" flag-short:"v"`
+	NoVerifyChecksums bool   `flag:"no-verify-checksums"`
+	StatusInterval    int    `flag:"status-interval" flag-short:"s"`
+}
+
+func (baseBackupOpts pgBaseBackupOptions) validate(setFlagFieldNames []string) error {
+
+	var errstrings []string
+
+	for _, setFlag := range setFlagFieldNames {
+
+		switch setFlag {
+		case "Format":
+			if !isValidValue([]string{"p", "plain", "t", "tar"}, baseBackupOpts.Format) {
+				err := errors.New("Invalid format provided for pg_basebackup backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "MaxRate":
+			err := validateMaxRate(baseBackupOpts.MaxRate)
+			if err != nil {
+				errstrings = append(errstrings, err.Error())
+			}
+		case "Compress":
+			if !isValidCompressLevel(baseBackupOpts.Compress) {
+				err := errors.New("Invalid compress level for pg_basebackup backup")
+				errstrings = append(errstrings, err.Error())
+			} else if baseBackupOpts.Format != "tar" {
+				err := errors.New("Compress level is only supported when using the tar format for a pg_basebackup backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "Checkpoint":
+			if !isValidValue([]string{"fast", "spread"}, baseBackupOpts.Checkpoint) {
+				err := errors.New("Invalid checkpoint provided for pg_basebackup backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		}
+	}
+
+	if len(errstrings) > 0 {
+		return errors.New(strings.Join(errstrings, "\n"))
+	}
+
+	return nil
+}
+
+func validateMaxRate(maxRate string) error {
+	var maxRateVal int
+	var convErr error
+	if strings.HasSuffix(maxRate, "k") {
+		maxRateVal, convErr = strconv.Atoi(strings.TrimSuffix(maxRate, "k"))
+	} else if strings.HasSuffix(maxRate, "M") {
+		maxRateVal, convErr = strconv.Atoi(strings.TrimSuffix(maxRate, "M"))
+		maxRateVal = maxRateVal * 1000 // convert MB to KB
+	} else {
+		maxRateVal, convErr = strconv.Atoi(maxRate)
+	}
+
+	if convErr != nil {
+		return errors.New("Invalid format for max rate value provided for pg_basebackup backup")
+	} else {
+		if maxRateVal < 32 || maxRateVal > 1024000 {
+			return errors.New("The max rate value provided for pg_basebackup backup is outside of the " +
+				"range allowed (between 32KB and 1024MB)")
+		}
+	}
+
+	return nil
+}
+
+func (baseBackupOpts pgBaseBackupOptions) getBlacklistFlags() ([]string, []string) {
+	return pgBasebackupOptsBlacklist, pgBasebackupOptsBlacklistShort
+}

--- a/apiserver/backupoptions/pgdumpoptions.go
+++ b/apiserver/backupoptions/pgdumpoptions.go
@@ -1,0 +1,278 @@
+package backupoptions
+
+/*
+Copyright 2017 Crunchy Data Solutions, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"errors"
+	"strings"
+)
+
+var pgDumpRestoreOptsBlacklist = []string{"--binary-upgrade", "--no-reconnect", "--dbname", "--host", "--port",
+	"--username", "--no-password", "--password", "--version"}
+
+var pgDumpRestoreOptsBlacklistShort = []string{"-R", "-d", "-h", "-p", "-U", "-w", "-W", "-V"}
+
+type pgDumpOptions struct {
+	DataOnly                   bool     `flag:"data-only" flag-short:"a"`
+	Blobs                      bool     `flag:"blobs" flag-short:"b"`
+	NoBlobs                    bool     `flag:"no-blobs" flag-short:"B"`
+	Clean                      bool     `flag:"clean" flag-short:"c"`
+	Create                     bool     `flag:"create" flag-short:"C"`
+	Encoding                   string   `flag:"encoding" flag-short:"E"`
+	Jobs                       int      `flag:"jobs" flag-short:"j"`
+	Format                     string   `flag:"format" flag-short:"F"`
+	Schema                     []string `flag:"schema" flag-short:"n"`
+	ExcludeSchema              string   `flag:"exclude-schema" flag-short:"N"`
+	Oids                       bool     `flag:"oids" flag-short:"o"`
+	NoOwner                    bool     `flag:"no-owner" flag-short:"O"`
+	SchemaOnly                 bool     `flag:"schema-only" flag-short:"s"`
+	SuperUser                  string   `flag:"superuser" flag-short:"S"`
+	Table                      []string `flag:"table" flag-short:"t"`
+	ExcludeTable               string   `flag:"exclude-table" flag-short:"T"`
+	Verbose                    bool     `flag:"verbose" flag-short:"v"`
+	NoPrivileges               bool     `flag:"no-privileges" flag-short:"x"`
+	NoACL                      bool     `flag:"no-acl"`
+	Compress                   int      `flag:"compress" flag-short:"Z"`
+	ColumnInserts              bool     `flag:"column-inserts"`
+	AttributeInserts           bool     `flag:"attribute-inserts"`
+	DisableDollarQuoting       bool     `flag:"disable-dollar-quoting"`
+	DisableTriggers            bool     `flag:"disable-triggers"`
+	EnableRowSecurity          bool     `flag:"exclude-row-security"`
+	ExcludeTableData           string   `flag:"exclude-table-data"`
+	IfExists                   bool     `flag:"if-exists"`
+	Inserts                    bool     `flag:"inserts"`
+	LockWaitTimeout            string   `flag:"lock-wait-timeout"`
+	LoadViaPartitionRoot       bool     `flag:"load-via-partition-root"`
+	NoComments                 bool     `flag:"no-comments"`
+	NoPublications             bool     `flag:"no-publications"` // PG 10 & 11 only
+	NoSecurityLabels           bool     `flag:"no-security-labels"`
+	NoSubscriptions            bool     `flag:"no-subscriptions"` // PG 10 & 11 only
+	NoSync                     bool     `flag:"no-sync"`
+	NoTableSpaces              bool     `flag:"no-tablespaces"`
+	NoUnloggedTableData        bool     `flag:"no-unlogged-table-data"`
+	QuoteAllIdentifiers        bool     `flag:"quote-all-identifiers"`
+	Section                    []string `flag:"section"`
+	SerializableDeferrable     bool     `flag:"serializable-deferrable"`
+	Snapshot                   string   `flag:"snapshot"`
+	StrictNames                string   `flag:"strict-names"` // PG 9.6, 10 & 11 only
+	UseSetSessionAuthorization bool     `flag:"use-set-session-authorization"`
+	Role                       string   `flag:"role"`
+}
+
+type pgDumpAllOptions struct {
+	DataOnly                   bool   `flag:"data-only" flag-short:"a"`
+	Clean                      bool   `flag:"clean" flag-short:"c"`
+	Encoding                   string `flag:"encoding" flag-short:"E"`
+	GlobalsOnly                bool   `flag:"globals-only"`
+	Oids                       bool   `flag:"oids" flag-short:"o"`
+	NoOwner                    bool   `flag:"no-owner" flag-short:"O"`
+	RolesOnly                  bool   `flag:"roles-only"`
+	SchemaOnly                 bool   `flag:"schema-only" flag-short:"s"`
+	SuperUser                  string `flag:"superuser" flag-short:"S"`
+	TablespacesOnly            bool   `flag:"tablespaces-only"`
+	Verbose                    bool   `flag:"verbose" flag-short:"v"`
+	NoPrivileges               bool   `flag:"no-privileges" flag-short:"x"`
+	NoACL                      bool   `flag:"no-acl"`
+	ColumnInserts              bool   `flag:"column-inserts"`
+	AttributeInserts           bool   `flag:"attribute-inserts"`
+	DisableDollarQuoting       bool   `flag:"disable-dollar-quoting"`
+	DisableTriggers            bool   `flag:"disable-triggers"`
+	IfExists                   bool   `flag:"if-exists"`
+	Inserts                    bool   `flag:"inserts"`
+	LockWaitTimeout            string `flag:"lock-wait-timeout"`
+	LoadViaPartitionRoot       bool   `flag:"load-via-partition-root"`
+	NoComments                 bool   `flag:"no-comments"`
+	NoPublications             bool   `flag:"no-publications"` // PG 10 & 11 only
+	NoRolePasswords            bool   `flag:"no-role-passwords"`
+	NoSecurityLabels           bool   `flag:"no-security-labels"`
+	NoSubscriptions            bool   `flag:"no-subscriptions"` // PG 10 & 11 only
+	NoSync                     bool   `flag:"no-sync"`
+	NoTableSpaces              bool   `flag:"no-tablespaces"`
+	NoUnloggedTableData        bool   `flag:"no-unlogged-table-data"`
+	QuoteAllIdentifiers        bool   `flag:"quote-all-identifiers"`
+	UseSetSessionAuthorization bool   `flag:"use-set-session-authorization"`
+	Role                       string `flag:"role"`
+	DumpAll                    bool   `flag:"dump-all"` // custom pgo backup opt used for pg_dumpall
+}
+
+type pgRestoreOptions struct {
+	DataOnly                   bool     `flag:"data-only" flag-short:"a"`
+	Clean                      bool     `flag:"clean" flag-short:"c"`
+	Create                     bool     `flag:"create" flag-short:"C"`
+	ExitOnError                bool     `flag:"exit-on-error" flag-short:"e"`
+	Filename                   string   `flag:"filename" flag-short:"f"`
+	Format                     string   `flag:"format" flag-short:"F"`
+	Index                      []string `flag:"index" flag-short:"I"`
+	Jobs                       int      `flag:"jobs" flag-short:"j"`
+	List                       bool     `flag:"list" flag-short:"l"`
+	UseList                    bool     `flag:"useList" flag-short:"L"`
+	Schema                     string   `flag:"schema" flag-short:"n"`
+	ExcludeSchema              string   `flag:"exclude-schema" flag-short:"N"`
+	NoOwner                    bool     `flag:"no-owner" flag-short:"O"`
+	Function                   []string `flag:"function" flag-short:"P"`
+	SchemaOnly                 bool     `flag:"schema-only" flag-short:"s"`
+	SuperUser                  string   `flag:"superuser" flag-short:"S"`
+	Table                      string   `flag:"table" flag-short:"t"`
+	Trigger                    []string `flag:"trigger" flag-short:"T"`
+	Verbose                    bool     `flag:"verbose" flag-short:"v"`
+	NoPrivileges               bool     `flag:"no-privileges" flag-short:"x"`
+	NoACL                      bool     `flag:"no-acl"`
+	SingleTransaction          bool     `flag:"single-transaction" flag-short:"1"`
+	DisableTriggers            bool     `flag:"disable-triggers"`
+	EnableRowSecurity          bool     `flag:"enable-row-security"`
+	IfExists                   bool     `flag:"if-exists"`
+	NoComments                 bool     `flag:"no-comments"`
+	NoDataForFailedTables      bool     `flag:"no-data-for-failed-tables"`
+	NoPublications             bool     `flag:"no-publications"` // PG 10 & 11 only
+	NoSecurityLabels           bool     `flag:"no-security-labels"`
+	NoSubscriptions            bool     `flag:"no-subscriptions"` // PG 10 & 11 only
+	NoTableSpaces              bool     `flag:"no-tablespaces"`
+	Section                    []string `flag:"section"`
+	StrictNames                string   `flag:"strict-names"` // PG 9.6, 10 & 11 only
+	UseSetSessionAuthorization bool     `flag:"use-set-session-authorization"`
+	Role                       string   `flag:"role"`
+}
+
+func (dumpOpts pgDumpOptions) validate(setFlagFieldNames []string) error {
+
+	var errstrings []string
+
+	for _, setFlag := range setFlagFieldNames {
+
+		switch setFlag {
+		case "Format":
+			if !isValidValue([]string{"p", "plain", "c", "custom", "t", "tar"}, dumpOpts.Format) {
+				err := errors.New("Invalid format provided for pg_dump backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "SuperUser":
+			if !dumpOpts.DisableTriggers {
+				err := errors.New("The --superuser option is only applicable for a pg_dump backup if the " +
+					"--disable-triggers option has also been specified")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "Compress":
+			if !isValidCompressLevel(dumpOpts.Compress) {
+				err := errors.New("Invalid compress level for pg_dump backup")
+				errstrings = append(errstrings, err.Error())
+			} else if dumpOpts.Format == "tar" {
+				err := errors.New("Compress level is not supported when using the tar format for a pg_dump backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "IfExists":
+			if !dumpOpts.Clean {
+				err := errors.New("The --if-exists option is only valid for a pg_dump backup if the --clean option is " +
+					"also specified")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "Section":
+			for _, currSection := range dumpOpts.Section {
+				if !isValidValue([]string{"pre-data", "data", "post-data"}, currSection) {
+					err := errors.New("Invalid section provided for pg_dump backup")
+					errstrings = append(errstrings, err.Error())
+				}
+			}
+		}
+	}
+
+	if len(errstrings) > 0 {
+		return errors.New(strings.Join(errstrings, "\n"))
+	}
+
+	return nil
+}
+
+func (dumpAllOpts pgDumpAllOptions) validate(setFlagFieldNames []string) error {
+
+	var errstrings []string
+
+	for _, setFlag := range setFlagFieldNames {
+
+		switch setFlag {
+		case "SuperUser":
+			if !dumpAllOpts.DisableTriggers {
+				err := errors.New("The --superuser option is only applicable for a pg_dumpall backup if the " +
+					"--disable-triggers option has also been specified")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "IfExists":
+			if !dumpAllOpts.Clean {
+				err := errors.New("The --if-exists option is only valid for a pg_dumpall backup if the --clean option is " +
+					"also specified")
+				errstrings = append(errstrings, err.Error())
+			}
+		}
+	}
+
+	if len(errstrings) > 0 {
+		return errors.New(strings.Join(errstrings, "\n"))
+	}
+
+	return nil
+}
+
+func (restoreOpts pgRestoreOptions) validate(setFlagFieldNames []string) error {
+
+	var errstrings []string
+
+	for _, setFlag := range setFlagFieldNames {
+
+		switch setFlag {
+		case "Format":
+			if !isValidValue([]string{"p", "plain", "c", "custom", "t", "tar"}, restoreOpts.Format) {
+				err := errors.New("Invalid format provided for pg_restore restore")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "SuperUser":
+			if !restoreOpts.DisableTriggers {
+				err := errors.New("The --superuser option is only applicable for a pg_restore restore if the " +
+					"--disable-triggers option has also been specified")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "IfExists":
+			if !restoreOpts.Clean {
+				err := errors.New("The --if-exists option is only valid for a pg_restore restore if the --clean option is " +
+					"also specified")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "Section":
+			for _, currSection := range restoreOpts.Section {
+				if !isValidValue([]string{"pre-data", "data", "post-data"}, currSection) {
+					err := errors.New("Invalid section provided for pg_restore restore")
+					errstrings = append(errstrings, err.Error())
+				}
+			}
+		}
+	}
+
+	if len(errstrings) > 0 {
+		return errors.New(strings.Join(errstrings, "\n"))
+	}
+
+	return nil
+}
+
+func (dumpOpts pgDumpOptions) getBlacklistFlags() ([]string, []string) {
+	return pgDumpRestoreOptsBlacklist, pgDumpRestoreOptsBlacklistShort
+}
+
+func (dumpAllOpts pgDumpAllOptions) getBlacklistFlags() ([]string, []string) {
+	return pgDumpRestoreOptsBlacklist, pgDumpRestoreOptsBlacklistShort
+}
+
+func (restoreOpts pgRestoreOptions) getBlacklistFlags() ([]string, []string) {
+	return pgDumpRestoreOptsBlacklist, pgDumpRestoreOptsBlacklistShort
+}

--- a/apiserver/backupservice/backupimpl.go
+++ b/apiserver/backupservice/backupimpl.go
@@ -18,6 +18,7 @@ limitations under the License.
 import (
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/apiserver"
+	"github.com/crunchydata/postgres-operator/apiserver/backupoptions"
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"github.com/crunchydata/postgres-operator/config"
 	"github.com/crunchydata/postgres-operator/kubeapi"
@@ -123,6 +124,15 @@ func CreateBackup(request *msgs.CreateBackupRequest, ns string) msgs.CreateBacku
 			log.Info("CreateBackup sc error is found " + request.StorageConfig)
 			resp.Status.Code = msgs.Error
 			resp.Status.Msg = request.StorageConfig + " Storage config was not found "
+			return resp
+		}
+	}
+
+	if request.BackupOpts != "" {
+		err := backupoptions.ValidateBackupOpts(request.BackupOpts, request)
+		if err != nil {
+			resp.Status.Code = msgs.Error
+			resp.Status.Msg = err.Error()
 			return resp
 		}
 	}


### PR DESCRIPTION
Added validation to the various backup and restore options that can be provided via the `--backup-opts` flag when using the `pgo backup` and `pgo restore` commands.  This allows for the identification of many common mistakes and errors when inputting backup/restore options at the PGO API server, prior to the creation of the job for a backup or restore.  This therefore provides immediate feedback to the user when an invalid backup/restore option has been provided, instead on requiring the user to wait for the backup/restore job to fail.  Types of errors captured by the backup options validation layer include basic command line syntax errors, the identification of unknown options, the identification of options not supported by PGO, invalid types (e.g. a string provided for a flag requiring an int), along with various business rules applicable to the various options supported by the various PGO backup and restore utilities.

[ch1889]
[ch1991]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Validation of any backup/restore options provided using the `--backup-opts` flag when performing a backup or restore are not validated by PGO, and the user must wait for the backup/restore job to fail in order to capture and identify any mistakes with the backup options provided.


**What is the new behavior (if this is a feature change)?**
Validation of and backup/restore options provided using the `--backup-opts` are validated at the PGO API server, allowing for the identification of many common mistakes and errors with any options provided prior to the creation of the backup/restore job.


**Other information**:
N/A