### PR TITLE
Add no_log to metrics namespace check

### DIFF
--- a/ansible/roles/pgo-metrics/tasks/kubernetes.yml
+++ b/ansible/roles/pgo-metrics/tasks/kubernetes.yml
@@ -3,6 +3,7 @@
   shell: "kubectl get namespace {{ metrics_namespace }}" 
   register: namespace_details
   ignore_errors: yes
+  no_log: true
   tags: install-metrics
 
 - name: Create Namespace {{ metrics_namespace }}

--- a/ansible/roles/pgo-metrics/tasks/openshift.yml
+++ b/ansible/roles/pgo-metrics/tasks/openshift.yml
@@ -3,6 +3,7 @@
   shell: "{{ openshift_oc_bin}} get project {{ metrics_namespace }}"
   register: namespace_details
   ignore_errors: yes
+  no_log: true
   tags: install-metrics
 
 - name: Create Project {{ metrics_namespace }}


### PR DESCRIPTION
Namespace check was outputting an error (although ignored) if it didn't exist - added `no_log=true` as this is just a pre-check for creating the missing namespace.

[CH3580]