### PR TITLE
Check that one and only one cluster name is specified

### DIFF
--- a/pgo/cmd/create.go
+++ b/pgo/cmd/create.go
@@ -100,8 +100,10 @@ var createClusterCmd = &cobra.Command{
 			return
 		}
 
-		if len(args) == 0 {
-			fmt.Println(`Error: A cluster name is required for this command.`)
+		numArgs := len(args)
+
+		if numArgs != 1 {
+			fmt.Println(`Error: A single cluster name is required for this command.`)
 		} else {
 			createCluster(args, Namespace)
 		}


### PR DESCRIPTION
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
pgo command checks for minimum number of cluster names but not maximum of 1


**What is the new behavior (if this is a feature change)?**
Updated to check for single cluster name.


**Other information**:
[ch2682]