### PR TITLE
Ansible Uninstall Cleanup Backrest Repo Service, PG Cluster PVCs & pgbouncer/pgpool Secrets

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-service-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-service-template.json
@@ -4,6 +4,7 @@
         "metadata": {
             "name": "{{.Name}}",
             "labels": {
+                "vendor": "crunchydata",
                 "name": "{{.Name}}",
                 "pgo-backrest-repo": "true",
                 "pg-cluster": "{{.ClusterName}}"

--- a/ansible/roles/pgo-operator/files/pgo-configs/pvc-storageclass.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pvc-storageclass.json
@@ -4,6 +4,7 @@
     "metadata": {
         "name": "{{.Name}}",
         "labels": {
+            "vendor": "crunchydata",
             "pgremove": "true",
             "pg-cluster": "{{.ClusterName}}"
         }

--- a/ansible/roles/pgo-operator/files/pgo-configs/pvc.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pvc.json
@@ -4,6 +4,7 @@
     "metadata": {
         "name": "{{.Name}}",
         "labels": {
+            "vendor": "crunchydata",
             "pgremove": "true",
             "pg-cluster": "{{.ClusterName}}"
         }

--- a/ansible/roles/pgo-operator/tasks/cleanup.yml
+++ b/ansible/roles/pgo-operator/tasks/cleanup.yml
@@ -54,6 +54,28 @@
   tags:
   - uninstall
 
+- name: Delete PG Cluster Services
+  shell: |
+    {{ kubectl_or_oc }} delete services --selector=vendor=crunchydata -n {{ item }}
+  with_items:
+  - "{{ watched_namespaces }}"
+  when: not preserve_pg_clusters|bool
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - uninstall
+
+- name: Delete PG PVC's
+  shell: |
+    {{ kubectl_or_oc }} delete pvc --selector=vendor=crunchydata -n {{ item }}
+  with_items:
+  - "{{ watched_namespaces }}"
+  when: not preserve_pg_clusters|bool
+  ignore_errors: yes
+  no_log: false
+  tags:
+  - uninstall
+
 - name: Delete Operator Deployment
   shell: |
     {{ kubectl_or_oc }} delete deployment postgres-operator -n {{ pgo_operator_namespace }}

--- a/conf/postgres-operator/pgo-backrest-repo-service-template.json
+++ b/conf/postgres-operator/pgo-backrest-repo-service-template.json
@@ -4,6 +4,7 @@
         "metadata": {
             "name": "{{.Name}}",
             "labels": {
+                "vendor": "crunchydata",
                 "name": "{{.Name}}",
                 "pgo-backrest-repo": "true",
                 "pg-cluster": "{{.ClusterName}}"

--- a/conf/postgres-operator/pvc-storageclass.json
+++ b/conf/postgres-operator/pvc-storageclass.json
@@ -4,6 +4,7 @@
     "metadata": {
         "name": "{{.Name}}",
         "labels": {
+            "vendor": "crunchydata",
             "pgremove": "true",
             "pg-cluster": "{{.ClusterName}}"
         }

--- a/conf/postgres-operator/pvc.json
+++ b/conf/postgres-operator/pvc.json
@@ -4,6 +4,7 @@
     "metadata": {
         "name": "{{.Name}}",
         "labels": {
+            "vendor": "crunchydata",
             "pgremove": "true",
             "pg-cluster": "{{.ClusterName}}"
         }

--- a/operator/cluster/pgbouncer.go
+++ b/operator/cluster/pgbouncer.go
@@ -20,6 +20,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
+	"time"
+
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/config"
 	"github.com/crunchydata/postgres-operator/events"
@@ -28,12 +31,10 @@ import (
 	"github.com/crunchydata/postgres-operator/util"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"os"
-	"time"
 )
 
 type PgbouncerPasswdFields struct {
@@ -673,6 +674,7 @@ func createPgbouncerSecret(clientset *kubernetes.Clientset, cl *crv1.Pgcluster, 
 	secret.ObjectMeta.Labels = make(map[string]string)
 	secret.ObjectMeta.Labels[config.LABEL_PG_CLUSTER] = db
 	secret.ObjectMeta.Labels[config.LABEL_PGBOUNCER] = "true"
+	secret.ObjectMeta.Labels[config.LABEL_VENDOR] = config.LABEL_CRUNCHY
 	secret.Data = make(map[string][]byte)
 
 	secret.Data["username"] = []byte(username)

--- a/operator/cluster/pgpool.go
+++ b/operator/cluster/pgpool.go
@@ -389,6 +389,7 @@ func CreatePgpoolSecret(clientset *kubernetes.Clientset, primary, replica, db, s
 	secret.ObjectMeta.Labels = make(map[string]string)
 	secret.ObjectMeta.Labels[config.LABEL_PG_CLUSTER] = db
 	secret.ObjectMeta.Labels[config.LABEL_PGPOOL] = "true"
+	secret.ObjectMeta.Labels[config.LABEL_VENDOR] = config.LABEL_CRUNCHY
 	secret.Data = make(map[string][]byte)
 	secret.Data["pgpool.conf"] = pgpoolConfBytes
 	secret.Data["pool_hba.conf"] = pgpoolHBABytes


### PR DESCRIPTION
The Ansible uninstaller now removes the `pgBackRest` repo service, all PG cluster PVC's and any `pgbouncer` and/or `pgpool` secrets.

The backrest repo template, PVC templates and pgbouncer/pgpool secrets have also been updated to include the `vendor=crunchydata` label, which facilitates the identification of PGO resources for cleanup.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `pgBackRest` repo service, PG cluster PVC's and any `pgbouncer` and/or `pgpool` secrets are not removed during an Ansible uninstall.

[ch5073]


**What is the new behavior (if this is a feature change)?**

The `pgBackRest` repo service, PG cluster PVC's and any `pgbouncer` and/or `pgpool` secrets are now removed during an Ansible uninstall.

**Other information**:

N/A