### PR TITLE
Update pgdg Repos in CentOS7 Containers & Update pgBackRest Version in all Containers

### DIFF
--- a/centos7/Dockerfile.pgo-apiserver.centos7
+++ b/centos7/Dockerfile.pgo-apiserver.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - Apiserver" \
 	description="Crunchy Data PostgreSQL Operator - Apiserver"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 # PGDG PostgreSQL Repository
 

--- a/centos7/Dockerfile.pgo-backrest-repo.centos7
+++ b/centos7/Dockerfile.pgo-backrest-repo.centos7
@@ -8,7 +8,8 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - Apiserver" \
 	description="Crunchy Data PostgreSQL Operator - Apiserver"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94" \
+    BACKREST_VERSION="2.12"
 
 # PGDG PostgreSQL Repository
 
@@ -16,7 +17,8 @@ RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/r
 
 RUN yum -y update && \
 #yum -y install epel-release && \
-yum -y install psmisc openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
+yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
+    psmisc openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
 yum -y clean all
 
 RUN groupadd pgbackrest -g 2000 && useradd pgbackrest -u 2000 -g 2000

--- a/centos7/Dockerfile.pgo-backrest-repo.centos7
+++ b/centos7/Dockerfile.pgo-backrest-repo.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - Apiserver" \
 	description="Crunchy Data PostgreSQL Operator - Apiserver"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
 
 # PGDG PostgreSQL Repository
 

--- a/centos7/Dockerfile.pgo-backrest-repo.centos7
+++ b/centos7/Dockerfile.pgo-backrest-repo.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - Apiserver" \
 	description="Crunchy Data PostgreSQL Operator - Apiserver"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
 
 # PGDG PostgreSQL Repository
 

--- a/centos7/Dockerfile.pgo-backrest-restore.centos7
+++ b/centos7/Dockerfile.pgo-backrest-restore.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/Dockerfile.pgo-backrest-restore.centos7
+++ b/centos7/Dockerfile.pgo-backrest-restore.centos7
@@ -8,11 +8,13 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94" \
+    BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
-RUN yum -y update && yum -y install psmisc openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" postgresql11-server procps-ng && yum -y clean all
+RUN yum -y update && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
+    psmisc openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" postgresql11-server procps-ng && yum -y clean all
 
 VOLUME ["/sshd", "/pgdata"]
 

--- a/centos7/Dockerfile.pgo-backrest-restore.centos7
+++ b/centos7/Dockerfile.pgo-backrest-restore.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/Dockerfile.pgo-backrest.centos7
+++ b/centos7/Dockerfile.pgo-backrest.centos7
@@ -8,11 +8,13 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94" \
+    BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
-RUN yum -y update && yum -y install postgresql11-server && yum -y install pgbackrest-"${BACKREST_VERSION}" && yum -y clean all
+RUN yum -y update && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
+    postgresql11-server && yum -y install pgbackrest-"${BACKREST_VERSION}" && yum -y clean all
 
 RUN mkdir -p /opt/cpm/bin /pgdata /backrestrepo && chown -R 26:26 /opt/cpm
 ADD bin/pgo-backrest/ /opt/cpm/bin

--- a/centos7/Dockerfile.pgo-backrest.centos7
+++ b/centos7/Dockerfile.pgo-backrest.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/Dockerfile.pgo-backrest.centos7
+++ b/centos7/Dockerfile.pgo-backrest.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 

--- a/centos7/Dockerfile.pgo-load.centos7
+++ b/centos7/Dockerfile.pgo-load.centos7
@@ -14,7 +14,7 @@ LABEL name="crunchydata/pgo-load" \
     io.openshift.expose-services="" \
     io.openshift.tags="crunchy,database"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 # PGDG PostgreSQL Repository
 

--- a/centos7/Dockerfile.pgo-sqlrunner.centos7
+++ b/centos7/Dockerfile.pgo-sqlrunner.centos7
@@ -6,7 +6,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - SQL Runner" \
 	description="Crunchy Data PostgreSQL Operator - SQL Runner"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 ENV PGROOT="/usr/pgsql-${PGVERSION}"
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}

--- a/centos7/Dockerfile.postgres-operator.centos7
+++ b/centos7/Dockerfile.postgres-operator.centos7
@@ -8,7 +8,7 @@ LABEL  Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator" \
 	description="Crunchy Data PostgreSQL Operator"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm"
 
 # PGDG PostgreSQL Repository
 

--- a/centos7/Dockerfile.repo-client.centos7
+++ b/centos7/Dockerfile.repo-client.centos7
@@ -8,7 +8,8 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - Apiserver" \
 	description="Crunchy Data PostgreSQL Operator - Apiserver"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94" \
+    BACKREST_VERSION="2.12"
 
 # PGDG PostgreSQL Repository
 
@@ -16,7 +17,8 @@ RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/r
 
 RUN yum -y update && \
 #yum -y install epel-release && \
-yum -y install openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
+yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
+    openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
 yum -y clean all
 
 RUN useradd pgbackrest

--- a/centos7/Dockerfile.repo-client.centos7
+++ b/centos7/Dockerfile.repo-client.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - Apiserver" \
 	description="Crunchy Data PostgreSQL Operator - Apiserver"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.12"
 
 # PGDG PostgreSQL Repository
 

--- a/centos7/Dockerfile.repo-client.centos7
+++ b/centos7/Dockerfile.repo-client.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - Apiserver" \
 	description="Crunchy Data PostgreSQL Operator - Apiserver"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-centos11-11-2.noarch.rpm" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" BACKREST_VERSION="2.10"
 
 # PGDG PostgreSQL Repository
 

--- a/rhel7/Dockerfile.pgo-backrest-repo.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-repo.rhel7
@@ -10,7 +10,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgo-backrest-repo" \
 	description="Crunchy Data PostgreSQL Operator - pgo-backrest-repo"
 
-ENV PGVERSION="11" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" BACKREST_VERSION="2.12"
 
 COPY redhat/atomic/pgo_backrest_repo/help.1 /help.1
 COPY redhat/atomic/pgo_backrest_repo/help.md /help.md

--- a/rhel7/Dockerfile.pgo-backrest-restore.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-restore.rhel7
@@ -10,7 +10,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgo-backrest-restore" \
 	description="pgBackRest backrest restore"
 
-ENV PGVERSION="11" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" BACKREST_VERSION="2.12"
 
 COPY redhat/atomic/pgo_backrest_restore/help.1 /help.1
 COPY redhat/atomic/pgo_backrest_restore/help.md /help.md

--- a/rhel7/Dockerfile.pgo-backrest.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest.rhel7
@@ -12,7 +12,7 @@ LABEL name="crunchydata/pgo-backrest-" \
     summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
     description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" BACKREST_VERSION="2.12"
 
 # Crunchy Postgres repo
 ADD conf/RPM-GPG-KEY-crunchydata  /


### PR DESCRIPTION
Updated the rpm used to install the pgdg repos in all CentOS7 Dockerfiles, and then updated those Dockerfiles as needed to properly install all required packages from the pgdg repos.  This includes disabling certain repos when installing pgBackRest to ensure the package is obtained from the proper repository according to the GPG installed when installing the pgdg repo rpm.

Also updated the version of pgBackRest across all CentOS7 and RHEL7 containers to v2.12.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Builds of PGO containers are failing due to a new pdgd repository architecture and installation process.

[ch3382]

**What is the new behavior (if this is a feature change)?**
PGO containers builds now succeed.


**Other information**:
N/A