### PR TITLE
fix pgpool pod label to be unique

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/pgpool-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgpool-template.json
@@ -6,7 +6,7 @@
         "labels": {
             "name": "{{.Name}}",
             "pg-cluster": "{{.ClusterName}}",
-            "crunchy-pgpool": "true",
+            "crunchy-pgpool-pod": "true",
             "service-name": "{{.Name}}",
 	    "vendor": "crunchydata"
         }
@@ -17,7 +17,7 @@
 		"matchLabels": {
             		"name": "{{.Name}}",
             		"pg-cluster": "{{.ClusterName}}",
-            		"crunchy-pgpool": "true",
+            		"crunchy-pgpool-pod": "true",
             		"service-name": "{{.Name}}",
 	    		"vendor": "crunchydata"
 		}
@@ -27,7 +27,7 @@
                 "labels": {
                     "name": "{{.Name}}",
                     "pg-cluster": "{{.ClusterName}}",
-                    "crunchy-pgpool": "true",
+                    "crunchy-pgpool-pod": "true",
                     "service-name": "{{.Name}}",
 	    	    "vendor": "crunchydata"
                 }

--- a/conf/postgres-operator/pgpool-template.json
+++ b/conf/postgres-operator/pgpool-template.json
@@ -6,7 +6,7 @@
         "labels": {
             "name": "{{.Name}}",
             "pg-cluster": "{{.ClusterName}}",
-            "crunchy-pgpool": "true",
+            "crunchy-pgpool-pod": "true",
             "service-name": "{{.Name}}",
 	    "vendor": "crunchydata"
         }
@@ -17,7 +17,7 @@
 		"matchLabels": {
             		"name": "{{.Name}}",
             		"pg-cluster": "{{.ClusterName}}",
-            		"crunchy-pgpool": "true",
+            		"crunchy-pgpool-pod": "true",
             		"service-name": "{{.Name}}",
 	    		"vendor": "crunchydata"
 		}
@@ -27,7 +27,7 @@
                 "labels": {
                     "name": "{{.Name}}",
                     "pg-cluster": "{{.ClusterName}}",
-                    "crunchy-pgpool": "true",
+                    "crunchy-pgpool-pod": "true",
                     "service-name": "{{.Name}}",
 	    	    "vendor": "crunchydata"
                 }

--- a/config/labels.go
+++ b/config/labels.go
@@ -110,6 +110,7 @@ const LABEL_USERNAME = "username"
 const LABEL_PASSWORD = "password"
 
 const LABEL_PGPOOL = "crunchy-pgpool"
+const LABEL_PGPOOL_POD = "crunchy-pgpool-pod"
 const LABEL_PGPOOL_SECRET = "pgpool-secret"
 const LABEL_PGPOOL_TASK_ADD = "pgpool-add"
 const LABEL_PGPOOL_TASK_DELETE = "pgpool-delete"

--- a/controller/podcontroller.go
+++ b/controller/podcontroller.go
@@ -315,7 +315,7 @@ func isPostgresPod(newpod *apiv1.Pod) bool {
 		log.Debugf("pgo-backrest-repo pod found [%s]", newpod.Name)
 		return false
 	}
-	if newpod.ObjectMeta.Labels[config.LABEL_PGPOOL] == "true" {
+	if newpod.ObjectMeta.Labels[config.LABEL_PGPOOL_POD] == "true" {
 		log.Debugf("pgpool pod found [%s]", newpod.Name)
 		return false
 	}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

pgpool when added with --pgpool was causing service-name labels to not be applied to the
postgres pods/deployments, which would then cause the cluster to fail since services were not reachable

**What is the new behavior (if this is a feature change)?**

the bug was in the pgpool pod labels, a unique pgpool pod label was added to pgpool-template.json to make those pods unique and easier to identify in podcontroller.go

**Other information**:
