### PR TITLE
Add playbooks RPM install instructions

### DIFF
--- a/ansible/roles/pgo-metrics/tasks/grafana.yml
+++ b/ansible/roles/pgo-metrics/tasks/grafana.yml
@@ -6,7 +6,7 @@
 
 - name: Set output directory fact
   set_fact:
-    grafana_output_dir: "./output/{{ metrics_namespace }}"
+    grafana_output_dir: "{{ ansible_env.HOME }}/.pgo/{{ metrics_namespace }}/output"
   tags: always
 
 - name: Ensure output directory exists

--- a/ansible/roles/pgo-metrics/tasks/prometheus.yml
+++ b/ansible/roles/pgo-metrics/tasks/prometheus.yml
@@ -6,7 +6,7 @@
 
 - name: Set output directory fact
   set_fact:
-    prom_output_dir: "./output/{{ metrics_namespace }}"
+    prom_output_dir: "{{ ansible_env.HOME }}/.pgo/{{ metrics_namespace }}/output"
   tags: always
 
 - name: Ensure output directory exists

--- a/ansible/roles/pgo-operator/tasks/main.yml
+++ b/ansible/roles/pgo-operator/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Set output directory fact
   set_fact:
-    output_dir: "./output/{{ pgo_operator_namespace }}"
+    output_dir: "{{ ansible_env.HOME }}/.pgo/{{ pgo_operator_namespace }}/output"
   tags: always
 
 - name: Ensure output directory exists

--- a/hugo/content/Installation/install-with-ansible/installing-metrics.md
+++ b/hugo/content/Installation/install-with-ansible/installing-metrics.md
@@ -67,6 +67,16 @@ the Metrics stack:
 ansible-playbook -i /path/to/inventory --tags=install-metrics main.yml
 ```
 
+If the Crunchy PostgreSQL Operator playbooks were installed using `yum`, use the
+following commands:
+
+```bash
+export ANSIBLE_ROLES_PATH=/usr/share/ansible/roles/crunchydata
+
+ansible-playbook -i /path/to/inventory --tags=install-metrics --ask-become-pass \
+    /usr/share/ansible/postgres-operator/playbooks/main.yml
+```
+
 ## Installing on MacOS
 
 On a MacOS host with Ansible installed we can run the following command to install 

--- a/hugo/content/Installation/install-with-ansible/installing-operator.md
+++ b/hugo/content/Installation/install-with-ansible/installing-operator.md
@@ -23,6 +23,16 @@ the PostgreSQL Operator:
 ansible-playbook -i /path/to/inventory --tags=install --ask-become-pass main.yml
 ```
 
+If the Crunchy PostgreSQL Operator playbooks were installed using `yum`, use the 
+following commands:
+
+```bash
+export ANSIBLE_ROLES_PATH=/usr/share/ansible/roles/crunchydata
+
+ansible-playbook -i /path/to/inventory --tags=install --ask-become-pass \
+    /usr/share/ansible/postgres-operator/playbooks/main.yml
+```
+
 ## Installing on MacOS
 
 On a MacOS host with Ansible installed we can run the following command to install

--- a/hugo/content/Installation/install-with-ansible/prerequisites.md
+++ b/hugo/content/Installation/install-with-ansible/prerequisites.md
@@ -42,6 +42,42 @@ can install:
 * Cluster RBAC
 * Create required namespaces
 
+## Obtaining Operator Ansible Role
+
+There are two ways to obtain the Crunchy PostgreSQL Operator Roles:
+
+* Cloning the [postgres-operator project](https://github.com/CrunchyData/postgres-operator)
+* `postgres-operator-playbooks` RPM provided for Crunchy customers via the [Crunchy Access Portal](https://access.crunchydata.com/).
+
+### GitHub Installation
+
+All necessary files (inventory, main playbook and roles) can be found in the `ansible` 
+directory in the  [postgres-operator project](https://github.com/CrunchyData/postgres-operator).
+
+### RPM Installation using Yum
+
+Available to Crunchy customers is an RPM containing all the necessary Ansible roles 
+and files required for installation using Ansible.  The RPM can be found in Crunchy's 
+yum repository.  For information on setting up `yum` to use the Crunchy repoistory, 
+see the [Crunchy Access Portal](https://access.crunchydata.com/).
+
+To install the Crunchy PostgreSQL Operator Ansible roles using `yum`, run the following 
+command on a RHEL or CentOS host:
+
+```bash
+sudo yum install postgres-operator-playbooks
+```
+
+* Ansible roles can be found in: `/usr/share/ansible/roles/crunchydata`
+* Ansible playbooks/inventory files can be found in: `/usr/share/ansible/postgres-operator/playbooks`
+
+Once installed users should take a copy of the `inventory` file included in the installation 
+using the following command:
+
+```bash
+cp /usr/share/ansible/postgres-operator/playbooks/inventory ${HOME?}
+```
+
 ## Configuring the Inventory File
 
 The `inventory` file included with the PostgreSQL Operator Playbooks allows installers 
@@ -287,7 +323,7 @@ over time.  The collectors included by the operator are:
 * Node Exporter - Host metrics where the PostgreSQL containers are running
 * PostgreSQL Exporter - PostgreSQL metrics
 
-The operator, however, does not install the neccessary timeseries database (Prometheus) for storing the collected 
+The operator, however, does not install the necessary timeseries database (Prometheus) for storing the collected 
 metrics or the front end visualization (Grafana) of those metrics.
 
 Included in these playbooks are roles for deploying Granfana and/or Prometheus.  See the `inventory` file 

--- a/hugo/content/Installation/install-with-ansible/uninstalling-metrics.md
+++ b/hugo/content/Installation/install-with-ansible/uninstalling-metrics.md
@@ -19,3 +19,13 @@ the following command:
 ```bash
 ansible-playbook -i /path/to/inventory --tags=deprovision-metrics main.yml
 ```
+
+If the Crunchy PostgreSQL Operator playbooks were installed using `yum`, use the
+following commands:
+
+```bash
+export ANSIBLE_ROLES_PATH=/usr/share/ansible/roles/crunchydata
+
+ansible-playbook -i /path/to/inventory --tags=deprovision-metrics \
+    /usr/share/ansible/postgres-operator/playbooks/main.yml
+```

--- a/hugo/content/Installation/install-with-ansible/uninstalling-operator.md
+++ b/hugo/content/Installation/install-with-ansible/uninstalling-operator.md
@@ -20,6 +20,16 @@ the following command:
 ansible-playbook -i /path/to/inventory --tags=deprovision main.yml
 ```
 
+If the Crunchy PostgreSQL Operator playbooks were installed using `yum`, use the
+following commands:
+
+```bash
+export ANSIBLE_ROLES_PATH=/usr/share/ansible/roles/crunchydata
+
+ansible-playbook -i /path/to/inventory --tags=deprovision \
+    /usr/share/ansible/postgres-operator/playbooks/main.yml
+```
+
 ## Deleting `pgo` Client
 
 To remove the `pgo` client, simply run the following command:

--- a/hugo/content/Installation/install-with-ansible/updating-operator.md
+++ b/hugo/content/Installation/install-with-ansible/updating-operator.md
@@ -31,6 +31,16 @@ the PostgreSQL Operator:
 ansible-playbook -i /path/to/inventory --tags=update --ask-become-pass main.yml
 ```
 
+If the Crunchy PostgreSQL Operator playbooks were installed using `yum`, use the
+following commands:
+
+```bash
+export ANSIBLE_ROLES_PATH=/usr/share/ansible/roles/crunchydata
+
+ansible-playbook -i /path/to/inventory --tags=update --ask-become-pass \
+    /usr/share/ansible/postgres-operator/playbooks/main.yml
+```
+
 ## Updating on MacOS
 
 On a MacOS host with Ansible installed we can run the following command to update  


### PR DESCRIPTION
Instructions to install the Crunchy RPM for the operator playbooks added to the documentation.  Adjusted some variables in the roles to support the 

[CH3469]