### PR TITLE
Fix PGBACKREST_PG1_PORT Environment Variable

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbackrest-env-vars.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbackrest-env-vars.json
@@ -22,7 +22,7 @@
                         "name": "PGBACKREST_LOG_PATH",
                         "value": "/tmp"
                     }, {
-                        "name": "PGBACKREST_PG_PORT",
+                        "name": "PGBACKREST_PG1_PORT",
                         "value": "{{.PgbackrestPGPort}}"
                     }, {
                         "name": "PGBACKREST_REPO_TYPE",

--- a/conf/postgres-operator/pgbackrest-env-vars.json
+++ b/conf/postgres-operator/pgbackrest-env-vars.json
@@ -22,7 +22,7 @@
                         "name": "PGBACKREST_LOG_PATH",
                         "value": "/tmp"
                     }, {
-                        "name": "PGBACKREST_PG_PORT",
+                        "name": "PGBACKREST_PG1_PORT",
                         "value": "{{.PgbackrestPGPort}}"
                     }, {
                         "name": "PGBACKREST_REPO_TYPE",


### PR DESCRIPTION
Fixed the **PGBACKREST_PG1_PORT** environment variable, which is set on crunchy-postgres/crunchy-postgres-gis containers. Specifically changed **PGBACKREST_PG_PORT** to **PGBACKREST_PG1_PORT**.  This will prevent ensure the port is properly set when running pgBackRest commands.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
`WARN: environment contains invalid option 'pg-port'` are shown in pg logs when running pgBackRest commands.

[ch3386]

**What is the new behavior (if this is a feature change)?**
**PGBACKREST_PG_PORT** has been changed to to **PGBACKREST_PG1_PORT**, preventing the `WARN: environment contains invalid option 'pg-port'` warnings when running pgBackRest commands, and ensuring the port is properly set.


**Other information**:
N/A