### PR TITLE
Update Namespace Controller Watchers

### DIFF
--- a/controller/namespacecontroller.go
+++ b/controller/namespacecontroller.go
@@ -119,7 +119,7 @@ func (c *NamespaceController) onUpdate(oldObj, newObj interface{}) {
 	log.Debugf("[NamespaceController] onUpdate ns=%s", newNs.ObjectMeta.SelfLink)
 
 	labels := newNs.GetObjectMeta().GetLabels()
-	if labels[config.LABEL_VENDOR] != config.LABEL_CRUNCHY {
+	if labels[config.LABEL_VENDOR] != config.LABEL_CRUNCHY || labels[config.LABEL_PGO_INSTALLATION_NAME] != operator.InstallationName {
 		log.Debugf("NamespaceController: onUpdate skipping namespace that is not crunchydata %s", newNs.ObjectMeta.SelfLink)
 		return
 	} else {

--- a/controller/namespacecontroller.go
+++ b/controller/namespacecontroller.go
@@ -124,6 +124,13 @@ func (c *NamespaceController) onUpdate(oldObj, newObj interface{}) {
 		return
 	} else {
 		log.Debugf("NamespaceController: onUpdate crunchy namespace updated %s", newNs.ObjectMeta.SelfLink)
+		c.ThePodController.SetupWatch(newNs.Name)
+		c.TheJobController.SetupWatch(newNs.Name)
+		c.ThePgpolicyController.SetupWatch(newNs.Name)
+		c.ThePgbackupController.SetupWatch(newNs.Name)
+		c.ThePgreplicaController.SetupWatch(newNs.Name)
+		c.ThePgclusterController.SetupWatch(newNs.Name)
+		c.ThePgtaskController.SetupWatch(newNs.Name)
 	}
 
 }


### PR DESCRIPTION
exist for namespace add controller function.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
After running the add-targeted-namespace.sh script for an existing namespace, the PGO reports success when creating a cluster. However, the deployment for the cluster is never created.


**What is the new behavior (if this is a feature change)?**
The Operator namespace controller was updated to setup the proper informers for a namespace when the namespace has been updated (i.e. when the onUpdate function is called).
[ch5543]


**Other information**:
