### PR TITLE
pgo: generate Bash completion on-demand (#667)

### DIFF
--- a/pgo/cmd/root.go
+++ b/pgo/cmd/root.go
@@ -84,14 +84,19 @@ func initConfig() {
 
 	GetCredentials()
 
-	generateBashCompletion()
+	if os.Getenv("GENERATE_BASH_COMPLETION") != "" {
+		if err := generateBashCompletion(); err != nil {
+			fmt.Printf("Error generating Bash completion: %v", err)
+		}
+	}
 }
 
-func generateBashCompletion() {
-	file, err2 := os.Create("/tmp/pgo-bash-completion.out")
-	if err2 != nil {
-		fmt.Println("Error: ", err2.Error())
+func generateBashCompletion() error {
+	log.Debugf("generating bash completion script")
+	file, err := os.Create("/tmp/pgo-bash-completion.out")
+	if err != nil {
+		return err
 	}
 	defer file.Close()
-	RootCmd.GenBashCompletion(file)
+	return RootCmd.GenBashCompletion(file)
 }


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

See #667. This annoying behavior is fixed in develop branch, but not in develop-3.5

**What is the new behavior (if this is a feature change)?**

Like in 4.*, Bash completion now will be generated only when enviroment variable `GENERATE_BASH_COMPLETION` is set to non-empty string.

**Other information**:
