### PR TITLE
Add list watch to scheduler, fix bugs

### DIFF
--- a/apiserver/scheduleservice/scheduleimpl.go
+++ b/apiserver/scheduleservice/scheduleimpl.go
@@ -58,7 +58,7 @@ func (s scheduleRequest) createBackRestSchedule(cluster *crv1.Pgcluster, ns stri
 		Type:      s.Request.ScheduleType,
 		Namespace: ns,
 		PGBackRest: PGBackRest{
-			Label:       fmt.Sprintf("pg-cluster=%s,service-name=%s", cluster.Name, cluster.Name),
+			Label:       fmt.Sprintf("pg-cluster=%s,name=%s,deployment-name=%s", cluster.Name, cluster.Name, cluster.Name),
 			Container:   "database",
 			Type:        s.Request.PGBackRestType,
 			StorageType: s.Request.BackrestStorageType,

--- a/pgo-scheduler/scheduler/pgbackrest.go
+++ b/pgo-scheduler/scheduler/pgbackrest.go
@@ -77,11 +77,6 @@ func (b BackRestBackupJob) Run() {
 		return
 	}
 
-	if cluster.Spec.UserLabels[config.LABEL_BACKREST] != "true" {
-		contextLogger.WithFields(log.Fields{}).Error("pgBackRest is not enabled")
-		return
-	}
-
 	taskName := fmt.Sprintf("%s-backrest-%s-backup-schedule", b.cluster, b.backupType)
 
 	result := crv1.Pgtask{}

--- a/pgo-scheduler/scheduler/pgbasebackup.go
+++ b/pgo-scheduler/scheduler/pgbasebackup.go
@@ -17,6 +17,7 @@ package scheduler
 
 import (
 	"fmt"
+
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/kubeapi"
 	log "github.com/sirupsen/logrus"

--- a/pgo-scheduler/scheduler/validate.go
+++ b/pgo-scheduler/scheduler/validate.go
@@ -78,15 +78,23 @@ func ValidateBackRestSchedule(scheduleType, deployment, label, backupType, stora
 			return errors.New("Backup Type required for pgBackRest schedules")
 		}
 
-		validBackupTypes := []string{
-			"full",
-			"incr",
-			"diff",
-		}
+		validBackupTypes := []string{"full", "incr", "diff"}
 
 		var valid bool
 		for _, bType := range validBackupTypes {
 			if backupType == bType {
+				valid = true
+				break
+			}
+		}
+
+		if !valid {
+			return fmt.Errorf("pgBackRest Backup Type invalid: %s", backupType)
+		}
+
+		validStorageTypes := []string{"local", "s3"}
+		for _, sType := range validStorageTypes {
+			if storageType == sType {
 				valid = true
 				break
 			}

--- a/pgo-scheduler/scheduler/validate_test.go
+++ b/pgo-scheduler/scheduler/validate_test.go
@@ -15,7 +15,6 @@ package scheduler
  limitations under the License.
 */
 
-
 import (
 	"testing"
 )
@@ -82,23 +81,26 @@ func TestValidScheduleType(t *testing.T) {
 
 func TestValidBackRestSchedule(t *testing.T) {
 	tests := []struct {
-		schedule, deployment, label, backupType string
-		valid                                   bool
+		schedule, deployment, label, backupType, storageType string
+		valid                                                bool
 	}{
-		{"pgbackrest", "testdeployment", "", "full", true},
-		{"pgbackrest", "", "testlabel=label", "diff", true},
-		{"pgbasebackup", "", "", "", false},
-		{"policy", "", "", "", false},
-		{"pgbackrest", "", "", "", false},
-		{"pgbackrest", "", "", "full", false},
-		{"pgbackrest", "testdeployment", "", "", false},
-		{"pgbackrest", "", "testlabel=label", "", false},
-		{"pgbackrest", "testdeployment", "", "foobar", false},
-		{"pgbackrest", "", "testlabel=label", "foobar", false},
+		{"pgbackrest", "testdeployment", "", "full", "local", true},
+		{"pgbackrest", "", "testlabel=label", "diff", "local", true},
+		{"pgbackrest", "testdeployment", "", "full", "s3", true},
+		{"pgbackrest", "", "testlabel=label", "diff", "s3", true},
+		{"pgbasebackup", "", "", "", "local", false},
+		{"policy", "", "", "", "local", false},
+		{"pgbackrest", "", "", "", "local", false},
+		{"pgbackrest", "", "", "full", "local", false},
+		{"pgbackrest", "testdeployment", "", "", "local", false},
+		{"pgbackrest", "", "testlabel=label", "", "local", false},
+		{"pgbackrest", "testdeployment", "", "foobar", "local", false},
+		{"pgbackrest", "", "testlabel=label", "foobar", "local", false},
+		{"pgbackrest", "", "testlabel=label", "foobar", "", false},
 	}
 
 	for i, test := range tests {
-		err := ValidateBackRestSchedule(test.schedule, test.deployment, test.label, test.backupType)
+		err := ValidateBackRestSchedule(test.schedule, test.deployment, test.label, test.backupType, test.storageType)
 		if test.valid && err != nil {
 			t.Fatalf("tests[%d] - invalid schedule type. expected valid, got invalid: %s",
 				i, err)


### PR DESCRIPTION
Replaced the time loops in the main app with watch lists that get events for configmaps.  

There were some bugs with scheduler that I fixed:
* Added namespace to the name in the internal map used to track schedules to avoid collision when clusters have same name in different namespaces
* Removed some labels that no longer exist
* Simplified add and delete schedules to reflect watch code

[CH3236]
