### PR TITLE
Remove clusteridentifier from event messages

### DIFF
--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -406,7 +406,6 @@ func TestCluster(name, selector, ns, pgouser string, allFlag bool) msgs.ClusterT
 				EventType: events.EventTestCluster,
 			},
 			Clustername:       c.Name,
-			Clusteridentifier: c.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 		}
 
 		err = events.Publish(f)

--- a/apiserver/labelservice/labelimpl.go
+++ b/apiserver/labelservice/labelimpl.go
@@ -140,7 +140,6 @@ func addLabels(items []crv1.Pgcluster, DryRun bool, LabelCmdLabel string, newLab
 					EventType: events.EventCreateLabel,
 				},
 				Clustername:       items[i].Spec.Name,
-				Clusteridentifier: items[i].ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 				Label:             LabelCmdLabel,
 			}
 

--- a/apiserver/loadservice/loadimpl.go
+++ b/apiserver/loadservice/loadimpl.go
@@ -196,7 +196,6 @@ func Load(request *msgs.LoadRequest, ns, pgouser string) msgs.LoadResponse {
 				EventType: events.EventLoad,
 			},
 			Clustername:       c.Name,
-			Clusteridentifier: c.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 			Loadconfig:        LoadCfg.TableToLoad,
 		}
 

--- a/apiserver/policyservice/policyimpl.go
+++ b/apiserver/policyservice/policyimpl.go
@@ -275,7 +275,6 @@ func ApplyPolicy(request *msgs.ApplyPolicyRequest, ns, pgouser string) msgs.Appl
 				EventType: events.EventApplyPolicy,
 			},
 			Clustername:       d.ObjectMeta.Labels[config.LABEL_PG_CLUSTER],
-			Clusteridentifier: d.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 			Policyname:        request.Name,
 		}
 

--- a/apiserver/reloadservice/reloadimpl.go
+++ b/apiserver/reloadservice/reloadimpl.go
@@ -119,7 +119,6 @@ func Reload(request *msgs.ReloadRequest, ns, username string) msgs.ReloadRespons
 				EventType: events.EventReloadCluster,
 			},
 			Clustername:       cluster.Spec.Name,
-			Clusteridentifier: cluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 		}
 
 		err = events.Publish(f)

--- a/apiserver/userservice/userimpl.go
+++ b/apiserver/userservice/userimpl.go
@@ -220,7 +220,6 @@ func UpdateUser(request *msgs.UpdateUserRequest, pgouser string) msgs.UpdateUser
 						EventType: events.EventChangePasswordUser,
 					},
 					Clustername:       cluster.Spec.Name,
-					Clusteridentifier: cluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 					PostgresUsername:  request.Username,
 					PostgresPassword:  request.Password,
 				}
@@ -756,7 +755,6 @@ func CreateUser(request *msgs.CreateUserRequest, pgouser string) msgs.CreateUser
 			PostgresUsername:  request.Username,
 			PostgresPassword:  newPassword,
 			Managed:           request.ManagedUser,
-			Clusteridentifier: c.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 		}
 
 		err = events.Publish(f)
@@ -897,7 +895,6 @@ func DeleteUser(request *msgs.DeleteUserRequest, pgouser string) msgs.DeleteUser
 			Clustername:       clusterName,
 			PostgresUsername:  request.Username,
 			Managed:           managed,
-			Clusteridentifier: cluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 		}
 
 		err = events.Publish(f)

--- a/controller/jobcontroller.go
+++ b/controller/jobcontroller.go
@@ -310,7 +310,6 @@ func (c *JobController) onUpdate(oldObj, newObj interface{}) {
 				EventType: events.EventBenchmarkCompleted,
 			},
 			Clustername:       labels[config.LABEL_PG_CLUSTER],
-			Clusteridentifier: labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 		}
 
 		err = events.Publish(f)
@@ -472,7 +471,6 @@ func publishBackupComplete(clusterName, clusterIdentifier, username, backuptype,
 			EventType: events.EventCreateBackupCompleted,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: clusterIdentifier,
 		BackupType:        backuptype,
 		Path:              path,
 	}
@@ -496,7 +494,6 @@ func publishRestoreComplete(clusterName, identifier, username, namespace string)
 			EventType: events.EventRestoreClusterCompleted,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: identifier,
 	}
 
 	err := events.Publish(f)
@@ -519,7 +516,6 @@ func publishDeleteClusterComplete(clusterName, identifier, username, namespace s
 			EventType: events.EventDeleteClusterCompleted,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: identifier,
 	}
 
 	err := events.Publish(f)

--- a/controller/podcontroller.go
+++ b/controller/podcontroller.go
@@ -409,7 +409,6 @@ func publishClusterComplete(clusterName, namespace string, cluster *crv1.Pgclust
 			EventType: events.EventCreateClusterCompleted,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: cluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 		WorkflowID:        cluster.Spec.UserLabels[config.LABEL_WORKFLOW_ID],
 	}
 
@@ -473,7 +472,6 @@ func publishPrimaryNotReady(clusterName, identifier, username, namespace string)
 			EventType: events.EventPrimaryNotReady,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: identifier,
 	}
 
 	err := events.Publish(f)

--- a/events/eventtype.go
+++ b/events/eventtype.go
@@ -106,9 +106,8 @@ type EventInterface interface {
 
 //--------
 type EventReloadClusterFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventReloadClusterFormat) GetHeader() EventHeader {
@@ -116,17 +115,16 @@ func (p EventReloadClusterFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventReloadClusterFormat) String() string {
-	msg := fmt.Sprintf("Event %s - (reload) name %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s - (reload) name %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventCreateClusterFailureFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	ErrorMessage      string `json:"errormessage"`
-	WorkflowID        string `json:"workflowid"`
+	EventHeader  `json:"eventheader"`
+	Clustername  string `json:"clustername"`
+	ErrorMessage string `json:"errormessage"`
+	WorkflowID   string `json:"workflowid"`
 }
 
 func (p EventCreateClusterFailureFormat) GetHeader() EventHeader {
@@ -134,16 +132,15 @@ func (p EventCreateClusterFailureFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventCreateClusterFailureFormat) String() string {
-	msg := fmt.Sprintf("Event %s - (create cluster failure) clustername %s workflow %s error %s id %s", lvl.EventHeader, lvl.Clustername, lvl.WorkflowID, lvl.ErrorMessage, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s - (create cluster failure) clustername %s workflow %s error %s", lvl.EventHeader, lvl.Clustername, lvl.WorkflowID, lvl.ErrorMessage)
 	return msg
 }
 
 //----------------------------
 type EventCreateClusterFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	WorkflowID        string `json:"workflowid"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
+	WorkflowID  string `json:"workflowid"`
 }
 
 func (p EventCreateClusterFormat) GetHeader() EventHeader {
@@ -151,32 +148,30 @@ func (p EventCreateClusterFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventCreateClusterFormat) String() string {
-	msg := fmt.Sprintf("Event %s - (create cluster) clustername %s workflow %s id %s", lvl.EventHeader, lvl.Clustername, lvl.WorkflowID, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s - (create cluster) clustername %s workflow %s", lvl.EventHeader, lvl.Clustername, lvl.WorkflowID)
 	return msg
 }
 
 //----------------------------
 type EventCreateClusterCompletedFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	WorkflowID        string `json:"workflowid"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
+	WorkflowID  string `json:"workflowid"`
 }
 
 func (p EventCreateClusterCompletedFormat) GetHeader() EventHeader {
 	return p.EventHeader
 }
 func (lvl EventCreateClusterCompletedFormat) String() string {
-	msg := fmt.Sprintf("Event %s - (create cluster completed) clustername %s workflow %s id %s", lvl.EventHeader, lvl.Clustername, lvl.WorkflowID, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s - (create cluster completed) clustername %s workflow %s", lvl.EventHeader, lvl.Clustername, lvl.WorkflowID)
 	return msg
 }
 
 //----------------------------
 type EventScaleClusterFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	Replicaname       string `json:"replicaname"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
+	Replicaname string `json:"replicaname"`
 }
 
 func (p EventScaleClusterFormat) GetHeader() EventHeader {
@@ -184,7 +179,7 @@ func (p EventScaleClusterFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventScaleClusterFormat) String() string {
-	msg := fmt.Sprintf("Event %s (scale) - clustername %s - replicaname %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Replicaname, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (scale) - clustername %s - replicaname %s", lvl.EventHeader, lvl.Clustername, lvl.Replicaname)
 	return msg
 }
 
@@ -207,10 +202,9 @@ func (lvl EventScaleClusterFailureFormat) String() string {
 
 //----------------------------
 type EventScaleDownClusterFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	Replicaname       string `json:"replicaname"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
+	Replicaname string `json:"replicaname"`
 }
 
 func (p EventScaleDownClusterFormat) GetHeader() EventHeader {
@@ -218,16 +212,15 @@ func (p EventScaleDownClusterFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventScaleDownClusterFormat) String() string {
-	msg := fmt.Sprintf("Event %s (scaledown) - clustername %s - replicaname %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Replicaname, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (scaledown) - clustername %s - replicaname %s", lvl.EventHeader, lvl.Clustername, lvl.Replicaname)
 	return msg
 }
 
 //----------------------------
 type EventFailoverClusterFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	Target            string `json:"target"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
+	Target      string `json:"target"`
 }
 
 func (p EventFailoverClusterFormat) GetHeader() EventHeader {
@@ -235,16 +228,15 @@ func (p EventFailoverClusterFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventFailoverClusterFormat) String() string {
-	msg := fmt.Sprintf("Event %s (failover) - clustername %s - target %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Target, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (failover) - clustername %s - target %s", lvl.EventHeader, lvl.Clustername, lvl.Target)
 	return msg
 }
 
 //----------------------------
 type EventFailoverClusterCompletedFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	Target            string `json:"target"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
+	Target      string `json:"target"`
 }
 
 func (p EventFailoverClusterCompletedFormat) GetHeader() EventHeader {
@@ -252,7 +244,7 @@ func (p EventFailoverClusterCompletedFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventFailoverClusterCompletedFormat) String() string {
-	msg := fmt.Sprintf("Event %s (failover completed) - clustername %s - target %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Target, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (failover completed) - clustername %s - target %s", lvl.EventHeader, lvl.Clustername, lvl.Target)
 	return msg
 }
 
@@ -288,9 +280,8 @@ func (lvl EventUpgradeClusterCompletedFormat) String() string {
 
 //----------------------------
 type EventDeleteClusterFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventDeleteClusterFormat) GetHeader() EventHeader {
@@ -298,15 +289,14 @@ func (p EventDeleteClusterFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventDeleteClusterFormat) String() string {
-	msg := fmt.Sprintf("Event %s (delete) - clustername %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (delete) - clustername %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventDeleteClusterCompletedFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventDeleteClusterCompletedFormat) GetHeader() EventHeader {
@@ -314,31 +304,29 @@ func (p EventDeleteClusterCompletedFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventDeleteClusterCompletedFormat) String() string {
-	msg := fmt.Sprintf("Event %s (delete completed) - clustername %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (delete completed) - clustername %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventTestClusterFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventTestClusterFormat) GetHeader() EventHeader {
 	return p.EventHeader
 }
 func (lvl EventTestClusterFormat) String() string {
-	msg := fmt.Sprintf("Event %s (test) - clustername %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (test) - clustername %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventCreateBackupFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	BackupType        string `json:"backuptype"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
+	BackupType  string `json:"backuptype"`
 }
 
 func (p EventCreateBackupFormat) GetHeader() EventHeader {
@@ -346,17 +334,16 @@ func (p EventCreateBackupFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventCreateBackupFormat) String() string {
-	msg := fmt.Sprintf("Event %s (create backup) - clustername %s - backuptype %s id %s", lvl.EventHeader, lvl.Clustername, lvl.BackupType, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (create backup) - clustername %s - backuptype %s", lvl.EventHeader, lvl.Clustername, lvl.BackupType)
 	return msg
 }
 
 //----------------------------
 type EventCreateBackupCompletedFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	BackupType        string `json:"backuptype"`
-	Path              string `json:"path"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
+	BackupType  string `json:"backuptype"`
+	Path        string `json:"path"`
 }
 
 func (p EventCreateBackupCompletedFormat) GetHeader() EventHeader {
@@ -364,18 +351,17 @@ func (p EventCreateBackupCompletedFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventCreateBackupCompletedFormat) String() string {
-	msg := fmt.Sprintf("Event %s (create backup completed) - clustername %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (create backup completed) - clustername %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventCreateUserFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	PostgresUsername  string `json:"postgresusername"`
-	PostgresPassword  string `json:"postgrespassword"`
-	Managed           bool   `json:"managed"`
+	EventHeader      `json:"eventheader"`
+	Clustername      string `json:"clustername"`
+	PostgresUsername string `json:"postgresusername"`
+	PostgresPassword string `json:"postgrespassword"`
+	Managed          bool   `json:"managed"`
 }
 
 func (p EventCreateUserFormat) GetHeader() EventHeader {
@@ -383,17 +369,16 @@ func (p EventCreateUserFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventCreateUserFormat) String() string {
-	msg := fmt.Sprintf("Event %s (create user) - clustername %s - postgres user [%s] id [%s]", lvl.EventHeader, lvl.Clustername, lvl.PostgresUsername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (create user) - clustername %s - postgres user [%s]", lvl.EventHeader, lvl.Clustername, lvl.PostgresUsername)
 	return msg
 }
 
 //----------------------------
 type EventDeleteUserFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	PostgresUsername  string `json:"postgresusername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	Managed           bool   `json:"managed"`
+	EventHeader      `json:"eventheader"`
+	Clustername      string `json:"clustername"`
+	PostgresUsername string `json:"postgresusername"`
+	Managed          bool   `json:"managed"`
 }
 
 func (p EventDeleteUserFormat) GetHeader() EventHeader {
@@ -401,17 +386,16 @@ func (p EventDeleteUserFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventDeleteUserFormat) String() string {
-	msg := fmt.Sprintf("Event %s (delete user) - clustername %s - postgres user [%s] id=[%s]", lvl.EventHeader, lvl.Clustername, lvl.PostgresUsername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (delete user) - clustername %s - postgres user [%s]", lvl.EventHeader, lvl.Clustername, lvl.PostgresUsername)
 	return msg
 }
 
 //----------------------------
 type EventChangePasswordUserFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	PostgresUsername  string `json:"postgresusername"`
-	PostgresPassword  string `json:"postgrespassword"`
+	EventHeader      `json:"eventheader"`
+	Clustername      string `json:"clustername"`
+	PostgresUsername string `json:"postgresusername"`
+	PostgresPassword string `json:"postgrespassword"`
 }
 
 func (p EventChangePasswordUserFormat) GetHeader() EventHeader {
@@ -419,16 +403,15 @@ func (p EventChangePasswordUserFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventChangePasswordUserFormat) String() string {
-	msg := fmt.Sprintf("Event %s (change password user) - clustername %s - postgres user [%s] id [%s]", lvl.EventHeader, lvl.Clustername, lvl.PostgresUsername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (change password user) - clustername %s - postgres user [%s]", lvl.EventHeader, lvl.Clustername, lvl.PostgresUsername)
 	return msg
 }
 
 //----------------------------
 type EventCreateLabelFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	Label             string `json:"label"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
+	Label       string `json:"label"`
 }
 
 func (p EventCreateLabelFormat) GetHeader() EventHeader {
@@ -436,7 +419,7 @@ func (p EventCreateLabelFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventCreateLabelFormat) String() string {
-	msg := fmt.Sprintf("Event %s (create label) - clustername %s - label [%s] id %s", lvl.EventHeader, lvl.Clustername, lvl.Label, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (create label) - clustername %s - label [%s]", lvl.EventHeader, lvl.Clustername, lvl.Label)
 	return msg
 }
 
@@ -473,10 +456,9 @@ func (lvl EventDeletePolicyFormat) String() string {
 
 //----------------------------
 type EventApplyPolicyFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	Policyname        string `json:"policyname"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
+	Policyname  string `json:"policyname"`
 }
 
 func (p EventApplyPolicyFormat) GetHeader() EventHeader {
@@ -484,16 +466,15 @@ func (p EventApplyPolicyFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventApplyPolicyFormat) String() string {
-	msg := fmt.Sprintf("Event %s (apply policy) - clustername %s - policy [%s] id %s", lvl.EventHeader, lvl.Clustername, lvl.Policyname, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (apply policy) - clustername %s - policy [%s]", lvl.EventHeader, lvl.Clustername, lvl.Policyname)
 	return msg
 }
 
 //----------------------------
 type EventLoadFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	Loadconfig        string `json:"loadconfig"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
+	Loadconfig  string `json:"loadconfig"`
 }
 
 func (p EventLoadFormat) GetHeader() EventHeader {
@@ -501,7 +482,7 @@ func (p EventLoadFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventLoadFormat) String() string {
-	msg := fmt.Sprintf("Event %s (load) - clustername %s - load config [%s] id [%s]", lvl.EventHeader, lvl.Clustername, lvl.Loadconfig, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (load) - clustername %s - load config [%s]", lvl.EventHeader, lvl.Clustername, lvl.Loadconfig)
 	return msg
 }
 
@@ -523,9 +504,8 @@ func (lvl EventLoadCompletedFormat) String() string {
 
 //----------------------------
 type EventBenchmarkFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifer"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventBenchmarkFormat) GetHeader() EventHeader {
@@ -533,15 +513,14 @@ func (p EventBenchmarkFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventBenchmarkFormat) String() string {
-	msg := fmt.Sprintf("Event %s (benchmark) - clustername %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (benchmark) - clustername %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventBenchmarkCompletedFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventBenchmarkCompletedFormat) GetHeader() EventHeader {
@@ -549,15 +528,14 @@ func (p EventBenchmarkCompletedFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventBenchmarkCompletedFormat) String() string {
-	msg := fmt.Sprintf("Event %s (benchmark completed) - clustername %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (benchmark completed) - clustername %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventCreatePgpoolFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventCreatePgpoolFormat) GetHeader() EventHeader {
@@ -565,15 +543,14 @@ func (p EventCreatePgpoolFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventCreatePgpoolFormat) String() string {
-	msg := fmt.Sprintf("Event %s (create pgpool) - clustername %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (create pgpool) - clustername %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventDeletePgpoolFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventDeletePgpoolFormat) GetHeader() EventHeader {
@@ -581,15 +558,14 @@ func (p EventDeletePgpoolFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventDeletePgpoolFormat) String() string {
-	msg := fmt.Sprintf("Event %s (delete pgpool) - clustername %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (delete pgpool) - clustername %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventCreatePgbouncerFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventCreatePgbouncerFormat) GetHeader() EventHeader {
@@ -603,9 +579,8 @@ func (lvl EventCreatePgbouncerFormat) String() string {
 
 //----------------------------
 type EventDeletePgbouncerFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventDeletePgbouncerFormat) GetHeader() EventHeader {
@@ -613,15 +588,14 @@ func (p EventDeletePgbouncerFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventDeletePgbouncerFormat) String() string {
-	msg := fmt.Sprintf("Event %s (delete pgbouncer) - clustername %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (delete pgbouncer) - clustername %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventRestoreClusterFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventRestoreClusterFormat) GetHeader() EventHeader {
@@ -629,15 +603,14 @@ func (p EventRestoreClusterFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventRestoreClusterFormat) String() string {
-	msg := fmt.Sprintf("Event %s (restore) - clustername %s  id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (restore) - clustername %s ", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventRestoreClusterCompletedFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventRestoreClusterCompletedFormat) GetHeader() EventHeader {
@@ -645,15 +618,14 @@ func (p EventRestoreClusterCompletedFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventRestoreClusterCompletedFormat) String() string {
-	msg := fmt.Sprintf("Event %s (restore completed) - clustername %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s (restore completed) - clustername %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventPrimaryNotReadyFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
+	EventHeader `json:"eventheader"`
+	Clustername string `json:"clustername"`
 }
 
 func (p EventPrimaryNotReadyFormat) GetHeader() EventHeader {
@@ -661,16 +633,15 @@ func (p EventPrimaryNotReadyFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventPrimaryNotReadyFormat) String() string {
-	msg := fmt.Sprintf("Event %s - (primary not ready) clustername %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s - (primary not ready) clustername %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 
 //----------------------------
 type EventPrimaryDeletedFormat struct {
-	EventHeader       `json:"eventheader"`
-	Clustername       string `json:"clustername"`
-	Clusteridentifier string `json:"clusteridentifier"`
-	Deploymentname    string `json:"deploymentname"`
+	EventHeader    `json:"eventheader"`
+	Clustername    string `json:"clustername"`
+	Deploymentname string `json:"deploymentname"`
 }
 
 func (p EventPrimaryDeletedFormat) GetHeader() EventHeader {
@@ -678,6 +649,6 @@ func (p EventPrimaryDeletedFormat) GetHeader() EventHeader {
 }
 
 func (lvl EventPrimaryDeletedFormat) String() string {
-	msg := fmt.Sprintf("Event %s - (primary deleted) clustername %s deployment %s id %s", lvl.EventHeader, lvl.Clustername, lvl.Deploymentname, lvl.Clusteridentifier)
+	msg := fmt.Sprintf("Event %s - (primary deleted) clustername %s deployment %s", lvl.EventHeader, lvl.Clustername, lvl.Deploymentname)
 	return msg
 }

--- a/operator/backrest/backup.go
+++ b/operator/backrest/backup.go
@@ -114,7 +114,6 @@ func Backrest(namespace string, clientset *kubernetes.Clientset, task *crv1.Pgta
 				EventType: events.EventCreateBackup,
 			},
 			Clustername:       jobFields.ClusterName,
-			Clusteridentifier: task.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 			BackupType:        "pgbackrest",
 		}
 

--- a/operator/backrest/restore.go
+++ b/operator/backrest/restore.go
@@ -483,7 +483,6 @@ func publishRestore(id, clusterName, username, namespace string) {
 			EventType: events.EventRestoreCluster,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: id,
 	}
 
 	err := events.Publish(f)

--- a/operator/cluster/cluster.go
+++ b/operator/cluster/cluster.go
@@ -106,7 +106,6 @@ func AddClusterBase(clientset *kubernetes.Clientset, client *rest.RESTClient, cl
 			EventType: events.EventCreateCluster,
 		},
 		Clustername:       cl.ObjectMeta.Name,
-		Clusteridentifier: cl.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 		WorkflowID:        cl.ObjectMeta.Labels[config.LABEL_WORKFLOW_ID],
 	}
 
@@ -236,7 +235,6 @@ func DeleteClusterBase(clientset *kubernetes.Clientset, restclient *rest.RESTCli
 			EventType: events.EventDeleteCluster,
 		},
 		Clustername:       cl.Spec.Name,
-		Clusteridentifier: cl.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 	}
 
 	err = events.Publish(f)
@@ -342,7 +340,6 @@ func ScaleDownBase(clientset *kubernetes.Clientset, client *rest.RESTClient, rep
 			EventType: events.EventScaleDownCluster,
 		},
 		Clustername:       replica.Spec.ClusterName,
-		Clusteridentifier: replica.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 	}
 
 	err = events.Publish(f)
@@ -402,7 +399,6 @@ func publishClusterCreateFailure(cl *crv1.Pgcluster, errorMsg string) {
 			EventType: events.EventCreateClusterFailure,
 		},
 		Clustername:       cl.ObjectMeta.Name,
-		Clusteridentifier: cl.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 		ErrorMessage:      errorMsg,
 		WorkflowID:        cl.ObjectMeta.Labels[config.LABEL_WORKFLOW_ID],
 	}

--- a/operator/cluster/clusterlogic.go
+++ b/operator/cluster/clusterlogic.go
@@ -407,7 +407,6 @@ func Scale(clientset *kubernetes.Clientset, client *rest.RESTClient, replica *cr
 			EventType: events.EventScaleCluster,
 		},
 		Clustername:       cluster.Spec.UserLabels[config.LABEL_REPLICA_NAME],
-		Clusteridentifier: cluster.Spec.UserLabels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 		Replicaname:       cluster.Spec.UserLabels[config.LABEL_PG_CLUSTER],
 	}
 
@@ -482,7 +481,6 @@ func publishScaleError(namespace string, username string, cluster *crv1.Pgcluste
 		},
 		Clustername:       cluster.Spec.UserLabels[config.LABEL_REPLICA_NAME],
 		Replicaname:       cluster.Spec.UserLabels[config.LABEL_PG_CLUSTER],
-		Clusteridentifier: cluster.Spec.UserLabels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 	}
 
 	err := events.Publish(f)
@@ -504,7 +502,6 @@ func publishDeleteCluster(namespace, username, clusterName, identifier string) {
 			EventType: events.EventDeleteCluster,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: identifier,
 	}
 
 	err := events.Publish(f)

--- a/operator/cluster/failover.go
+++ b/operator/cluster/failover.go
@@ -86,7 +86,6 @@ func FailoverBase(namespace string, clientset *kubernetes.Clientset, client *res
 			EventType: events.EventFailoverCluster,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: cluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 		Target:            task.ObjectMeta.Labels[config.LABEL_TARGET],
 	}
 

--- a/operator/cluster/failoverlogic.go
+++ b/operator/cluster/failoverlogic.go
@@ -285,7 +285,6 @@ func publishPromoteEvent(identifier, namespace, username, clusterName, target st
 			EventType: events.EventFailoverCluster,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: identifier,
 		Target:            target,
 	}
 
@@ -308,7 +307,6 @@ func publishPrimaryDeleted(identifier, clusterName, deploymentToDelete, username
 			EventType: events.EventPrimaryDeleted,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: identifier,
 		Deploymentname:    deploymentToDelete,
 	}
 

--- a/operator/cluster/pgbouncer.go
+++ b/operator/cluster/pgbouncer.go
@@ -182,7 +182,6 @@ func AddPgbouncerFromTask(clientset *kubernetes.Clientset, restclient *rest.REST
 			EventType: events.EventCreatePgbouncer,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: pgcluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 	}
 
 	err = events.Publish(f)
@@ -252,7 +251,6 @@ func DeletePgbouncerFromTask(clientset *kubernetes.Clientset, restclient *rest.R
 			EventType: events.EventDeletePgbouncer,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: pgcluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 	}
 
 	err = events.Publish(f)

--- a/operator/cluster/pgpool.go
+++ b/operator/cluster/pgpool.go
@@ -173,7 +173,6 @@ func AddPgpoolFromTask(clientset *kubernetes.Clientset, restclient *rest.RESTCli
 			EventType: events.EventCreatePgpool,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: pgcluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 	}
 
 	err = events.Publish(f)
@@ -242,7 +241,6 @@ func DeletePgpoolFromTask(clientset *kubernetes.Clientset, restclient *rest.REST
 			EventType: events.EventDeletePgpool,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: pgcluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 	}
 
 	err = events.Publish(f)

--- a/operator/task/rmdata.go
+++ b/operator/task/rmdata.go
@@ -176,7 +176,6 @@ func publishDeleteCluster(clusterName, identifier, username, namespace string) {
 			EventType: events.EventDeleteCluster,
 		},
 		Clustername:       clusterName,
-		Clusteridentifier: identifier,
 	}
 
 	err := events.Publish(f)


### PR DESCRIPTION
 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
**Currently under test - opening for code review**

**Type of Changes:**
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**
Currently, the Clusteridentifier field in event messages is not populated, largely due to a lack of the `pg-cluster-id` labelling.

**What is the new behavior (if this is a feature change)?**
The Clusteridentifier field will no longer be part of event messages.
