### PR TITLE
implements probles for apiserver and scheduler

### DIFF
--- a/deploy/deployment.json
+++ b/deploy/deployment.json
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "postgres-operator",
         "labels": {
-        	"vendor": "crunchydata"
+            "vendor": "crunchydata"
         }
     },
     "spec": {
@@ -13,12 +13,13 @@
             "metadata": {
                 "labels": {
                     "name": "postgres-operator",
-        	    "vendor": "crunchydata"
+                    "vendor": "crunchydata"
                 }
             },
             "spec": {
                 "serviceAccountName": "postgres-operator",
-                "containers": [{
+                "containers": [
+                    {
                         "name": "apiserver",
                         "image": "$PGO_IMAGE_PREFIX/pgo-apiserver:$PGO_IMAGE_TAG",
                         "imagePullPolicy": "IfNotPresent",
@@ -27,6 +28,20 @@
                                 "containerPort": $PGO_APISERVER_PORT
                             }
                         ],
+                        "readinessProbe": {
+                            "tcpSocket": {
+                                "port": $PGO_APISERVER_PORT
+                            },
+                            "initialDelaySeconds": 15,
+                            "periodSeconds": 5
+                        },
+                        "livenessProbe": {
+                            "tcpSocket": {
+                                "port": $PGO_APISERVER_PORT
+                            },
+                            "initialDelaySeconds": 15,
+                            "periodSeconds": 5
+                        },
                         "env": [
                             {
                                 "name": "CRUNCHY_DEBUG",
@@ -67,20 +82,21 @@
                         ],
                         "volumeMounts": [
                         ]
-                    }, {
+                    }, 
+                    {
                         "name": "operator",
                         "image": "$PGO_IMAGE_PREFIX/postgres-operator:$PGO_IMAGE_TAG",
                         "imagePullPolicy": "IfNotPresent",
-			"readinessProbe": {
-				"exec": {
-					"command": [
-						"ls",
-						"/tmp"
-					]
-				},
-				"initialDelaySeconds": 4,
-				"periodSeconds": 5
-			},
+                        "readinessProbe": {
+                            "exec": {
+                                "command": [
+                                    "ls",
+                                    "/tmp"
+                                ]
+                            },
+                            "initialDelaySeconds": 4,
+                            "periodSeconds": 5
+                        },
                         "env": [
                             {
                                 "name": "CRUNCHY_DEBUG",
@@ -121,19 +137,22 @@
                         ],
                         "volumeMounts": [
                         ]
-                    }, {
+                    }, 
+                    {
                         "name": "scheduler",
                         "image": "$PGO_IMAGE_PREFIX/pgo-scheduler:$PGO_IMAGE_TAG",
-			"readinessProbe": {
-				"exec": {
-					"command": [
-						"ls",
-						"/tmp"
-					]
-				},
-				"initialDelaySeconds": 4,
-				"periodSeconds": 5
-			},
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                   "bash",
+                                    "-c",
+                                    "test -n \"$(find /tmp/scheduler.hb -newermt '61 sec ago')\""
+                                ]
+                            },
+                            "failureThreshold": 2,
+                            "initialDelaySeconds": 60,
+                            "periodSeconds": 60
+                        },
                         "env": [
                             {
                                 "name": "PGO_OPERATOR_NAMESPACE",
@@ -151,16 +170,17 @@
                                 "name": "TIMEOUT",
                                 "value": "3600"
                             },
-			    {
-				"name": "EVENT_ADDR",
-                        	"value": "localhost:4150"
-			    }
+                            {
+                                "name": "EVENT_ADDR",
+                                "value": "localhost:4150"
+                            }
                         ],
                         "volumeMounts": [
                         ],
                         "resources": {},
                         "imagePullPolicy": "IfNotPresent"
-                    }, {
+                    }, 
+                    {
                         "name": "event",
                         "image": "$PGO_IMAGE_PREFIX/pgo-event:$PGO_IMAGE_TAG",
                         "env": [


### PR DESCRIPTION
- scheduler touches a sentinel file per minute with a liveness check
verifying it is executing schedule
- apiserver is limited to TCP port check while configured for
strict client x509 verification (kubelet doesn't provide a cert
when checking HTTPS probes)

 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable? (kube, don't have an openshift testbed)

**Type of Changes:**

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**
Currently there are no probes for the apiserver container and the readiness probe for the scheduler container is ineffective.

**What is the new behavior (if this is a feature change)?**
Scheduler container will be restarted by kube if it fails to execute its heartbeat job. (Takes 2 failures)
Apiserver container will be restarted/removed from the service routing if it stops responding on its configured port. (liveness and readiness consequences)
