### PR TITLE
Fix namespace issue with pgdump restore

### DIFF
--- a/apiserver/pgdumpservice/pgdumpimpl.go
+++ b/apiserver/pgdumpservice/pgdumpimpl.go
@@ -484,7 +484,7 @@ func Restore(request *msgs.PgRestoreRequest, ns string) msgs.PgRestoreResponse {
 		log.Debugf("deleting prior pgtask %s", pgtask.Name)
 		err = kubeapi.Deletepgtask(apiserver.RESTClient,
 			pgtask.Name,
-			apiserver.Namespace)
+			ns)
 		if err != nil {
 			resp.Status.Code = msgs.Error
 			resp.Status.Msg = err.Error()
@@ -495,7 +495,7 @@ func Restore(request *msgs.PgRestoreRequest, ns string) msgs.PgRestoreResponse {
 	//create a pgtask for the restore workflow
 	err = kubeapi.Createpgtask(apiserver.RESTClient,
 		pgtask,
-		apiserver.Namespace)
+		ns)
 	if err != nil {
 		resp.Status.Code = msgs.Error
 		resp.Status.Msg = err.Error()


### PR DESCRIPTION

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
pgo restore --backup-type=pgdump was erroring out as it was retrieving the current namespace from the wrong field.


**What is the new behavior (if this is a feature change)?**
The restore works as expected now and restores properly


**Other information**:
[ch3392]