### PR TITLE
Only Create Secret 'pgo-backrest-repo-config' in the Operator namespace

### DIFF
--- a/deploy/create-target-rbac.sh
+++ b/deploy/create-target-rbac.sh
@@ -22,18 +22,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 
 echo ""
-echo "creating pgo-backrest-repo-config in namespace " $1
-
-$PGO_CMD --namespace=$1 delete secret pgo-backrest-repo-config 
-
-$PGO_CMD --namespace=$1 create secret generic pgo-backrest-repo-config \
-	--from-file=config=$PGOROOT/conf/pgo-backrest-repo/config \
-	--from-file=sshd_config=$PGOROOT/conf/pgo-backrest-repo/sshd_config \
-	--from-file=aws-s3-credentials.yaml=$PGOROOT/conf/pgo-backrest-repo/aws-s3-credentials.yaml \
-	--from-file=aws-s3-ca.crt=$PGOROOT/conf/pgo-backrest-repo/aws-s3-ca.crt
-
-
-echo ""
 echo "creating target rbac role and rolebinding in namespace " $1
 echo "operator is assumed to be deployed into " $2
 

--- a/deploy/install-rbac.sh
+++ b/deploy/install-rbac.sh
@@ -46,14 +46,9 @@ source $DIR/gen-sshd-keys.sh
 IFS=', ' read -r -a array <<< "$NAMESPACE"
 
 echo ""
-echo "create pgo-backrest-repo-config Secret into each namespace the Operator is watching..."
+echo "create required rbac in each namespace the Operator is watching..."
 for ns in "${array[@]}"
 do
-        $PGO_CMD get secret pgo-backrest-repo-config --namespace=$ns > /dev/null 2> /dev/null
-        if [ $? -eq 0 ]
-        then
-                $PGO_CMD delete secret  pgo-backrest-repo-config --namespace=$ns > /dev/null 2> /dev/null
-        fi
         $DIR/create-target-rbac.sh $ns $PGO_OPERATOR_NAMESPACE
 done
 


### PR DESCRIPTION
Secret **pgo-backrest-repo-config** is now only created in the Operator namespace when installing PGO via bash.  The secret is therefore no longer created in all namespaces targeted by the Operator (where the it is no longer needed).

This brings the bash install process inline with the Ansible install process for PGO, which also only creates secret **pgo-backrest-repo-config** in the Operator namespace.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
When installing PGO via bash, secret **pgo-backrest-repo-config** is installed in all namespaces targeted by the Operator, even though it is not needed in these namespaces.  Also, when installing via Ansible, the secret is only installed in the Operator namespace.

[ch4093]

**What is the new behavior (if this is a feature change)?**
Secret **pgo-backrest-repo-config** is no longer created in all namespaces targeted by the Operator, but rather is only created in the Operator namespace.


**Other information**:
N/A