### PR TITLE
adds setup for TestRolename var that is used in the event tests

### DIFF
--- a/testing/events/README.md
+++ b/testing/events/README.md
@@ -4,6 +4,7 @@ eventtest requires:
  * pass in the cluster name on the command line using -clustername flag
  * pass in the namespace on the command line using -namespace flag
  * pass in the username on the command line using -username flag
+ * pass in the rolename on the command line using -rolename flag
  * pass in the endpoint for the event router -event-tcp-address="127.0.0.1:14150"
 
 You can port-forward to the event router as follows:

--- a/testing/events/setupkube.go
+++ b/testing/events/setupkube.go
@@ -21,6 +21,7 @@ var (
 	kubeconfig      = flag.String("kubeconfig", "./config", "absolute path to the kubeconfig file")
 	namespace       = flag.String("namespace", "pgouser1", "namespace to test within ")
 	username        = flag.String("username", "pgouser1", "username to test within ")
+	rolename	= flag.String("rolename", "pgoadmin", "rolename to test with")
 	testclustername = flag.String("clustername", "", "cluster name to test with")
 	eventTcpAddress = flag.String("event-tcp-address", "localhost:14150", "tcp port to the event pgo-event port")
 
@@ -28,6 +29,7 @@ var (
 	Namespace       = "pgouser1"
 	TestUsername    = "pgouser1"
 	TestClusterName = "foo"
+	TestRolename	= "pgoadmin"
 	SLEEP_SECS      = 10
 )
 
@@ -60,9 +62,13 @@ func SetupKube() (*kubernetes.Clientset, *rest.RESTClient) {
 	if *username != "" {
 		TestUsername = *username
 	}
+	if *rolename != "" {
+		TestRolename = *rolename
+	}
 
 	log.Infof("running test in namespace %s\n", Namespace)
 	log.Infof("running test as user %s\n", TestUsername)
+	log.Infof("running test with pgorole %s\n", TestRolename)
 	log.Infof("running test on cluster %s\n", TestClusterName)
 	// uses the current context in kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
the event go tests were setup to use a rolename but that flag didn't exist and wasn't being used


**What is the new behavior (if this is a feature change)?**
adds flag


**Other information**:
