### PR TITLE
change pgo show cluster and pgo show policy to accept --all flag inst…

### DIFF
--- a/apiserver.go
+++ b/apiserver.go
@@ -88,7 +88,7 @@ func main() {
 	r.HandleFunc("/version", versionservice.VersionHandler)
 	r.HandleFunc("/health", versionservice.HealthHandler)
 	r.HandleFunc("/policies", policyservice.CreatePolicyHandler)
-	r.HandleFunc("/policies/{name}", policyservice.ShowPolicyHandler).Methods("GET")
+	r.HandleFunc("/showpolicies", policyservice.ShowPolicyHandler).Methods("POST")
 	//here
 	r.HandleFunc("/policiesdelete/{name}", policyservice.DeletePolicyHandler).Methods("GET")
 	r.HandleFunc("/workflow/{id}", workflowservice.ShowWorkflowHandler).Methods("GET")
@@ -104,7 +104,7 @@ func main() {
 	r.HandleFunc("/usersdelete/{name}", userservice.DeleteUserHandler).Methods("GET")
 	r.HandleFunc("/upgrades", upgradeservice.CreateUpgradeHandler).Methods("POST")
 	r.HandleFunc("/clusters", clusterservice.CreateClusterHandler).Methods("POST")
-	r.HandleFunc("/clusters/{name}", clusterservice.ShowClusterHandler).Methods("GET")
+	r.HandleFunc("/showclusters", clusterservice.ShowClusterHandler).Methods("POST")
 	//here
 	r.HandleFunc("/clustersdelete/{name}", clusterservice.DeleteClusterHandler).Methods("GET")
 	r.HandleFunc("/clustersupdate/{name}", clusterservice.UpdateClusterHandler).Methods("GET")

--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -109,19 +109,22 @@ func DeleteCluster(name, selector string, deleteData, deleteBackups bool, ns str
 }
 
 // ShowCluster ...
-func ShowCluster(name, selector, ccpimagetag, ns string) msgs.ShowClusterResponse {
+func ShowCluster(name, selector, ccpimagetag, ns, allflag string) msgs.ShowClusterResponse {
 	var err error
 
 	response := msgs.ShowClusterResponse{}
 	response.Status = msgs.Status{Code: msgs.Ok, Msg: ""}
 	response.Results = make([]msgs.ShowClusterDetail, 0)
 
-	if selector == "" && name == "all" {
+	if selector == "" && allflag == "true" {
+		log.Debugf("allflags set to true")
 	} else {
 		if selector == "" {
 			selector = "name=" + name
 		}
 	}
+
+	log.Debugf("selector on showCluster is %s", selector)
 
 	clusterList := crv1.PgclusterList{}
 

--- a/apiserver/clusterservice/clusterservice.go
+++ b/apiserver/clusterservice/clusterservice.go
@@ -85,17 +85,20 @@ func CreateClusterHandler(w http.ResponseWriter, r *http.Request) {
 // returns a ShowClusterResponse
 func ShowClusterHandler(w http.ResponseWriter, r *http.Request) {
 	var ns string
-	vars := mux.Vars(r)
-	log.Debugf("clusterservice.ShowClusterHandler %v\n", vars)
 
-	clustername := vars["name"]
+	var request msgs.ShowClusterRequest
+	_ = json.NewDecoder(r.Body).Decode(&request)
 
-	selector := r.URL.Query().Get("selector")
-	ccpimagetag := r.URL.Query().Get("ccpimagetag")
-	clientVersion := r.URL.Query().Get("version")
-	namespace := r.URL.Query().Get("namespace")
+	log.Debugf("clusterservice.ShowClusterHandler %v\n", request)
+	clustername := request.Clustername
 
-	log.Debugf("ShowClusterHandler: parameters name [%s] selector [%s] ccpimagetag [%s] version [%s] namespace [%s]", clustername, selector, ccpimagetag, clientVersion, namespace)
+	selector := request.Selector
+	ccpimagetag := request.Ccpimagetag
+	clientVersion := request.ClientVersion
+	namespace := request.Namespace
+	allflag := request.Allflag
+
+	log.Debugf("ShowClusterHandler: parameters name [%s] selector [%s] ccpimagetag [%s] version [%s] namespace [%s] allflag [%s]", clustername, selector, ccpimagetag, clientVersion, namespace, allflag)
 
 	username, err := apiserver.Authn(apiserver.SHOW_CLUSTER_PERM, w, r)
 	if err != nil {
@@ -126,7 +129,7 @@ func ShowClusterHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp = ShowCluster(clustername, selector, ccpimagetag, ns)
+	resp = ShowCluster(clustername, selector, ccpimagetag, ns, allflag)
 	json.NewEncoder(w).Encode(resp)
 
 }

--- a/apiserver/policyservice/policyimpl.go
+++ b/apiserver/policyservice/policyimpl.go
@@ -74,10 +74,10 @@ func CreatePolicy(RESTClient *rest.RESTClient, policyName, policyURL, policyFile
 }
 
 // ShowPolicy ...
-func ShowPolicy(RESTClient *rest.RESTClient, name, ns string) crv1.PgpolicyList {
+func ShowPolicy(RESTClient *rest.RESTClient, name, allflags, ns string) crv1.PgpolicyList {
 	policyList := crv1.PgpolicyList{}
 
-	if name == "all" {
+	if allflags == "true" {
 		//get a list of all policies
 		err := kubeapi.Getpgpolicies(RESTClient,
 			&policyList,

--- a/apiserver/policyservice/policyservice.go
+++ b/apiserver/policyservice/policyservice.go
@@ -132,12 +132,13 @@ func DeletePolicyHandler(w http.ResponseWriter, r *http.Request) {
 func ShowPolicyHandler(w http.ResponseWriter, r *http.Request) {
 	var ns string
 
-	vars := mux.Vars(r)
+	var request msgs.ShowPolicyRequest
+	_ = json.NewDecoder(r.Body).Decode(&request)
 
-	policyname := vars["name"]
+	policyname := request.Policyname
 
-	clientVersion := r.URL.Query().Get("version")
-	namespace := r.URL.Query().Get("namespace")
+	clientVersion := request.ClientVersion
+	namespace := request.Namespace
 
 	log.Debugf("ShowPolicyHandler parameters version [%s] namespace [%s] name [%s]", clientVersion, namespace, policyname)
 
@@ -150,7 +151,7 @@ func ShowPolicyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debug("policyservice.ShowPolicyHandler GET called")
+	log.Debug("policyservice.ShowPolicyHandler POST called")
 	resp := msgs.ShowPolicyResponse{}
 	resp.Status.Code = msgs.Ok
 	resp.Status.Msg = ""
@@ -170,7 +171,7 @@ func ShowPolicyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp.PolicyList = ShowPolicy(apiserver.RESTClient, policyname, ns)
+	resp.PolicyList = ShowPolicy(apiserver.RESTClient, policyname, request.Allflag, ns)
 
 	json.NewEncoder(w).Encode(resp)
 

--- a/apiservermsgs/clustermsgs.go
+++ b/apiservermsgs/clustermsgs.go
@@ -19,6 +19,16 @@ import (
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 )
 
+// ShowClusterRequest ...
+type ShowClusterRequest struct {
+	Clustername   string
+	Selector      string
+	Ccpimagetag   string
+	ClientVersion string
+	Namespace     string
+	Allflag       string
+}
+
 // CreateClusterRequest ...
 type CreateClusterRequest struct {
 	Name                string

--- a/apiservermsgs/policymsgs.go
+++ b/apiservermsgs/policymsgs.go
@@ -19,6 +19,15 @@ import (
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 )
 
+// ShowPolicyRequest ...
+type ShowPolicyRequest struct {
+	Selector      string
+	Namespace     string
+	Allflag       string
+	ClientVersion string
+	Policyname    string
+}
+
 // CreatePolicyRequest ...
 type CreatePolicyRequest struct {
 	Name          string

--- a/pgo/api/cluster.go
+++ b/pgo/api/cluster.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	//"strconv"
 
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	log "github.com/sirupsen/logrus"
@@ -29,24 +30,23 @@ const (
 	createClusterURL = "%s/clusters"
 	deleteClusterURL = "%s/clustersdelete/%s?selector=%s&delete-data=%t&delete-backups=%t&version=%s&namespace=%s"
 	updateClusterURL = "%s/clustersupdate/%s?selector=%s&autofail=%s&version=%s&namespace=%s"
-	showClusterURL   = "%s/clusters/%s?selector=%s&version=%s&ccpimagetag=%s&namespace=%s"
+	showClusterURL   = "%s/showclusters"
 )
 
-func ShowCluster(httpclient *http.Client, arg, selector, ccpimagetag string, SessionCredentials *msgs.BasicAuthCredentials, ns string) (msgs.ShowClusterResponse, error) {
+func ShowCluster(httpclient *http.Client, SessionCredentials *msgs.BasicAuthCredentials, request *msgs.ShowClusterRequest) (msgs.ShowClusterResponse, error) {
 
 	var response msgs.ShowClusterResponse
 
-	url := fmt.Sprintf(showClusterURL, SessionCredentials.APIServerURL, arg, selector, msgs.PGO_VERSION, ccpimagetag, ns)
+	jsonValue, _ := json.Marshal(request)
+	url := fmt.Sprintf(showClusterURL, SessionCredentials.APIServerURL)
+	log.Debugf("showCluster called...[%s]", url)
 
-	log.Debugf("show cluster called [%s]", url)
-
-	action := "GET"
-	req, err := http.NewRequest(action, url, nil)
-
+	action := "POST"
+	req, err := http.NewRequest(action, url, bytes.NewBuffer(jsonValue))
 	if err != nil {
 		return response, err
 	}
-
+	req.Header.Set("Content-Type", "application/json")
 	req.SetBasicAuth(SessionCredentials.Username, SessionCredentials.Password)
 
 	resp, err := httpclient.Do(req)

--- a/pgo/api/policy.go
+++ b/pgo/api/policy.go
@@ -24,19 +24,21 @@ import (
 	"net/http"
 )
 
-func ShowPolicy(httpclient *http.Client, arg string, SessionCredentials *msgs.BasicAuthCredentials, ns string) (msgs.ShowPolicyResponse, error) {
+func ShowPolicy(httpclient *http.Client, SessionCredentials *msgs.BasicAuthCredentials, request *msgs.ShowPolicyRequest) (msgs.ShowPolicyResponse, error) {
 
 	var response msgs.ShowPolicyResponse
 
-	url := SessionCredentials.APIServerURL + "/policies/" + arg + "?version=" + msgs.PGO_VERSION + "&namespace=" + ns
+	jsonValue, _ := json.Marshal(request)
+	url := SessionCredentials.APIServerURL + "/showpolicies"
 	log.Debugf("showPolicy called...[%s]", url)
 
-	action := "GET"
-	req, err := http.NewRequest(action, url, nil)
+	action := "POST"
+	req, err := http.NewRequest(action, url, bytes.NewBuffer(jsonValue))
 	if err != nil {
+		response.Status.Code = msgs.Error
 		return response, err
 	}
-
+	req.Header.Set("Content-Type", "application/json")
 	req.SetBasicAuth(SessionCredentials.Username, SessionCredentials.Password)
 	resp, err := httpclient.Do(req)
 	if err != nil {

--- a/pgo/cmd/cluster.go
+++ b/pgo/cmd/cluster.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"github.com/crunchydata/postgres-operator/pgo/api"
@@ -68,14 +69,25 @@ func showCluster(args []string, ns string) {
 	}
 
 	log.Debugf("selector is %s", Selector)
-	if len(args) == 0 && Selector != "" {
-		args = make([]string, 1)
-		args[0] = "all"
+	if len(args) == 0 && !AllFlag && Selector == "" {
+		fmt.Println("Error: ", "--all needs to be set or a cluster name be entered or a --selector be specified")
+		os.Exit(2)
 	}
+	if Selector != "" || AllFlag {
+		args = make([]string, 1)
+		args[0] = ""
+	}
+
+	r := new(msgs.ShowClusterRequest)
+	r.Selector = Selector
+	r.Namespace = ns
+	r.Allflag = strconv.FormatBool(AllFlag)
+	r.ClientVersion = msgs.PGO_VERSION
 
 	for _, v := range args {
 
-		response, err := api.ShowCluster(httpclient, v, Selector, CCPImageTag, &SessionCredentials, ns)
+		r.Clustername = v
+		response, err := api.ShowCluster(httpclient, &SessionCredentials, r)
 		if err != nil {
 			fmt.Println("Error: ", err.Error())
 			os.Exit(2)

--- a/pgo/cmd/policy.go
+++ b/pgo/cmd/policy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
+	"strconv"
 )
 
 var applyCmd = &cobra.Command{
@@ -107,8 +108,20 @@ func applyPolicy(args []string, ns string) {
 }
 func showPolicy(args []string, ns string) {
 
+	r := new(msgs.ShowPolicyRequest)
+	r.Selector = Selector
+	r.Namespace = ns
+	r.Allflag = strconv.FormatBool(AllFlag)
+	r.ClientVersion = msgs.PGO_VERSION
+
+	if len(args) == 0 && AllFlag {
+		args = []string{""}
+	}
+
 	for _, v := range args {
-		response, err := api.ShowPolicy(httpclient, v, &SessionCredentials, ns)
+		r.Policyname = v
+
+		response, err := api.ShowPolicy(httpclient, &SessionCredentials, r)
 
 		if err != nil {
 			fmt.Println("Error: " + err.Error())

--- a/pgo/cmd/show.go
+++ b/pgo/cmd/show.go
@@ -25,6 +25,7 @@ import (
 const TreeBranch = "\t"
 const TreeTrunk = "\t"
 
+var AllFlag bool
 var ShowPVC bool
 var PVCRoot string
 
@@ -108,6 +109,8 @@ func init() {
 	ShowClusterCmd.Flags().StringVarP(&CCPImageTag, "ccp-image-tag", "", "", "Filter the results based on the image tag of the cluster.")
 	ShowClusterCmd.Flags().StringVarP(&OutputFormat, "output", "o", "", "The output format. Currently, json is the only supported value.")
 	ShowClusterCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
+	ShowClusterCmd.Flags().BoolVar(&AllFlag, "all", false, "show all resources.")
+	ShowPolicyCmd.Flags().BoolVar(&AllFlag, "all", false, "show all resources.")
 	ShowPVCCmd.Flags().StringVarP(&NodeLabel, "node-label", "", "", "The node label (key=value) to use")
 	ShowPVCCmd.Flags().StringVarP(&PVCRoot, "pvc-root", "", "", "The PVC directory to list.")
 	ShowScheduleCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
@@ -164,10 +167,11 @@ var ShowPolicyCmd = &cobra.Command{
 	Short: "Show policy information",
 	Long: `Show policy information. For example:
 
+	pgo show policy --all
 	pgo show policy policy1`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 {
-			fmt.Println("Error: Policy name(s) required for this command.")
+		if len(args) == 0 && !AllFlag {
+			fmt.Println("Error: Policy name(s) or --all required for this command.")
 		} else {
 			if Namespace == "" {
 				Namespace = PGONamespace
@@ -232,14 +236,14 @@ var ShowClusterCmd = &cobra.Command{
 	Short: "Show cluster information",
 	Long: `Show a PostgreSQL cluster. For example:
 
-	pgo show cluster all
+	pgo show cluster --all
 	pgo show cluster mycluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if Namespace == "" {
 			Namespace = PGONamespace
 		}
-		if Selector == "" && len(args) == 0 {
-			fmt.Println("Error: Cluster name(s) required for this command.")
+		if Selector == "" && len(args) == 0 && !AllFlag {
+			fmt.Println("Error: Cluster name(s), --selector, or --all required for this command.")
 		} else {
 			showCluster(args, Namespace)
 		}


### PR DESCRIPTION
…ead of special all keyword to better mirror what kubectl does, this changes the API calls from GET to POST as well on ShowCluster and ShowPolicy

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

pgo show cluster all 
pgo show policy all

those command show all the resources of their respective types....

**What is the new behavior (if this is a feature change)?**

pgo show cluster --all
pgo show policy --all

the new --all flag is added and replaces the 'all' keyword to mirror how kubectl does this


**Other information**:
