### PR TITLE
Small typo fix and also harden UBI builds such that they fail if dependencies are missing

### DIFF
--- a/centos7/Dockerfile.pgo-backrest-repo.centos7
+++ b/centos7/Dockerfile.pgo-backrest-repo.centos7
@@ -20,7 +20,7 @@ RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/r
 RUN yum -y update && \
 #yum -y install epel-release && \
 yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
-    psmisc openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
+    psmisc openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" hostname procps-ng && \
 yum -y clean all
 
 RUN groupadd pgbackrest -g 2000 && useradd pgbackrest -u 2000 -g 2000

--- a/centos7/Dockerfile.repo-client.centos7
+++ b/centos7/Dockerfile.repo-client.centos7
@@ -20,7 +20,7 @@ RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/r
 RUN yum -y update && \
 #yum -y install epel-release && \
 yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
-    openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
+    openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" hostname procps-ng && \
 yum -y clean all
 
 RUN useradd pgbackrest

--- a/rhel7/Dockerfile.pgo-backrest-repo.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-repo.rhel7
@@ -22,7 +22,7 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 RUN yum -y --enablerepo=rhel-7-server-ose-3.11-rpms --disablerepo=crunchy* update && \
-yum -y install psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
+yum -y install psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" hostname procps-ng && \
 yum -y clean all
 
 RUN groupadd pgbackrest -g 2000 && useradd pgbackrest -u 2000 -g 2000

--- a/ubi7/Dockerfile.pgo-apiserver.ubi7
+++ b/ubi7/Dockerfile.pgo-apiserver.ubi7
@@ -26,7 +26,7 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager  postgresql${PGVERSION} hostname \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False  postgresql${PGVERSION} hostname \
  && yum -y clean all
 
 ADD bin/apiserver /usr/local/bin

--- a/ubi7/Dockerfile.pgo-backrest-repo.ubi7
+++ b/ubi7/Dockerfile.pgo-backrest-repo.ubi7
@@ -22,7 +22,7 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
 yum -y clean all
 
 RUN groupadd pgbackrest -g 2000 && useradd pgbackrest -u 2000 -g 2000

--- a/ubi7/Dockerfile.pgo-backrest-repo.ubi7
+++ b/ubi7/Dockerfile.pgo-backrest-repo.ubi7
@@ -22,7 +22,7 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" hostname pgocps-ng && \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" hostname procps-ng && \
 yum -y clean all
 
 RUN groupadd pgbackrest -g 2000 && useradd pgbackrest -u 2000 -g 2000

--- a/ubi7/Dockerfile.pgo-backrest-restore.ubi7
+++ b/ubi7/Dockerfile.pgo-backrest-restore.ubi7
@@ -22,7 +22,7 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" postgresql11-server procps-ng \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False psmisc openssh-server openssh-clients crunchy-backrest-"${BACKREST_VERSION}" postgresql11-server procps-ng \
  && yum -y clean all
 
 VOLUME ["/sshd", "/pgdata"]

--- a/ubi7/Dockerfile.pgo-backrest.ubi7
+++ b/ubi7/Dockerfile.pgo-backrest.ubi7
@@ -25,8 +25,8 @@ COPY redhat/licenses /licenses
 COPY licenses /licenses
 
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager postgresql11-server \
- && yum -y install --disableplugin=subscription-manager crunchy-backrest-"${BACKREST_VERSION}" \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql11-server \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False crunchy-backrest-"${BACKREST_VERSION}" \
  && yum -y clean all
 
 #RUN mkdir -p /opt/cpm/bin /pgdata /backrestrepo && chown -R 26:26 /opt/cpm && chmod -R g=u /pgdata 

--- a/ubi7/Dockerfile.pgo-load.ubi7
+++ b/ubi7/Dockerfile.pgo-load.ubi7
@@ -30,7 +30,7 @@ RUN yum -y update --disableplugin=subscription-manager \
 	gettext \
 	hostname \
 	procps-ng \
- && yum -y install --disableplugin=subscription-manager postgresql${PGVERSION} \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql${PGVERSION} \
  && yum clean all -y
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf

--- a/ubi7/Dockerfile.pgo-sqlrunner.ubi7
+++ b/ubi7/Dockerfile.pgo-sqlrunner.ubi7
@@ -22,7 +22,7 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager postgresql${PGVERSION} \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql${PGVERSION} \
  && yum -y clean all
 
 RUN mkdir -p /opt/cpm/bin /opt/cpm/conf /pgconf \

--- a/ubi7/Dockerfile.postgres-operator.ubi7
+++ b/ubi7/Dockerfile.postgres-operator.ubi7
@@ -26,7 +26,7 @@ ADD conf/crunchypg11.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata
 
 RUN yum -y update --disableplugin=subscription-manager \
- && yum -y install --disableplugin=subscription-manager postgresql${PGVERSION} \
+ && yum -y install --disableplugin=subscription-manager --setopt=skip_missing_names_on_install=False postgresql${PGVERSION} \
  && yum -y clean all
 
 ADD bin/postgres-operator /usr/local/bin


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

There are 2 minor issues fixed:
1) The pgocps-ng RPM was changed to procops-ng.  This typo fix doesn't really have much impact, because procops-ng is already installed on the base image by default.
2) Yum has an interesting behavior where if you do "yum install a b c", and b is not available, it will say "package b is not found", and then install a and c, continuing.  The error code is zero and yum considers that the process passed.  Since this is not ideal, and we would rather fail whenever any package that's needed cannot be found, I added a flag to the yum installs for ubi images "--setopt=skip_missing_names_on_install=False".  This flag will cause builds to fail if any needed dependency cannot be found.

**What is the new behavior (if this is a feature change)?**

Builds are hardened for UBI.

**Other information**:
