### PR TITLE
Ansible always create ns

### DIFF
--- a/ansible/roles/pgo-operator/tasks/main.yml
+++ b/ansible/roles/pgo-operator/tasks/main.yml
@@ -58,6 +58,9 @@
 
 - name: Deploy PostgreSQL Operator
   block:
+    - include_tasks: namespace.yml
+      tags: [install, update]
+    
     - include_tasks: crds.yml
       tags: [install]
 
@@ -209,6 +212,7 @@
       when: uname_result.stdout == "Darwin" and pgo_client_install == "true"
       tags: [install, update]
 
-    - include_tasks: openshift_namespace.yml
-      when: openshift_host is defined and not pgo_cluster_admin|bool
+    - name: Wait for PGO deployment to finish rolling out in order to create Watched Namespaces
+      command: "{{ kubectl_or_oc }} rollout status deployment/postgres-operator -n {{ pgo_operator_namespace }}"
+      async: 600
       tags: [install, update]

--- a/ansible/roles/pgo-operator/tasks/main.yml
+++ b/ansible/roles/pgo-operator/tasks/main.yml
@@ -212,7 +212,7 @@
       when: uname_result.stdout == "Darwin" and pgo_client_install == "true"
       tags: [install, update]
 
-    - name: Wait for PGO deployment to finish rolling out in order to create Watched Namespaces
+    - name: Wait for PGO to finish deploying
       command: "{{ kubectl_or_oc }} rollout status deployment/postgres-operator -n {{ pgo_operator_namespace }}"
       async: 600
       tags: [install, update]

--- a/ansible/roles/pgo-operator/tasks/namespace.yml
+++ b/ansible/roles/pgo-operator/tasks/namespace.yml
@@ -1,11 +1,4 @@
 ---
-- name: Wait for PGO deployment to finish rolling out in order to create Watched Namespaces
-  command: "{{ kubectl_or_oc }} rollout status deployment/postgres-operator -n {{ pgo_operator_namespace }}"
-  async: 600
-  tags:
-  - install
-  - update
-
 - name: Create Watched Namespaces
   shell: "{{ target_ns_script }}"
   vars:

--- a/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
+++ b/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
@@ -30,7 +30,7 @@ fi
 
 # set the labels so that this namespace is owned by this installation
 {{ kubectl_or_oc }} label namespace/{{ item }} pgo-created-by=add-script
-{{ kubectl_or_oc }} label namespace/{{ item }} vendor=crunchy
+{{ kubectl_or_oc }} label namespace/{{ item }} vendor=crunchydata
 {{ kubectl_or_oc }} label namespace/{{ item }} pgo-installation-name={{ pgo_installation_name }}
 
 # create RBAC

--- a/deploy/add-targeted-namespace.sh
+++ b/deploy/add-targeted-namespace.sh
@@ -32,7 +32,8 @@ else
 fi
 
 # set the labels so that this namespace is owned by this installation
-$PGO_CMD label namespace/$1 vendor=crunchy
+$PGO_CMD label namespace/$1 pgo-created-by=add-script
+$PGO_CMD label namespace/$1 vendor=crunchydata
 $PGO_CMD label namespace/$1 pgo-installation-name=$PGO_INSTALLATION_NAME
 
 # create RBAC


### PR DESCRIPTION
The Ansible installer now always creates target namespaces prior to deploying the PGO.  This ensures that the the initial target namespaces for the PGO are properly created when using a Kubernetes version prior to v1.12 (versions <1.12 are unable to support the dynamic namespace functionality now included in the PGO. 

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The Ansible installer only creates the targeted namespaces for OCP installs.

[ch5490]

**What is the new behavior (if this is a feature change)?**

The Ansible installer creates the targeted namespaces prior to deploying the PGO for all PGO installations.

**Other information**:

N/A