### PR TITLE
Limit pgo-backrest-role to required namespaces

### DIFF
--- a/ansible/inventory
+++ b/ansible/inventory
@@ -30,7 +30,10 @@ crunchy_debug='false'
 # The following settings configure the Crunchy PostgreSQL Operator 
 # functionality.
 # ===================
-pgo_client_install='true'
+
+# PGO Admin Credentials
+pgo_admin_username='admin'
+pgo_admin_password=''
 
 # Namespace where operator will be deployed
 # NOTE: Ansible will create namespaces that don't exist
@@ -39,13 +42,6 @@ pgo_operator_namespace='pgo'
 # Comma separated list of namespaces Operator will manage
 # NOTE: Ansible will create namespaces that don't exist
 namespace='pgo'
-
-# PGO Admin Credentials
-pgo_admin_username='admin'
-pgo_admin_password=''
-
-# PGO TLS
-pgo_tls_no_verify='false'
 
 # Crunchy Container Suite images to use. The tags centos7 and rhel7 are acceptable.
 # CentOS7 images can be found in dockerhub: https://hub.docker.com/u/crunchydata
@@ -56,6 +52,12 @@ ccp_image_tag='centos7-11.2-2.4.0'
 # Crunchy PostgreSQL Operator images to use.  The tags centos7 and rhel7 are acceptable.
 pgo_image_prefix='crunchydata'
 pgo_image_tag='centos7-4.0.0'
+
+# PGO Client Install
+pgo_client_install='true'
+
+# PGO TLS
+pgo_tls_no_verify='false'
 
 # This will set default enhancements for operator deployed PostgreSQL clusters
 auto_failover='false'
@@ -96,25 +98,6 @@ db_password_length=20
 db_port=5432
 db_replicas=0
 db_user='testuser'
-
-# ==================
-# Metrics
-# ==================
-# Optional installation of Grafana and Prometheus optimized 
-# to work with the Crunchy PostgreSQL Operator
-metrics_namespace='metrics'
-
-grafana_install='true'
-grafana_admin_username='admin'
-grafana_admin_password=''
-#grafana_storage_access_mode='ReadWriteOnce'
-#grafana_storage_class_name='fast'
-#grafana_volume_size='1G'
-
-prometheus_install='true'
-#prometheus_storage_access_mode='ReadWriteOnce'
-#prometheus_storage_class_name='fast'
-#prometheus_volume_size='1G'
 
 # ==================
 # Storage Settings

--- a/ansible/roles/pgo-operator/tasks/cleanup.yml
+++ b/ansible/roles/pgo-operator/tasks/cleanup.yml
@@ -55,7 +55,9 @@
 
 - name: Delete existing Service Account
   shell: |
-    {{ kubectl_or_oc }} delete serviceaccount postgres-operator -n {{ pgo_operator_namespace }}
+    {{ kubectl_or_oc }} delete serviceaccount postgres-operator -n {{ item }}
+  with_items:
+  - "{{ all_namespaces }}"
   ignore_errors: yes
   no_log: false
   tags:
@@ -66,7 +68,7 @@
   shell: |
     {{ kubectl_or_oc }} delete serviceaccount pgo-backrest -n {{ item }}
   with_items:
-  - "{{ all_namespaces }}"
+  - "{{ namespace.split(',') }}"
   ignore_errors: yes
   no_log: false
   tags:
@@ -99,18 +101,18 @@
   - deprovision
   - update
 
-- name: Delete existing Role Binding
+- name: Delete existing Backrest Role Binding
   shell: |
     {{ kubectl_or_oc }} delete rolebinding pgo-backrest-role-binding -n {{ item }}
   with_items:
-  - "{{ all_namespaces }}"
+  - "{{ namespace.split(',') }}"
   ignore_errors: yes
   no_log: false
   tags:
   - deprovision
   - update
 
-- name: Delete existing Role Binding
+- name: Delete existing PGO Role Binding
   shell: |
     {{ kubectl_or_oc }} delete rolebinding pgo-role-binding -n {{ item }}
   with_items:
@@ -121,18 +123,18 @@
   - deprovision
   - update
 
-- name: Delete existing Role
+- name: Delete existing Backrest Role
   shell: |
     {{ kubectl_or_oc }} delete role pgo-backrest-role -n {{ item }}
   with_items:
-  - "{{ all_namespaces }}"
+  - "{{ namespace.split(',') }}"
   ignore_errors: yes
   no_log: false
   tags:
   - deprovision
   - update
 
-- name: Delete existing Role
+- name: Delete existing PGO Role
   shell: |
     {{ kubectl_or_oc }} delete role pgo-role -n {{ item }}
   with_items:
@@ -145,7 +147,7 @@
 
 - name: Delete existing Custom Objects
   shell: |
-    {{ kubectl_or_oc }} delete pgbackups,pgclusters,pgpolicies,pgreplicas,pgtasks -n {{ pgo_operator_namespace }} --all
+    {{ kubectl_or_oc }} delete pgbackups,pgclusters,pgpolicies,pgreplicas,pgtasks -n {{ item }} --all
   with_items:
   - "{{ all_namespaces }}"
   ignore_errors: yes

--- a/ansible/roles/pgo-operator/tasks/main.yml
+++ b/ansible/roles/pgo-operator/tasks/main.yml
@@ -82,17 +82,32 @@
     
     - name: Template PGO RBAC
       template:
-        src: rbac.yaml.j2
-        dest: "{{ output_dir }}/rbac-{{ item }}.yaml"
+        src: pgo-role-rbac.yaml.j2
+        dest: "{{ output_dir }}/pgo-role-rbac-{{ item }}.yaml"
         mode: '0600'
       with_items: 
       - "{{ all_namespaces }}"
       tags: [install, update]
 
     - name: Create PGO RBAC
-      command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/rbac-{{ item }}.yaml"
+      command: "{{ kubectl_or_oc }} create -f {{ output_dir }}//pgo-role-rbac-{{ item }}.yaml"
       with_items: 
       - "{{ all_namespaces }}"
+      tags: [install, update]
+
+    - name: Template PGO Backrest RBAC
+      template:
+        src: pgo-backrest-role-rbac.yaml.j2
+        dest: "{{ output_dir }}/pgo-backrest-role-rbac-{{ item }}.yaml"
+        mode: '0600'
+      with_items:
+      - "{{ namespace.split(',') }}"
+      tags: [install, update]
+
+    - name: Create PGO Backrest RBAC
+      command: "{{ kubectl_or_oc }} create -f {{ output_dir }}//pgo-backrest-role-rbac-{{ item }}.yaml"
+      with_items:
+      - "{{ namespace.split(',') }}"
       tags: [install, update]
 
     - name: Template PGO User

--- a/ansible/roles/pgo-operator/templates/pgo-backrest-role-rbac.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/pgo-backrest-role-rbac.yaml.j2
@@ -1,0 +1,33 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: pgo-backrest-role
+  namespace: {{ item }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pgo-backrest
+  namespace: {{ item }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: pgo-backrest-role-binding
+  namespace: {{ item }}
+subjects:
+- kind: ServiceAccount
+  name: pgo-backrest
+  namespace: {{ item }}
+roleRef:
+  kind: Role
+  name: pgo-backrest-role
+  apiGroup: rbac.authorization.k8s.io

--- a/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
@@ -44,36 +44,3 @@ roleRef:
   kind: Role
   name: pgo-role
   apiGroup: rbac.authorization.k8s.io
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: pgo-backrest-role
-  namespace: {{ item }}
-rules:
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "list"]
-- apiGroups: [""]
-  resources: ["pods/exec"]
-  verbs: ["create"]
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: pgo-backrest
-  namespace: {{ item }}
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: pgo-backrest-role-binding
-  namespace: {{ item }}
-subjects:
-- kind: ServiceAccount
-  name: pgo-backrest
-  namespace: {{ item }}
-roleRef:
-  kind: Role
-  name: pgo-backrest-role
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
`pgo-backrest-role` was being created in all namespaces (operator + targets) instead of just targets.

Removed duplicate metrics block in inventory file.

[CH3502]