### PR TITLE
Initialize Label Map if Necessary when PGO Takes Ownership of a Namespace 

### DIFF
--- a/ns/nslogic.go
+++ b/ns/nslogic.go
@@ -19,16 +19,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"os"
+	"strings"
+
 	"github.com/crunchydata/postgres-operator/config"
 	"github.com/crunchydata/postgres-operator/events"
 	"github.com/crunchydata/postgres-operator/kubeapi"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
-	"os"
-	"strings"
 )
 
 const PGO_TARGET_ROLE = "pgo-target-role"
@@ -496,6 +497,9 @@ func ValidateNamespaces(clientset *kubernetes.Clientset, installationName, pgoNa
 				log.Infof("%s namespace already part of this installation", namespace.Name)
 			} else {
 				log.Infof("%s namespace will be updated to be owned by this installation", namespace.Name)
+				if namespace.ObjectMeta.Labels == nil {
+					namespace.ObjectMeta.Labels = make(map[string]string)
+				}
 				namespace.ObjectMeta.Labels[config.LABEL_VENDOR] = config.LABEL_CRUNCHY
 				namespace.ObjectMeta.Labels[config.LABEL_PGO_INSTALLATION_NAME] = installationName
 				err := kubeapi.UpdateNamespace(clientset, namespace)


### PR DESCRIPTION
The label map for a namespace is now initialized if it is `nil` (i.e. if the namespace doesn't have any existing labels) when the PGO attempts to take ownership of an existing namespace and therefore set the required PGO namespace labels.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
When the PGO attempts to take ownership of an existing Namespace without any labels during Operator initialization, a `nil map` error is thrown, and the PGO is unable to take ownership of the namespace. This results in invalid PGO RBAC for the namespace.

[ch4813]

**What is the new behavior (if this is a feature change)?**
The Namespace label map is initialized when `nil` prior to setting any labels when the PGO takes ownership of the namespace.


**Other information**:
N/A