### PR TITLE
Scrape cAdvisor for Container metrics

### DIFF
--- a/ansible/roles/pgo-metrics/tasks/prometheus.yml
+++ b/ansible/roles/pgo-metrics/tasks/prometheus.yml
@@ -46,6 +46,7 @@
         dest: "{{ prom_output_dir }}/{{ item | replace('.j2', '') }}"
         mode: '0600'
       with_items: 
+      - prometheus-config.yaml.j2
       - prometheus-pvc.json.j2
       - prometheus-service.json.j2
       - prometheus-deployment.json.j2
@@ -54,6 +55,7 @@
     - name: Create Prometheus Objects
       command: "{{ kubectl_or_oc }} create -f {{ prom_output_dir }}/{{ item }} -n {{ metrics_namespace }}"
       with_items:
+      - prometheus-config.yaml
       - prometheus-pvc.json
       - prometheus-service.json
       - prometheus-deployment.json

--- a/ansible/roles/pgo-metrics/templates/prometheus-config.yaml.j2
+++ b/ansible/roles/pgo-metrics/templates/prometheus-config.yaml.j2
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: crunchy-prometheus
+data:
+  prometheus.yml: |-
+    ---
+    global:
+      scrape_interval: 10s
+      scrape_timeout: 10s
+      evaluation_interval: 5s
+
+    scrape_configs:
+    - job_name: cadvisor
+      kubernetes_sd_configs:
+      - role: node
+
+      metrics_path: /metrics/cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+      relabel_configs:
+      # Replace IP address with hostname when using HTTPS.
+      - action: replace
+        source_labels: [__scheme__,__meta_kubernetes_node_address_Hostname,__address__]
+        regex: 'https;([^;]+);.*:(\d+)'
+        target_label: __address__
+        replacement: '$1:$2'
+
+      metric_relabel_configs:
+      # Keep only metrics attributed to pods.
+      - action: keep
+        source_labels: [pod,pod_name]
+        separator: ''
+        regex: '.+'
+
+    - job_name: crunchy-collect
+      kubernetes_sd_configs:
+      - role: pod
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_crunchy_collect]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: 5432
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: 10000
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        regex: (^[^-]*).*
+        target_label: instance
+        replacement: '$1'
+      - source_labels: [__meta_kubernetes_namespace,__meta_kubernetes_pod_label_name]
+        target_label: job
+        separator: ': '
+        replacement: '$1$2'

--- a/ansible/roles/pgo-metrics/templates/prometheus-config.yaml.j2
+++ b/ansible/roles/pgo-metrics/templates/prometheus-config.yaml.j2
@@ -19,15 +19,8 @@ data:
       scheme: https
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-      relabel_configs:
-      # Replace IP address with hostname when using HTTPS.
-      - action: replace
-        source_labels: [__scheme__,__meta_kubernetes_node_address_Hostname,__address__]
-        regex: 'https;([^;]+);.*:(\d+)'
-        target_label: __address__
-        replacement: '$1:$2'
 
       metric_relabel_configs:
       # Keep only metrics attributed to pods.

--- a/ansible/roles/pgo-metrics/templates/prometheus-deployment.json.j2
+++ b/ansible/roles/pgo-metrics/templates/prometheus-deployment.json.j2
@@ -49,6 +49,11 @@
                         "env": [],
                         "volumeMounts": [
                             {
+                                "mountPath": "/conf",
+                                "name": "prometheusconf",
+                                "readOnly": true
+                            },
+                            {
                                 "mountPath": "/data",
                                 "name": "prometheusdata",
                                 "readOnly": false
@@ -57,6 +62,12 @@
                     }
                 ],
                 "volumes": [
+                    {
+                        "name": "prometheusconf",
+                        "configMap": {
+                            "name": "crunchy-prometheus"
+                        }
+                    },
                     {
                         "name": "prometheusdata",
                         "persistentVolumeClaim": {

--- a/ansible/roles/pgo-metrics/templates/prometheus-rbac.json.j2
+++ b/ansible/roles/pgo-metrics/templates/prometheus-rbac.json.j2
@@ -10,6 +10,8 @@
                 ""
             ],
             "resources": [
+                "nodes",
+                "nodes/metrics",
                 "pods"
             ],
             "verbs": [


### PR DESCRIPTION
We should look at `container_*` metrics to monitor individual clusters.

Unfortunately, this has the undesirable effect of showing `cadvisor` in the dropdowns of existing Grafana dashboards.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - Validated in GKE and k3s clusters.
   - Does not work in minikube.

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)
