### PR TITLE
Update pgBackRest Version to 2.13 in RHEL Images

### DIFF
--- a/rhel7/Dockerfile.pgo-backrest-repo.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-repo.rhel7
@@ -10,7 +10,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgo-backrest-repo" \
 	description="Crunchy Data PostgreSQL Operator - pgo-backrest-repo"
 
-ENV PGVERSION="11" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" BACKREST_VERSION="2.13"
 
 COPY redhat/atomic/pgo_backrest_repo/help.1 /help.1
 COPY redhat/atomic/pgo_backrest_repo/help.md /help.md

--- a/rhel7/Dockerfile.pgo-backrest-restore.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-restore.rhel7
@@ -10,7 +10,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgo-backrest-restore" \
 	description="pgBackRest backrest restore"
 
-ENV PGVERSION="11" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" BACKREST_VERSION="2.13"
 
 COPY redhat/atomic/pgo_backrest_restore/help.1 /help.1
 COPY redhat/atomic/pgo_backrest_restore/help.md /help.md

--- a/rhel7/Dockerfile.pgo-backrest.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest.rhel7
@@ -12,7 +12,7 @@ LABEL name="crunchydata/pgo-backrest-" \
     summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
     description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" BACKREST_VERSION="2.10"
+ENV PGVERSION="11" BACKREST_VERSION="2.13"
 
 # Crunchy Postgres repo
 ADD conf/RPM-GPG-KEY-crunchydata  /


### PR DESCRIPTION
Update pgBackRest version to 2.13 in all RHEL containers with pgBackRest installed.