### PR TITLE
Ensure Controller Mutex is Always Unlocked

### DIFF
--- a/controller/backupcontroller.go
+++ b/controller/backupcontroller.go
@@ -272,11 +272,11 @@ func (c *PgbackupController) SetupWatch(ns string) {
 
 	// don't create informer for namespace if one has already been created
 	c.informerNsMutex.Lock()
+	defer c.informerNsMutex.Unlock()
 	if _, ok := c.InformerNamespaces[ns]; ok {
 		return
 	}
 	c.InformerNamespaces[ns] = struct{}{}
-	c.informerNsMutex.Unlock()
 
 	source := cache.NewListWatchFromClient(
 		c.PgbackupClient,

--- a/controller/clustercontroller.go
+++ b/controller/clustercontroller.go
@@ -257,11 +257,11 @@ func (c *PgclusterController) SetupWatch(ns string) {
 
 	// don't create informer for namespace if one has already been created
 	c.informerNsMutex.Lock()
+	defer c.informerNsMutex.Unlock()
 	if _, ok := c.InformerNamespaces[ns]; ok {
 		return
 	}
 	c.InformerNamespaces[ns] = struct{}{}
-	c.informerNsMutex.Unlock()
 
 	source := cache.NewListWatchFromClient(
 		c.PgclusterClient,

--- a/controller/jobcontroller.go
+++ b/controller/jobcontroller.go
@@ -434,11 +434,11 @@ func (c *JobController) SetupWatch(ns string) {
 
 	// don't create informer for namespace if one has already been created
 	c.informerNsMutex.Lock()
+	defer c.informerNsMutex.Unlock()
 	if _, ok := c.InformerNamespaces[ns]; ok {
 		return
 	}
 	c.InformerNamespaces[ns] = struct{}{}
-	c.informerNsMutex.Unlock()
 
 	source := cache.NewListWatchFromClient(
 		c.JobClientset.BatchV1().RESTClient(),

--- a/controller/podcontroller.go
+++ b/controller/podcontroller.go
@@ -350,11 +350,11 @@ func (c *PodController) SetupWatch(ns string) {
 
 	// don't create informer for namespace if one has already been created
 	c.informerNsMutex.Lock()
+	defer c.informerNsMutex.Unlock()
 	if _, ok := c.InformerNamespaces[ns]; ok {
 		return
 	}
 	c.InformerNamespaces[ns] = struct{}{}
-	c.informerNsMutex.Unlock()
 
 	source := cache.NewListWatchFromClient(
 		c.PodClientset.CoreV1().RESTClient(),

--- a/controller/policycontroller.go
+++ b/controller/policycontroller.go
@@ -154,11 +154,11 @@ func (c *PgpolicyController) SetupWatch(ns string) {
 
 	// don't create informer for namespace if one has already been created
 	c.informerNsMutex.Lock()
+	defer c.informerNsMutex.Unlock()
 	if _, ok := c.InformerNamespaces[ns]; ok {
 		return
 	}
 	c.InformerNamespaces[ns] = struct{}{}
-	c.informerNsMutex.Unlock()
 
 	source := cache.NewListWatchFromClient(
 		c.PgpolicyClient,

--- a/controller/replicacontroller.go
+++ b/controller/replicacontroller.go
@@ -192,11 +192,11 @@ func (c *PgreplicaController) SetupWatch(ns string) {
 
 	// don't create informer for namespace if one has already been created
 	c.informerNsMutex.Lock()
+	defer c.informerNsMutex.Unlock()
 	if _, ok := c.InformerNamespaces[ns]; ok {
 		return
 	}
 	c.InformerNamespaces[ns] = struct{}{}
-	c.informerNsMutex.Unlock()
 
 	source := cache.NewListWatchFromClient(
 		c.PgreplicaClient,

--- a/controller/taskcontroller.go
+++ b/controller/taskcontroller.go
@@ -239,11 +239,11 @@ func (c *PgtaskController) SetupWatch(ns string) {
 
 	// don't create informer for namespace if one has already been created
 	c.informerNsMutex.Lock()
+	defer c.informerNsMutex.Unlock()
 	if _, ok := c.InformerNamespaces[ns]; ok {
 		return
 	}
 	c.InformerNamespaces[ns] = struct{}{}
-	c.informerNsMutex.Unlock()
 
 	source := cache.NewListWatchFromClient(
 		c.PgtaskClient,


### PR DESCRIPTION
Ensure the mutex found in various PGO controllers is always unlocked.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The mutex found in various PGO controllers is not always unlocked.

[ch5376]

**What is the new behavior (if this is a feature change)?**

The mutex found in various PGO controllers will always be unlocked.

**Other information**:

N/A