### PR TITLE
Enable load balancing for pgpool

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/pgpool.conf
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgpool.conf
@@ -259,7 +259,7 @@ failover_if_affected_tuples_mismatch = off
 # LOAD BALANCING MODE
 #------------------------------------------------------------------------------
 
-load_balance_mode = off
+load_balance_mode = on
                                    # Activate load balancing mode
                                    # (change requires restart)
 ignore_leading_white_space = on

--- a/conf/postgres-operator/pgpool.conf
+++ b/conf/postgres-operator/pgpool.conf
@@ -259,7 +259,7 @@ failover_if_affected_tuples_mismatch = off
 # LOAD BALANCING MODE
 #------------------------------------------------------------------------------
 
-load_balance_mode = off
+load_balance_mode = on
                                    # Activate load balancing mode
                                    # (change requires restart)
 ignore_leading_white_space = on


### PR DESCRIPTION
Load balancing was not enabled so queries were not being sent to replicas.  After enabling it in the configuration file I can see the `select_cnt` increasing:

```sql
[vagrant@ocp1 ~]$ psql -d postgres -h 172.30.152.109 -U testuser -x -c "SHOW POOL_NODES"
Password for user testuser:
-[ RECORD 1 ]------+--------------------
node_id            | 0
hostname           | pgpooltest
port               | 5432
status             | up
lb_weight          | 0.500000
role               | primary
select_cnt         | 206506
load_balance_node  | true
replication_delay  | 0
last_status_change | 2019-04-17 20:46:40
-[ RECORD 2 ]------+--------------------
node_id            | 1
hostname           | pgpooltest-replica
port               | 5432
status             | up
lb_weight          | 0.500000
role               | standby
select_cnt         | 202567
load_balance_node  | false
replication_delay  | 0
last_status_change | 2019-04-17 20:46:40
```