### PR TITLE
Ansible Namespace Deprovisioning, Namespace Creation (OCP only) & Cleanup Fixes

### DIFF
--- a/ansible/inventory
+++ b/ansible/inventory
@@ -70,10 +70,14 @@ pgo_image_tag='centos7-4.1.0'
 
 # PGO Client Install
 pgo_client_install='true'
-pgo_client_version='4.1.0'
+pgo_client_version='v4.1.0'
 
 # PGO TLS
 pgo_tls_no_verify='false'
+
+# Set to 'true' to assign the cluster-admin role to the PGO service account.  Needed for
+# OCP installs to enable dynamic namespace creation (see the PGO docs for more details).
+#pgo_cluster_admin='false'
 
 # This will set default enhancements for operator deployed PostgreSQL clusters
 auto_failover='false'
@@ -238,3 +242,17 @@ prometheus_install='false'
 #prometheus_volume_size='1G'
 #prometheus_supplemental_groups=65534
 #prometheus_fs_group=26
+
+
+# ==================
+# Namespace Cleanup
+# ==================
+# The following settings determine whether or not the PGO and metrics namespaces (defined using 
+# inventory variables 'pgo_operator_namespace', 'namespace' and 'metrics_namespace') are deleted
+# when deprovisioning. Please note that this will also result in the deletion of any non-PGO
+# resources deployed in these namespaces, and cannot be undone. By default (and unless otherwise 
+# specified using the variables below), all namespaces will be preserved when deprovisioning.
+
+#delete_operator_namespace: 'false'
+#delete_watched_namespaces: 'false'
+#delete_metrics_namespace: 'false'

--- a/ansible/roles/pgo-metrics/tasks/kubernetes_cleanup.yml
+++ b/ansible/roles/pgo-metrics/tasks/kubernetes_cleanup.yml
@@ -1,0 +1,9 @@
+---
+- name: Delete Metrics Namespace (Kubernetes)
+  shell: |
+    kubectl delete namespace {{ metrics_namespace }}
+  when: delete_metrics_namespace|bool
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision-metrics

--- a/ansible/roles/pgo-metrics/tasks/main.yml
+++ b/ansible/roles/pgo-metrics/tasks/main.yml
@@ -28,6 +28,14 @@
 - include_tasks: cleanup.yml
   tags: [deprovision-metrics, upgrade-metrics]
 
+- include_tasks: kubernetes_cleanup.yml
+  when: kubernetes_context is defined
+  tags: [deprovision-metrics]
+
+- include_tasks: openshift_cleanup.yml
+  when: openshift_host is defined
+  tags: [deprovision-metrics]
+
 - name: Use kubectl or oc
   set_fact:
     kubectl_or_oc: "{{ openshift_oc_bin if openshift_oc_bin is defined else 'kubectl' }}"

--- a/ansible/roles/pgo-metrics/tasks/openshift_cleanup.yml
+++ b/ansible/roles/pgo-metrics/tasks/openshift_cleanup.yml
@@ -1,0 +1,9 @@
+---
+- name: Delete Metrics Namespace (Openshift)
+  shell: |
+    {{ openshift_oc_bin}} delete project {{ metrics_namespace }}
+  when: delete_metrics_namespace|bool
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision-metrics

--- a/ansible/roles/pgo-operator/defaults/main.yml
+++ b/ansible/roles/pgo-operator/defaults/main.yml
@@ -19,3 +19,8 @@ common_name: "crunchydata"
 crunchy_debug: "false"
 
 pgo_client_install: "true"
+pgo_cluster_admin: "false"
+
+delete_operator_namespace: "false"
+delete_watched_namespaces: "false"
+delete_metrics_namespace: "false"

--- a/ansible/roles/pgo-operator/tasks/cleanup.yml
+++ b/ansible/roles/pgo-operator/tasks/cleanup.yml
@@ -27,12 +27,20 @@
 - name: Delete existing secrets (Operator Namespace)
   shell: |
     {{ kubectl_or_oc }} delete secret pgo-backrest-repo-config pgorole-{{ pgo_admin_role_name }} \
-      pgouser-{{ pgo_admin_role_name }} -n {{ pgo_operator_namespace }}
+      pgouser-{{ pgo_admin_username }} -n {{ pgo_operator_namespace }}
   ignore_errors: yes
   no_log: false
   tags:
   - deprovision
   - update
+
+- name: Delete pgo.tls secret
+  shell: |
+    {{ kubectl_or_oc }} delete secret pgo.tls -n {{ pgo_operator_namespace }}
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision
 
 - name: Delete existing Services
   shell: |
@@ -43,7 +51,7 @@
   - deprovision
   - update
 
-- name: Delete existing Service Account
+- name: Delete existing Service Account (Operator Namespace)
   shell: |
     {{ kubectl_or_oc }} delete serviceaccount postgres-operator -n {{ pgo_operator_namespace }}
   ignore_errors: yes
@@ -53,7 +61,7 @@
   - update
   when: create_rbac|bool
 
-- name: Delete existing Service Account
+- name: Delete existing Service Accounts (Watched Namespaces)
   shell: |
     {{ kubectl_or_oc }} delete serviceaccount pgo-backrest -n {{ item }}
   with_items:
@@ -70,6 +78,15 @@
     {{ kubectl_or_oc }} delete clusterrolebinding {{ item }}
   with_items:
   - "pgo-cluster-role"
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision
+  - update
+  when: create_rbac|bool
+
+- name: Delete cluster-admin Cluster Role Binding for PGO Service Account
+  command: "{{ kubectl_or_oc }} delete clusterrolebinding pgo-cluster-admin"
   ignore_errors: yes
   no_log: false
   tags:

--- a/ansible/roles/pgo-operator/tasks/kubernetes_cleanup.yml
+++ b/ansible/roles/pgo-operator/tasks/kubernetes_cleanup.yml
@@ -1,0 +1,20 @@
+---
+- name: Delete Watched Namespaces (Kubernetes)
+  shell: |
+    kubectl delete namespace {{ item }}
+  when: delete_watched_namespaces|bool
+  ignore_errors: yes
+  with_items:
+  - "{{ namespace.split(',') }}"
+  no_log: false
+  tags:
+  - deprovision
+
+- name: Delete Operator Namespace (Kubernetes)
+  shell: |
+    kubectl delete namespace {{ pgo_operator_namespace }}
+  when: delete_operator_namespace|bool
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision

--- a/ansible/roles/pgo-operator/tasks/main.yml
+++ b/ansible/roles/pgo-operator/tasks/main.yml
@@ -50,6 +50,14 @@
 - include_tasks: cleanup.yml
   tags: [deprovision, update]
 
+- include_tasks: kubernetes_cleanup.yml
+  when: kubernetes_context is defined
+  tags: [deprovision]
+
+- include_tasks: openshift_cleanup.yml
+  when: openshift_host is defined
+  tags: [deprovision]
+
 - include_tasks: certs.yml
   tags: [install]
 
@@ -100,7 +108,15 @@
       command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/cluster-rbac.yaml -n {{ pgo_operator_namespace }}"
       tags: [install, update]
       when: create_rbac|bool
-    
+
+    - name: Create cluster-admin Cluster Role Binding for PGO Service Account
+      command: | 
+        {{ kubectl_or_oc }} create clusterrolebinding pgo-cluster-admin \
+          --clusterrole cluster-admin \
+          --user system:serviceaccount:{{ pgo_operator_namespace }}:postgres-operator
+      when: create_rbac|bool and pgo_cluster_admin|bool
+      tags: [install, update]
+      
     - name: Template PGO RBAC
       template:
         src: pgo-role-rbac.yaml.j2
@@ -197,4 +213,8 @@
         dest: "/usr/local/bin/pgo"
         mode: 0755
       when: uname_result.stdout == "Darwin" and pgo_client_install == "true"
+      tags: [install, update]
+
+    - include_tasks: openshift_namespace.yml
+      when: openshift_host is defined and not pgo_cluster_admin|bool
       tags: [install, update]

--- a/ansible/roles/pgo-operator/tasks/openshift.yml
+++ b/ansible/roles/pgo-operator/tasks/openshift.yml
@@ -7,7 +7,7 @@
   - install
   - update
 
-- name: Create Project {{ item.item }}
+- name: Create PGO Namespace
   shell: "{{ openshift_oc_bin}} new-project {{ pgo_operator_namespace }}"
   when: namespace_details.rc != 0
   tags:

--- a/ansible/roles/pgo-operator/tasks/openshift_cleanup.yml
+++ b/ansible/roles/pgo-operator/tasks/openshift_cleanup.yml
@@ -1,0 +1,20 @@
+---
+- name: Delete Watched Namespaces (Openshift)
+  shell: |
+    {{ openshift_oc_bin}} delete project {{ item }}
+  when: delete_watched_namespaces|bool
+  ignore_errors: yes
+  with_items:
+  - "{{ namespace.split(',') }}"
+  no_log: false
+  tags:
+  - deprovision
+
+- name: Delete Operator Namespace (Openshift)
+  shell: |
+    {{ openshift_oc_bin}} delete project {{ pgo_operator_namespace }}
+  when: delete_operator_namespace|bool
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - deprovision

--- a/ansible/roles/pgo-operator/tasks/openshift_namespace.yml
+++ b/ansible/roles/pgo-operator/tasks/openshift_namespace.yml
@@ -1,0 +1,18 @@
+---
+- name: Wait for PGO deployment to finish rolling out in order to create Watched Namespaces
+  command: "{{ kubectl_or_oc }} rollout status deployment/postgres-operator -n {{ pgo_operator_namespace }}"
+  async: 600
+  tags:
+  - install
+  - update
+
+- name: Create Watched Namespaces
+  shell: "{{ target_ns_script }}"
+  vars:
+    target_namespace: !unsafe "{{.TargetNamespace}}"
+    operator_namespace: !unsafe "{{.OperatorNamespace}}"
+    target_ns_script: "{{ lookup('template', 'add-targeted-namespace.sh.j2') }}"
+  with_items: "{{ namespace.split(',') }}"
+  tags:
+  - install
+  - update

--- a/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
+++ b/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
@@ -1,0 +1,45 @@
+#!/bin/bash 
+# Copyright 2019 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+if [[ -z "{{ item }}" ]]; then
+	echo "usage:  add-targeted-namespace.sh mynewnamespace"
+	exit
+fi
+
+
+# create the namespace if necessary
+{{ kubectl_or_oc }} get ns {{ item }}  > /dev/null
+if [ $? -eq 0 ]; then
+	echo "namespace" {{ item }} "already exists"
+else
+	echo "namespace" {{ item }} "is new"
+	{{ kubectl_or_oc }} create ns {{ item }}
+fi
+
+# set the labels so that this namespace is owned by this installation
+{{ kubectl_or_oc }} label namespace/{{ item }} pgo-created-by=add-script
+{{ kubectl_or_oc }} label namespace/{{ item }} vendor=crunchy
+{{ kubectl_or_oc }} label namespace/{{ item }} pgo-installation-name={{ pgo_installation_name }}
+
+# create RBAC
+{{ kubectl_or_oc }} -n {{ item }} delete sa pgo-backrest-sa
+{{ kubectl_or_oc }} -n {{ item }} delete role pgo-target-role pgo-backrest-role
+{{ kubectl_or_oc }} -n {{ item }} delete rolebinding pgo-target-role-binding pgo-backrest-role-binding
+
+cat {{ role_path }}/files/pgo-configs/pgo-backrest-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
+cat {{ role_path }}/files/pgo-configs/pgo-target-role.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
+cat {{ role_path }}/files/pgo-configs/pgo-target-role-binding.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | sed 's/{{ operator_namespace }}/'"{{ pgo_operator_namespace }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
+cat {{ role_path }}/files/pgo-configs/pgo-backrest-role.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
+cat {{ role_path }}/files/pgo-configs/pgo-backrest-role-binding.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -

--- a/deploy/add-targeted-namespace.sh
+++ b/deploy/add-targeted-namespace.sh
@@ -36,8 +36,8 @@ $PGO_CMD label namespace/$1 vendor=crunchy
 $PGO_CMD label namespace/$1 pgo-installation-name=$PGO_INSTALLATION_NAME
 
 # create RBAC
-$PGO_CMD -n $1 delete sa pgo-backrest-sa 
-$PGO_CMD -n $1 delete sa pgo-target-sa
+$PGO_CMD -n $1 delete sa pgo-backrest 
+$PGO_CMD -n $1 delete sa pgo-target
 $PGO_CMD -n $1 delete role pgo-target-role pgo-backrest-role
 $PGO_CMD -n $1 delete rolebinding pgo-target-role-binding pgo-backrest-role-binding
 

--- a/hugo/content/Installation/install-with-ansible/prerequisites.md
+++ b/hugo/content/Installation/install-with-ansible/prerequisites.md
@@ -119,6 +119,10 @@ The following are the variables available for configuration:
 | `replica_storage`                 | storageos   | Set to configure which storage definition to use when creating volumes used by PostgreSQL replicas on all newly created clusters.                                                |
 | `scheduler_timeout`               | 3600        | Set to a value in seconds to configure the `pgo-scheduler` timeout threshold when waiting for schedules to complete.                                                             |
 | `service_type`                    | ClusterIP   | Set to configure the type of Kubernetes service provisioned on all newly created clusters.                                                                                       |
+| `delete_operator_namespace`       | false       | Set to configure whether or not the PGO operator namespace (defined using variable `pgo_operator_namespace`) is deleted when deprovisioning the PGO.                             |
+| `delete_watched_namespaces`       | false       | Set to configure whether or not the PGO watched namespaces (defined using variable `namespace`) are deleted when deprovisioning the PGO.                                         |
+| `delete_metrics_namespace`        | false       | Set to configure whether or not the metrics namespace (defined using variable `metrics_namespace`) is deleted when deprovisioning the metrics infrastructure                     |
+| `pgo_cluster_admin`               | false       | Determines whether or not the `cluster-admin` role is assigned to the PGO service account. Must be `true` to enable PGO namespace & role creation when installing in OpenShift.  |
 
 {{% notice tip %}}
 To retrieve the `kubernetes_context` value for Kubernetes installs, run the following command:

--- a/hugo/content/Security/_index.md
+++ b/hugo/content/Security/_index.md
@@ -39,10 +39,11 @@ If you do not allow create/update of namespaces, you can manually
 create Operator target namespaces using the following script:
     deploy/add-targeted-namespace.sh
 
-WARNING:  currently with version 4.1.0 of the Operator when running
-on OCP 3.11, you are REQUIRED to use the deploy/add-targeted-namespace.sh
-script to add new targeted namespaces.  This is a bug that will be
-fixed in a later version of the Operator.
+WARNING: Unless the `cluster-admin` role has been assigned to the PGO service account during
+installation (specifically using the `pgo_cluster_admin` variable, which is available for Ansible
+installs only), when running version 4.1.0 of the Operator on OCP 3.11, you are REQUIRED to use the
+`deploy/add-targeted-namespace.sh` script to add new targeted namespaces.  This is a bug that will
+be fixed in a later version of the Operator.
 
 This script creates the following RBAC namespace resources in the Operator
 namespace (e.g. pgo namespace):


### PR DESCRIPTION
Added namespace deprovisioning and namespace creation (for OCP installs only) to the Ansbile installer.  Also updated Ansible deprovisioning to properly remove all PGO resources.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

[ch4882]
[ch4880]
[ch4893]

**What is the new behavior (if this is a feature change)?**

- The option to delete operator, watched and metrics namespaces when deprovisioning the PGO and/or the metrics stack
- The Ansible installer now automatically runs the `add-targeted-namespace.sh` script for OpenShift install to create any watched namespaces following deployment of the PGO
- Provided the ability to assign the `cluster-admin` role to the PGO Service Account to work around the current limitation within OpenShift that prevents the operator from creating the proper RBAC during operator initialization (when this is enabled, the `add-targeted-namespace.sh` script isn't run, since the PGO will be able to create the namespaces and associated RBAC itself)

All secrets are now also properly cleaned up when deprovisioning, in addition to various other general cleanup and documentation updates.

**Other information**:
N/A