### PR TITLE
Fix missing --selector option on pgo create pgbouncer command

### DIFF
--- a/hugo/content/operatorcli/pgo-overview.md
+++ b/hugo/content/operatorcli/pgo-overview.md
@@ -316,6 +316,7 @@ To add a pgbouncer Deployment to your Postgres cluster, enter:
 You can add pgbouncer after a Postgres cluster is created as follows:
 
     pgo create pgbouncer mycluster
+	pgo create pgbouncer --selector=name=mycluster
 
 You can also specify a pgbouncer password as follows:
 

--- a/pgo/cmd/create.go
+++ b/pgo/cmd/create.go
@@ -287,4 +287,6 @@ func init() {
 
 	// createPgbouncerCmd.Flags().StringVarP(&PgBouncerUser, "pgbouncer-user", "", "", "Username for the crunchy-pgboucer deployment, default is 'pgbouncer'.")
 	createPgbouncerCmd.Flags().StringVarP(&PgBouncerPassword, "pgbouncer-pass", "", "", "Password for the pgbouncer user of the crunchy-pgboucer deployment.")
+	createPgbouncerCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+
 }


### PR DESCRIPTION
**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
pgo create pgbouncer does not recognize the --selector option. It appears to have been removed unintentionally.


**What is the new behavior (if this is a feature change)?**
pgo create pgbouncer --selector=name=mycluster will add pgbouncer to cluster(s) matching selector


**Other information**:
[ch3179]