### PR TITLE
change getsecrets selector to exclude pgo-backrest-repo secrets

### DIFF
--- a/apiserver/common.go
+++ b/apiserver/common.go
@@ -33,7 +33,7 @@ var backrestStorageTypes = []string{"local", "s3"}
 func GetSecrets(cluster *crv1.Pgcluster, ns string) ([]msgs.ShowUserSecret, error) {
 
 	output := make([]msgs.ShowUserSecret, 0)
-	selector := config.LABEL_PGBOUNCER + "!=true," + config.LABEL_PGPOOL + "!=true," + config.LABEL_PG_CLUSTER + "=" + cluster.Spec.Name
+	selector := "!" + config.LABEL_PGO_BACKREST_REPO + "," + config.LABEL_PGBOUNCER + "!=true," + config.LABEL_PGPOOL + "!=true," + config.LABEL_PG_CLUSTER + "=" + cluster.Spec.Name
 
 	secrets, err := kubeapi.GetSecrets(Clientset, selector, ns)
 	if err != nil {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

pgo test  command is including the pgo-backrest-repo Secrets which don't work for pgo test

**What is the new behavior (if this is a feature change)?**

the selector for GetSecrets includes a "!pgo-backrest-repo" exclusion to remove the secret
from the list being processed.

**Other information**:
