### PR TITLE
Only Add User Labels to Deployments & Pods if they Meet Kubernetes Label Requirements  

### DIFF
--- a/operator/backrest/repo.go
+++ b/operator/backrest/repo.go
@@ -104,10 +104,11 @@ func CreateRepoDeployment(clientset *kubernetes.Clientset, namespace string, clu
 		SshdPort:              operator.Pgo.Cluster.BackrestPort,
 		PgbackrestStanza:      "db",
 		PgbackrestRepoType:    operator.GetRepoType(cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE]),
-		PgbackrestS3EnvVars:   operator.GetPgbackrestS3EnvVars(cluster.Spec.UserLabels, clientset, namespace),
-		Name:                  repoName,
-		ClusterName:           cluster.Name,
-		SecurityContext:       util.CreateSecContext(cluster.Spec.PrimaryStorage.Fsgroup, cluster.Spec.PrimaryStorage.SupplementalGroups),
+		PgbackrestS3EnvVars: operator.GetPgbackrestS3EnvVars(cluster.Labels[config.LABEL_BACKREST],
+			cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], clientset, namespace),
+		Name:            repoName,
+		ClusterName:     cluster.Name,
+		SecurityContext: util.CreateSecContext(cluster.Spec.PrimaryStorage.Fsgroup, cluster.Spec.PrimaryStorage.SupplementalGroups),
 	}
 	log.Debugf(fields.Name)
 

--- a/operator/backrest/restore.go
+++ b/operator/backrest/restore.go
@@ -161,7 +161,8 @@ func Restore(restclient *rest.RESTClient, namespace string, clientset *kubernete
 		PgbackrestRepo1Host: task.Spec.Parameters[config.LABEL_PGBACKREST_REPO_HOST],
 		NodeSelector:        operator.GetAffinity(task.Spec.Parameters["NodeLabelKey"], task.Spec.Parameters["NodeLabelValue"], "In"),
 		PgbackrestRepoType:  operator.GetRepoType(task.Spec.Parameters[config.LABEL_BACKREST_STORAGE_TYPE]),
-		PgbackrestS3EnvVars: operator.GetPgbackrestS3EnvVars(cluster.Spec.UserLabels, clientset, namespace),
+		PgbackrestS3EnvVars: operator.GetPgbackrestS3EnvVars(cluster.Labels[config.LABEL_BACKREST],
+			cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], clientset, namespace),
 	}
 
 	var doc2 bytes.Buffer
@@ -428,7 +429,8 @@ func CreateRestoredDeployment(restclient *rest.RESTClient, cluster *crv1.Pgclust
 		BadgerAddon:             operator.GetBadgerAddon(clientset, namespace, cluster),
 		PgbackrestEnvVars: operator.GetPgbackrestEnvVars(cluster.Labels[config.LABEL_BACKREST], cluster.Spec.ClusterName, restoreToName,
 			cluster.Spec.Port, cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE]),
-		PgbackrestS3EnvVars: operator.GetPgbackrestS3EnvVars(cluster.Spec.UserLabels, clientset, namespace),
+		PgbackrestS3EnvVars: operator.GetPgbackrestS3EnvVars(cluster.Labels[config.LABEL_BACKREST],
+			cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], clientset, namespace),
 	}
 
 	log.Debug("collectaddon value is [" + deploymentFields.CollectAddon + "]")

--- a/operator/cluster/clusterlogic.go
+++ b/operator/cluster/clusterlogic.go
@@ -29,9 +29,11 @@ import (
 	"github.com/crunchydata/postgres-operator/operator"
 	"github.com/crunchydata/postgres-operator/operator/backrest"
 	"github.com/crunchydata/postgres-operator/util"
+
 	//jsonpatch "github.com/evanphx/json-patch"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/apps/v1"
+
 	//"k8s.io/apimachinery/pkg/api/meta"
 	//"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -137,7 +139,8 @@ func AddCluster(clientset *kubernetes.Clientset, client *rest.RESTClient, cl *cr
 		PgmonitorEnvVars:        operator.GetPgmonitorEnvVars(cl.Spec.UserLabels[config.LABEL_COLLECT]),
 		PgbackrestEnvVars: operator.GetPgbackrestEnvVars(cl.Labels[config.LABEL_BACKREST], cl.Spec.ClusterName, cl.Spec.Name,
 			cl.Spec.Port, cl.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE]),
-		PgbackrestS3EnvVars: operator.GetPgbackrestS3EnvVars(cl.Spec.UserLabels, clientset, namespace),
+		PgbackrestS3EnvVars: operator.GetPgbackrestS3EnvVars(cl.Labels[config.LABEL_BACKREST],
+			cl.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], clientset, namespace),
 	}
 
 	log.Debug("collectaddon value is [" + deploymentFields.CollectAddon + "]")
@@ -341,7 +344,8 @@ func Scale(clientset *kubernetes.Clientset, client *rest.RESTClient, replica *cr
 		PgmonitorEnvVars:        operator.GetPgmonitorEnvVars(cluster.Spec.UserLabels[config.LABEL_COLLECT]),
 		PgbackrestEnvVars: operator.GetPgbackrestEnvVars(cluster.Labels[config.LABEL_BACKREST], replica.Spec.ClusterName, replica.Spec.Name,
 			cluster.Spec.Port, cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE]),
-		PgbackrestS3EnvVars: operator.GetPgbackrestS3EnvVars(cluster.Spec.UserLabels, clientset, namespace),
+		PgbackrestS3EnvVars: operator.GetPgbackrestS3EnvVars(cluster.Labels[config.LABEL_BACKREST],
+			cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], clientset, namespace),
 	}
 
 	switch replica.Spec.ReplicaStorage.StorageType {


### PR DESCRIPTION
Right now all user provided options (e.g. flags provided on the PGO command line) are turned into Kubernetes labels, which are then added to the deployment and pod for a PG cluster.  However, certain user options and values that are valid on the command line, are not considered valid Kuberentes labels (e.g. commas are not allowed by Kubernetes, preventing the --pgbackrest-storage-type option, which is comma-separated, from being used as a label).  This results in PG deployment and pod failures when PGO attempts to create deployments and pods containing these labels.

This change prevents any user labels from being set as deployment and pod labels if the label does not meet the requirements for a Kubernetes label.  This will prevent deployment failures when user labels that do not conform to Kubernetes requirements are utilized, e.g. when the comma-separated --pgbackrest-storage-type option is used.  The user labels will instead  be tracked in the pgcluster cluster, which is the authoritative source for cluster configuration.

Also updated the labels used to determine if pgBackRest is enabled and therefore if AWS S3 storage for pgBackRest should be enabled.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
PGO attempts to add all user labels as labels for the pg cluster deployment and pods, resulting in errors if the user label does not conform to Kubernetes label requirements.  For instance, if value "local,s3" is specified for --pgbackrest-storage-type when creating a cluster, the deployment will fail since Kubernetes does not allow commas in label values.

[ch3277]

**What is the new behavior (if this is a feature change)?**
User labels that do not conform to Kubernetes label requirements are not added as labels to the PG deployment and pod.


**Other information**:
N/A