### PR TITLE
Build fix: update PGDG rpm location to rhel8 path

### DIFF
--- a/centos7/Dockerfile.pgo-apiserver.centos7
+++ b/centos7/Dockerfile.pgo-apiserver.centos7
@@ -12,7 +12,7 @@ ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
 
 # PGDG PostgreSQL Repository
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-8-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install postgresql11 hostname && yum -y clean all
 

--- a/centos7/Dockerfile.pgo-backrest-repo.centos7
+++ b/centos7/Dockerfile.pgo-backrest-repo.centos7
@@ -12,7 +12,7 @@ ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2
 
 # PGDG PostgreSQL Repository
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-8-x86_64/${PGDG_REPO}
 
 RUN yum -y update && \
 #yum -y install epel-release && \

--- a/centos7/Dockerfile.pgo-backrest-restore.centos7
+++ b/centos7/Dockerfile.pgo-backrest-restore.centos7
@@ -10,7 +10,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 
 ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-8-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install psmisc openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" postgresql11-server procps-ng && yum -y clean all
 

--- a/centos7/Dockerfile.pgo-backrest.centos7
+++ b/centos7/Dockerfile.pgo-backrest.centos7
@@ -8,9 +8,9 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.12"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-8-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install postgresql11-server && yum -y install pgbackrest-"${BACKREST_VERSION}" && yum -y clean all
 

--- a/centos7/Dockerfile.pgo-load.centos7
+++ b/centos7/Dockerfile.pgo-load.centos7
@@ -18,7 +18,7 @@ ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
 
 # PGDG PostgreSQL Repository
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-8-x86_64/${PGDG_REPO}
 
 RUN yum -y update &&  yum -y install epel-release \
  && yum install -y \

--- a/centos7/Dockerfile.pgo-sqlrunner.centos7
+++ b/centos7/Dockerfile.pgo-sqlrunner.centos7
@@ -9,7 +9,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
 ENV PGROOT="/usr/pgsql-${PGVERSION}"
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-8-x86_64/${PGDG_REPO}
 
 RUN yum -y update \
  && yum -y install epel-release \

--- a/centos7/Dockerfile.postgres-operator.centos7
+++ b/centos7/Dockerfile.postgres-operator.centos7
@@ -12,7 +12,7 @@ ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
 
 # PGDG PostgreSQL Repository
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-8-x86_64/${PGDG_REPO}
 
 RUN yum -y update && yum -y install hostname postgresql11  && yum -y clean all
 

--- a/centos7/Dockerfile.repo-client.centos7
+++ b/centos7/Dockerfile.repo-client.centos7
@@ -12,7 +12,7 @@ ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2
 
 # PGDG PostgreSQL Repository
 
-RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
+RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-8-x86_64/${PGDG_REPO}
 
 RUN yum -y update && \
 #yum -y install epel-release && \


### PR DESCRIPTION

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ x ] Breaking change (fix or feature that would cause existing functionality to change)
**What is the current behavior? (link to any open issues here)**
Centos7 build is broken due to path changes in PGDG repository

**What is the new behavior (if this is a feature change)?**
This corrects the Centos7 build but there may be some issues due to PGDG being in flux. 

**Other information**:
