### PR TITLE
update selector to include pgpool label = true

### DIFF
--- a/apiserver/pgdumpservice/pgdumpimpl.go
+++ b/apiserver/pgdumpservice/pgdumpimpl.go
@@ -305,7 +305,7 @@ func getDeployName(cluster *crv1.Pgcluster, ns string) (string, error) {
 func getPrimaryPodName(cluster *crv1.Pgcluster, ns string) (string, error) {
 	var podname string
 
-	selector := config.LABEL_PGPOOL + "!=true," + config.LABEL_PG_CLUSTER + "=" + cluster.Spec.Name + "," + config.LABEL_SERVICE_NAME + "=" + cluster.Spec.Name
+	selector := config.LABEL_SERVICE_NAME + "=" + cluster.Spec.Name
 
 	pods, err := kubeapi.GetPods(apiserver.Clientset, selector, ns)
 	if err != nil {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The selector for getPrimaryPodName ignores pods with pgpool enabled so it returns "primary pod is not in Ready state".


**What is the new behavior (if this is a feature change)?**
Now the function checks that the service_name matches the cluster name


**Other information**:
[ch4753]