### PR TITLE
Update Deployment apiVersion to apps/v1

### DIFF
--- a/ansible/roles/pgo-metrics/templates/grafana-deployment.json.j2
+++ b/ansible/roles/pgo-metrics/templates/grafana-deployment.json.j2
@@ -1,11 +1,17 @@
 {
-    "apiVersion": "extensions/v1beta1",
+    "apiVersion": "apps/v1",
     "kind": "Deployment",
     "metadata": {
         "name": "crunchy-grafana"
     },
     "spec": {
         "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "name": "{{ grafana_service_name }}",
+                "vendor": "crunchydata"
+            }
+        },
         "template": {
             "metadata": {
                 "labels": {

--- a/ansible/roles/pgo-metrics/templates/prometheus-deployment.json.j2
+++ b/ansible/roles/pgo-metrics/templates/prometheus-deployment.json.j2
@@ -1,11 +1,17 @@
 {
-    "apiVersion": "extensions/v1beta1",
+    "apiVersion": "apps/v1",
     "kind": "Deployment",
     "metadata": {
         "name": "crunchy-prometheus"
     },
     "spec": {
         "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "name": "{{ prometheus_service_name }}",
+                "vendor": "crunchydata"
+            }
+        },
         "template": {
             "metadata": {
                 "labels": {

--- a/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -1,11 +1,16 @@
 {
-    "apiVersion": "extensions/v1beta1",
+    "apiVersion": "apps/v1",
     "kind": "Deployment",
     "metadata": {
         "name": "postgres-operator"
     },
     "spec": {
         "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "name": "postgres-operator"
+            }
+        },
         "template": {
             "metadata": {
                 "labels": {

--- a/deploy/deployment.json
+++ b/deploy/deployment.json
@@ -1,11 +1,16 @@
 {
-    "apiVersion": "extensions/v1beta1",
+    "apiVersion": "apps/v1",
     "kind": "Deployment",
     "metadata": {
         "name": "postgres-operator"
     },
     "spec": {
         "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "name": "postgres-operator"
+            }
+        },
         "template": {
             "metadata": {
                 "labels": {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Deployments are made using apiVersion "extensions/v1beta". Deployment where moved to "apps/v1" a while ago and "extensions/v1beta" is not supported by Kubernetes 1.16 anymore.


**What is the new behavior (if this is a feature change)?**
Changes all deployments in the repo to "apps/v1"


**Other information**:
All currently supported Kubernetes versions already support "apps/v1"