### PR TITLE
Fix Invalid 'backrestrepo' Mount Path in Cluster Deployment

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -87,7 +87,7 @@
                             "name": "pgdata",
                             "readOnly": false
                         }, {
-                            "mountPath": "/backuprestrepo",
+                            "mountPath": "/backrestrepo",
                             "name": "backrestrepo"
                         }, {
                             "mountPath": "/pguser",

--- a/conf/postgres-operator/cluster-deployment.json
+++ b/conf/postgres-operator/cluster-deployment.json
@@ -87,7 +87,7 @@
                             "name": "pgdata",
                             "readOnly": false
                         }, {
-                            "mountPath": "/backuprestrepo",
+                            "mountPath": "/backrestrepo",
                             "name": "backrestrepo"
                         }, {
                             "mountPath": "/pguser",


### PR DESCRIPTION
Fixes the invalid `mountPath` name for the `/backrestrepo` volume in the cluster deployment.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The invalid `mountPath` name for the `backrestrepo` volume results in invalid permissions for the `backrestrepo` volume, which can lead to permissions errors when the `crunchy-postgres` container attempts to create the pgBackRest repository directory.

[ch4112]

**What is the new behavior (if this is a feature change)?**
The `mountPath` name has been updated to `backrestrepo` in the cluster deployment.


**Other information**:
N/A