### PR TITLE
adds validation on username

### DIFF
--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -302,7 +302,7 @@ func (c *PgoConfig) Validate() error {
 			return errors.New(errPrefix + "Invalid PGBadgerPort: " + err.Error())
 		}
 	}
-    if c.Cluster.ExporterPort == "" {
+        if c.Cluster.ExporterPort == "" {
 		c.Cluster.ExporterPort = DEFAULT_EXPORTER_PORT
 		log.Infof("setting ExporterPort to default %s", c.Cluster.ExporterPort)
 	} else {
@@ -482,7 +482,7 @@ func (c *PgoConfig) Validate() error {
 		// validates that username can be used as the kubernetes secret name
 		// Must consist of lower case alphanumeric characters, 
 		// '-' or '.', and must start and end with an alphanumeric character
-        errs := validation.IsDNS1123Subdomain(c.Cluster.User)
+                errs := validation.IsDNS1123Subdomain(c.Cluster.User)
 		if len(errs) > 0 {
 			var msg string
 			for i := range errs{

--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"regexp"
 
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/kubeapi"
@@ -477,6 +478,13 @@ func (c *PgoConfig) Validate() error {
 
 	if c.Cluster.User == "" {
 		return errors.New(errPrefix + "Cluster.User is required")
+	} else {
+		//checks that username is valid
+		re := regexp.MustCompile("^[a-z0-9.-]*$")
+		if !re.MatchString(c.Cluster.User) {
+			msg := "user name is required to contain lowercase letters, numbers, '.' and '-' only."
+			return errors.New(errPrefix + msg)
+		}
 	}
 	return err
 }


### PR DESCRIPTION
- can only contain lowercase letters, numbers, `-`, and `.`

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable? tested



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
currently there is no validation on the username that gets passed in with the pgoconfig. Usernames 
are stored as kube secrets so they can only have `-`, `.`, lowercase letters, and numbers as characters.

**What is the new behavior (if this is a feature change)?**
This adds a validation step to make sure the username can be stored with a kube secret.



**Other information**:
[ch5411]
https://github.com/CrunchyData/crunchy-containers/pull/1123