### PR TITLE
Update doc title sections, fix broken links

### DIFF
--- a/ansible/inventory
+++ b/ansible/inventory
@@ -102,7 +102,6 @@ backrest_storage='storage1'
 backup_storage='storage1'
 primary_storage='storage2'
 replica_storage='storage3'
-xlog_storage='storage1'
 
 storage1_access_mode='ReadWriteMany'
 storage1_size='1G'

--- a/hugo/content/Installation/install-with-ansible/installation/_index.md
+++ b/hugo/content/Installation/install-with-ansible/installation/_index.md
@@ -1,6 +1,0 @@
----
-title: "Installation"
-date:
-draft: false
-weight: 3
----

--- a/hugo/content/Installation/install-with-ansible/installing-ansible.md
+++ b/hugo/content/Installation/install-with-ansible/installing-ansible.md
@@ -2,7 +2,7 @@
 title: "Installing Ansible"
 date:
 draft: false
-weight: 30
+weight: 20
 ---
 
 ## Installing Ansible on Linux, MacOS or Windows Ubuntu Subsystem

--- a/hugo/content/Installation/install-with-ansible/installing-metrics.md
+++ b/hugo/content/Installation/install-with-ansible/installing-metrics.md
@@ -2,24 +2,25 @@
 title: "Installing Metrics Stack"
 date:
 draft: false
-weight: 40
+weight: 22
 ---
 
 # Installing
 
-The following assumes the proper [prerequisites are satisfied](/getting-started/prerequisites)
-we can now install the Grafana and Prometheus services.
+The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prereq/prerequisites/)
+we can now install the PostgreSQL Operator.
+
+The commands should be run in the directory where the Crunchy PostgreSQL Operator
+playbooks is stored.  See the `ansible` directory in the Crunchy PostgreSQL Operator
+project for the inventory file, main playbook and ansible roles.
 
 ## Installing on Linux
 
 On a Linux host with Ansible installed we can run the following command to install 
 the Metrics stack:
 
-The following command should be run from the directory where the
-`postgres-operator-playbooks` project is located:
-
 ```bash
-ansible-playbook -i /path/to/inventory main.yml --tags=install-metrics
+ansible-playbook -i /path/to/inventory --tags=install-metrics main.yml
 ```
 
 ## Installing on MacOS
@@ -27,11 +28,8 @@ ansible-playbook -i /path/to/inventory main.yml --tags=install-metrics
 On a MacOS host with Ansible installed we can run the following command to install 
 the Metrics stack:
 
-The following command should be run from the directory where the
-`postgres-operator-playbooks` project is located:
-
 ```bash
-ansible-playbook -i /path/to/inventory main.yml --tags=install-metrics
+ansible-playbook -i /path/to/inventory --tags=install-metrics main.yml
 ```
 
 ## Installing on Windows
@@ -39,11 +37,8 @@ ansible-playbook -i /path/to/inventory main.yml --tags=install-metrics
 On a Windows host with the Ubuntu subsystem we can run the following commands to install 
 the Metrics stack:
 
-The following command should be run from the directory where the
-`postgres-operator-playbooks` project is located:
-
 ```bash
-ansible-playbook -i /path/to/inventory main.yml --tags=install-metrics
+ansible-playbook -i /path/to/inventory --tags=install-metrics main.yml
 ```
 
 ## Verifying the Installation

--- a/hugo/content/Installation/install-with-ansible/installing-operator.md
+++ b/hugo/content/Installation/install-with-ansible/installing-operator.md
@@ -1,55 +1,47 @@
 ---
-title: "Updating PostgreSQL Operator"
+title: "Installing PostgreSQL Operator"
 date:
 draft: false
-weight: 50
+weight: 21
 ---
 
-# Updating
+# Installing
 
-Updating the Crunchy PostgreSQL Operator is essential to the lifecycle management 
-of the service.  Using the `update` flag will:
+The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prereq/prerequisites/)
+we can now install the PostgreSQL Operator.
 
-* Update and redeploy the operator deployment
-* Recreate configuration maps used by operator
-* Remove any deprecated objects
-* Allow administrators to change settings configured in the `inventory`
-
-The following assumes the proper [prerequisites are satisfied](/getting-started/prerequisites)
-we can now update the PostgreSQL Operator.
-
-The commands should be run in the directory where the Crunchy PostgreSQL Operator 
-playbooks is stored.  See the `ansible` directory in the Crunchy PostgreSQL Operator 
+The commands should be run in the directory where the Crunchy PostgreSQL Operator
+playbooks is stored.  See the `ansible` directory in the Crunchy PostgreSQL Operator
 project for the inventory file, main playbook and ansible roles.
 
-## Updating on Linux
+## Installing on Linux
 
-On a Linux host with Ansible installed we can run the following command to update  
+On a Linux host with Ansible installed we can run the following command to install 
 the PostgreSQL Operator:
 
 ```bash
-ansible-playbook -i /path/to/inventory main.yml --tags=update --ask-become-pass
+ansible-playbook -i /path/to/inventory --tags=install --ask-become-pass main.yml
 ```
 
-## Updating on MacOS
+## Installing on MacOS
 
-On a MacOS host with Ansible installed we can run the following command to update  
+On a MacOS host with Ansible installed we can run the following command to install
 the PostgreSQL Operator.
 
 ```bash
-ansible-playbook -i /path/to/inventory main.yml --tags=update --ask-become-pass
+ansible-playbook -i /path/to/inventory --tags=install --ask-become-pass main.yml
 ```
 
-## Updating on Windows Ubuntu Subsystem
+## Installing on Windows Ubuntu Subsystem
 
-On a Windows host with an Ubuntu subsystem we can run the following commands to update  
+On a Windows host with an Ubuntu subsystem we can run the following commands to install 
 the PostgreSQL Operator.
 
 ```bash
-ansible-playbook -i /path/to/inventory main.yml --tags=update --ask-become-pass
+ansible-playbook -i /path/to/inventory --tags=install --ask-become-pass main.yml
 ```
 
-## Verifying the Update
+## Verifying the Installation
 
 This may take a few minutes to deploy.  To check the status of the deployment run 
 the following:
@@ -66,7 +58,7 @@ oc get pods -n <NAMESPACE_NAME>
 
 ## Configure Environment Variables
 
-After the Crunchy PostgreSQL Operator has successfully been updated we will need 
+After the Crunchy PostgreSQL Operator has successfully been installed we will need 
 to configure local environment variables before using the `pgo` client.
 
 To configure the environment variables used by `pgo` run the following command:
@@ -111,4 +103,4 @@ pgo version
 ```
 
 If the above command outputs versions of both the client and API server, the Crunchy 
-PostgreSQL Operator has been updated successfully.
+PostgreSQL Operator has been installed successfully.

--- a/hugo/content/Installation/install-with-ansible/prereq/_index.md
+++ b/hugo/content/Installation/install-with-ansible/prereq/_index.md
@@ -1,6 +1,0 @@
----
-title: "Prerequiste"
-date:
-draft: false
-weight: 2
----

--- a/hugo/content/Installation/install-with-ansible/prerequisites.md
+++ b/hugo/content/Installation/install-with-ansible/prerequisites.md
@@ -2,7 +2,7 @@
 title: "Prerequisites"
 date:
 draft: false
-weight: 20
+weight: 10
 ---
 
 # Prerequisites
@@ -85,6 +85,7 @@ The following are the variables available for configuration:
 | `log_statement`                   | none        | Set to `none`, `ddl`, `mod`, or `all` to configure the statements that will be logged in PostgreSQL's logs on all newly created clusters.                                        |
 | `metrics`                         | false       | Set to true enable performance metrics on all newly created clusters.                                                                                                            |
 | `metrics_namespace`               | metrics     | Configures the target namespace when deploying Grafana and/or Prometheus                                                                                                         |
+| `namespace`                       |             | Set to a comma delimited string of all the namespaces Operator will manage.                                                                                                      |
 | `openshift_host`                  |             | When deploying to OpenShift, set to configure the hostname of the OpenShift cluster to connect to.                                                                               |
 | `openshift_password`              |             | When deploying to OpenShift, set to configure the password used for login.                                                                                                       |
 | `openshift_skip_tls_verify`       |             | When deploying to Openshift, set to ignore the integrity of TLS certificates for the OpenShift cluster.                                                                          |
@@ -111,9 +112,7 @@ The following are the variables available for configuration:
 | `storage<ID>_size`                |             | Set to configure the size of the volumes created when using this storage definition.                                                                                             |
 | `storage<ID>_supplemental_groups` |             | Set to configure any supplemental groups that should be added to security contexts on newly created clusters.                                                                    |
 | `storage<ID>_type`                |             | Set to either `create` or `dynamic` to configure the operator to create persistent volumes or have them created dynamically by a storage class.                                  |
-| `namespace`               |             | Set to a comma delimited string of all the namespaces Operator will manage.                                                                                                      |
 | `xlog_storage`                    | storage1    | Set to configure which storage definition to use when creating volumes used to store Write Ahead Logs (WAL) archives on all newly created clusters.                              |
-
 
 {{% notice tip %}}
 To retrieve the `kubernetes_context` value for Kubernetes installs, run the following command:

--- a/hugo/content/Installation/install-with-ansible/prerequisites.md
+++ b/hugo/content/Installation/install-with-ansible/prerequisites.md
@@ -112,7 +112,6 @@ The following are the variables available for configuration:
 | `storage<ID>_size`                |             | Set to configure the size of the volumes created when using this storage definition.                                                                                             |
 | `storage<ID>_supplemental_groups` |             | Set to configure any supplemental groups that should be added to security contexts on newly created clusters.                                                                    |
 | `storage<ID>_type`                |             | Set to either `create` or `dynamic` to configure the operator to create persistent volumes or have them created dynamically by a storage class.                                  |
-| `xlog_storage`                    | storage1    | Set to configure which storage definition to use when creating volumes used to store Write Ahead Logs (WAL) archives on all newly created clusters.                              |
 
 {{% notice tip %}}
 To retrieve the `kubernetes_context` value for Kubernetes installs, run the following command:

--- a/hugo/content/Installation/install-with-ansible/uninstall/_index.md
+++ b/hugo/content/Installation/install-with-ansible/uninstall/_index.md
@@ -1,6 +1,0 @@
----
-title: "Uninstall"
-date:
-draft: false
-weight: 4
----

--- a/hugo/content/Installation/install-with-ansible/uninstalling-metrics.md
+++ b/hugo/content/Installation/install-with-ansible/uninstalling-metrics.md
@@ -2,13 +2,13 @@
 title: "Uninstalling Metrics Stack"
 date:
 draft: false
-weight: 50
+weight: 41
 ---
 
 # Uninstalling the Metrics Stack
 
-The following assumes the proper [prerequisites are satisfied](/getting-started/prerequisites)
-we can now deprovision the PostgreSQL Operator.
+The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prereq/prerequisites/)
+we can now deprovision the PostgreSQL Operator Metrics Infrastructure.
 
 First, it is recommended to use the playbooks tagged with the same version
 of the Metrics stack currently deployed.
@@ -17,5 +17,5 @@ With the correct playbooks acquired and prerequisites satisfied, simply run
 the following command:
 
 ```bash
-ansible-playbook -i /path/to/inventory main.yml --tags=deprovision-metrics
+ansible-playbook -i /path/to/inventory --tags=deprovision-metrics main.yml
 ```

--- a/hugo/content/Installation/install-with-ansible/uninstalling-operator.md
+++ b/hugo/content/Installation/install-with-ansible/uninstalling-operator.md
@@ -2,12 +2,12 @@
 title: "Uninstalling PostgreSQL Operator"
 date:
 draft: false
-weight: 50
+weight: 40
 ---
 
 # Uninstalling PostgreSQL Operator
 
-The following assumes the proper [prerequisites are satisfied](/getting-started/prerequisites)
+The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prereq/prerequisites/)
 we can now deprovision the PostgreSQL Operator.
 
 First, it is recommended to use the playbooks tagged with the same version
@@ -17,7 +17,7 @@ With the correct playbooks acquired and prerequisites satisfied, simply run
 the following command:
 
 ```bash
-ansible-playbook -i /path/to/inventory main.yml --tags=deprovision
+ansible-playbook -i /path/to/inventory --tags=deprovision main.yml
 ```
 
 ## Deleting `pgo` Client

--- a/hugo/content/Installation/install-with-ansible/updating-operator.md
+++ b/hugo/content/Installation/install-with-ansible/updating-operator.md
@@ -1,47 +1,55 @@
 ---
-title: "Installing PostgreSQL Operator"
+title: "Updating PostgreSQL Operator"
 date:
 draft: false
-weight: 40
+weight: 30
 ---
 
-# Installing
+# Updating
 
-The following assumes the proper [prerequisites are satisfied](/getting-started/prerequisites)
-we can now install the PostgreSQL Operator.
+Updating the Crunchy PostgreSQL Operator is essential to the lifecycle management 
+of the service.  Using the `update` flag will:
 
-The commands should be run in the directory where the Crunchy PostgreSQL Operator
-playbooks is stored.  See the `ansible` directory in the Crunchy PostgreSQL Operator
+* Update and redeploy the operator deployment
+* Recreate configuration maps used by operator
+* Remove any deprecated objects
+* Allow administrators to change settings configured in the `inventory`
+
+The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prereq/prerequisites/)
+we can now update the PostgreSQL Operator.
+
+The commands should be run in the directory where the Crunchy PostgreSQL Operator 
+playbooks is stored.  See the `ansible` directory in the Crunchy PostgreSQL Operator 
 project for the inventory file, main playbook and ansible roles.
 
-## Installing on Linux
+## Updating on Linux
 
-On a Linux host with Ansible installed we can run the following command to install 
+On a Linux host with Ansible installed we can run the following command to update  
 the PostgreSQL Operator:
 
 ```bash
-ansible-playbook -i /path/to/inventory main.yml --tags=install --ask-become-pass
+ansible-playbook -i /path/to/inventory --tags=update --ask-become-pass main.yml
 ```
 
-## Installing on MacOS
+## Updating on MacOS
 
-On a MacOS host with Ansible installed we can run the following command to install
+On a MacOS host with Ansible installed we can run the following command to update  
 the PostgreSQL Operator.
 
 ```bash
-ansible-playbook -i /path/to/inventory main.yml --tags=install --ask-become-pass
+ansible-playbook -i /path/to/inventory --tags=update --ask-become-pass main.yml
 ```
 
-## Installing on Windows Ubuntu Subsystem
+## Updating on Windows Ubuntu Subsystem
 
-On a Windows host with an Ubuntu subsystem we can run the following commands to install 
+On a Windows host with an Ubuntu subsystem we can run the following commands to update  
 the PostgreSQL Operator.
 
 ```bash
-ansible-playbook -i /path/to/inventory main.yml --tags=install --ask-become-pass
+ansible-playbook -i /path/to/inventory --tags=update --ask-become-pass main.yml
 ```
 
-## Verifying the Installation
+## Verifying the Update
 
 This may take a few minutes to deploy.  To check the status of the deployment run 
 the following:
@@ -58,7 +66,7 @@ oc get pods -n <NAMESPACE_NAME>
 
 ## Configure Environment Variables
 
-After the Crunchy PostgreSQL Operator has successfully been installed we will need 
+After the Crunchy PostgreSQL Operator has successfully been updated we will need 
 to configure local environment variables before using the `pgo` client.
 
 To configure the environment variables used by `pgo` run the following command:
@@ -103,4 +111,4 @@ pgo version
 ```
 
 If the above command outputs versions of both the client and API server, the Crunchy 
-PostgreSQL Operator has been installed successfully.
+PostgreSQL Operator has been updated successfully.

--- a/hugo/content/Installation/operator-install.md
+++ b/hugo/content/Installation/operator-install.md
@@ -1,8 +1,8 @@
 ---
-title: "Operator Installation"
+title: "Install Operator Using Bash"
 date:
 draft: false
-weight: 301
+weight: 300
 ---
 
 A full installation of the Operator includes the following steps:


### PR DESCRIPTION
Installation titles have been changed to: _Install Operator Using Bash_ and _Install Operator Using Ansible_

Fixed broken links for prereqs and updated commands to separate inventory and main playbook for better error handling.

Removed unused `xlog_storage` vars as they've been removed in 4.0.

[CH3491]
[CH3492]
[CH3503]