### PR TITLE
updates ansible rbac yaml to match bash install

### DIFF
--- a/ansible/roles/pgo-operator/tasks/cleanup.yml
+++ b/ansible/roles/pgo-operator/tasks/cleanup.yml
@@ -79,11 +79,11 @@
 
 - name: Delete existing Cluster Role Bindings
   shell: |
-    {{ kubectl_or_oc }} delete clusterrolebinding {{ pgo_operator_namespace }}{{ item }} -n {{ pgo_operator_namespace }}
+    {{ kubectl_or_oc }} delete clusterrolebinding {{ item }}{{ pgo_operator_namespace }} -n {{ pgo_operator_namespace }}
   with_items:
-  - "clusterbinding"
-  - "clusterbindingcrd"
-  - "clusterbindingsecret"
+  - "pgopclusterbinding-"
+  - "pgopclusterbindingcrd-"
+  - "pgopclusterbindingsecret-"
   ignore_errors: yes
   no_log: false
   tags:
@@ -93,11 +93,11 @@
 
 - name: Delete existing Cluster Roles
   shell: |
-    {{ kubectl_or_oc }} delete clusterrole {{ pgo_operator_namespace }}{{ item }} -n {{ pgo_operator_namespace }}
+    {{ kubectl_or_oc }} delete clusterrole {{ item }}{{ pgo_operator_namespace }} -n {{ pgo_operator_namespace }}
   with_items:
-  - "clusterrole"
-  - "clusterrolecrd"
-  - "clusterrolesecret"
+  - "pgopclusterrole-"
+  - "pgopclusterrolecrd-"
+  - "pgopclusterrolesecret-"
   ignore_errors: yes
   no_log: false
   tags:

--- a/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
@@ -8,7 +8,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ pgo_operator_namespace }}clusterrolesecret
+  name: pgopclusterrolesecret-{{ pgo_operator_namespace }}
 rules:
   - verbs:
       - get
@@ -22,7 +22,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ pgo_operator_namespace }}clusterrole
+  name: pgopclusterrole-{{ pgo_operator_namespace }}
 rules:
   - verbs:
       - get
@@ -39,7 +39,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ pgo_operator_namespace }}clusterrolecrd
+  name: pgopclusterrolecrd-{{ pgo_operator_namespace }}
 rules:
   - verbs:
       - '*'
@@ -55,11 +55,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ pgo_operator_namespace }}clusterbinding
+  name: pgopclusterbinding-{{ pgo_operator_namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ pgo_operator_namespace }}clusterrole
+  name: pgopclusterrole-{{ pgo_operator_namespace }}
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
@@ -68,11 +68,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ pgo_operator_namespace }}clusterbindingcrd
+  name: pgopclusterbindingcrd-{{ pgo_operator_namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ pgo_operator_namespace }}clusterrolecrd
+  name: pgopclusterrolecrd-{{ pgo_operator_namespace }}
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
@@ -81,11 +81,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ pgo_operator_namespace }}clusterbindingsecret
+  name: pgopclusterbindingsecret-{{ pgo_operator_namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ pgo_operator_namespace }}clusterrolesecret
+  name: pgopclusterrolesecret-{{ pgo_operator_namespace }}
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User


### PR DESCRIPTION
**Checklist:**
Updates ansible Cluster Role and Cluster Role Binding names to match documentation and bash install
 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently ansible creates cluster roles/role bindings with names like 
```
 - "clusterbinding" + {{ pgo_operator_namespace }}
 - "clusterbindingcrd" + {{ pgo_operator_namespace }}
 - "clusterbindingsecret" + {{ pgo_operator_namespace }}
```

**What is the new behavior (if this is a feature change)?**
Now names are created like 
```
 - "pgopclusterbinding-" + {{ pgo_operator_namespace }}
 - "pgopclusterbindingcrd-" + {{ pgo_operator_namespace }}
 - "pgopclusterbindingsecret-" + {{ pgo_operator_namespace }}
```

**Other information**:
[ch4530]