### PR TITLE
Prevent Creation of pgcluster Labels that Violate Kubernetes Labeling Requirements

### DIFF
--- a/ansible/roles/pgo-operator/tasks/cleanup.yml
+++ b/ansible/roles/pgo-operator/tasks/cleanup.yml
@@ -31,7 +31,6 @@
   no_log: false
   tags:
   - uninstall
-  - update
 
 - name: Delete PG Cluster Jobs
   shell: |
@@ -43,7 +42,6 @@
   no_log: false
   tags:
   - uninstall
-  - update
 
 - name: Delete PG Cluster Secrets
   shell: |
@@ -55,7 +53,6 @@
   no_log: false
   tags:
   - uninstall
-  - update
 
 - name: Delete Operator Deployment
   shell: |


### PR DESCRIPTION
Prevent a user label from being added to a `pgcluster` as a Kubernetes label if the user label does not meet the requirements for a Kubernetes label (e.g. if it contains invalid characters).  For instance, if `local,s3` is specified for `--pgbackrest-storage-type`, it won't be added as a Kubernetes label for the `pgcluster`, since it contains an invlaid value for a Kubernetes label (specifically a comma).  This follows the same strategy currently in place to prevent invalid labels from being added to other Kuberentes resources, e.g. a PG primary deployment.

Also updated the Ansible playbook to prevent PG clusters (as well as associated PG cluster secrets and jobs) from being removed when the `update` tag is utilized.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

When `local,s3` is specified for `--pgbackrest-storage-type`, the proper labels are not applied to the `pgcluster` that is created.

[ch4859]

PG clusters (as well as associated PG cluster secrets and jobs) are removed when the `update` tag is utilized with the Ansible installer.

**What is the new behavior (if this is a feature change)?**

The proper labels are applied to a `pgcluster` when `local,s3` is specified for `--pgbackrest-storage-type`.

PG clusters (as well as associated PG cluster secrets and jobs) are not removed when the `update` tag is utilized.

**Other information**:
