### PR TITLE
Updated Method for Setting AWS S3 Key & Key Secret when Pushing Archives to S3 Buckets

### DIFF
--- a/ansible/inventory
+++ b/ansible/inventory
@@ -89,11 +89,11 @@ auto_failover_sleep_secs=9
 scheduler_timeout=3600
 
 # pgBackRest S3 Settings
-#backrest_aws_s3_key=""
-#backrest_aws_s3_secret=""
-#backrest_aws_s3_bucket=""
-#backrest_aws_s3_endpoint=""
-#backrest_aws_s3_region=""
+#backrest_aws_s3_key=''
+#backrest_aws_s3_secret=''
+#backrest_aws_s3_bucket=''
+#backrest_aws_s3_endpoint=''
+#backrest_aws_s3_region=''
 
 # ===================
 # PostgreSQL Settings

--- a/ansible/roles/pgo-operator/templates/aws-s3-credentials.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/aws-s3-credentials.yaml.j2
@@ -1,3 +1,3 @@
 ---
-aws-s3-key: "{{ backrest_aws_s3_key }}"
-aws-s3-key-secret: "{{ backrest_aws_s3_secret }}"
+aws-s3-key: {{ backrest_aws_s3_key }}
+aws-s3-key-secret: {{ backrest_aws_s3_secret }}

--- a/bin/pgo-backrest-repo/archive-push-s3.sh
+++ b/bin/pgo-backrest-repo/archive-push-s3.sh
@@ -1,4 +1,4 @@
-# .bashrc
+#!/bin/bash
 
 awsKeySecret() {
     val=$(grep "$1" -m 1 /sshd/aws-s3-credentials.yaml | sed "s/^.*:\s*//")
@@ -12,3 +12,5 @@ awsKeySecret() {
 
 export PGBACKREST_REPO1_S3_KEY=$(awsKeySecret "aws-s3-key")
 export PGBACKREST_REPO1_S3_KEY_SECRET=$(awsKeySecret "aws-s3-key-secret")
+
+pgbackrest "$@"

--- a/centos7/Dockerfile.pgo-backrest-repo.centos7
+++ b/centos7/Dockerfile.pgo-backrest-repo.centos7
@@ -22,12 +22,12 @@ yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
 yum -y clean all
 
 RUN groupadd pgbackrest -g 2000 && useradd pgbackrest -u 2000 -g 2000
-ADD bin/pgo-backrest-repo/pgo-backrest-repo.sh /usr/local/bin
-RUN chmod +x /usr/local/bin/pgo-backrest-repo.sh && mkdir -p /opt/cpm/bin && chown -R pgbackrest:pgbackrest /opt/cpm
+ADD bin/pgo-backrest-repo /usr/local/bin
+RUN chmod +x /usr/local/bin/pgo-backrest-repo.sh /usr/local/bin/archive-push-s3.sh \
+    && mkdir -p /opt/cpm/bin \
+    && chown -R pgbackrest:pgbackrest /opt/cpm
 
 ADD bin/uid_pgbackrest.sh /opt/cpm/bin
-
-ADD conf/pgo-backrest-repo/.bashrc /home/pgbackrest
 
 RUN chmod g=u /etc/passwd && \
         chmod g=u /etc/group

--- a/conf/postgres-operator/pgbackrest-s3-env-vars.json
+++ b/conf/postgres-operator/pgbackrest-s3-env-vars.json
@@ -16,3 +16,6 @@
                     "name": "PGBACKREST_REPO1_S3_CA_FILE",
                     "value": "/sshd/aws-s3-ca.crt"
                     }, {
+                    "name": "PGBACKREST_REPO1_HOST_CMD",
+                    "value": "/usr/local/bin/archive-push-s3.sh"
+                    }, {

--- a/rhel7/Dockerfile.pgo-backrest-repo.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-repo.rhel7
@@ -25,12 +25,13 @@ yum -y install psmisc openssh-server openssh-clients crunchy-backrest-"${BACKRES
 yum -y clean all
 
 RUN groupadd pgbackrest -g 2000 && useradd pgbackrest -u 2000 -g 2000
-ADD bin/pgo-backrest-repo/pgo-backrest-repo.sh /usr/local/bin
-RUN chmod +x /usr/local/bin/pgo-backrest-repo.sh && mkdir -p /opt/cpm/bin && chown -R pgbackrest:pgbackrest /opt/cpm
+ADD bin/pgo-backrest-repo /usr/local/bin
+RUN chmod +x /usr/local/bin/pgo-backrest-repo.sh /usr/local/bin/archive-push-s3.sh \
+    && mkdir -p /opt/cpm/bin \
+    && chown -R pgbackrest:pgbackrest /opt/cpm
 
 ADD bin/uid_pgbackrest.sh /opt/cpm/bin
 
-ADD conf/pgo-backrest-repo/.bashrc /
 
 RUN chmod g=u /etc/passwd && \
         chmod g=u /etc/group


### PR DESCRIPTION
Updated the method for setting the AWS S3 key and key secret needed by pgBackRest to authenticate into AWS when pushing archives to an S3 bucket.  Instead of using a `.bashrc` file, which can result in inconsistent behavior in certain environments where the container user is inconsistent (e.g. the arbitrary user ID's set by OCP), a script is now used to set the the AWS S3 key and key secret environment before pgBackRest is called.  Please note that this change applies to S3-enabled clusters only.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
When using AWS S3 storage with pgBackRest in an OCP cluster, `pgbackrest archive-push` commands fail with an authentication error.

[ch4637]

**What is the new behavior (if this is a feature change)?**
Archive pushes to AWS S3 via the `pgbackrest archive-push` command works properly across all supported environments, including OCP.


**Other information**:
N/A