### PR TITLE
Queue pgbackup

### DIFF
--- a/conf/postgres-operator/pgo.yaml
+++ b/conf/postgres-operator/pgo.yaml
@@ -4,7 +4,7 @@ Cluster:
   CCPImagePrefix:  crunchydata
   Metrics:  false
   Badger:  false
-  CCPImageTag:  centos7-11.4-2.4.2-rc2
+  CCPImageTag:  rhel7-11.4-2.4.2-rc2
   Port:  5432
   User:  testuser
   Database:  userdb
@@ -101,4 +101,4 @@ Pgo:
   PreferredFailoverNode:  
   Audit:  false
   PGOImagePrefix:  crunchydata
-  PGOImageTag:  centos7-4.1.0-rc2
+  PGOImageTag:  rhel7-4.1.0-rc2

--- a/controller/backupcontroller.go
+++ b/controller/backupcontroller.go
@@ -17,19 +17,21 @@ limitations under the License.
 
 import (
 	"context"
-
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"strings"
+	//	"time"
 
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/kubeapi"
 	"github.com/crunchydata/postgres-operator/ns"
 	"github.com/crunchydata/postgres-operator/operator"
 	backupoperator "github.com/crunchydata/postgres-operator/operator/backup"
+	"k8s.io/client-go/util/workqueue"
 )
 
 // PgbackupController holds connections required by the controller
@@ -38,11 +40,17 @@ type PgbackupController struct {
 	PgbackupScheme    *runtime.Scheme
 	PgbackupClientset *kubernetes.Clientset
 	Ctx               context.Context
+	Queue             workqueue.RateLimitingInterface
+	UpdateQueue       workqueue.RateLimitingInterface
 }
 
 // Run starts controller
 func (c *PgbackupController) Run() error {
 	log.Debugf("Watch Pgbackup objects")
+
+	//shut down the work queue to cause workers to end
+	defer c.Queue.ShutDown()
+	defer c.UpdateQueue.ShutDown()
 
 	err := c.watchPgbackups(c.Ctx)
 	if err != nil {
@@ -51,6 +59,9 @@ func (c *PgbackupController) Run() error {
 	}
 
 	<-c.Ctx.Done()
+
+	log.Debugf("Watch Pgbackup ending")
+
 	return c.Ctx.Err()
 }
 
@@ -66,8 +77,149 @@ func (c *PgbackupController) watchPgbackups(ctx context.Context) error {
 	return nil
 }
 
+func (c *PgbackupController) RunWorker() {
+
+	//process the 'add' work queue forever
+	for c.processNextItem() {
+	}
+}
+
+func (c *PgbackupController) RunUpdateWorker() {
+
+	//process the 'add' work queue forever
+	for c.processNextUpdateItem() {
+	}
+}
+
+func (c *PgbackupController) processNextUpdateItem() bool {
+	// Wait until there is a new item in the working queue
+	key, quit := c.UpdateQueue.Get()
+	if quit {
+		return false
+	}
+
+	log.Debugf("working on %s", key.(string))
+	keyParts := strings.Split(key.(string), "/")
+	keyNamespace := keyParts[0]
+	keyResourceName := keyParts[1]
+
+	log.Debugf("update queue got key ns=[%s] resource=[%s]", keyNamespace, keyResourceName)
+
+	// Tell the queue that we are done with processing this key. This unblocks the key for other workers
+	// This allows safe parallel processing because two pods with the same key are never processed in
+	// parallel.
+	defer c.UpdateQueue.Done(key)
+
+	// Invoke the method containing the business logic
+	// for pgbackups, the convention is the CRD name is always
+	// the same as the pg-cluster label value
+
+	// in this case, the de-dupe logic is to test whether a backup
+	// job is already running, if so, then we don't create another
+	// backup job
+	selector := "pg-cluster=" + keyResourceName + ",pgbackup=true"
+	jobs, err := kubeapi.GetJobs(c.PgbackupClientset, selector, keyNamespace)
+	if err != nil {
+		log.Errorf("update working...error found " + err.Error())
+		return true
+	}
+
+	jobRunning := false
+	for _, j := range jobs.Items {
+		if j.Status.Succeeded <= 0 {
+			jobRunning = true
+		}
+	}
+
+	if jobRunning {
+		log.Debugf("update working...found job already, would do nothing")
+	} else {
+		log.Debugf("update working...no job found, means we process")
+		b := crv1.Pgbackup{}
+		found, err := kubeapi.Getpgbackup(c.PgbackupClient, &b, keyResourceName, keyNamespace)
+		if found {
+			state := crv1.PgbackupStateProcessed
+			message := "Successfully processed Pgbackup by controller"
+			err = kubeapi.PatchpgbackupStatus(c.PgbackupClient, state, message, &b, b.ObjectMeta.Namespace)
+			if err != nil {
+				log.Errorf("ERROR updating pgbackup status: %s", err.Error())
+			}
+
+			backupoperator.AddBackupBase(c.PgbackupClientset, c.PgbackupClient, &b, b.ObjectMeta.Namespace)
+
+			//no error, tell the queue to stop tracking history
+			c.UpdateQueue.Forget(key)
+		}
+	}
+
+	return true
+}
+
+func (c *PgbackupController) processNextItem() bool {
+	// Wait until there is a new item in the working queue
+	key, quit := c.Queue.Get()
+	if quit {
+		return false
+	}
+
+	log.Debugf("working on %s", key.(string))
+	keyParts := strings.Split(key.(string), "/")
+	keyNamespace := keyParts[0]
+	keyResourceName := keyParts[1]
+
+	log.Debugf("queue got key ns=[%s] resource=[%s]", keyNamespace, keyResourceName)
+
+	// Tell the queue that we are done with processing this key. This unblocks the key for other workers
+	// This allows safe parallel processing because two pods with the same key are never processed in
+	// parallel.
+	defer c.Queue.Done(key)
+
+	// Invoke the method containing the business logic
+	// for pgbackups, the convention is the CRD name is always
+	// the same as the pg-cluster label value
+
+	// in this case, the de-dupe logic is to test whether a backup
+	// job is already running, if so, then we don't create another
+	// backup job
+	selector := "pg-cluster=" + keyResourceName + ",pgbackup=true"
+	jobs, err := kubeapi.GetJobs(c.PgbackupClientset, selector, keyNamespace)
+	if err != nil {
+		log.Errorf("working...error found " + err.Error())
+		return true
+	}
+
+	jobRunning := false
+	for _, j := range jobs.Items {
+		if j.Status.Succeeded <= 0 {
+			jobRunning = true
+		}
+	}
+
+	if jobRunning {
+		log.Debugf("working...found job already, would do nothing")
+	} else {
+		log.Debugf("working...no job found, means we process")
+		b := crv1.Pgbackup{}
+		found, err := kubeapi.Getpgbackup(c.PgbackupClient, &b, keyResourceName, keyNamespace)
+		if found {
+			state := crv1.PgbackupStateProcessed
+			message := "Successfully processed Pgbackup by controller"
+			err = kubeapi.PatchpgbackupStatus(c.PgbackupClient, state, message, &b, b.ObjectMeta.Namespace)
+			if err != nil {
+				log.Errorf("ERROR updating pgbackup status: %s", err.Error())
+			}
+			backupoperator.AddBackupBase(c.PgbackupClientset, c.PgbackupClient, &b, b.ObjectMeta.Namespace)
+
+			//no error, tell the queue to stop tracking history
+			c.Queue.Forget(key)
+		}
+	}
+	return true
+}
+
 // onAdd is called when a pgbackup is added
 func (c *PgbackupController) onAdd(obj interface{}) {
+
 	backup := obj.(*crv1.Pgbackup)
 	log.Debugf("[PgbackupController] ns=%s onAdd %s", backup.ObjectMeta.Namespace, backup.ObjectMeta.SelfLink)
 
@@ -78,22 +230,12 @@ func (c *PgbackupController) onAdd(obj interface{}) {
 		return
 	}
 
-	// NEVER modify objects from the store. It's a read-only, local cache.
-	// You can use backupScheme.Copy() to make a deep copy of original object and modify this copy
-	// Or create a copy manually for better performance
-	copyObj := backup.DeepCopyObject()
-
-	backupCopy := copyObj.(*crv1.Pgbackup)
-
-	state := crv1.PgbackupStateProcessed
-	message := "Successfully processed Pgbackup by controller"
-	err := kubeapi.PatchpgbackupStatus(c.PgbackupClient, state, message, backupCopy, backup.ObjectMeta.Namespace)
-	if err != nil {
-		log.Errorf("ERROR updating pgbackup status: %s", err.Error())
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err == nil {
+		log.Debugf("[PgbackupController] putting key in queue %s", key)
+		c.Queue.Add(key)
 	}
 
-	//handle new pgbackups
-	backupoperator.AddBackupBase(c.PgbackupClientset, c.PgbackupClient, backupCopy, backup.ObjectMeta.Namespace)
 }
 
 // onUpdate is called when a pgbackup is updated
@@ -105,8 +247,14 @@ func (c *PgbackupController) onUpdate(oldObj, newObj interface{}) {
 	if oldBackup.Spec.BackupStatus != crv1.PgBackupJobReSubmitted &&
 		backup.Spec.BackupStatus == crv1.PgBackupJobReSubmitted {
 		log.Debugf("[PgbackupController] ns=%s onUpdate %s re-submitted", backup.ObjectMeta.Namespace, backup.ObjectMeta.SelfLink)
-		backupoperator.AddBackupBase(c.PgbackupClientset, c.PgbackupClient, backup, backup.ObjectMeta.Namespace)
+
+		key, err := cache.MetaNamespaceKeyFunc(oldObj)
+		if err == nil {
+			log.Debugf("[PgbackupController] putting key in update queue %s", key)
+			c.UpdateQueue.Add(key)
+		}
 	}
+
 }
 
 // onDelete is called when a pgbackup is deleted

--- a/controller/jobcontroller.go
+++ b/controller/jobcontroller.go
@@ -145,13 +145,10 @@ func (c *JobController) onUpdate(oldObj, newObj interface{}) {
 
 		}
 
-		//update the pgbackup status
-		backup.Spec.BackupStatus = status
-
 		//update the pgbackup
-		err = kubeapi.Updatepgbackup(c.JobClient, &backup, backupName, job.ObjectMeta.Namespace)
+		err = kubeapi.PatchpgbackupBackupStatus(c.JobClient, status, &backup, job.ObjectMeta.Namespace)
 		if err != nil {
-			log.Error("error in updating pgbackup " + labels["pg-cluster"] + err.Error())
+			log.Error("error in patching pgbackup " + labels["pg-cluster"] + err.Error())
 			return
 		}
 

--- a/controller/replicacontroller.go
+++ b/controller/replicacontroller.go
@@ -17,19 +17,19 @@ limitations under the License.
 
 import (
 	"context"
+	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/kubeapi"
 	"github.com/crunchydata/postgres-operator/ns"
 	"github.com/crunchydata/postgres-operator/operator"
+	clusteroperator "github.com/crunchydata/postgres-operator/operator/cluster"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/fields"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-
-	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
-	clusteroperator "github.com/crunchydata/postgres-operator/operator/cluster"
+	"k8s.io/client-go/util/workqueue"
+	"strings"
 )
 
 // PgreplicaController holds the connections for the controller
@@ -37,11 +37,15 @@ type PgreplicaController struct {
 	PgreplicaClient    *rest.RESTClient
 	PgreplicaScheme    *runtime.Scheme
 	PgreplicaClientset *kubernetes.Clientset
-	Ctx                context.Context
+	Queue              workqueue.RateLimitingInterface
+
+	Ctx context.Context
 }
 
 // Run starts an pgreplica resource controller
 func (c *PgreplicaController) Run() error {
+
+	defer c.Queue.ShutDown()
 
 	err := c.watchPgreplicas(c.Ctx)
 	if err != nil {
@@ -66,6 +70,73 @@ func (c *PgreplicaController) watchPgreplicas(ctx context.Context) error {
 	return nil
 }
 
+func (c *PgreplicaController) RunWorker() {
+
+	//process the 'add' work queue forever
+	for c.processNextItem() {
+	}
+}
+
+func (c *PgreplicaController) processNextItem() bool {
+	// Wait until there is a new item in the working queue
+	key, quit := c.Queue.Get()
+	if quit {
+		return false
+	}
+
+	log.Debugf("working on %s", key.(string))
+	keyParts := strings.Split(key.(string), "/")
+	keyNamespace := keyParts[0]
+	keyResourceName := keyParts[1]
+
+	log.Debugf("pgreplica queue got key ns=[%s] resource=[%s]", keyNamespace, keyResourceName)
+
+	// Tell the queue that we are done with processing this key. This unblocks the key for other workers
+	// This allows safe parallel processing because two pods with the same key are never processed in
+	// parallel.
+	defer c.Queue.Done(key)
+	// Invoke the method containing the business logic
+	// for pgbackups, the convention is the CRD name is always
+	// the same as the pg-cluster label value
+
+	// in this case, the de-dupe logic is to test whether a replica
+	// deployment exists already , if so, then we don't create another
+	// backup job
+	_, found, _ := kubeapi.GetDeployment(c.PgreplicaClientset, keyResourceName, keyNamespace)
+
+	depRunning := false
+	if found {
+		depRunning = true
+	}
+
+	if depRunning {
+		log.Debugf("working...found replica already, would do nothing")
+	} else {
+		log.Debugf("working...no replica found, means we process")
+
+		//handle the case of when a pgreplica is added which is
+		//scaling up a cluster
+		replica := crv1.Pgreplica{}
+		found, err := kubeapi.Getpgreplica(c.PgreplicaClient, &replica, keyResourceName, keyNamespace)
+		if !found {
+			log.Error(err)
+			return false
+		}
+		clusteroperator.ScaleBase(c.PgreplicaClientset, c.PgreplicaClient, &replica, replica.ObjectMeta.Namespace)
+
+		state := crv1.PgreplicaStateProcessed
+		message := "Successfully processed Pgreplica by controller"
+		err = kubeapi.PatchpgreplicaStatus(c.PgreplicaClient, state, message, &replica, replica.ObjectMeta.Namespace)
+		if err != nil {
+			log.Errorf("ERROR updating pgreplica status: %s", err.Error())
+		}
+
+		//no error, tell the queue to stop tracking history
+		c.Queue.Forget(key)
+	}
+	return true
+}
+
 // onAdd is called when a pgreplica is added
 func (c *PgreplicaController) onAdd(obj interface{}) {
 	replica := obj.(*crv1.Pgreplica)
@@ -78,22 +149,11 @@ func (c *PgreplicaController) onAdd(obj interface{}) {
 		return
 	}
 
-	// NEVER modify objects from the store. It's a read-only, local cache.
-	// You can use clusterScheme.Copy() to make a deep copy of original object and modify this copy
-	// Or create a copy manually for better performance
-	copyObj := replica.DeepCopyObject()
-	replicaCopy := copyObj.(*crv1.Pgreplica)
-
-	state := crv1.PgreplicaStateProcessed
-	message := "Successfully processed Pgreplica by controller"
-	err := kubeapi.PatchpgreplicaStatus(c.PgreplicaClient, state, message, replicaCopy, replica.ObjectMeta.Namespace)
-	if err != nil {
-		log.Errorf("ERROR updating pgreplica status: %s", err.Error())
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err == nil {
+		log.Debugf("onAdd putting key in queue %s", key)
+		c.Queue.Add(key)
 	}
-
-	//handle the case of when a pgreplica is added which is
-	//scaling up a cluster
-	clusteroperator.ScaleBase(c.PgreplicaClientset, c.PgreplicaClient, replicaCopy, replicaCopy.ObjectMeta.Namespace)
 
 }
 
@@ -108,8 +168,6 @@ func (c *PgreplicaController) onUpdate(oldObj, newObj interface{}) {
 func (c *PgreplicaController) onDelete(obj interface{}) {
 	replica := obj.(*crv1.Pgreplica)
 	log.Debugf("[PgreplicaController] OnDelete ns=%s %s", replica.ObjectMeta.Namespace, replica.ObjectMeta.SelfLink)
-
-	//clusteroperator.DeleteReplica(c.PgreplicaClientset, replica, replica.ObjectMeta.Namespace)
 
 	clusteroperator.ScaleDownBase(c.PgreplicaClientset, c.PgreplicaClient, replica, replica.ObjectMeta.Namespace)
 

--- a/postgres-operator.go
+++ b/postgres-operator.go
@@ -115,6 +115,7 @@ func main() {
 		PgreplicaClient:    crdClient,
 		PgreplicaScheme:    crdScheme,
 		PgreplicaClientset: Clientset,
+		Queue:              workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		Ctx:                ctx,
 	}
 	pgBackupcontroller := controller.PgbackupController{
@@ -158,6 +159,7 @@ func main() {
 	go pgTaskcontroller.Run()
 	go pgClustercontroller.Run()
 	go pgReplicacontroller.Run()
+	go pgReplicacontroller.RunWorker()
 	go pgBackupcontroller.Run()
 	go pgBackupcontroller.RunWorker()
 	go pgBackupcontroller.RunUpdateWorker()

--- a/postgres-operator.go
+++ b/postgres-operator.go
@@ -24,11 +24,12 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	crunchylog "github.com/crunchydata/postgres-operator/logging"
+	log "github.com/sirupsen/logrus"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/crunchydata/postgres-operator/controller"
 	"github.com/crunchydata/postgres-operator/ns"
@@ -40,6 +41,7 @@ import (
 )
 
 var Clientset *kubernetes.Clientset
+
 //var log *logrus.Entry
 
 func main() {
@@ -120,6 +122,8 @@ func main() {
 		PgbackupScheme:    crdScheme,
 		PgbackupClientset: Clientset,
 		Ctx:               ctx,
+		Queue:             workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		UpdateQueue:       workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 	}
 	pgPolicycontroller := controller.PgpolicyController{
 		PgpolicyClient:    crdClient,
@@ -155,6 +159,8 @@ func main() {
 	go pgClustercontroller.Run()
 	go pgReplicacontroller.Run()
 	go pgBackupcontroller.Run()
+	go pgBackupcontroller.RunWorker()
+	go pgBackupcontroller.RunUpdateWorker()
 	go pgPolicycontroller.Run()
 	go podcontroller.Run()
 	go nscontroller.Run()


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

since pgbackup events are not being queued, multiple onAdd events are seen to be
happening on OCP primarily (as designed within kube!)...the backup controller
takes action on both 'add' events which can result in seeing double backup jobs
created.

this same double 'add' event can happen in the pgreplica controller resulting in 
more than the requested replicas being created.

**What is the new behavior (if this is a feature change)?**

a queue is introduced for both pgreplica and pgbackup crd events, a worker
is started that processes each queue for add and update events.  This allows
for de-dupe logic to make sure double events are not processed.

**Other information**:
