### PR TITLE
Return stdout/stderr when exec errors

### DIFF
--- a/kubeapi/exec.go
+++ b/kubeapi/exec.go
@@ -74,7 +74,7 @@ func ExecToPodThroughAPI(config *rest.Config, clientset *kubernetes.Clientset, c
 	})
 	if err != nil {
 		log.Error(err)
-		return "", "", err
+		return stdout.String(), stderr.String(), err
 	}
 
 	return stdout.String(), stderr.String(), nil


### PR DESCRIPTION
If an error occurred during an exec we are returning empty strings instead of stdout and stderr .  The error captured in `err` is very generic, `stderr` contains the actual error.