### PR TITLE
Fix Namespace Used to Lookup 'pgo-backrest-repo-config' Secret when Enabling S3 Support

### DIFF
--- a/operator/clusterutilities.go
+++ b/operator/clusterutilities.go
@@ -367,7 +367,7 @@ func GetPgbackrestS3EnvVars(backrestLabel, backRestStorageTypeLabel string,
 			PgbackrestS3Region:   Pgo.Cluster.BackrestS3Region,
 		}
 
-		secret, secretExists, err := kubeapi.GetSecret(clientset, "pgo-backrest-repo-config", ns)
+		secret, secretExists, err := kubeapi.GetSecret(clientset, "pgo-backrest-repo-config", PgoNamespace)
 		if err != nil {
 			log.Error(err.Error())
 			return ""

--- a/operator/common.go
+++ b/operator/common.go
@@ -29,6 +29,8 @@ import (
 var CRUNCHY_DEBUG bool
 var NAMESPACE string
 
+var PgoNamespace string
+
 var Pgo config.PgoConfig
 
 type containerResourcesTemplateFields struct {
@@ -36,7 +38,7 @@ type containerResourcesTemplateFields struct {
 	LimitsMemory, LimitsCPU     string
 }
 
-func Initialize(clientset *kubernetes.Clientset, namespace string) {
+func Initialize(clientset *kubernetes.Clientset) {
 
 	tmp := os.Getenv("CRUNCHY_DEBUG")
 	if tmp == "true" {
@@ -53,9 +55,15 @@ func Initialize(clientset *kubernetes.Clientset, namespace string) {
 		log.Error("NAMESPACE env var is set to empty string which pgo intprets as meaning you want it to watch 'all' namespaces.")
 	}
 
+	PgoNamespace = os.Getenv("PGO_OPERATOR_NAMESPACE")
+	if PgoNamespace == "" {
+		log.Error("PGO_OPERATOR_NAMESPACE environment variable is not set and is required, this is the namespace that the Operator is to run within.")
+		os.Exit(2)
+	}
+
 	var err error
 
-	err = Pgo.GetConfig(clientset, namespace)
+	err = Pgo.GetConfig(clientset, PgoNamespace)
 	if err != nil {
 		log.Error(err)
 		log.Error("pgo-config files and templates did not load")

--- a/postgres-operator.go
+++ b/postgres-operator.go
@@ -37,7 +37,6 @@ import (
 )
 
 var Clientset *kubernetes.Clientset
-var PgoNamespace string
 
 func main() {
 	kubeconfig := flag.String("kubeconfig", "", "Path to a kube config. Only required if out-of-cluster.")
@@ -49,12 +48,6 @@ func main() {
 		log.Debug("debug flag set to true")
 	} else {
 		log.Info("debug flag set to false")
-	}
-
-	PgoNamespace = os.Getenv("PGO_OPERATOR_NAMESPACE")
-	if PgoNamespace == "" {
-		log.Error("PGO_OPERATOR_NAMESPACE environment variable is not set and is required, this is the namespace that the Operator is to run within.")
-		os.Exit(2)
 	}
 
 	namespaceList := util.GetNamespaces()
@@ -81,7 +74,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	operator.Initialize(Clientset, PgoNamespace)
+	operator.Initialize(Clientset)
 
 	//validate the NAMESPACE env var
 	err = util.ValidateNamespaces(Clientset)


### PR DESCRIPTION
Updated the namespace being utilized to lookup the **pgo-backrest-repo-config** secret when enabling AWS S3 support for a cluster (specifically when creating the pgBackRest shared repo deployment).  The Operator namespace is now utilized when looking up this secret (instead of the namespace for the cluster itself), in support of Ansible PGO installs where the **pgo-backrest-repo-config** secret is created in the Operator namespace only.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The wrong namespace (specifically the namespace of the cluster) is being utilized to lookup the **pgo-backrest-repo-config** secret when enabling AWS S3 support for a cluster (specifically when creating the pgBackRest shared repo deployment).

[ch4085]

**What is the new behavior (if this is a feature change)?**
The Operator namespace is now utilized when looking up this secret (instead of the namespace for the cluster itself), in support of Ansible PGO installs where the **pgo-backrest-repo-config** secret is created in the Operator namespace only.


**Other information**:
N/A