### PR TITLE
add CRUNCHY_DEBUG env variable to scheduler container

### DIFF
--- a/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -123,6 +123,10 @@
                             {
                                 "name": "TIMEOUT",
                                 "value": "{{ scheduler_timeout }}"
+                            },
+                            {
+                                "name": "CRUNCHY_DEBUG",
+                                "value": "{{ crunchy_debug }}"
                             }
                         ],
                         "volumeMounts": [],


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
If `crunchy_debug` is defined in the the Ansible inventory it is applied to all containers of postgres-operator, except the scheduler.


**What is the new behavior (if this is a feature change)?**
If `crunchy_debug` is defined the environment variable `CRUNCHY_DEBUG` is also defined in the environment of the scheduler container.