### PR TITLE
Configurable creation of RBAC resources

### DIFF
--- a/ansible/inventory
+++ b/ansible/inventory
@@ -25,6 +25,13 @@ crunchy_debug='false'
 # ==================
 # kubernetes_context=''
 
+# Create RBAC
+# ==================
+# Note: you may disable creating RBAC resources if they where already
+# provisoned by a cluster admin.
+# ==================
+create_rbac='true'
+
 # ===================
 # PGO Settings
 # The following settings configure the Crunchy PostgreSQL Operator 

--- a/ansible/roles/pgo-metrics/tasks/cleanup.yml
+++ b/ansible/roles/pgo-metrics/tasks/cleanup.yml
@@ -45,6 +45,7 @@
   no_log: false
   tags:
   - deprovision-metrics
+  when: create_rbac|bool
 
 - name: Delete Prometheus Service Account
   shell: |
@@ -53,6 +54,7 @@
   no_log: false
   tags:
   - deprovision-metrics
+  when: create_rbac|bool
 
 - name: Delete Grafana PVC
   shell: |

--- a/ansible/roles/pgo-metrics/tasks/prometheus.yml
+++ b/ansible/roles/pgo-metrics/tasks/prometheus.yml
@@ -23,6 +23,23 @@
 
 - name: Deploy Prometheus
   block:
+    - name: Template Prometheus RBAC
+      template:
+        src: "{{ item }}"
+        dest: "{{ prom_output_dir }}/{{ item | replace('.j2', '') }}"
+        mode: '0600'
+      with_items:
+      - prometheus-rbac.json.j2
+      tags: [install-metrics]
+      when: create_rbac|bool
+
+    - name: Create Prometheus RBAC
+      command: "{{ kubectl_or_oc }} create -f {{ prom_output_dir }}/{{ item }} -n {{ metrics_namespace }}"
+      with_items:
+      - prometheus-rbac.json
+      tags: [install-metrics]
+      when: create_rbac|bool
+
     - name: Template Prometheus Objects
       template:
         src: "{{ item }}"
@@ -30,7 +47,6 @@
         mode: '0600'
       with_items: 
       - prometheus-pvc.json.j2
-      - prometheus-rbac.json.j2
       - prometheus-service.json.j2
       - prometheus-deployment.json.j2
       tags: [install-metrics]
@@ -39,7 +55,6 @@
       command: "{{ kubectl_or_oc }} create -f {{ prom_output_dir }}/{{ item }} -n {{ metrics_namespace }}"
       with_items:
       - prometheus-pvc.json
-      - prometheus-rbac.json
       - prometheus-service.json
       - prometheus-deployment.json
       tags: [install-metrics]

--- a/ansible/roles/pgo-operator/tasks/cleanup.yml
+++ b/ansible/roles/pgo-operator/tasks/cleanup.yml
@@ -63,6 +63,7 @@
   tags:
   - deprovision
   - update
+  when: create_rbac|bool
 
 - name: Delete existing Service Account
   shell: |
@@ -74,6 +75,7 @@
   tags:
   - deprovision
   - update
+  when: create_rbac|bool
 
 - name: Delete existing Cluster Role Bindings
   shell: |
@@ -87,6 +89,7 @@
   tags:
   - deprovision
   - update
+  when: create_rbac|bool
 
 - name: Delete existing Cluster Roles
   shell: |
@@ -100,6 +103,7 @@
   tags:
   - deprovision
   - update
+  when: create_rbac|bool
 
 - name: Delete existing Backrest Role Binding
   shell: |
@@ -111,6 +115,7 @@
   tags:
   - deprovision
   - update
+  when: create_rbac|bool
 
 - name: Delete existing PGO Role Binding
   shell: |
@@ -122,6 +127,7 @@
   tags:
   - deprovision
   - update
+  when: create_rbac|bool
 
 - name: Delete existing Backrest Role
   shell: |
@@ -133,6 +139,7 @@
   tags:
   - deprovision
   - update
+  when: create_rbac|bool
 
 - name: Delete existing PGO Role
   shell: |
@@ -144,6 +151,7 @@
   tags:
   - deprovision
   - update
+  when: create_rbac|bool
 
 - name: Delete existing Custom Objects
   shell: |

--- a/ansible/roles/pgo-operator/tasks/main.yml
+++ b/ansible/roles/pgo-operator/tasks/main.yml
@@ -72,10 +72,12 @@
         dest: "{{ output_dir }}/cluster-rbac.yaml"
         mode: '0600'
       tags: [install, update]
+      when: create_rbac|bool
 
     - name: Create Cluster RBAC
       command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/cluster-rbac.yaml -n {{ pgo_operator_namespace }}"
       tags: [install, update]
+      when: create_rbac|bool
     
     - name: Template PGO RBAC
       template:
@@ -85,12 +87,14 @@
       with_items: 
       - "{{ all_namespaces }}"
       tags: [install, update]
+      when: create_rbac|bool
 
     - name: Create PGO RBAC
       command: "{{ kubectl_or_oc }} create -f {{ output_dir }}//pgo-role-rbac-{{ item }}.yaml"
       with_items: 
       - "{{ all_namespaces }}"
       tags: [install, update]
+      when: create_rbac|bool
 
     - name: Template PGO Backrest RBAC
       template:
@@ -100,12 +104,14 @@
       with_items:
       - "{{ namespace.split(',') }}"
       tags: [install, update]
+      when: create_rbac|bool
 
     - name: Create PGO Backrest RBAC
       command: "{{ kubectl_or_oc }} create -f {{ output_dir }}//pgo-backrest-role-rbac-{{ item }}.yaml"
       with_items:
       - "{{ namespace.split(',') }}"
       tags: [install, update]
+      when: create_rbac|bool
 
     - name: Template PGO User
       template:


### PR DESCRIPTION
This change makes creating any needed RBAC resources optional. This helps make the operator deployable in clusters where RBAC has been preconfigured to a degree that forbids the postgresql-operator-admin to deploy new RBAC rules.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?

See above.

 - [ ] Have you updated or added documentation for the change, as applicable?

There are no applicable changes as far as I can tell. This PR does not aim at making an installation without `cluster-admin` supported, it aims at making it feasible.

 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The operator needs to be able to deploy the following resources:

* Custom Resource Definitions                                                   
* Cluster RBAC                                                                  
* Create required namespaces       

As [per the docs](https://crunchydata.github.io/postgres-operator/stable/installation/install-with-ansible/prerequisites/#permissions) `cluster-admin` is required for the deployment.

**What is the new behavior (if this is a feature change)?**

This PR adds an additional `create_rbac` ansible variable that may be used to configure if RBAC Roles and RoleBindings should be created during the operator installation.

**Other information**:

This helps in situations where a `cluster-admin` prefers to manage RBAC rules on their own. One use-case of this could be if a customer has a dedicated security team that is in charge of RBAC.
If this gets merged an admin would need to ensure that they create Namepsaces, ServiceAccounts, Roles and, RoleBindings on their own before they go on to deploy the postgresql-operator.