### PR TITLE
passes in pgo.yaml user to be used for create secrets

### DIFF
--- a/apis/cr/v1/common.go
+++ b/apis/cr/v1/common.go
@@ -21,7 +21,7 @@ import ()
 const RootSecretSuffix = "-postgres-secret"
 
 // UserSecretSuffix ...
-const UserSecretSuffix = "-testuser-secret"
+const UserSecretSuffix = "-secret"
 
 // PrimarySecretSuffix ...
 const PrimarySecretSuffix = "-primaryuser-secret"


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently the user name in the pgo.yaml file is being ignored.  The hardcoded value `testuser` is used to create the postgres user secret


**What is the new behavior (if this is a feature change)?**
Now the value set in pgo.yaml will be used to create the secret. The default is still `testuser`


**Other information**:
[ch4290]