### PR TITLE
Moved VOLUME Instructions After RUN Instructions in BackRest Restore & Load Dockerfiles

### DIFF
--- a/centos7/Dockerfile.pgo-backrest-restore.centos7
+++ b/centos7/Dockerfile.pgo-backrest-restore.centos7
@@ -16,8 +16,6 @@ RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/r
 RUN yum -y update && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
     psmisc openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" postgresql11-server procps-ng && yum -y clean all
 
-VOLUME ["/sshd", "/pgdata"]
-
 RUN mkdir -p /opt/cpm/bin /pgdata && chown -R 26:26 /opt/cpm
 ADD bin/pgo-backrest-restore/ /opt/cpm/bin
 ADD bin/uid_postgres.sh /opt/cpm/bin
@@ -26,6 +24,8 @@ RUN chmod g=u /etc/passwd && \
         chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+VOLUME ["/sshd", "/pgdata"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/centos7/Dockerfile.pgo-load.centos7
+++ b/centos7/Dockerfile.pgo-load.centos7
@@ -37,10 +37,10 @@ ADD bin/uid_postgres.sh /opt/cpm/bin
 ADD conf/pgo-load/ /opt/cpm/conf
 RUN chown -R 26:26 /opt/cpm
 
-VOLUME /pgdata
-
 RUN chmod g=u /etc/passwd && \
         chmod g=u /etc/group
+
+VOLUME /pgdata
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/Dockerfile.pgo-backrest-restore.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-restore.rhel7
@@ -24,8 +24,6 @@ RUN yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* updat
  && yum -y install psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" postgresql11-server procps-ng \
  && yum -y clean all
 
-VOLUME ["/sshd", "/pgdata"]
-
 RUN mkdir -p /opt/cpm/bin /pgdata && chown -R 26:26 /opt/cpm
 ADD bin/pgo-backrest-restore/ /opt/cpm/bin
 ADD bin/uid_postgres.sh /opt/cpm/bin
@@ -34,6 +32,8 @@ RUN chmod g=u /etc/passwd && \
         chmod g=u /etc/group
 
 RUN mkdir /.ssh && chown 26:0 /.ssh && chmod g+rwx /.ssh
+
+VOLUME ["/sshd", "/pgdata"]
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 

--- a/rhel7/Dockerfile.pgo-load.rhel7
+++ b/rhel7/Dockerfile.pgo-load.rhel7
@@ -38,10 +38,10 @@ ADD bin/uid_postgres.sh /opt/cpm/bin
 ADD conf/pgo-load/ /opt/cpm/conf
 RUN chown -R 26:26 /opt/cpm
 
-VOLUME /pgdata
-
 RUN chmod g=u /etc/passwd && \
         chmod g=u /etc/group
+
+VOLUME /pgdata
 
 ENTRYPOINT ["/opt/cpm/bin/uid_postgres.sh"]
 


### PR DESCRIPTION
Moved **VOLUME** instructions after all **RUN** instructions in the **pgo-backrest-restore** and **pgo-load** Dockerfiles.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Invalid permissions for the volumes specified in the VOLUME instruction in the **pgo-backrest-restore** and **pgo-load** Dockerfiles.

[ch4775]

**What is the new behavior (if this is a feature change)?**
Valid permissions for the volumes specified in the VOLUME instruction in the **pgo-backrest-restore** and **pgo-load** Dockerfiles.


**Other information**:
N/A