### PR TITLE
Add Missing Shorthand Flags for pg_dumpall Backup Option Validation

### DIFF
--- a/apiserver/backupoptions/pgdumpoptions.go
+++ b/apiserver/backupoptions/pgdumpoptions.go
@@ -76,13 +76,13 @@ type pgDumpAllOptions struct {
 	DataOnly                   bool   `flag:"data-only" flag-short:"a"`
 	Clean                      bool   `flag:"clean" flag-short:"c"`
 	Encoding                   string `flag:"encoding" flag-short:"E"`
-	GlobalsOnly                bool   `flag:"globals-only"`
+	GlobalsOnly                bool   `flag:"globals-only" flag-short:"g"`
 	Oids                       bool   `flag:"oids" flag-short:"o"`
 	NoOwner                    bool   `flag:"no-owner" flag-short:"O"`
-	RolesOnly                  bool   `flag:"roles-only"`
+	RolesOnly                  bool   `flag:"roles-only" flag-short:"r"`
 	SchemaOnly                 bool   `flag:"schema-only" flag-short:"s"`
 	SuperUser                  string `flag:"superuser" flag-short:"S"`
-	TablespacesOnly            bool   `flag:"tablespaces-only"`
+	TablespacesOnly            bool   `flag:"tablespaces-only" flag-short:"t"`
 	Verbose                    bool   `flag:"verbose" flag-short:"v"`
 	NoPrivileges               bool   `flag:"no-privileges" flag-short:"x"`
 	NoACL                      bool   `flag:"no-acl"`


### PR DESCRIPTION
Added missing shorthand flags for the following pg_dumpall options, which are used to validate any backup options provided when peforming a backup with pg_dumpall:

- -g (--globals-only)
- -r (--roles-only)
- -t (--tablespaces-only)

This will ensure the user can utilize the shorthand version of these flags when performing a backup.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
An error is thrown when the following options are specified for a pg_dumpall backup, forcing the use of the long version of the option:

- -g
- -r
- -t

[ch3472]

**What is the new behavior (if this is a feature change)?**
The following shorthand options can now be specified when performing a pg_dumpall backup:

- -g
- -r
- -t

**Other information**:
N/A