### PR TITLE
Ch2682

### DIFF
--- a/pgo/cmd/cluster.go
+++ b/pgo/cmd/cluster.go
@@ -22,6 +22,7 @@ import (
 
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"github.com/crunchydata/postgres-operator/pgo/api"
+	"github.com/crunchydata/postgres-operator/pgo/util"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -166,8 +167,13 @@ func printPolicies(d *msgs.ShowClusterDeployment) {
 func createCluster(args []string, ns string) {
 	var err error
 
-	if len(args) == 0 {
-		fmt.Println("Error: Cluster name argument is required.")
+	if len(args) != 1 {
+		fmt.Println("Error: A single Cluster name argument is required.")
+		return
+	}
+
+	if !util.IsValidForResourceName(args[0]) {
+		fmt.Println("Error: Cluster name specified is not valid name - must be lowercase alphanumeric")
 		return
 	}
 

--- a/pgo/cmd/create.go
+++ b/pgo/cmd/create.go
@@ -100,8 +100,10 @@ var createClusterCmd = &cobra.Command{
 			return
 		}
 
-		if len(args) == 0 {
-			fmt.Println(`Error: A cluster name is required for this command.`)
+		numArgs := len(args)
+
+		if numArgs != 1 {
+			fmt.Println(`Error: A single cluster name is required for this command.`)
 		} else {
 			createCluster(args, Namespace)
 		}

--- a/pgo/cmd/create.go
+++ b/pgo/cmd/create.go
@@ -100,9 +100,7 @@ var createClusterCmd = &cobra.Command{
 			return
 		}
 
-		numArgs := len(args)
-
-		if numArgs != 1 {
+		if len(args) != 1 {
 			fmt.Println(`Error: A single cluster name is required for this command.`)
 		} else {
 			createCluster(args, Namespace)

--- a/pgo/util/validation.go
+++ b/pgo/util/validation.go
@@ -1,0 +1,35 @@
+package util
+
+/*
+ Copyright 2018 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import (
+	log "github.com/sirupsen/logrus"
+	"regexp"
+)
+
+var validResourceName = regexp.MustCompile(`^[a-z0-9.\-]+$`).MatchString
+
+// validates whether a string meets requirements for a valid resource name for kubernetes.
+// It can consist of lowercase alphanumeric characters, '-' and '.', per
+//
+//      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+//
+func IsValidForResourceName(target string) bool {
+
+	log.Debugf("IsValidForResourceName: %s", target)
+
+	return validResourceName(target)
+}


### PR DESCRIPTION
**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
pgo create cluster command allowed multiple cluster names to be submitted and would subsequently ignore the extra without notification or validation.


**What is the new behavior (if this is a feature change)?**
Added validation to allow only one cluster name and validate it as a proper k8s resource name.


**Other information**:
[ch2682]