### PR TITLE
Events are Created for Cluster Deletion & Events are no Longer Created for Stanza Creation

### DIFF
--- a/controller/jobcontroller.go
+++ b/controller/jobcontroller.go
@@ -520,7 +520,7 @@ func publishDeleteClusterComplete(clusterName, identifier, username, namespace s
 	topics := make([]string, 1)
 	topics[0] = events.EventTopicCluster
 
-	f := events.EventDeleteClusterFormat{
+	f := events.EventDeleteClusterCompletedFormat{
 		EventHeader: events.EventHeader{
 			Namespace: namespace,
 			Username:  username,

--- a/controller/jobcontroller.go
+++ b/controller/jobcontroller.go
@@ -104,7 +104,9 @@ func (c *JobController) onUpdate(oldObj, newObj interface{}) {
 
 	//handle the case of rmdata jobs succeeding
 	if job.Status.Succeeded > 0 && labels[config.LABEL_RMDATA] == "true" {
-		log.Debugf("jobController onUpdate rmdata job case")
+		log.Debugf("jobController onUpdate rmdata job succeeded")
+		publishDeleteClusterComplete(labels[config.LABEL_PG_CLUSTER], job.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
+			job.ObjectMeta.Labels[config.LABEL_PGOUSER], job.ObjectMeta.Namespace)
 		/**
 		err = handleRmdata(job, c.JobClient, c.JobClientset, job.ObjectMeta.Namespace)
 		if err != nil {
@@ -236,7 +238,7 @@ func (c *JobController) onUpdate(oldObj, newObj interface{}) {
 	}
 
 	//handle the case of a backrest job being added
-	if labels[config.LABEL_BACKREST] == "true" {
+	if labels[config.LABEL_BACKREST] == "true" && labels[config.LABEL_BACKREST_COMMAND] == "backup" {
 		log.Debugf("jobController onUpdate backrest job case")
 		log.Debugf("got a backrest job status=%d", job.Status.Succeeded)
 		if job.Status.Succeeded == 1 {
@@ -512,4 +514,26 @@ func publishRestoreComplete(clusterName, identifier, username, namespace string)
 		log.Error(err.Error())
 	}
 
+}
+
+func publishDeleteClusterComplete(clusterName, identifier, username, namespace string) {
+	topics := make([]string, 1)
+	topics[0] = events.EventTopicCluster
+
+	f := events.EventDeleteClusterFormat{
+		EventHeader: events.EventHeader{
+			Namespace: namespace,
+			Username:  username,
+			Topic:     topics,
+			Timestamp: events.GetTimestamp(),
+			EventType: events.EventDeleteClusterCompleted,
+		},
+		Clustername:       clusterName,
+		Clusteridentifier: identifier,
+	}
+
+	err := events.Publish(f)
+	if err != nil {
+		log.Error(err.Error())
+	}
 }

--- a/controller/jobcontroller.go
+++ b/controller/jobcontroller.go
@@ -525,7 +525,7 @@ func publishDeleteClusterComplete(clusterName, identifier, username, namespace s
 			Namespace: namespace,
 			Username:  username,
 			Topic:     topics,
-			Timestamp: events.GetTimestamp(),
+			Timestamp: time.Now(),
 			EventType: events.EventDeleteClusterCompleted,
 		},
 		Clustername:       clusterName,

--- a/events/eventtype.go
+++ b/events/eventtype.go
@@ -49,6 +49,7 @@ const (
 	EventUpgradeCluster           = "UpgradeCluster"
 	EventUpgradeClusterCompleted  = "UpgradeClusterCompleted"
 	EventDeleteCluster            = "DeleteCluster"
+	EventDeleteClusterCompleted   = "DeleteClusterCompleted"
 	EventTestCluster              = "TestCluster"
 	EventCreateLabel              = "CreateLabel"
 	EventLoad                     = "Load"

--- a/events/eventtype.go
+++ b/events/eventtype.go
@@ -303,6 +303,22 @@ func (lvl EventDeleteClusterFormat) String() string {
 }
 
 //----------------------------
+type EventDeleteClusterCompletedFormat struct {
+	EventHeader       `json:"eventheader"`
+	Clustername       string `json:"clustername"`
+	Clusteridentifier string `json:"clusteridentifier"`
+}
+
+func (p EventDeleteClusterCompletedFormat) GetHeader() EventHeader {
+	return p.EventHeader
+}
+
+func (lvl EventDeleteClusterCompletedFormat) String() string {
+	msg := fmt.Sprintf("Event %s (delete completed) - clustername %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	return msg
+}
+
+//----------------------------
 type EventTestClusterFormat struct {
 	EventHeader       `json:"eventheader"`
 	Clustername       string `json:"clustername"`

--- a/operator/task/rmdata.go
+++ b/operator/task/rmdata.go
@@ -172,7 +172,7 @@ func publishDeleteCluster(clusterName, identifier, username, namespace string) {
 			Namespace: namespace,
 			Username:  username,
 			Topic:     topics,
-			Timestamp: events.GetTimestamp(),
+			Timestamp: time.Now(),
 			EventType: events.EventDeleteCluster,
 		},
 		Clustername:       clusterName,

--- a/operator/task/rmdata.go
+++ b/operator/task/rmdata.go
@@ -18,8 +18,12 @@ package task
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"time"
+
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/config"
+	"github.com/crunchydata/postgres-operator/events"
 	"github.com/crunchydata/postgres-operator/kubeapi"
 	"github.com/crunchydata/postgres-operator/operator"
 	"github.com/crunchydata/postgres-operator/util"
@@ -29,8 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"os"
-	"time"
 )
 
 type rmdatajobTemplateFields struct {
@@ -122,6 +124,8 @@ func RemoveData(namespace string, clientset *kubernetes.Clientset, restclient *r
 	}
 	log.Debugf("successfully created rmdata job %s", jobname)
 
+	publishDeleteCluster(task.Spec.Parameters[config.LABEL_PG_CLUSTER], task.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
+		task.ObjectMeta.Labels[config.LABEL_PGOUSER], namespace)
 }
 
 func PatchpgtaskDeleteDataStatus(restclient *rest.RESTClient, oldCrd *crv1.Pgtask, namespace string) error {
@@ -157,4 +161,26 @@ func PatchpgtaskDeleteDataStatus(restclient *rest.RESTClient, oldCrd *crv1.Pgtas
 
 	return err6
 
+}
+
+func publishDeleteCluster(clusterName, identifier, username, namespace string) {
+	topics := make([]string, 1)
+	topics[0] = events.EventTopicCluster
+
+	f := events.EventDeleteClusterFormat{
+		EventHeader: events.EventHeader{
+			Namespace: namespace,
+			Username:  username,
+			Topic:     topics,
+			Timestamp: events.GetTimestamp(),
+			EventType: events.EventDeleteCluster,
+		},
+		Clustername:       clusterName,
+		Clusteridentifier: identifier,
+	}
+
+	err := events.Publish(f)
+	if err != nil {
+		log.Error(err.Error())
+	}
 }


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- Events are not published for cluster deletion
- A `CreateBackupCompleted` event is published when a `stanza-create` job is completed

[ch5227]
[ch5299]

**What is the new behavior (if this is a feature change)?**

- Events are published for cluster deletion
- An event is not published when a `stanza-create` job is completed

**Other information**:

N/A
