### PR TITLE
Updated Ansible Preflight Checklist, pgo_tls_no_verify default value and Documentation

### DIFF
--- a/ansible/roles/pgo-preflight/tasks/check_inventory.yml
+++ b/ansible/roles/pgo-preflight/tasks/check_inventory.yml
@@ -25,8 +25,11 @@
     - archive_mode
     - archive_timeout
     - auto_failover_sleep_secs
+    - auto_failover_replace_replica
+    - db_name
     - db_password_age_days
     - db_password_length
+    - create_rbac
     - db_port
     - db_replicas
     - db_user
@@ -37,3 +40,4 @@
     - pgo_client_version
     - pgbadgerport
     - exporterport
+    - scheduler_timeout

--- a/ansible/roles/pgo-preflight/tasks/main.yml
+++ b/ansible/roles/pgo-preflight/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Check if required Kube or OpenShift variables are defined
   fail: msg="Please specify either OpenShift or Kubernetes variables in inventory"
-  when: openshift_user is undefined and openshift_token is undefined and kubernetes_context is undefined
+  when: openshift_user is undefined and openshift_host is undefined and openshift_token is undefined and kubernetes_context is undefined
   tags: always
 
 - include_tasks: check_openshift.yml

--- a/hugo/content/Installation/install-with-ansible/prerequisites.md
+++ b/hugo/content/Installation/install-with-ansible/prerequisites.md
@@ -136,7 +136,7 @@ The following are the variables available for configuration:
 | `pgo_image_prefix`                | crunchydata | Configures the image prefix used when creating containers for the Crunchy PostgreSQL Operator (apiserver, operator, scheduler..etc).                                             |
 | `pgo_image_tag`                   |             | Configures the image tag used when creating containers for the Crunchy PostgreSQL Operator (apiserver, operator, scheduler..etc)                                                 |
 | `pgo_operator_namespace`          |             | Set to configure the namespace where Operator will be deployed.                                                                                                                  |
-| `pgo_tls_no_verify`               |             | Set to configure Operator to verify TLS certificates.                                                                                                                            |
+| `pgo_tls_no_verify`               | false       | Set to configure Operator to verify TLS certificates.                                                                                                                            |
 | `pgo_disable_tls`                 | false       | Set to configure whether or not TLS should be enabled for the Crunchy PostgreSQL Operator apiserver.                                                                             |
 | `pgo_apiserver_port`              | 8443        | Set to configure the port used by the Crunchy PostgreSQL Operator apiserver.                                                                                                     |
 | `pgo_disable_eventing`            | false       | Set to configure whether or not eventing should be enabled for the Crunchy PostgreSQL Operator installation.                                                                     |
@@ -185,7 +185,6 @@ PostgreSQL Operator:
 * `ccp_image_prefix`
 * `ccp_image_tag`
 * `pgo_client_version`
-* `pgo_tls_no_verify`
 * `auto_failover`
 * `backrest`
 * `badger`
@@ -193,8 +192,11 @@ PostgreSQL Operator:
 * `archive_mode`
 * `archive_timeout`
 * `auto_failover_sleep_secs`
+* `auto_failover_replace_replica`
 * `db_password_age_days`
 * `db_password_length`
+* `create_rbac`
+* `db_name`
 * `db_port`
 * `db_replicas`
 * `db_user`
@@ -204,6 +206,7 @@ PostgreSQL Operator:
 * `backup_storage`
 * `pgbadgerport`
 * `exporterport`
+* `scheduler_timeout`
 
 Additionally, `storage` variables will need to be defined to provide the Crunchy PGO with any required storage configuration.  Guidance for defining `storage` variables can be found in the next section.
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Ansible preflight checks and default values need to be updated to reflect
current installation requirements.


**What is the new behavior (if this is a feature change)?**
[ch4267]
Added the following variables to preflight checklist:
db_name
create_rbac
auto_failover_replace_replica
scheduler_timeout
-Added openshift_host check added to postgres-operator/ansible/roles/pgo-preflight/tasks/main.yml
'when' clause
-Updated documentation to reflect changes to preflight checklist. …
-Updated documentation to indicate pgo_tls_no_verify default value
and removed from minimal variable requirement list.

**Other information**:
