### PR TITLE
Create 'pgo-target' SA when Running Add Targeted Namespace Scripts

### DIFF
--- a/ansible/roles/pgo-operator/tasks/cleanup.yml
+++ b/ansible/roles/pgo-operator/tasks/cleanup.yml
@@ -111,7 +111,7 @@
 
 - name: Delete existing Service Accounts (Watched Namespaces)
   shell: |
-    {{ kubectl_or_oc }} delete serviceaccount pgo-backrest -n {{ item }}
+    {{ kubectl_or_oc }} delete serviceaccount pgo-target pgo-backrest -n {{ item }}
   with_items:
   - "{{ watched_namespaces }}"
   ignore_errors: yes

--- a/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
+++ b/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
@@ -34,11 +34,13 @@ fi
 {{ kubectl_or_oc }} label namespace/{{ item }} pgo-installation-name={{ pgo_installation_name }}
 
 # create RBAC
-{{ kubectl_or_oc }} -n {{ item }} delete sa pgo-backrest-sa
+{{ kubectl_or_oc }} -n {{ item }} delete sa pgo-backrest
+{{ kubectl_or_oc }} -n {{ item }} delete sa pgo-target
 {{ kubectl_or_oc }} -n {{ item }} delete role pgo-target-role pgo-backrest-role
 {{ kubectl_or_oc }} -n {{ item }} delete rolebinding pgo-target-role-binding pgo-backrest-role-binding
 
 cat {{ role_path }}/files/pgo-configs/pgo-backrest-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
+cat {{ role_path }}/files/pgo-configs/pgo-target-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-target-role.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-target-role-binding.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | sed 's/{{ operator_namespace }}/'"{{ pgo_operator_namespace }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-backrest-role.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -

--- a/deploy/add-targeted-namespace.sh
+++ b/deploy/add-targeted-namespace.sh
@@ -36,11 +36,13 @@ $PGO_CMD label namespace/$1 vendor=crunchy
 $PGO_CMD label namespace/$1 pgo-installation-name=$PGO_INSTALLATION_NAME
 
 # create RBAC
-$PGO_CMD -n $1 delete sa pgo-backrest
+$PGO_CMD -n $1 delete sa pgo-backrest 
+$PGO_CMD -n $1 delete sa pgo-target
 $PGO_CMD -n $1 delete role pgo-target-role pgo-backrest-role
 $PGO_CMD -n $1 delete rolebinding pgo-target-role-binding pgo-backrest-role-binding
 
 cat $PGOROOT/conf/postgres-operator/pgo-backrest-sa.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
+cat $PGOROOT/conf/postgres-operator/pgo-target-sa.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
 cat $PGOROOT/conf/postgres-operator/pgo-target-role.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
 cat $PGOROOT/conf/postgres-operator/pgo-target-role-binding.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | sed 's/{{.OperatorNamespace}}/'"$PGO_OPERATOR_NAMESPACE"'/' | $PGO_CMD -n $1 create -f -
 cat $PGOROOT/conf/postgres-operator/pgo-backrest-role.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -


### PR DESCRIPTION
Both versions of the `add-targeted-namespace.sh` script (both the version that can be run manually in the `$PGOROOT/deploy` directory, as well as the version included as part of the Ansible installer), now once again create the `pgo-target` Service Account, which will be needed to support `rmdata` jobs.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `add-targeted-namespace.sh` scripts do not create the `pgo-target` `ServiceAccount`.

[ch4954]

**What is the new behavior (if this is a feature change)?**

The `add-targeted-namespace.sh` scripts create the `pgo-target` `ServiceAccount`.

**Other information**:

N/A