### PR TITLE
makes service ports templated

### DIFF
--- a/ansible/inventory
+++ b/ansible/inventory
@@ -87,6 +87,9 @@ backrest='true'
 badger='false'
 metrics='false'
 
+# pgbadger Defaults
+pgbadgerport='10000'
+
 # pgBackRest Defaults
 archive_mode='true'
 archive_timeout=60
@@ -228,6 +231,7 @@ resource2_limits_cpu=4.0
 
 # Note: Ansible will create namespaces that don't exist
 metrics_namespace='metrics'
+exporterport='9187'
 
 grafana_install='false'
 grafana_admin_username='admin'

--- a/ansible/roles/pgo-operator/files/pgo-configs/cluster-service.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/cluster-service.json
@@ -26,8 +26,8 @@
     }, {
     "name": "pgbadger",
     "protocol": "TCP",
-    "port": 10000,
-    "targetPort": 10000,
+    "port": {{.PGBadgerPort}},
+    "targetPort": {{.PGBadgerPort}},
     "nodePort": 0
     }, {
     "name": "sshd",
@@ -38,8 +38,8 @@
     }, {
     "name": "postgres-exporter",
     "protocol": "TCP",
-    "port": 9187,
-    "targetPort": 9187,
+    "port": {{.ExporterPort}},
+    "targetPort": {{.ExporterPort}},
     "nodePort": 0
     }
     ],

--- a/ansible/roles/pgo-operator/templates/pgo.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/pgo.yaml.j2
@@ -13,6 +13,8 @@ Cluster:
   Metrics:  {{ metrics }}
   Badger:  {{ badger }}
   Port:  {{ db_port }}
+  PGBadgerPort: {{ pgbadgerport }}
+  ExporterPort: {{ exporterport }}
   User:  {{ db_user}}
   Database:  {{ db_name }}
   PasswordAgeDays:  {{ db_password_age_days }}

--- a/ansible/roles/pgo-preflight/tasks/check_inventory.yml
+++ b/ansible/roles/pgo-preflight/tasks/check_inventory.yml
@@ -35,3 +35,5 @@
     - primary_storage
     - replica_storage
     - pgo_client_version
+    - pgbadgerport
+    - exporterport

--- a/apis/cr/v1/cluster.go
+++ b/apis/cr/v1/cluster.go
@@ -40,6 +40,8 @@ type PgclusterSpec struct {
 	CCPImage           string               `json:"ccpimage"`
 	CCPImageTag        string               `json:"ccpimagetag"`
 	Port               string               `json:"port"`
+	PGBadgerPort       string               `json:"pgbadgerport"`
+	ExporterPort       string               `json:"exporterport"`
 	NodeName           string               `json:"nodename"`
 	PrimaryStorage     PgStorageSpec        `json:primarystorage`
 	ArchiveStorage     PgStorageSpec        `json:archivestorage`

--- a/apis/cr/v1/deepcopy.go
+++ b/apis/cr/v1/deepcopy.go
@@ -117,6 +117,8 @@ func (in *Pgcluster) DeepCopyInto(out *Pgcluster) {
 		CCPImage:           in.Spec.CCPImage,
 		CCPImageTag:        in.Spec.CCPImageTag,
 		Port:               in.Spec.Port,
+		PGBadgerPort:       in.Spec.PGBadgerPort,
+		ExporterPort:       in.Spec.ExporterPort,
 		NodeName:           in.Spec.NodeName,
 		PrimaryStorage:     in.Spec.PrimaryStorage,
 		ReplicaStorage:     in.Spec.ReplicaStorage,

--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -865,6 +865,8 @@ func getClusterParams(request *msgs.CreateClusterRequest, name string, userLabel
 	spec.Name = name
 	spec.ClusterName = name
 	spec.Port = apiserver.Pgo.Cluster.Port
+	spec.PGBadgerPort = apiserver.Pgo.Cluster.PGBadgerPort
+	spec.ExporterPort = apiserver.Pgo.Cluster.ExporterPort
 	spec.SecretFrom = ""
 	spec.PrimaryHost = name
 	if request.Policies == "" {

--- a/conf/postgres-operator/cluster-service.json
+++ b/conf/postgres-operator/cluster-service.json
@@ -26,8 +26,8 @@
     }, {
     "name": "pgbadger",
     "protocol": "TCP",
-    "port": 10000,
-    "targetPort": 10000,
+    "port": {{.PGBadgerPort}},
+    "targetPort": {{.PGBadgerPort}},
     "nodePort": 0
     }, {
     "name": "sshd",
@@ -38,8 +38,8 @@
     }, {
     "name": "postgres-exporter",
     "protocol": "TCP",
-    "port": 9187,
-    "targetPort": 9187,
+    "port": {{.ExporterPort}},
+    "targetPort": {{.ExporterPort}},
     "nodePort": 0
     }
     ],

--- a/conf/postgres-operator/pgo.yaml
+++ b/conf/postgres-operator/pgo.yaml
@@ -6,6 +6,8 @@ Cluster:
   Badger:  false
   CCPImageTag:  centos7-11.5-2.4.2
   Port:  5432
+  PGBadgerPort: 10000
+  ExporterPort: 9187
   User:  testuser
   Database:  userdb
   PasswordAgeDays:  60

--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -203,6 +203,8 @@ type ClusterStruct struct {
 	Metrics                 bool   `yaml:"Metrics"`
 	Badger                  bool   `yaml:"Badger"`
 	Port                    string `yaml:"Port"`
+	PGBadgerPort            string `yaml:"PGBadgerPort"`
+	ExporterPort            string `yaml:"ExporterPort"`
 	User                    string `yaml:"User"`
 	ArchiveTimeout          string `yaml:"ArchiveTimeout"`
 	Database                string `yaml:"Database"`
@@ -278,6 +280,9 @@ var log_statement_values = []string{"ddl", "none", "mod", "all"}
 const DEFAULT_LOG_STATEMENT = "none"
 const DEFAULT_LOG_MIN_DURATION_STATEMENT = "60000"
 const DEFAULT_BACKREST_PORT = 2022
+const DEFAULT_PGBADGER_PORT = "10000"
+const DEFAULT_EXPORTER_PORT = "9187"
+const DEFAULT_POSTGRES_PORT = "5432"
 const DEFAULT_BACKREST_SSH_KEY_BITS = 2048
 
 func (c *PgoConfig) Validate() error {
@@ -288,6 +293,31 @@ func (c *PgoConfig) Validate() error {
 		c.Cluster.BackrestPort = DEFAULT_BACKREST_PORT
 		log.Infof("setting BackrestPort to default %d", c.Cluster.BackrestPort)
 	}
+	if c.Cluster.PGBadgerPort == "" {
+		c.Cluster.PGBadgerPort = DEFAULT_PGBADGER_PORT
+		log.Infof("setting PGBadgerPort to default %s", c.Cluster.PGBadgerPort)
+	} else {
+		if _, err := strconv.Atoi(c.Cluster.PGBadgerPort); err != nil {
+			return errors.New(errPrefix + "Invalid PGBadgerPort: " + err.Error())
+		}
+	}
+    if c.Cluster.ExporterPort == "" {
+		c.Cluster.ExporterPort = DEFAULT_EXPORTER_PORT
+		log.Infof("setting ExporterPort to default %s", c.Cluster.ExporterPort)
+	} else {
+		if _, err := strconv.Atoi(c.Cluster.ExporterPort); err != nil {
+			return errors.New(errPrefix + "Invalid ExporterPort: " + err.Error())
+		}
+	}
+	if c.Cluster.Port == "" {
+		c.Cluster.Port = DEFAULT_POSTGRES_PORT
+		log.Infof("setting Postgres Port to default %s", c.Cluster.Port)
+	} else {
+		if _, err := strconv.Atoi(c.Cluster.Port); err != nil {
+			return errors.New(errPrefix + "Invalid Port: " + err.Error())
+		}
+	}
+
 
 	if c.Cluster.LogStatement != "" {
 		found := false

--- a/hugo/content/Configuration/pgo-yaml-configuration.md
+++ b/hugo/content/Configuration/pgo-yaml-configuration.md
@@ -20,6 +20,8 @@ The *pgo.yaml* file is broken into major sections as described below:
 |CCPImagePrefix        |newly created containers will be based on this image prefix (e.g. crunchydata), update this if you require a custom image prefix
 |CCPImageTag        |newly created containers will be based on this image version (e.g. centos7-11.5-2.4.2), unless you override it using the --ccp-image-tag command line flag
 |Port        | the PostgreSQL port to use for new containers (e.g. 5432)
+|PGBadgerPort | the port used to connect to pgbadger (e.g. 10000)
+|ExporterPort | the port used to connect to postgres exporter (e.g. 9187)
 |LogStatement        | postgresql.conf log_statement value (required field)
 |LogMinDurationStatement        | postgresql.conf log_min_duration_statement value (required field)
 |User        | the PostgreSQL normal user name

--- a/hugo/content/Installation/install-with-ansible/prerequisites.md
+++ b/hugo/content/Installation/install-with-ansible/prerequisites.md
@@ -151,6 +151,8 @@ The following are the variables available for configuration:
 | `delete_watched_namespaces`       | false       | Set to configure whether or not the PGO watched namespaces (defined using variable `namespace`) are deleted when uninstalling the PGO.                                         |
 | `delete_metrics_namespace`        | false       | Set to configure whether or not the metrics namespace (defined using variable `metrics_namespace`) is deleted when uninstalling the metrics infrastructure                     |
 | `pgo_cluster_admin`               | false       | Determines whether or not the `cluster-admin` role is assigned to the PGO service account. Must be `true` to enable PGO namespace & role creation when installing in OpenShift.  |
+| `pgbadgerport`                    | 10000       | Set to configure the default port used to connect to pgbadger.  |
+| `exporter`                        | 9187        | Set to configure the default port used to connect to postgres exporter.  |
 
 {{% notice tip %}}
 To retrieve the `kubernetes_context` value for Kubernetes installs, run the following command:
@@ -200,6 +202,8 @@ PostgreSQL Operator:
 * `replica_storage`
 * `backrest_storage`
 * `backup_storage`
+* `pgbadgerport`
+* `exporterport`
 
 Additionally, `storage` variables will need to be defined to provide the Crunchy PGO with any required storage configuration.  Guidance for defining `storage` variables can be found in the next section.
 

--- a/operator/backrest/repo.go
+++ b/operator/backrest/repo.go
@@ -91,7 +91,6 @@ func CreateRepoDeployment(clientset *kubernetes.Clientset, namespace string, clu
 	}
 
 	//create backrest repo deployment
-	log.Debug("hi from backup create repo deploy")
 	fields := RepoDeploymentTemplateFields{
 		PGOImagePrefix:        operator.Pgo.Pgo.PGOImagePrefix,
 		PGOImageTag:           operator.Pgo.Pgo.PGOImageTag,

--- a/operator/cluster/cluster.go
+++ b/operator/cluster/cluster.go
@@ -42,6 +42,8 @@ type ServiceTemplateFields struct {
 	ServiceName string
 	ClusterName string
 	Port        string
+	PGBadgerPort string
+	ExporterPort string
 	ServiceType string
 }
 
@@ -291,6 +293,8 @@ func ScaleBase(clientset *kubernetes.Clientset, client *rest.RESTClient, replica
 		ServiceName: serviceName,
 		ClusterName: replica.Spec.ClusterName,
 		Port:        cluster.Spec.Port,
+		PGBadgerPort: cluster.Spec.PGBadgerPort,
+		ExporterPort: cluster.Spec.ExporterPort,
 		ServiceType: st,
 	}
 

--- a/operator/cluster/clusterlogic.go
+++ b/operator/cluster/clusterlogic.go
@@ -55,6 +55,8 @@ func AddCluster(clientset *kubernetes.Clientset, client *rest.RESTClient, cl *cr
 		ServiceName: cl.Spec.Name,
 		ClusterName: cl.Spec.Name,
 		Port:        cl.Spec.Port,
+		PGBadgerPort: cl.Spec.PGBadgerPort,
+		ExporterPort: cl.Spec.ExporterPort,
 		ServiceType: st,
 	}
 

--- a/operator/cluster/pgbouncer.go
+++ b/operator/cluster/pgbouncer.go
@@ -358,6 +358,8 @@ func AddPgbouncer(clientset *kubernetes.Clientset, restclient *rest.RESTClient, 
 		svcFields.ServiceName = pgbouncerName
 		svcFields.ClusterName = clusterName
 		svcFields.Port = operator.Pgo.Cluster.Port
+		svcFields.PGBadgerPort = operator.Pgo.Cluster.PGBadgerPort
+		svcFields.ExporterPort = operator.Pgo.Cluster.ExporterPort
 
 		err = CreateService(clientset, &svcFields, namespace)
 		if err != nil {

--- a/operator/cluster/pgpool.go
+++ b/operator/cluster/pgpool.go
@@ -333,6 +333,8 @@ func AddPgpool(clientset *kubernetes.Clientset, cl *crv1.Pgcluster, namespace st
 		svcFields.ServiceName = pgpoolName
 		svcFields.ClusterName = clusterName
 		svcFields.Port = operator.Pgo.Cluster.Port
+		svcFields.PGBadgerPort = operator.Pgo.Cluster.PGBadgerPort
+		svcFields.ExporterPort = operator.Pgo.Cluster.ExporterPort
 
 		err = CreateService(clientset, &svcFields, namespace)
 		if err != nil {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable? (tested with bash/ansible on kube)



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
- service ports are hardcoded in cluster-service.json
- validation is not done on postgres port

**What is the new behavior (if this is a feature change)?**
- service ports are pulled from pgo.yaml and inventory files
- validation is done on service ports



**Other information**:
[ch1866]