### PR TITLE
Add environment vars loading for username/password

### DIFF
--- a/apiservermsgs/common.go
+++ b/apiservermsgs/common.go
@@ -34,3 +34,7 @@ type BasicAuthCredentials struct {
 	Password     string
 	APIServerURL string
 }
+
+func (b BasicAuthCredentials) HasUsernameAndPassword() bool {
+	return len(b.Username) > 0 && len(b.Password) > 0
+}

--- a/hugo/content/operatorcli/pgo-overview.md
+++ b/hugo/content/operatorcli/pgo-overview.md
@@ -470,3 +470,11 @@ Create a cluster with a Custom ConfigMap:
 |pgo-ca-cert |The CA Certificate file path for authenticating to the PostgreSQL Operator apiserver. Override with PGO_CA_CERT environment variable|
 |pgo-client-cert |The Client Certificate file path for authenticating to the PostgreSQL Operator apiserver.  Override with PGO_CLIENT_CERT environment variable|
 |pgo-client-key |The Client Key file path for authenticating to the PostgreSQL Operator apiserver.  Override with PGO_CLIENT_KEY environment variable|
+
+## pgo Global Environment Variables
+*pgo* will pick up these settings if set in your environment:
+
+| Name | Description | NOTES |
+|PGOUSERNAME |The username (role) used for auth on the operator apiserver. | Requires that PGOUSERPASS be set. |
+|PGOUSERPASS |The password for used for auth on the operator apiserver. | Requires that PGOUSERNAME be set. |
+|PGOUSER |The path the the pgorole file. | Will be ignored if either PGOUSERNAME or PGOUSERPASS are set. |


### PR DESCRIPTION
These feature allows for users to store credentials in a manner other
than a plaintext file. This method is preferred in some environments
where writing credentials to a plaintext file is not permitted.

PGOUSERNAME and PGOUSERPASS were chosen to be in line with PGOUSER but
be more specific. The idea that if either are set then the PGOUSER file
will be ignored is deliberate. These vars are part of a new feature
only and as such using either is interpreted as an attempt to use both.
The decision to rename pgouserenvvar to pgoUserFileEnvVar was made to
reduce confusion between the username/password auth and file based auth.
The function added to apiservermsgs/common.go was added in place of
changing SessionCredentials to *SessionCredentials and performing a nil
check.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The current behavior is that pgo only supports pulling username:password from a plaintext file.


**What is the new behavior (if this is a feature change)?**
Pgo can pull username:password from environment vars.


**Other information**:
