### PR TITLE
Update to how CentOS containers utilize the upstream PostgreSQL repos…

### DIFF
--- a/centos7/Dockerfile.pgo-backrest-repo.centos7
+++ b/centos7/Dockerfile.pgo-backrest-repo.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - Apiserver" \
 	description="Crunchy Data PostgreSQL Operator - Apiserver"
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94" \
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg11"\
     BACKREST_VERSION="2.17"
 
 COPY redhat/licenses /licenses
@@ -19,7 +19,7 @@ RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/r
 
 RUN yum -y update && \
 #yum -y install epel-release && \
-yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
+yum -y install --disablerepo="${PGDG_REPO_DISABLE}" --enablerepo="${PGDG_REPO_ENABLE}" \
     psmisc openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" hostname procps-ng && \
 yum -y clean all
 

--- a/centos7/Dockerfile.pgo-backrest-restore.centos7
+++ b/centos7/Dockerfile.pgo-backrest-restore.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94" \
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg11" \
     BACKREST_VERSION="2.17"
 
 COPY redhat/licenses /licenses
@@ -16,7 +16,7 @@ COPY licenses /licenses
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
-RUN yum -y update && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
+RUN yum -y update && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" --enablerepo="${PGDG_REPO_ENABLE}" \
     psmisc openssh-server openssh-clients pgbackrest-"${BACKREST_VERSION}" postgresql11-server procps-ng && yum -y clean all
 
 RUN mkdir -p /opt/cpm/bin /pgdata && chown -R 26:26 /opt/cpm

--- a/centos7/Dockerfile.pgo-backrest.centos7
+++ b/centos7/Dockerfile.pgo-backrest.centos7
@@ -8,7 +8,7 @@ LABEL Vendor="Crunchy Data Solutions" \
 	summary="Crunchy Data PostgreSQL Operator - pgBackRest" \
 	description="pgBackRest image that is integrated for use with Crunchy Data's PostgreSQL Operator."
 
-ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg10,pgdg96,pgdg95,pgdg94" \
+ENV PGVERSION="11" PGDG_REPO="pgdg-redhat-repo-latest.noarch.rpm" PGDG_REPO_DISABLE="pgdg*" PGDG_REPO_ENABLE="pgdg11" \
     BACKREST_VERSION="2.17"
 
 COPY redhat/licenses /licenses
@@ -16,8 +16,14 @@ COPY licenses /licenses
 
 RUN rpm -Uvh https://download.postgresql.org/pub/repos/yum/${PGVERSION}/redhat/rhel-7-x86_64/${PGDG_REPO}
 
-RUN yum -y update && yum -y install --disablerepo="${PGDG_REPO_DISABLE}" \
-    postgresql11-server && yum -y install pgbackrest-"${BACKREST_VERSION}" && yum -y clean all
+RUN yum -y update && \
+    yum -y install \
+    --disablerepo="${PGDG_REPO_DISABLE}" \
+    --enablerepo="${PGDG_REPO_ENABLE}" \
+    --setopt=skip_missing_names_on_install=False \
+    postgresql11-server \
+    pgbackrest-"${BACKREST_VERSION}" \
+    && yum -y clean all
 
 RUN mkdir -p /opt/cpm/bin /pgdata /backrestrepo && chown -R 26:26 /opt/cpm
 ADD bin/pgo-backrest/ /opt/cpm/bin


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
currently the build will fail because pgdg enable the pgdg12 repo. pgdg12 is not disabled so it fails when building any other version.


**What is the new behavior (if this is a feature change)?**
this update disables each pgdg repo and only enables the one for the correct version. It also updates the pgo-backrest image for stability and readability. The yum command is updated so that all packages are installed with the same yum call. The `--setopt` flag is added so that the command fails if any package is not found.


**Other information**:
[ch5887]