### PR TITLE
Moved when to do create .pgouser file

### DIFF
--- a/hugo/content/Installation/operator-install.md
+++ b/hugo/content/Installation/operator-install.md
@@ -154,12 +154,36 @@ Other settings in *pgo.yaml* are described in the [pgo.yaml Configuration](/conf
 
 The Operator implements its own RBAC (Role Based Access Controls) for authenticating Operator users access to the Operator REST API.
 
-There is a default set of Roles and Users defined respectively in the following files:
+There is a default set of Roles and Users defined respectively in the following files and can be copied into your home directory as such:
 
 ```
 ./conf/postgres-operator/pgouser
 ./conf/postgres-operator/pgorole
+
+cp ./conf/postgres-operator/pgouser $HOME/.pgouser
+cp ./conf/postgres-operator/pgorole $HOME/.pgorole
 ```
+
+Or create a *.pgouser* file in your home directory with a credential known by the Operator (see your administrator for Operator credentials to use):
+```
+    username:password
+or
+    pgouser1:password
+or
+    pgouser2:password
+or
+    pgouser3:password
+or
+    readonlyuser:password
+```
+
+Each example above has different priviledges in the Operator.  You can create this file as follows:
+
+    echo "pgouser3:password" > $HOME/.pgouser
+
+Note, you can also store the pgouser file in alternate locations, see the
+Security documentation for details.
+
 Operator security is discussed in the Security section [Security](/security) of the documentation.
 
 Adjust these settings to meet your local requirements.
@@ -246,25 +270,6 @@ Next, the *pgo* client needs to reference the keys used to secure the Operator R
 You can also specify these keys on the command line as follows:
 
     pgo version --pgo-ca-cert=$PGOROOT/conf/postgres-operator/server.crt --pgo-client-cert=$PGOROOT/conf/postgres-operator/server.crt --pgo-client-key=$PGOROOT/conf/postgres-operator/server.key
-
-Lastly, create a *.pgouser* file in your home directory with a credential known by the Operator (see your administrator for Operator credentials to use):
-
-    username:password
-or
-    pgouser1:password
-or
-    pgouser2:password
-or
-    pgouser3:password
-or
-    readonlyuser:password
-
-Each example above has different priviledges in the Operator.  You can create this file as follows:
-
-    echo "pgouser3:password" > $HOME/.pgouser
-
-Note, you can also store the pgouser file in alternate locations, see the
-Security documentation for details.
 
 {{% notice tip %}} if you are running the Operator on Google Cloud, you would open up another terminal and run *kubectl port-forward ...* to forward the Operator pod port 8443 to your localhost where you can access the Operator API from your local workstation.
 {{% /notice %}}


### PR DESCRIPTION
I move the directions to create the .pgouser file up to the operator security section since this is where we told users where the default set of roles and users are defined.  The user will get an error when trying to execute pgo version in the pgo cli section because the creation of the .pgouser file was not done yet and was told how to create the file later in the document.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
