### PR TITLE
add backrest command label to all backrest-jobs to assist in backup j…

### DIFF
--- a/apiserver/backrestservice/backrestimpl.go
+++ b/apiserver/backrestservice/backrestimpl.go
@@ -134,7 +134,8 @@ func CreateBackup(request *msgs.CreateBackrestBackupRequest, ns string) msgs.Cre
 
 			//remove any previous backup job
 
-			selector := config.LABEL_PG_CLUSTER + "=" + clusterName + "," + config.LABEL_BACKREST + "=true"
+			//selector := config.LABEL_PG_CLUSTER + "=" + clusterName + "," + config.LABEL_BACKREST + "=true"
+			selector := config.LABEL_BACKREST_COMMAND + "=" + crv1.PgtaskBackrestBackup + "," + config.LABEL_PG_CLUSTER + "=" + clusterName + "," + config.LABEL_BACKREST + "=true"
 			err = kubeapi.DeleteJobs(apiserver.Clientset, selector, ns)
 			if err != nil {
 				log.Error(err)
@@ -366,9 +367,9 @@ func getInfo(clusterName, storageType, podname, ns string) (string, error) {
 	cmd = append(cmd, backrestInfoCommand)
 
 	log.Debugf("command is %v ", cmd)
-	
+
 	var output string
-	if storageType != "s3" { 
+	if storageType != "s3" {
 		outputLocal, stderr, err := kubeapi.ExecToPodThroughAPI(apiserver.RESTConfig, apiserver.Clientset, cmd, containername, podname, ns, nil)
 		if err != nil {
 			log.Error(err, stderr)
@@ -376,7 +377,7 @@ func getInfo(clusterName, storageType, podname, ns string) (string, error) {
 		}
 		output = "\nStorage Type: local\n" + outputLocal
 	}
-	
+
 	if strings.Contains(storageType, "s3") {
 		cmd = append(cmd, repoTypeFlagS3)
 		outputS3, stderr, err := kubeapi.ExecToPodThroughAPI(apiserver.RESTConfig, apiserver.Clientset, cmd, containername, podname, ns, nil)
@@ -385,7 +386,7 @@ func getInfo(clusterName, storageType, podname, ns string) (string, error) {
 			return "", err
 		}
 		output = output + "\nStorage Type: s3\n" + outputS3
-	} 
+	}
 
 	log.Debug("output=[" + output + "]")
 

--- a/conf/postgres-operator/backrest-job.json
+++ b/conf/postgres-operator/backrest-job.json
@@ -7,6 +7,7 @@
                     "vendor": "crunchydata",
                     "pgo-backrest": "true",
                     "pgo-backrest-job": "true",
+                    "backrest-command": "{{.Command}}",
                     "pg-cluster": "{{.ClusterName}}"
                 }
     },
@@ -19,6 +20,7 @@
                     "vendor": "crunchydata",
                     "pgo-backrest": "true",
                     "pgo-backrest-job": "true",
+                    "backrest-command": "{{.Command}}",
                     "pg-cluster": "{{.ClusterName}}"
                 }
             },

--- a/conf/postgres-operator/pgo.yaml
+++ b/conf/postgres-operator/pgo.yaml
@@ -4,7 +4,7 @@ Cluster:
   CCPImagePrefix:  crunchydata
   Metrics:  false
   Badger:  false
-  CCPImageTag:  rhel7-11.3-2.4.0-rc10
+  CCPImageTag:  centos7-11.3-2.4.0-rc10
   Port:  5432
   User:  testuser
   Database:  userdb
@@ -24,10 +24,10 @@ Cluster:
   AutofailReplaceReplica:  false
   LogStatement:  none
   LogMinDurationStatement:  60000
-PrimaryStorage: hostpathstorage
-BackupStorage: hostpathstorage
-ReplicaStorage: hostpathstorage
-BackrestStorage: hostpathstorage
+PrimaryStorage: storageos
+BackupStorage: storageos
+ReplicaStorage: storageos
+BackrestStorage: storageos
 Storage:
   hostpathstorage:
     AccessMode:  ReadWriteMany
@@ -101,5 +101,5 @@ Pgo:
   PreferredFailoverNode:  
   Audit:  false
   PGOImagePrefix:  crunchydata
-  PGOImageTag:  rhel7-4.0.0-rc13
+  PGOImageTag:  centos7-4.0.0-rc13
 


### PR DESCRIPTION
…ob cleanup

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

backrest create stanza jobs were being removed as part of backup job cleanup, people typically would like to keep the stanza create job around for debugging.

**What is the new behavior (if this is a feature change)?**

a backrest-command label is added to backrest-job.json, this stores the backrest command being submitted, that label is now checked when deleting any prior backrest backup jobs.

**Other information**:
