### PR TITLE
Delete CRDs and PGO client when Deprovisioning & Reinstall PGO Client when Updating

### DIFF
--- a/ansible/roles/pgo-operator/tasks/cleanup.yml
+++ b/ansible/roles/pgo-operator/tasks/cleanup.yml
@@ -154,6 +154,14 @@
   no_log: false
   tags: deprovision
 
+- name: Delete Custom Resource Definitions
+  shell: |
+    {{ kubectl_or_oc }} delete crds pgbackups.crunchydata.com pgclusters.crunchydata.com \
+        pgpolicies.crunchydata.com pgreplicas.crunchydata.com pgtasks.crunchydata.com
+  ignore_errors: yes
+  no_log: false
+  tags: deprovision
+
 - name: Check for output directory
   stat:
     path: "{{ output_dir }}"
@@ -177,3 +185,14 @@
     state: directory
     mode: 0700
   tags: always
+
+- name: Delete PGO client
+  become: yes
+  become_method: sudo
+  file:
+    state: absent
+    path: "/usr/local/bin/pgo"
+  when: pgo_client_install == "true"
+  ignore_errors: yes
+  no_log: false
+  tags: deprovision

--- a/ansible/roles/pgo-operator/tasks/main.yml
+++ b/ansible/roles/pgo-operator/tasks/main.yml
@@ -186,6 +186,7 @@
         url: "{{ pgo_client_url }}/pgo"
         dest: "/usr/local/bin/pgo"
         mode: 0755
+        force: yes
       when: uname_result.stdout == "Linux" and pgo_client_install == "true"
       tags: [install, update]
 

--- a/hugo/content/Installation/install-with-ansible/uninstalling-operator.md
+++ b/hugo/content/Installation/install-with-ansible/uninstalling-operator.md
@@ -17,7 +17,7 @@ With the correct playbooks acquired and prerequisites satisfied, simply run
 the following command:
 
 ```bash
-ansible-playbook -i /path/to/inventory --tags=deprovision main.yml
+ansible-playbook -i /path/to/inventory --tags=deprovision --ask-become-pass main.yml
 ```
 
 If the Crunchy PostgreSQL Operator playbooks were installed using `yum`, use the
@@ -26,13 +26,15 @@ following commands:
 ```bash
 export ANSIBLE_ROLES_PATH=/usr/share/ansible/roles/crunchydata
 
-ansible-playbook -i /path/to/inventory --tags=deprovision \
+ansible-playbook -i /path/to/inventory --tags=deprovision --ask-become-pass \
     /usr/share/ansible/postgres-operator/playbooks/main.yml
 ```
 
 ## Deleting `pgo` Client
 
-To remove the `pgo` client, simply run the following command:
+If variable `pgo_client_install` is set to `true` in the `inventory` file, the `pgo` client will also be uninstalled when deprovisioning.
+
+Otherwise, the `pgo` client can be manually uninstalled by running the following command:
 
 ```
 rm /usr/local/bin/pgo

--- a/hugo/content/Installation/install-with-ansible/updating-operator.md
+++ b/hugo/content/Installation/install-with-ansible/updating-operator.md
@@ -14,6 +14,7 @@ of the service.  Using the `update` flag will:
 * Recreate configuration maps used by operator
 * Remove any deprecated objects
 * Allow administrators to change settings configured in the `inventory`
+* Reinstall the `pgo` client if a new version is specified
 
 The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prereq/prerequisites/)
 we can now update the PostgreSQL Operator.


### PR DESCRIPTION
Includes the following changes to the PGO Ansible Playbooks:
* The PGO CRD's are now deleted when deprovisioning
* The PGO client is now uninstalled when deprovisioning (assuming `pgo_client_install='true'` in the `inventory` file)
* The PGO client is reinstalled if a new version specified in the `inventory` file via the `pgo_image_tag` variable (assuming `pgo_client_install='true'` in the `inventory` file)

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
* The PGO CRD's are not deleted when deprovisioning
* The PGO client is not uninstalled when deprovisioning
* The PGO client is not reinstalled when updating

[ch4109]

**What is the new behavior (if this is a feature change)?**
* The PGO CRD's are deleted when deprovisioning
* The PGO client is uninstalled when deprovisioning
* The PGO client is reinstalled when updating


**Other information**:
N/A