### PR TITLE
Let Kubernetes encode secrets during RBAC install

### DIFF
--- a/deploy/install-bootstrap-creds.sh
+++ b/deploy/install-bootstrap-creds.sh
@@ -17,26 +17,23 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # fill out these variables if you want to change the
 # default pgo bootstrap user and role
-export EXAMPLE_USERNAME=pgoadmin
-export EXAMPLE_PASSWORD=examplepassword
-export EXAMPLE_ROLENAME=pgoadmin
-export PGOADMIN_PERMS=`echo -n "DeleteNamespace,CreateNamespace,UpdatePgorole,ShowPgorole,DeletePgorole,CreatePgorole,UpdatePgouser,ShowPgouser,DeletePgouser,CreatePgouser,Cat,Ls,ShowNamespace,CreateDump,RestoreDump,ScaleCluster,CreateSchedule,DeleteSchedule,ShowSchedule,DeletePgbouncer,CreatePgbouncer,DeletePgpool,CreatePgpool,Restore,RestorePgbasebackup,ShowSecrets,Reload,ShowConfig,Status,DfCluster,DeleteCluster,ShowCluster,CreateCluster,TestCluster,ShowBackup,DeleteBackup,CreateBackup,Label,Load,CreatePolicy,DeletePolicy,ShowPolicy,ApplyPolicy,ShowWorkflow,ShowPVC,CreateUpgrade,CreateUser,DeleteUser,UpdateUser,ShowUser,Version,CreateFailover,UpdateCluster,CreateBenchmark,ShowBenchmark,DeleteBenchmark,UpdateNamespace" | base64 --wrap=0`
-export PGOADMIN_ROLENAME=`echo -n $EXAMPLE_ROLENAME | base64 --wrap=0`
+export PGOADMIN_USERNAME=pgoadmin
+export PGOADMIN_PASSWORD=examplepassword
+export PGOADMIN_ROLENAME=pgoadmin
+export PGOADMIN_PERMS="DeleteNamespace,CreateNamespace,UpdatePgorole,ShowPgorole,DeletePgorole,CreatePgorole,UpdatePgouser,ShowPgouser,DeletePgouser,CreatePgouser,Cat,Ls,ShowNamespace,CreateDump,RestoreDump,ScaleCluster,CreateSchedule,DeleteSchedule,ShowSchedule,DeletePgbouncer,CreatePgbouncer,DeletePgpool,CreatePgpool,Restore,RestorePgbasebackup,ShowSecrets,Reload,ShowConfig,Status,DfCluster,DeleteCluster,ShowCluster,CreateCluster,TestCluster,ShowBackup,DeleteBackup,CreateBackup,Label,Load,CreatePolicy,DeletePolicy,ShowPolicy,ApplyPolicy,ShowWorkflow,ShowPVC,CreateUpgrade,CreateUser,DeleteUser,UpdateUser,ShowUser,Version,CreateFailover,UpdateCluster,CreateBenchmark,ShowBenchmark,DeleteBenchmark,UpdateNamespace"
 
 # see if the bootstrap pgorole Secret exists or not, deleting it if found
-$PGO_CMD get secret pgorole-$EXAMPLE_ROLENAME -n $PGO_OPERATOR_NAMESPACE 2> /dev/null > /dev/null
+$PGO_CMD get secret pgorole-$PGOADMIN_ROLENAME -n $PGO_OPERATOR_NAMESPACE 2> /dev/null > /dev/null
 if [ $? -eq 0 ]; then
-	$PGO_CMD delete secret pgorole-$EXAMPLE_ROLENAME -n $PGO_OPERATOR_NAMESPACE
+	$PGO_CMD delete secret pgorole-$PGOADMIN_ROLENAME -n $PGO_OPERATOR_NAMESPACE
 fi
 
 expenv -f $DIR/pgorole-pgoadmin.yaml | $PGO_CMD create -f -
 
 # see if the bootstrap pgouser Secret exists or not, deleting it if found
-export PGOADMIN_USERNAME=`echo -n $EXAMPLE_USERNAME | base64 --wrap=0`
-export PGOADMIN_PASSWORD=`echo -n $EXAMPLE_PASSWORD | base64 --wrap=0`
-$PGO_CMD get secret pgouser-$EXAMPLE_USERNAME -n $PGO_OPERATOR_NAMESPACE  2> /dev/null > /dev/null
+$PGO_CMD get secret pgouser-$PGOADMIN_USERNAME -n $PGO_OPERATOR_NAMESPACE  2> /dev/null > /dev/null
 if [ $? -eq 0 ]; then
-	$PGO_CMD delete secret pgouser-$EXAMPLE_USERNAME -n $PGO_OPERATOR_NAMESPACE
+	$PGO_CMD delete secret pgouser-$PGOADMIN_USERNAME -n $PGO_OPERATOR_NAMESPACE
 fi
 expenv -f $DIR/pgouser-admin.yaml | $PGO_CMD create -f -
 

--- a/deploy/pgorole-pgoadmin.yaml
+++ b/deploy/pgorole-pgoadmin.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-data:
+stringData:
   permissions: $PGOADMIN_PERMS
   rolename: $PGOADMIN_ROLENAME
 kind: Secret
@@ -7,9 +7,9 @@ metadata:
   labels:
     pgo-created-by: bootstrap
     pgo-pgorole: "true"
-    rolename: $EXAMPLE_ROLENAME
+    rolename: $PGOADMIN_ROLENAME
     vendor: crunchydata
-  name: pgorole-$EXAMPLE_ROLENAME
+  name: pgorole-$PGOADMIN_ROLENAME
   namespace: $PGO_OPERATOR_NAMESPACE
 type: Opaque
 

--- a/deploy/pgorole.yaml
+++ b/deploy/pgorole.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-data:
+stringData:
   permissions: $PGO_PERMS
   rolename: $PGO_ROLENAME
 kind: Secret
@@ -7,9 +7,9 @@ metadata:
   labels:
     pgo-created-by: upgrade
     pgo-pgorole: "true"
-    rolename: $ROLENAME
+    rolename: $PGO_ROLENAME
     vendor: crunchydata
-  name: pgorole-$ROLENAME
+  name: pgorole-$PGO_ROLENAME
   namespace: $PGO_OPERATOR_NAMESPACE
 type: Opaque
 

--- a/deploy/pgouser-admin.yaml
+++ b/deploy/pgouser-admin.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-data:
+stringData:
   password: $PGOADMIN_PASSWORD
   username: $PGOADMIN_USERNAME
   roles: $PGOADMIN_ROLENAME
@@ -8,9 +8,9 @@ metadata:
   labels:
     pgo-created-by: bootstrap
     pgo-pgouser: "true"
-    username: $EXAMPLE_USERNAME
+    username: $PGOADMIN_USERNAME
     vendor: crunchydata
-  name: pgouser-$EXAMPLE_USERNAME
+  name: pgouser-$PGOADMIN_USERNAME
   namespace: $PGO_OPERATOR_NAMESPACE
 type: Opaque
 

--- a/deploy/pgouser.yaml
+++ b/deploy/pgouser.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-data:
+stringData:
   password: $PGO_PASSWORD
   username: $PGO_USERNAME
   roles: $PGO_ROLENAME
@@ -8,9 +8,9 @@ metadata:
   labels:
     pgo-created-by: upgrade
     pgo-pgouser: "true"
-    username: $USERNAME
+    username: $PGO_USERNAME
     vendor: crunchydata
-  name: pgouser-$USERNAME
+  name: pgouser-$PGO_USERNAME
   namespace: $PGO_OPERATOR_NAMESPACE
 type: Opaque
 

--- a/deploy/upgrade-creds.sh
+++ b/deploy/upgrade-creds.sh
@@ -49,14 +49,13 @@ do
         exit 1
     fi
 
-    export ROLENAME=$role
-    export PGO_ROLENAME=`echo -n $ROLENAME | base64 --wrap=0`
-    export PGO_PERMS=`echo -n $perms | base64 --wrap=0`
+    export PGO_ROLENAME=$role
+    export PGO_PERMS=$perms
 
     # see if the bootstrap pgorole Secret exists or not, deleting it if found
-    $PGO_CMD get secret pgorole-$ROLENAME -n $PGO_OPERATOR_NAMESPACE 2> /dev/null
+    $PGO_CMD get secret pgorole-$PGO_ROLENAME -n $PGO_OPERATOR_NAMESPACE 2> /dev/null
     if [ $? -eq 0 ]; then
-        $PGO_CMD delete secret pgorole-$ROLENAME -n $PGO_OPERATOR_NAMESPACE
+        $PGO_CMD delete secret pgorole-$PGO_ROLENAME -n $PGO_OPERATOR_NAMESPACE
     fi
 
     expenv -f $DIR/pgorole.yaml | $PGO_CMD create -f -
@@ -71,18 +70,14 @@ do
         exit 1
     fi
 
-    export USERNAME=$user
-    export PASSWORD=$pass
-    export ROLENAME=$role
+    export PGO_USERNAME=$user
+    export PGO_PASSWORD=$pass
+    export PGO_ROLENAME=$role
 
     # see if the bootstrap pgouser Secret exists or not, deleting it if found
-    export PGO_USERNAME=`echo -n $USERNAME | base64 --wrap=0`
-    export PGO_PASSWORD=`echo -n $PASSWORD | base64 --wrap=0`
-    export PGO_ROLENAME=`echo -n $ROLENAME | base64 --wrap=0`
-
-    $PGO_CMD get secret pgouser-$USERNAME -n $PGO_OPERATOR_NAMESPACE  2> /dev/null
+    $PGO_CMD get secret pgouser-$PGO_USERNAME -n $PGO_OPERATOR_NAMESPACE  2> /dev/null
     if [ $? -eq 0 ]; then
-        $PGO_CMD delete secret pgouser-$USERNAME -n $PGO_OPERATOR_NAMESPACE
+        $PGO_CMD delete secret pgouser-$PGO_USERNAME -n $PGO_OPERATOR_NAMESPACE
     fi
     expenv -f $DIR/pgouser.yaml | $PGO_CMD create -f -
 done < "$USER_INPUT"


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

`make installrbac` does not create pgoadmin role or user on macOS:
```
➜ make installrbac
cd deploy && ./install-rbac.sh
…
base64: unrecognized option `--wrap=0'
Usage:  base64 [-hvD] [-b num] [-i in_file] [-o out_file]
…
secret "pgorole-pgoadmin" deleted
error: error validating "STDIN": error validating data: [unknown object type "nil" in Secret.data.permissions, unknown object type "nil" in Secret.data.rolename]
…
base64: unrecognized option `--wrap=0'
Usage:  base64 [-hvD] [-b num] [-i in_file] [-o out_file]
…
secret "pgouser-pgoadmin" deleted
error: error validating "STDIN": error validating data: [unknown object type "nil" in Secret.data.password, unknown object type "nil" in Secret.data.roles, unknown object type "nil"
 in Secret.data.username]
…

➜ kubectl get secret -n "$PGO_OPERATOR_NAMESPACE" pgouser-pgoadmin
Error from server (NotFound): secrets "pgouser-pgoadmin" not found
```

**What is the new behavior (if this is a feature change)?**

No longer depends on a system's `base64` command.

```
➜ make installrbac
cd deploy && ./install-rbac.sh
…
secret/pgorole-pgoadmin created
secret/pgouser-pgoadmin created
…

➜ kubectl get secret -n "$PGO_OPERATOR_NAMESPACE" pgouser-pgoadmin -o yaml
apiVersion: v1
data:
  password: ZXhhbXBsZXBhc3N3b3Jk
  roles: cGdvYWRtaW4=
  username: cGdvYWRtaW4=
…
```