### PR TITLE
Update show.go

### DIFF
--- a/pgo/cmd/show.go
+++ b/pgo/cmd/show.go
@@ -102,7 +102,7 @@ func init() {
 	ShowCmd.AddCommand(ShowScheduleCmd)
 	ShowCmd.AddCommand(ShowUserCmd)
 
-	ShowBackupCmd.Flags().StringVarP(&showBackupType, "backup-type", "", "pgbackrest", "The backup type output to list. Valid choices are pgbasebackup or pgbackrest (default).")
+	ShowBackupCmd.Flags().StringVarP(&showBackupType, "backup-type", "", "pgbackrest", "The backup type output to list. Valid choices are pgbasebackup or pgbackrest.")
 	ShowBenchmarkCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
 	ShowClusterCmd.Flags().StringVarP(&CCPImageTag, "ccp-image-tag", "", "", "Filter the results based on the image tag of the cluster.")
 	ShowClusterCmd.Flags().StringVarP(&OutputFormat, "output", "o", "", "The output format. Currently, json is the only supported value.")


### PR DESCRIPTION
removes extra default from cli help

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
```
$pgo show backup -h
  --backup-type string   The backup type output to list. Valid choices are pgbasebackup or pgbackrest (default). (default "pgbackrest")
``` 


**What is the new behavior (if this is a feature change)?**



**Other information**:
