### PR TITLE
Fixed Invalid Links to 'Prerequisites' page in Ansible Install Docs

### DIFF
--- a/hugo/content/Installation/install-with-ansible/installing-metrics.md
+++ b/hugo/content/Installation/install-with-ansible/installing-metrics.md
@@ -16,7 +16,7 @@ using the provided Ansible roles.
 
 ## Prerequisites
 
-The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prereq/prerequisites/)
+The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prerequisites/)
 we can now install the PostgreSQL Operator.
 
 At a minimum, the following inventory variables should be configured to install the 

--- a/hugo/content/Installation/install-with-ansible/installing-operator.md
+++ b/hugo/content/Installation/install-with-ansible/installing-operator.md
@@ -7,7 +7,7 @@ weight: 21
 
 # Installing
 
-The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prereq/prerequisites/)
+The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prerequisites/)
 we can now install the PostgreSQL Operator.
 
 The commands should be run in the directory where the Crunchy PostgreSQL Operator

--- a/hugo/content/Installation/install-with-ansible/uninstalling-metrics.md
+++ b/hugo/content/Installation/install-with-ansible/uninstalling-metrics.md
@@ -7,7 +7,7 @@ weight: 41
 
 # Uninstalling the Metrics Stack
 
-The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prereq/prerequisites/)
+The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prerequisites/)
 we can now deprovision the PostgreSQL Operator Metrics Infrastructure.
 
 First, it is recommended to use the playbooks tagged with the same version

--- a/hugo/content/Installation/install-with-ansible/uninstalling-operator.md
+++ b/hugo/content/Installation/install-with-ansible/uninstalling-operator.md
@@ -7,7 +7,7 @@ weight: 40
 
 # Uninstalling PostgreSQL Operator
 
-The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prereq/prerequisites/)
+The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prerequisites/)
 we can now deprovision the PostgreSQL Operator.
 
 First, it is recommended to use the playbooks tagged with the same version

--- a/hugo/content/Installation/install-with-ansible/updating-operator.md
+++ b/hugo/content/Installation/install-with-ansible/updating-operator.md
@@ -16,7 +16,7 @@ of the service.  Using the `update` flag will:
 * Allow administrators to change settings configured in the `inventory`
 * Reinstall the `pgo` client if a new version is specified
 
-The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prereq/prerequisites/)
+The following assumes the proper [prerequisites are satisfied](/installation/install-with-ansible/prerequisites/)
 we can now update the PostgreSQL Operator.
 
 The commands should be run in the directory where the Crunchy PostgreSQL Operator 


### PR DESCRIPTION
Fixed invalid links to the Ansible **Prerequisites** page in the Ansible installation documentation.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Various links to the the Ansible **Prerequisites** page in the Ansible installation documentation are broken.


**What is the new behavior (if this is a feature change)?**

Links to the the Ansible **Prerequisites** page in the Ansible installation documentation now work as expected.

**Other information**:

N/A