### PR TITLE
Update Postgres Operator Upgrade Procedures to Match Updated Code Beh…

### DIFF
--- a/hugo/content/Upgrade/upgrade40to41.md
+++ b/hugo/content/Upgrade/upgrade40to41.md
@@ -163,23 +163,23 @@ Verify this by running:
 
 At this point, the Operator will be running version 4.1.0, and new clusters will be built using the appropriate specifications defined in your pgo.yaml file. For the existing clusters, upgrades can be performed with the following steps.
 
-To bring your clusters up to the latest versions of Postgres and Containers, for each of your clusters you will want to run the following:
-```
-pgo scaledown <clustername> --query
-pgo scaledown <clustername> --target
-```
+{{% notice info %}}
 
-Now that your cluster only has one pod you can run the minor upgrade:
+Before beginning your upgrade procedure, be sure to consult the [Compatibility Requirements Page]
+( {{< relref "configuration/compatibility.md" >}}) for container dependency information.
+
+{{% / notice %}}
+
+To start, execute the minor upgrade command:
 
     pgo upgrade cluster <clustername>
 
-By default this command updates the cluster with the values in the pgo.yaml.  If however you are running more than one version of Postgres clusters you can run the following to upgrade any clusters that do not match what is in your current configuration.
+If you would like to know more about the Postgres Cluster minor upgrade, please see the [Upgrade Page]
+( {{< relref "upgrade/_index.md" >}}) for additional information.
+
+By default this command updates the cluster with the values in the pgo.yaml.  If however you are running more than one version of Postgres clusters you can run the following command to upgrade any clusters that do not match what is in your current configuration.
 
     pgo upgrade <clustername> --ccp-image-tag=<imagetag>
-
-Once the minor upgrade is done you can scale your cluster back to the previous number of replicas, for example:
-
-    pgo scale <clustername> --replica-count=2
 
 There is a bug in the operator where the image version for the backrest repo deployment is not updated with a pgo upgrade. As a workaround for this you need to redeploy the backrest shared repo deployment with the correct image version.
 


### PR DESCRIPTION
…avior

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**
In line with commit "Update cluster upgrade"
https://github.com/CrunchyData/postgres-operator/pull/1027
The upgrade procedures have been updated.

For the PGO 4.0.1 to 4.1.0 upgrade procedure, the new
functionality is referenced in place of the previous
manner of executing the upgrade.

For the PGO 3.5 Minor Version upgrade procedure, the
upgrade procedure has been updated so that the behavior
will match the updated 4.1.0 code change.


**Other information**:
[ch5533]