### PR TITLE
removed pgo version from code block

### DIFF
--- a/hugo/content/Installation/operator-install.md
+++ b/hugo/content/Installation/operator-install.md
@@ -230,7 +230,6 @@ Prior to using *pgo*, users testing the Operator on a single host can specify th
     NAME                CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
     postgres-operator   10.104.47.110   <none>        8443/TCP   7m
     $ export PGO_APISERVER_URL=https://10.104.47.110:8443
-    pgo version
 ```
 
 That URL address needs to be reachable from your local *pgo* client host.  Your Kubernetes administrator will likely need to create a network route, ingress, or LoadBalancer service to expose the Operator REST API to applications outside of the Kubernetes cluster.  Your Kubernetes administrator might also allow you to run the Kubernetes port-forward command, contact your adminstrator for details.


### PR DESCRIPTION
I removed pgo version from the code block that shows the user how to get the service ip for the operator and sets the PGO_APISERVER_URL.  If the user tries to do a pgo version at this point and error will occur because .pgouser is not set up yet, that is further down in the instructions

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
