### PR TITLE
Fix timeout when creating authorizations for pgbouncer

### DIFF
--- a/controller/podcontroller.go
+++ b/controller/podcontroller.go
@@ -209,7 +209,8 @@ func (c *PodController) checkReadyStatus(oldpod, newpod *apiv1.Pod, cluster *crv
 
 					// if this is a pgbouncer enabled cluster, add authorizations to the database.
 					if cluster.Labels[config.LABEL_PGBOUNCER] == "true" {
-						taskoperator.UpdatePgBouncerAuthorizations(clusterName, c.PodClientset, c.PodClient, newpod.ObjectMeta.Namespace)
+						taskoperator.UpdatePgBouncerAuthorizations(clusterName, c.PodClientset, c.PodClient, newpod.ObjectMeta.Namespace,
+							newpod.Status.PodIP)
 					}
 
 				}

--- a/operator/cluster/pgbouncer.go
+++ b/operator/cluster/pgbouncer.go
@@ -145,7 +145,6 @@ func AddPgbouncerFromTask(clientset *kubernetes.Clientset, restclient *rest.REST
 
 	// add necessary fields from task to the cluster for pgbouncer specifics
 	pgcluster.Spec.UserLabels[config.LABEL_PGBOUNCER_USER] = task.Spec.Parameters[config.LABEL_PGBOUNCER_USER]
-	// pgcluster.Spec.UserLabels[config.LABEL_PGBOUNCER_PASS] = task.Spec.Parameters[config.LABEL_PGBOUNCER_PASS]
 
 	err = AddPgbouncer(clientset, restclient, &pgcluster, namespace, true, true)
 	if err != nil {

--- a/operator/task/pgbouncer.go
+++ b/operator/task/pgbouncer.go
@@ -24,11 +24,11 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"time"
+	//	"time"
 )
 
 // Update authorizations for pgbouncer user in postgres database
-func UpdatePgBouncerAuthorizations(clusterName string, clientset *kubernetes.Clientset, RESTClient *rest.RESTClient, ns string) {
+func UpdatePgBouncerAuthorizations(clusterName string, clientset *kubernetes.Clientset, RESTClient *rest.RESTClient, ns, podIP string) {
 
 	taskName := clusterName + crv1.PgtaskUpdatePgbouncerAuths
 	task := crv1.Pgtask{}
@@ -51,12 +51,8 @@ func UpdatePgBouncerAuthorizations(clusterName string, clientset *kubernetes.Cli
 			log.Debug(err.Error())
 		} else {
 
-			log.Debug("Updating pgbouncer authorization in postgres container - 2 sec wait to prevent timeout")
-
-			// this is needed to allow the service be enabled after the pod goes ready. consider hitting pod directly instead of service.
-			time.Sleep(2 * time.Second)
-
-			err = clusteroperator.UpdatePgBouncerAuthorizations(clientset, ns, username, password, secretName, clusterName)
+			log.Debugf("Updating pgbouncer auth at ip %s", podIP)
+			err = clusteroperator.UpdatePgBouncerAuthorizations(clientset, ns, username, password, secretName, clusterName, podIP)
 
 			if err != nil {
 				log.Debug("Failed to update existing pgbouncer credentials")

--- a/operator/task/pgbouncer.go
+++ b/operator/task/pgbouncer.go
@@ -24,7 +24,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	//	"time"
 )
 
 // Update authorizations for pgbouncer user in postgres database


### PR DESCRIPTION
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Under certain conditions, depending on size of kubernetes cluster and resource utilization at the time of creating a pgcluster, the sql connection to the postgres database through the service would timeout.


**What is the new behavior (if this is a feature change)?**
The authorization code accesses the pod directly, once it is ready, through the pods private cluster ip address. This is only done for when the postgres cluster is created with the --pgbouncer flag. When pgbouncer is added through an existing cluster, the service is used. 


**Other information**:
