### PR TITLE
adds more updates to use pgo.yaml user

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/pgpool-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgpool-template.json
@@ -44,7 +44,7 @@
 		    {{.ContainerResources }}
                     "env": [{
                         "name": "PG_USERNAME",
-                        "value": "testuser"
+                        "value": "{{.User}}"
                     }, {
                         "name": "PG_PASSWORD",
                         "value": "password"

--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -874,7 +874,6 @@ func getClusterParams(request *msgs.CreateClusterRequest, name string, userLabel
 		spec.Policies = request.Policies
 	}
 
-	spec.User = "testuser"
 	spec.Database = "userdb"
 	spec.Replicas = "0"
 	str := apiserver.Pgo.Cluster.Replicas
@@ -898,8 +897,8 @@ func getClusterParams(request *msgs.CreateClusterRequest, name string, userLabel
 		spec.Port = str
 	}
 	str = apiserver.Pgo.Cluster.User
-	log.Debugf("Pgo.Cluster.User is %s", apiserver.Pgo.Cluster.User)
 	if str != "" {
+		log.Debugf("Pgo.Cluster.User is %s", str)
 		spec.User = str
 	}
 	str = apiserver.Pgo.Cluster.Database

--- a/conf/postgres-operator/pgpool-template.json
+++ b/conf/postgres-operator/pgpool-template.json
@@ -44,7 +44,7 @@
 		    {{.ContainerResources }}
                     "env": [{
                         "name": "PG_USERNAME",
-                        "value": "{{.PGUser}}"
+                        "value": "{{.User}}"
                     }, {
                         "name": "PG_PASSWORD",
                         "value": "password"

--- a/conf/postgres-operator/pgpool-template.json
+++ b/conf/postgres-operator/pgpool-template.json
@@ -44,7 +44,7 @@
 		    {{.ContainerResources }}
                     "env": [{
                         "name": "PG_USERNAME",
-                        "value": "testuser"
+                        "value": "{{.PGUser}}"
                     }, {
                         "name": "PG_PASSWORD",
                         "value": "password"

--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -282,6 +282,7 @@ const DEFAULT_BACKREST_SSH_KEY_BITS = 2048
 
 func (c *PgoConfig) Validate() error {
 	var err error
+	errMsg := "Error in pgoconfig: check pgo.yaml: "
 
 	if c.Cluster.BackrestPort == 0 {
 		c.Cluster.BackrestPort = DEFAULT_BACKREST_PORT
@@ -296,7 +297,7 @@ func (c *PgoConfig) Validate() error {
 			}
 		}
 		if !found {
-			return errors.New("Cluster.LogStatement does not container a valid value for log_statement")
+			return errors.New(errMsg + "Cluster.LogStatement does not container a valid value for log_statement")
 		}
 	} else {
 		log.Info("using default log_statement value since it was not specified in pgo.yaml")
@@ -306,7 +307,7 @@ func (c *PgoConfig) Validate() error {
 	if c.Cluster.LogMinDurationStatement != "" {
 		_, err = strconv.Atoi(c.Cluster.LogMinDurationStatement)
 		if err != nil {
-			return errors.New("Cluster.LogMinDurationStatement invalid int value found")
+			return errors.New(errMsg + "Cluster.LogMinDurationStatement invalid int value found")
 		}
 	} else {
 		log.Info("using default log_min_duration_statement value since it was not specified in pgo.yaml")
@@ -316,25 +317,25 @@ func (c *PgoConfig) Validate() error {
 	if c.Cluster.PrimaryNodeLabel != "" {
 		parts := strings.Split(c.Cluster.PrimaryNodeLabel, "=")
 		if len(parts) != 2 {
-			return errors.New("Cluster.PrimaryNodeLabel does not follow key=value format")
+			return errors.New(errMsg+ "Cluster.PrimaryNodeLabel does not follow key=value format")
 		}
 	}
 
 	if c.Cluster.ReplicaNodeLabel != "" {
 		parts := strings.Split(c.Cluster.ReplicaNodeLabel, "=")
 		if len(parts) != 2 {
-			return errors.New("Cluster.ReplicaNodeLabel does not follow key=value format")
+			return errors.New(errMsg + "Cluster.ReplicaNodeLabel does not follow key=value format")
 		}
 	}
 
 	log.Infof("pgo.yaml Cluster.Backrest is %v", c.Cluster.Backrest)
 	_, ok := c.Storage[c.PrimaryStorage]
 	if !ok {
-		return errors.New("PrimaryStorage setting required")
+		return errors.New(errMsg + "PrimaryStorage setting required")
 	}
 	_, ok = c.Storage[c.BackupStorage]
 	if !ok {
-		return errors.New("BackupStorage setting required")
+		return errors.New(errMsg + "BackupStorage setting required")
 	}
 	_, ok = c.Storage[c.BackrestStorage]
 	if !ok {
@@ -344,7 +345,7 @@ func (c *PgoConfig) Validate() error {
 
 	_, ok = c.Storage[c.ReplicaStorage]
 	if !ok {
-		return errors.New("ReplicaStorage setting required")
+		return errors.New(errMsg + "ReplicaStorage setting required")
 	}
 	for k, _ := range c.Storage {
 		_, err = c.GetStorageSpec(k)
@@ -353,10 +354,10 @@ func (c *PgoConfig) Validate() error {
 		}
 	}
 	if c.Pgo.PGOImagePrefix == "" {
-		return errors.New("Pgo.PGOImagePrefix is required")
+		return errors.New(errMsg + "Pgo.PGOImagePrefix is required")
 	}
 	if c.Pgo.PGOImageTag == "" {
-		return errors.New("Pgo.PGOImageTag is required")
+		return errors.New(errMsg + "Pgo.PGOImageTag is required")
 	}
 	if c.Pgo.AutofailSleepSeconds == "" {
 		log.Warn("Pgo.AutofailSleepSeconds not set, using default ")
@@ -364,55 +365,55 @@ func (c *PgoConfig) Validate() error {
 	}
 	c.Pgo.AutofailSleepSecondsValue, err = strconv.Atoi(c.Pgo.AutofailSleepSeconds)
 	if err != nil {
-		return errors.New("Pgo.AutofailSleepSeconds invalid int value found")
+		return errors.New(errMsg + "Pgo.AutofailSleepSeconds invalid int value found")
 	}
 
 	if c.DefaultContainerResources != "" {
 		_, ok = c.ContainerResources[c.DefaultContainerResources]
 		if !ok {
-			return errors.New("DefaultContainerResources setting invalid")
+			return errors.New(errMsg + "DefaultContainerResources setting invalid")
 		}
 	}
 	if c.DefaultLspvcResources != "" {
 		_, ok = c.ContainerResources[c.DefaultLspvcResources]
 		if !ok {
-			return errors.New("DefaultLspvcResources setting invalid")
+			return errors.New(errMsg + "DefaultLspvcResources setting invalid")
 		}
 	}
 	if c.DefaultLoadResources != "" {
 		_, ok = c.ContainerResources[c.DefaultLoadResources]
 		if !ok {
-			return errors.New("DefaultLoadResources setting invalid")
+			return errors.New(errMsg + "DefaultLoadResources setting invalid")
 		}
 	}
 	if c.DefaultRmdataResources != "" {
 		_, ok = c.ContainerResources[c.DefaultRmdataResources]
 		if !ok {
-			return errors.New("DefaultRmdataResources setting invalid")
+			return errors.New(errMsg + "DefaultRmdataResources setting invalid")
 		}
 	}
 	if c.DefaultBackupResources != "" {
 		_, ok = c.ContainerResources[c.DefaultBackupResources]
 		if !ok {
-			return errors.New("DefaultBackupResources setting invalid")
+			return errors.New(errMsg + "DefaultBackupResources setting invalid")
 		}
 	}
 	if c.DefaultBadgerResources != "" {
 		_, ok = c.ContainerResources[c.DefaultBadgerResources]
 		if !ok {
-			return errors.New("DefaultBadgerResources setting invalid")
+			return errors.New(errMsg + "DefaultBadgerResources setting invalid")
 		}
 	}
 	if c.DefaultPgpoolResources != "" {
 		_, ok = c.ContainerResources[c.DefaultPgpoolResources]
 		if !ok {
-			return errors.New("DefaultPgpoolResources setting invalid")
+			return errors.New(errMsg + "DefaultPgpoolResources setting invalid")
 		}
 	}
 	if c.DefaultPgbouncerResources != "" {
 		_, ok = c.ContainerResources[c.DefaultPgbouncerResources]
 		if !ok {
-			return errors.New("DefaultPgbouncerResources setting invalid")
+			return errors.New(errMsg + "DefaultPgbouncerResources setting invalid")
 		}
 	}
 
@@ -421,7 +422,7 @@ func (c *PgoConfig) Validate() error {
 	} else {
 		_, err := strconv.Atoi(c.Cluster.ArchiveTimeout)
 		if err != nil {
-			return errors.New("Cluster.ArchiveTimeout invalid int value found")
+			return errors.New(errMsg + "Cluster.ArchiveTimeout invalid int value found")
 		}
 	}
 
@@ -432,16 +433,20 @@ func (c *PgoConfig) Validate() error {
 		if c.Cluster.ServiceType != DEFAULT_SERVICE_TYPE &&
 			c.Cluster.ServiceType != LOAD_BALANCER_SERVICE_TYPE &&
 			c.Cluster.ServiceType != NODEPORT_SERVICE_TYPE {
-			return errors.New("Cluster.ServiceType is required to be either ClusterIP, NodePort, or LoadBalancer")
+			return errors.New(errMsg + "Cluster.ServiceType is required to be either ClusterIP, NodePort, or LoadBalancer")
 		}
 	}
 
 	if c.Cluster.CCPImagePrefix == "" {
-		return errors.New("Cluster.CCPImagePrefix is required")
+		return errors.New(errMsg + "Cluster.CCPImagePrefix is required")
 	}
 
 	if c.Cluster.CCPImageTag == "" {
-		return errors.New("Cluster.CCPImageTag is required")
+		return errors.New(errMsg + "Cluster.CCPImageTag is required")
+	}
+
+	if c.Cluster.User == "" {
+		return errors.New(errMsg + "Cluster.User is required")
 	}
 	return err
 }

--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -282,7 +282,7 @@ const DEFAULT_BACKREST_SSH_KEY_BITS = 2048
 
 func (c *PgoConfig) Validate() error {
 	var err error
-	errMsg := "Error in pgoconfig: check pgo.yaml: "
+	errPrefix := "Error in pgoconfig: check pgo.yaml: "
 
 	if c.Cluster.BackrestPort == 0 {
 		c.Cluster.BackrestPort = DEFAULT_BACKREST_PORT
@@ -297,7 +297,7 @@ func (c *PgoConfig) Validate() error {
 			}
 		}
 		if !found {
-			return errors.New(errMsg + "Cluster.LogStatement does not container a valid value for log_statement")
+			return errors.New(errPrefix + "Cluster.LogStatement does not container a valid value for log_statement")
 		}
 	} else {
 		log.Info("using default log_statement value since it was not specified in pgo.yaml")
@@ -307,7 +307,7 @@ func (c *PgoConfig) Validate() error {
 	if c.Cluster.LogMinDurationStatement != "" {
 		_, err = strconv.Atoi(c.Cluster.LogMinDurationStatement)
 		if err != nil {
-			return errors.New(errMsg + "Cluster.LogMinDurationStatement invalid int value found")
+			return errors.New(errPrefix + "Cluster.LogMinDurationStatement invalid int value found")
 		}
 	} else {
 		log.Info("using default log_min_duration_statement value since it was not specified in pgo.yaml")
@@ -317,25 +317,25 @@ func (c *PgoConfig) Validate() error {
 	if c.Cluster.PrimaryNodeLabel != "" {
 		parts := strings.Split(c.Cluster.PrimaryNodeLabel, "=")
 		if len(parts) != 2 {
-			return errors.New(errMsg+ "Cluster.PrimaryNodeLabel does not follow key=value format")
+			return errors.New(errPrefix+ "Cluster.PrimaryNodeLabel does not follow key=value format")
 		}
 	}
 
 	if c.Cluster.ReplicaNodeLabel != "" {
 		parts := strings.Split(c.Cluster.ReplicaNodeLabel, "=")
 		if len(parts) != 2 {
-			return errors.New(errMsg + "Cluster.ReplicaNodeLabel does not follow key=value format")
+			return errors.New(errPrefix + "Cluster.ReplicaNodeLabel does not follow key=value format")
 		}
 	}
 
 	log.Infof("pgo.yaml Cluster.Backrest is %v", c.Cluster.Backrest)
 	_, ok := c.Storage[c.PrimaryStorage]
 	if !ok {
-		return errors.New(errMsg + "PrimaryStorage setting required")
+		return errors.New(errPrefix + "PrimaryStorage setting required")
 	}
 	_, ok = c.Storage[c.BackupStorage]
 	if !ok {
-		return errors.New(errMsg + "BackupStorage setting required")
+		return errors.New(errPrefix + "BackupStorage setting required")
 	}
 	_, ok = c.Storage[c.BackrestStorage]
 	if !ok {
@@ -345,7 +345,7 @@ func (c *PgoConfig) Validate() error {
 
 	_, ok = c.Storage[c.ReplicaStorage]
 	if !ok {
-		return errors.New(errMsg + "ReplicaStorage setting required")
+		return errors.New(errPrefix + "ReplicaStorage setting required")
 	}
 	for k, _ := range c.Storage {
 		_, err = c.GetStorageSpec(k)
@@ -354,10 +354,10 @@ func (c *PgoConfig) Validate() error {
 		}
 	}
 	if c.Pgo.PGOImagePrefix == "" {
-		return errors.New(errMsg + "Pgo.PGOImagePrefix is required")
+		return errors.New(errPrefix + "Pgo.PGOImagePrefix is required")
 	}
 	if c.Pgo.PGOImageTag == "" {
-		return errors.New(errMsg + "Pgo.PGOImageTag is required")
+		return errors.New(errPrefix + "Pgo.PGOImageTag is required")
 	}
 	if c.Pgo.AutofailSleepSeconds == "" {
 		log.Warn("Pgo.AutofailSleepSeconds not set, using default ")
@@ -365,55 +365,55 @@ func (c *PgoConfig) Validate() error {
 	}
 	c.Pgo.AutofailSleepSecondsValue, err = strconv.Atoi(c.Pgo.AutofailSleepSeconds)
 	if err != nil {
-		return errors.New(errMsg + "Pgo.AutofailSleepSeconds invalid int value found")
+		return errors.New(errPrefix + "Pgo.AutofailSleepSeconds invalid int value found")
 	}
 
 	if c.DefaultContainerResources != "" {
 		_, ok = c.ContainerResources[c.DefaultContainerResources]
 		if !ok {
-			return errors.New(errMsg + "DefaultContainerResources setting invalid")
+			return errors.New(errPrefix + "DefaultContainerResources setting invalid")
 		}
 	}
 	if c.DefaultLspvcResources != "" {
 		_, ok = c.ContainerResources[c.DefaultLspvcResources]
 		if !ok {
-			return errors.New(errMsg + "DefaultLspvcResources setting invalid")
+			return errors.New(errPrefix + "DefaultLspvcResources setting invalid")
 		}
 	}
 	if c.DefaultLoadResources != "" {
 		_, ok = c.ContainerResources[c.DefaultLoadResources]
 		if !ok {
-			return errors.New(errMsg + "DefaultLoadResources setting invalid")
+			return errors.New(errPrefix + "DefaultLoadResources setting invalid")
 		}
 	}
 	if c.DefaultRmdataResources != "" {
 		_, ok = c.ContainerResources[c.DefaultRmdataResources]
 		if !ok {
-			return errors.New(errMsg + "DefaultRmdataResources setting invalid")
+			return errors.New(errPrefix + "DefaultRmdataResources setting invalid")
 		}
 	}
 	if c.DefaultBackupResources != "" {
 		_, ok = c.ContainerResources[c.DefaultBackupResources]
 		if !ok {
-			return errors.New(errMsg + "DefaultBackupResources setting invalid")
+			return errors.New(errPrefix + "DefaultBackupResources setting invalid")
 		}
 	}
 	if c.DefaultBadgerResources != "" {
 		_, ok = c.ContainerResources[c.DefaultBadgerResources]
 		if !ok {
-			return errors.New(errMsg + "DefaultBadgerResources setting invalid")
+			return errors.New(errPrefix + "DefaultBadgerResources setting invalid")
 		}
 	}
 	if c.DefaultPgpoolResources != "" {
 		_, ok = c.ContainerResources[c.DefaultPgpoolResources]
 		if !ok {
-			return errors.New(errMsg + "DefaultPgpoolResources setting invalid")
+			return errors.New(errPrefix + "DefaultPgpoolResources setting invalid")
 		}
 	}
 	if c.DefaultPgbouncerResources != "" {
 		_, ok = c.ContainerResources[c.DefaultPgbouncerResources]
 		if !ok {
-			return errors.New(errMsg + "DefaultPgbouncerResources setting invalid")
+			return errors.New(errPrefix + "DefaultPgbouncerResources setting invalid")
 		}
 	}
 
@@ -422,7 +422,7 @@ func (c *PgoConfig) Validate() error {
 	} else {
 		_, err := strconv.Atoi(c.Cluster.ArchiveTimeout)
 		if err != nil {
-			return errors.New(errMsg + "Cluster.ArchiveTimeout invalid int value found")
+			return errors.New(errPrefix + "Cluster.ArchiveTimeout invalid int value found")
 		}
 	}
 
@@ -433,20 +433,20 @@ func (c *PgoConfig) Validate() error {
 		if c.Cluster.ServiceType != DEFAULT_SERVICE_TYPE &&
 			c.Cluster.ServiceType != LOAD_BALANCER_SERVICE_TYPE &&
 			c.Cluster.ServiceType != NODEPORT_SERVICE_TYPE {
-			return errors.New(errMsg + "Cluster.ServiceType is required to be either ClusterIP, NodePort, or LoadBalancer")
+			return errors.New(errPrefix + "Cluster.ServiceType is required to be either ClusterIP, NodePort, or LoadBalancer")
 		}
 	}
 
 	if c.Cluster.CCPImagePrefix == "" {
-		return errors.New(errMsg + "Cluster.CCPImagePrefix is required")
+		return errors.New(errPrefix + "Cluster.CCPImagePrefix is required")
 	}
 
 	if c.Cluster.CCPImageTag == "" {
-		return errors.New(errMsg + "Cluster.CCPImageTag is required")
+		return errors.New(errPrefix + "Cluster.CCPImageTag is required")
 	}
 
 	if c.Cluster.User == "" {
-		return errors.New(errMsg + "Cluster.User is required")
+		return errors.New(errPrefix + "Cluster.User is required")
 	}
 	return err
 }

--- a/operator/cluster/pgpool.go
+++ b/operator/cluster/pgpool.go
@@ -58,6 +58,7 @@ type PgpoolTemplateFields struct {
 	Port               string
 	PrimaryServiceName string
 	ReplicaServiceName string
+	User		   string
 }
 
 const PGPOOL_SUFFIX = "-pgpool"
@@ -274,6 +275,7 @@ func AddPgpool(clientset *kubernetes.Clientset, cl *crv1.Pgcluster, namespace st
 		log.Debug("pgpool secret created")
 	}
 
+	user := cl.Spec.User
 	clusterName := cl.Spec.Name
 	pgpoolName := clusterName + PGPOOL_SUFFIX
 	log.Debugf("adding a pgpool %s", pgpoolName)
@@ -287,6 +289,7 @@ func AddPgpool(clientset *kubernetes.Clientset, cl *crv1.Pgcluster, namespace st
 		Port:               operator.Pgo.Cluster.Port,
 		SecretsName:        secretName,
 		ContainerResources: "",
+		User:		    user,
 	}
 
 	if operator.Pgo.DefaultPgpoolResources != "" {


### PR DESCRIPTION
- updates templates for bash/ansible
- adds error prefix for pgoconfig validation
- removes default user as testuser so operator now fails to start if
	user is not set in pgo.yaml

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
currently testuser is a hardcoded default in the pgpool templates


**What is the new behavior (if this is a feature change)?**
-Now the templates pull the db user from the pgo config (pgo.yaml or inventory file)
-adds a error message prefix to the errors in validation function for config. Prefix tells user what file to check
-removes the default user of testuser if user is not defined in the pgo.yaml file.


**Other information**:
[ch4290]
[ch5411]