### PR TITLE
implements authentication bypass endpoints

### DIFF
--- a/apiserver/middleware.go
+++ b/apiserver/middleware.go
@@ -1,0 +1,69 @@
+package apiserver
+
+/*
+Copyright 2019 Crunchy Data Solutions, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// certEnforcer is a contextual middleware for deferred enforcement of
+// client certificates. It assumes any certificates presented where validated
+// as part of establishing the TLS connection.
+type certEnforcer struct {
+	skip map[string]struct{}
+}
+
+// NewCertEnforcer ensures a certEnforcer is created with skipped routes
+// and validates that the configured routes are allowed
+func NewCertEnforcer(reqRoutes []string) (*certEnforcer, error) {
+	allowed := map[string]struct{}{
+		// List of allowed routes is part of the published documentation
+		"/health": struct{}{},
+	}
+
+	ce := &certEnforcer{
+		skip: map[string]struct{}{},
+	}
+
+	for _, route := range reqRoutes {
+		r := strings.TrimSpace(route)
+		if _, ok := allowed[r]; !ok {
+			return nil, fmt.Errorf("Disabling auth unsupported for route [%s]", r)
+		}
+		ce.skip[r] = struct{}{}
+	}
+	return ce, nil
+}
+
+// Enforce is an HTTP middleware for selectively enforcing deferred client
+// certificate checks based on the certEnforcer's skip list
+func (ce *certEnforcer) Enforce(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if _, ok := ce.skip[path]; ok {
+			next.ServeHTTP(w, r)
+		} else {
+			clientCerts := len(r.TLS.PeerCertificates) > 0
+			if !clientCerts {
+				http.Error(w, "Forbidden: Client Certificate Required", http.StatusForbidden)
+			} else {
+				next.ServeHTTP(w, r)
+			}
+		}
+	})
+}

--- a/apiserver/versionservice/versionservice.go
+++ b/apiserver/versionservice/versionservice.go
@@ -44,8 +44,6 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 
 // HealthHandler ...
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
-
-	w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 

--- a/hugo/content/Configuration/configuration.md
+++ b/hugo/content/Configuration/configuration.md
@@ -52,6 +52,33 @@ Files within this directory are used specifically when creating PostgreSQL Clust
 
 As with the other Operator templates, administrators can make custom changes to this set of templates to add custom features or metadata into the Resources created by the Operator.
 
+## Operator API Server
+
+The Operator's API server can be configured to allow access to select URL routes
+without requiring TLS authentication from the client and without
+the HTTP Basic authentication used for role-based-access.
+
+This configuration is performed by defining the `NOAUTH_ROUTES` environment
+variable for the apiserver container within the Operator pod. Typically, this
+configuration is made within the `deploy/deployment.yaml` file.
+
+The `NOAUTH_ROUTES` variable must be set to a comma-separated list of
+URL routes. For example: `/health,/version,/example3` would opt to **disable**
+authentication for `$APISERVER_URL/health`, `$APISERVER_URL/version`, and
+`$APISERVER_URL/example3` respectively.
+
+Currently, only the following routes may have authentication disabled using
+this setting:
+
+```
+/health
+```
+
+If the health route has its authentication disabled, the existing readiness 
+and liveness probes for the apiserver container could be enhanced by 
+configuring them with HTTP-based checks against the health route.
+
+
 ## Security
 
 Setting up pgo users and general security configuration is described in the [Security](/security) section of this documentation.

--- a/hugo/content/Configuration/configuration.md
+++ b/hugo/content/Configuration/configuration.md
@@ -59,8 +59,30 @@ without requiring TLS authentication from the client and without
 the HTTP Basic authentication used for role-based-access.
 
 This configuration is performed by defining the `NOAUTH_ROUTES` environment
-variable for the apiserver container within the Operator pod. Typically, this
-configuration is made within the `deploy/deployment.yaml` file.
+variable for the apiserver container within the Operator pod. 
+
+Typically, this configuration is made within the `deploy/deployment.json` 
+file for bash-based installations and 
+`ansible/roles/pgo-operator/templates/deployment.json.j2` for ansible installations.
+
+For example:
+```
+...
+    containers: [
+        {
+        	"name": "apiserver"
+        	"env": [
+                {
+                	"name": "NOAUTH_ROUTES",
+                	"value": "/health"
+                }
+        	]
+        	...
+        }
+        ...
+    ]
+...
+```
 
 The `NOAUTH_ROUTES` variable must be set to a comma-separated list of
 URL routes. For example: `/health,/version,/example3` would opt to **disable**


### PR DESCRIPTION
Enables the bypassing of authentication modes for URL routes, allowing health check endpoint to be accessible to large-scale monitoring tools.

**Checklist:**

 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
(Kubernetes only)

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**
Currently, all URL routes require mutual TLS authentication and all but the `/health` route requires HTTP Basic authentication. The `/health` route potentially prompts for HTTP Basic, but does not enforce it.

**What is the new behavior (if this is a feature change)?**
When the `NOAUTH_ROUTES` environment variable is correctly configured, the server's TLS configuration is reduced to verifying presented client certificates if presented vice both requiring and verifying client certificates.
For all protected routes, the existence of verified client certificates is confirmed or a HTTP Forbidden status is returned.
For noauth routes, that verified certificate check is skipped.

At this time, only the `/health` endpoint is allowed to be a noauth route. Enabling future endpoints will require they remove dependencies on the username returned from HTTP Basic authentication.
`/health` already had no dependency and no validation prior to this change.