### PR TITLE
updates docs to reference pgouser file instead of pgorole

### DIFF
--- a/hugo/content/operatorcli/pgo-cli-global-variables.md
+++ b/hugo/content/operatorcli/pgo-cli-global-variables.md
@@ -13,4 +13,4 @@ weight: 3
 |------|-------------|-------|
 |PGOUSERNAME |The username (role) used for auth on the operator apiserver. | Requires that PGOUSERPASS be set. |
 |PGOUSERPASS |The password for used for auth on the operator apiserver. | Requires that PGOUSERNAME be set. |
-|PGOUSER |The path the the pgorole file. | Will be ignored if either PGOUSERNAME or PGOUSERPASS are set. |
+|PGOUSER |The path the the pgouser file. | Will be ignored if either PGOUSERNAME or PGOUSERPASS are set. |

--- a/hugo/content/operatorcli/pgo-overview.md
+++ b/hugo/content/operatorcli/pgo-overview.md
@@ -583,4 +583,4 @@ Create a cluster with a Custom ConfigMap:
 | :--           | :--                                                          | :--                                                               |
 | `PGOUSERNAME` | The username (role) used for auth on the operator apiserver. | Requires that `PGOUSERPASS` be set.                               |
 | `PGOUSERPASS` | The password for used for auth on the operator apiserver.    | Requires that `PGOUSERNAME` be set.                               |
-| `PGOUSER`     | The path to the pgorole file.                                | Will be ignored if either `PGOUSERNAME` or `PGOUSERPASS` are set. |
+| `PGOUSER`     | The path to the pgouser file.                                | Will be ignored if either `PGOUSERNAME` or `PGOUSERPASS` are set. |


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:

The pgorole file not longer is used so this env var should be documented to be the path for the pgouser file.

[ch4624]