### PR TITLE
add queue to cluster controller for onAdd events

### DIFF
--- a/conf/postgres-operator/pgo.yaml
+++ b/conf/postgres-operator/pgo.yaml
@@ -4,7 +4,7 @@ Cluster:
   CCPImagePrefix:  crunchydata
   Metrics:  false
   Badger:  false
-  CCPImageTag:  rhel7-11.4-2.4.2-rc2
+  CCPImageTag:  centos7-11.4-2.4.2-rc2
   Port:  5432
   User:  testuser
   Database:  userdb
@@ -101,4 +101,4 @@ Pgo:
   PreferredFailoverNode:  
   Audit:  false
   PGOImagePrefix:  crunchydata
-  PGOImageTag:  rhel7-4.1.0-rc2
+  PGOImageTag:  centos7-4.1.0-rc2

--- a/controller/clustercontroller.go
+++ b/controller/clustercontroller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crunchydata/postgres-operator/ns"
 	"github.com/crunchydata/postgres-operator/operator"
 	"io/ioutil"
+	"strings"
 
 	clusteroperator "github.com/crunchydata/postgres-operator/operator/cluster"
 	log "github.com/sirupsen/logrus"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 )
 
 // PgclusterController holds the connections for the controller
@@ -40,12 +42,16 @@ type PgclusterController struct {
 	PgclusterClient    *rest.RESTClient
 	PgclusterScheme    *runtime.Scheme
 	PgclusterClientset *kubernetes.Clientset
+	Queue              workqueue.RateLimitingInterface
 	Ctx                context.Context
 }
 
 // Run starts an pgcluster resource controller
 func (c *PgclusterController) Run() error {
 	log.Debug("Watch Pgcluster objects")
+
+	//shut down the work queue to cause workers to end
+	defer c.Queue.ShutDown()
 
 	err := c.watchPgclusters(c.Ctx)
 	if err != nil {
@@ -54,6 +60,7 @@ func (c *PgclusterController) Run() error {
 	}
 
 	<-c.Ctx.Done()
+
 	return c.Ctx.Err()
 }
 
@@ -80,25 +87,76 @@ func (c *PgclusterController) onAdd(obj interface{}) {
 		return
 	}
 
-	// NEVER modify objects from the store. It's a read-only, local cache.
-	// You can use clusterScheme.Copy() to make a deep copy of original object and modify this copy
-	// Or create a copy manually for better performance
-	copyObj := cluster.DeepCopyObject()
-	clusterCopy := copyObj.(*crv1.Pgcluster)
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err == nil {
+		log.Debugf("cluster putting key in queue %s", key)
+		c.Queue.Add(key)
+	}
 
-	addIdentifier(clusterCopy)
+}
+
+func (c *PgclusterController) RunWorker() {
+
+	//process the 'add' work queue forever
+	for c.processNextItem() {
+	}
+}
+
+func (c *PgclusterController) processNextItem() bool {
+	// Wait until there is a new item in the working queue
+	key, quit := c.Queue.Get()
+	if quit {
+		return false
+	}
+
+	log.Debugf("working on %s", key.(string))
+	keyParts := strings.Split(key.(string), "/")
+	keyNamespace := keyParts[0]
+	keyResourceName := keyParts[1]
+
+	log.Debugf("cluster add queue got key ns=[%s] resource=[%s]", keyNamespace, keyResourceName)
+
+	// Tell the queue that we are done with processing this key. This unblocks the key for other workers
+	// This allows safe parallel processing because two pods with the same key are never processed in
+	// parallel.
+	defer c.Queue.Done(key)
+
+	// Invoke the method containing the business logic
+	// for pgbackups, the convention is the CRD name is always
+	// the same as the pg-cluster label value
+
+	// in this case, the de-dupe logic is to test whether a cluster
+	// deployment exists , if so, then we don't create another
+	_, found, err := kubeapi.GetDeployment(c.PgclusterClientset, keyResourceName, keyNamespace)
+
+	if found {
+		log.Debugf("cluster add - dep already found, not creating again")
+		return true
+	}
+
+	//get the pgcluster
+	cluster := crv1.Pgcluster{}
+	found, err = kubeapi.Getpgcluster(c.PgclusterClient, &cluster, keyResourceName, keyNamespace)
+	if !found {
+		log.Debugf("cluster add - pgcluster not found, this is invalid")
+		return false
+	}
+
+	addIdentifier(&cluster)
 
 	state := crv1.PgclusterStateProcessed
 	message := "Successfully processed Pgcluster by controller"
-	err := kubeapi.PatchpgclusterStatus(c.PgclusterClient, state, message, clusterCopy, cluster.ObjectMeta.Namespace)
+	err = kubeapi.PatchpgclusterStatus(c.PgclusterClient, state, message, &cluster, keyNamespace)
 	if err != nil {
 		log.Errorf("ERROR updating pgcluster status on add: %s", err.Error())
+		return false
 	}
 
 	log.Debugf("pgcluster added: %s", cluster.ObjectMeta.Name)
 
-	clusteroperator.AddClusterBase(c.PgclusterClientset, c.PgclusterClient, clusterCopy, cluster.ObjectMeta.Namespace)
+	clusteroperator.AddClusterBase(c.PgclusterClientset, c.PgclusterClient, &cluster, cluster.ObjectMeta.Namespace)
 
+	return true
 }
 
 // onUpdate is called when a pgcluster is updated

--- a/postgres-operator.go
+++ b/postgres-operator.go
@@ -109,6 +109,7 @@ func main() {
 		PgclusterClient:    crdClient,
 		PgclusterScheme:    crdScheme,
 		PgclusterClientset: Clientset,
+		Queue:              workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		Ctx:                ctx,
 	}
 	pgReplicacontroller := controller.PgreplicaController{
@@ -158,6 +159,7 @@ func main() {
 	defer cancelFunc()
 	go pgTaskcontroller.Run()
 	go pgClustercontroller.Run()
+	go pgClustercontroller.RunWorker()
 	go pgReplicacontroller.Run()
 	go pgReplicacontroller.RunWorker()
 	go pgBackupcontroller.Run()


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
its possible for 2 onAdd events for pgcluster to be sent to the controller, this causes
a duplicate try at creating a cluster which throws various errors in the logs


**What is the new behavior (if this is a feature change)?**

a queue is used and de-dupe logic in the cluster controller to detect and avoid trying
to create the same cluster twice.

**Other information**:
