### PR TITLE
Updates operator to set service ports as env vars.

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/collect.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/collect.json
@@ -2,7 +2,7 @@
     "name": "collect",
     "image": "{{.CCPImagePrefix}}/crunchy-collect:{{.CCPImageTag}}",
     "ports": [{
-        "containerPort": 9187,
+        "containerPort": {{.ExporterPort}},
         "protocol": "TCP"
     }],
     "env": [{
@@ -12,6 +12,9 @@
     {
     	"name": "JOB_NAME",
     	"value": "{{.JobName}}"
+    },{
+        "name": "POSTGRES_EXPORTER_PORT",
+        "value": "{{.ExporterPort}}"
     }
     ]
 }

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbadger.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbadger.json
@@ -1,23 +1,26 @@
             ,{
                 "name": "pgbadger",
-		"image": "{{.CCPImagePrefix}}/crunchy-pgbadger:{{.CCPImageTag}}",
+		        "image": "{{.CCPImagePrefix}}/crunchy-pgbadger:{{.CCPImageTag}}",
                 "ports": [ {
-                        "containerPort": 10000,
+                        "containerPort": {{.PGBadgerPort}},
                         "protocol": "TCP"
                     }
                 ],
                 "readinessProbe": {
                     "tcpSocket": {
-                        "port": 10000
+                        "port": {{.PGBadgerPort}}
                     },
                     "initialDelaySeconds": 20,
                     "periodSeconds": 10
                 },
-		{{.ContainerResources }}
+		        {{.ContainerResources }}
                 "env": [ {
-		"name": "BADGER_TARGET",
-		"value": "{{.BadgerTarget}}"
-		} ],
+		            "name": "BADGER_TARGET",
+		            "value": "{{.BadgerTarget}}"
+		        },{
+                    "name": "PGBADGER_SERVICE_PORT",
+                    "value": "{{.PGBadgerPort}}"
+                } ],
                 "volumeMounts": [
                     {
                         "mountPath": "/pgdata",

--- a/conf/postgres-operator/collect.json
+++ b/conf/postgres-operator/collect.json
@@ -2,7 +2,7 @@
     "name": "collect",
     "image": "{{.CCPImagePrefix}}/crunchy-collect:{{.CCPImageTag}}",
     "ports": [{
-        "containerPort": 9187,
+        "containerPort": {{.ExporterPort}},
         "protocol": "TCP"
     }],
     "env": [
@@ -25,6 +25,9 @@
         {
             "name": "JOB_NAME",
             "value": "{{.JobName}}"
+        },{
+            "name": "POSTGRES_EXPORTER_PORT",
+            "value": "{{.ExporterPort}}"
         }
     ],
     "volumeMounts": [

--- a/conf/postgres-operator/pgbadger.json
+++ b/conf/postgres-operator/pgbadger.json
@@ -1,23 +1,26 @@
             ,{
                 "name": "pgbadger",
-		"image": "{{.CCPImagePrefix}}/crunchy-pgbadger:{{.CCPImageTag}}",
+		        "image": "{{.CCPImagePrefix}}/crunchy-pgbadger:{{.CCPImageTag}}",
                 "ports": [ {
-                        "containerPort": 10000,
+                        "containerPort": {{.PGBadgerPort}},
                         "protocol": "TCP"
                     }
                 ],
                 "readinessProbe": {
                     "tcpSocket": {
-                        "port": 10000
+                        "port": {{.PGBadgerPort}}
                     },
                     "initialDelaySeconds": 20,
                     "periodSeconds": 10
                 },
-		{{.ContainerResources }}
+		         {{.ContainerResources }}
                 "env": [ {
-		"name": "BADGER_TARGET",
-		"value": "{{.BadgerTarget}}"
-		} ],
+		            "name": "BADGER_TARGET",
+		            "value": "{{.BadgerTarget}}"
+		        }, {
+                    "name": "PGBADGER_SERVICE_PORT",
+                    "value": "{{.PGBadgerPort}}"
+                } ],
                 "volumeMounts": [
                     {
                         "mountPath": "/pgdata",

--- a/operator/clusterutilities.go
+++ b/operator/clusterutilities.go
@@ -50,6 +50,7 @@ type collectTemplateFields struct {
 	CCPImageTag     string
 	CCPImagePrefix  string
 	PgPort          string
+	ExporterPort    string
 }
 
 //consolidate
@@ -57,6 +58,7 @@ type badgerTemplateFields struct {
 	CCPImageTag        string
 	CCPImagePrefix     string
 	BadgerTarget       string
+	PGBadgerPort       string
 	ContainerResources string
 }
 
@@ -158,6 +160,7 @@ func GetBadgerAddon(clientset *kubernetes.Clientset, namespace string, cluster *
 		badgerTemplateFields := badgerTemplateFields{}
 		badgerTemplateFields.CCPImageTag = spec.CCPImageTag
 		badgerTemplateFields.BadgerTarget = pgbadger_target
+		badgerTemplateFields.PGBadgerPort = spec.PGBadgerPort
 		badgerTemplateFields.CCPImagePrefix = Pgo.Cluster.CCPImagePrefix
 		badgerTemplateFields.ContainerResources = ""
 
@@ -199,6 +202,7 @@ func GetCollectAddon(clientset *kubernetes.Clientset, namespace string, spec *cr
 		collectTemplateFields.Name = spec.Name
 		collectTemplateFields.JobName = spec.Name
 		collectTemplateFields.CCPImageTag = spec.CCPImageTag
+		collectTemplateFields.ExporterPort = spec.ExporterPort
 		collectTemplateFields.CCPImagePrefix = Pgo.Cluster.CCPImagePrefix
 		collectTemplateFields.PgPort = spec.Port
 


### PR DESCRIPTION
Currently pgbadger and postgres-exporter service ports are used
to create the service but not passed into the container. This
update changes the deployment json files so that the service ports
are set in the environment of the container. The ports defined in
the pgo-config are passed into the deployment templates and used
to create the containers.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable? (kube)



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
currently ports are hardcoded 


**What is the new behavior (if this is a feature change)?**
Now ports from the pgo-config are passed into the deployment templates


**Other information**:
[ch1866]