### PR TITLE
Adding the disabling of RH sub manager for UBI builds

### DIFF
--- a/ubi7/Dockerfile.pgo-apiserver.ubi7
+++ b/ubi7/Dockerfile.pgo-apiserver.ubi7
@@ -25,7 +25,8 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-RUN yum -y update && yum -y install postgresql${PGVERSION} hostname \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager  postgresql${PGVERSION} hostname \
  && yum -y clean all
 
 ADD bin/apiserver /usr/local/bin

--- a/ubi7/Dockerfile.pgo-backrest-repo.ubi7
+++ b/ubi7/Dockerfile.pgo-backrest-repo.ubi7
@@ -21,7 +21,8 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-RUN yum -y update && yum -y install psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
 yum -y clean all
 
 RUN groupadd pgbackrest -g 2000 && useradd pgbackrest -u 2000 -g 2000

--- a/ubi7/Dockerfile.pgo-backrest-restore.ubi7
+++ b/ubi7/Dockerfile.pgo-backrest-restore.ubi7
@@ -21,7 +21,8 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-RUN yum -y update && yum -y install psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" postgresql11-server procps-ng \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" postgresql11-server procps-ng \
  && yum -y clean all
 
 VOLUME ["/sshd", "/pgdata"]

--- a/ubi7/Dockerfile.pgo-backrest.ubi7
+++ b/ubi7/Dockerfile.pgo-backrest.ubi7
@@ -24,8 +24,9 @@ COPY redhat/atomic/pgo_backrest/help.md /help.md
 COPY redhat/licenses /licenses
 COPY licenses /licenses
 
-RUN yum -y update && yum -y install postgresql11-server \
- && yum -y install crunchy-backrest-"${BACKREST_VERSION}" \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager postgresql11-server \
+ && yum -y install --disableplugin=subscription-manager crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 #RUN mkdir -p /opt/cpm/bin /pgdata /backrestrepo && chown -R 26:26 /opt/cpm && chmod -R g=u /pgdata 

--- a/ubi7/Dockerfile.pgo-event.ubi7
+++ b/ubi7/Dockerfile.pgo-event.ubi7
@@ -19,7 +19,8 @@ COPY redhat/atomic/pgo_event/help.md /help.md
 COPY redhat/licenses /licenses
 COPY licenses /licenses
 
-RUN yum -y update && yum -y clean all
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y clean all
 
 ADD bin/pgo-event /usr/local/bin
 

--- a/ubi7/Dockerfile.pgo-load.ubi7
+++ b/ubi7/Dockerfile.pgo-load.ubi7
@@ -25,11 +25,12 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-RUN yum -y update && yum install -y \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum install -y --disableplugin=subscription-manager \
 	gettext \
 	hostname \
 	procps-ng \
- && yum -y install postgresql${PGVERSION} \
+ && yum -y install --disableplugin=subscription-manager postgresql${PGVERSION} \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf

--- a/ubi7/Dockerfile.pgo-lspvc.ubi7
+++ b/ubi7/Dockerfile.pgo-lspvc.ubi7
@@ -20,7 +20,8 @@ COPY licenses /licenses
 #RUN rpm --import RPM-GPG-KEY-crunchydata
 
 
-RUN yum -y update && yum -y clean all
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y clean all
 
 #RUN mkdir -p /opt/cpm/bin && chown -R 26:26 /opt/cpm
 #RUN mkdir /pgdata && chmod -R g=u /pgdata

--- a/ubi7/Dockerfile.pgo-rmdata.ubi7
+++ b/ubi7/Dockerfile.pgo-rmdata.ubi7
@@ -15,7 +15,8 @@ COPY redhat/atomic/pgo_rmdata/help.md /help.md
 COPY redhat/licenses /licenses
 COPY licenses /licenses
 
-RUN yum -y update && yum -y clean all
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y clean all
 
 ADD bin/pgo-rmdata/ /usr/local/bin
 

--- a/ubi7/Dockerfile.pgo-scheduler.ubi7
+++ b/ubi7/Dockerfile.pgo-scheduler.ubi7
@@ -17,7 +17,8 @@ COPY redhat/atomic/pgo_scheduler/help.md /help.md
 COPY redhat/licenses /licenses
 COPY licenses /licenses
 
-RUN yum -y update && yum clean all -y
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgo-config \
  && chown -R 2:2 /opt/cpm /pgo-config

--- a/ubi7/Dockerfile.pgo-sqlrunner.ubi7
+++ b/ubi7/Dockerfile.pgo-sqlrunner.ubi7
@@ -21,8 +21,8 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-RUN yum -y update \
- && yum -y install postgresql${PGVERSION} \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager postgresql${PGVERSION} \
  && yum -y clean all
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgconf \

--- a/ubi7/Dockerfile.postgres-operator.ubi7
+++ b/ubi7/Dockerfile.postgres-operator.ubi7
@@ -25,8 +25,8 @@ ADD conf/RPM-GPG-KEY-crunchydata  /
 ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
-RUN yum -y update \
- && yum -y install postgresql${PGVERSION} \
+RUN yum -y update --disableplugin=subscription-manager \
+ && yum -y install --disableplugin=subscription-manager postgresql${PGVERSION} \
  && yum -y clean all
 
 ADD bin/postgres-operator /usr/local/bin


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
When building using UBI on a registered RHEL VM the container will pull in all the packages it uses from rhel server rpms instead of from the UBI repo.

**What is the new behavior (if this is a feature change)?**
All packages will be pulled only from the UBI repo or EPEL.  The resulting backrest packages will be broken because of the missing openssh server package in UBI but we are working on finding a fix for this.

**Other information**:
