### PR TITLE
add_target_namespace pains

### DIFF
--- a/deploy/add-targeted-namespace.sh
+++ b/deploy/add-targeted-namespace.sh
@@ -14,13 +14,16 @@
 
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
+# Enforce required environment variables
+test="${PGO_CMD:?Need to set PGO_CMD env variable}"
+test="${PGOROOT:?Need to set PGOROOT env variable}"
+test="${PGO_OPERATOR_NAMESPACE:?Need to set PGO_OPERATOR_NAMESPACE env variable}"
+test="${PGO_INSTALLATION_NAME:?Need to set PGO_INSTALLATION_NAME env variable}"
 
 if [[ -z "$1" ]]; then
 	echo "usage:  add-targeted-namespace.sh mynewnamespace"
 	exit
 fi
-
 
 # create the namespace if necessary
 $PGO_CMD get ns $1  > /dev/null

--- a/hugo/content/Installation/install-with-ansible/prerequisites.md
+++ b/hugo/content/Installation/install-with-ansible/prerequisites.md
@@ -46,6 +46,8 @@ can install:
 
 However, if the user wishes to add a new watched namespace after installation, where the user would normally use pgo create namespace to add the new namespace, they should instead run the add-targeted-namespace.sh script or they may give themselves cluster-admin privileges instead of having to run setupnamespaces.sh script. Again, this is only required when running on a Kuberenetes distribution whose version is below 1.12. In Kubernetes version 1.12+ the pgo create namespace command works as expected.
 
+add-targeted-namespace.sh requires the additional environment variable PGO_INSTALLATION_NAME set to the unique name given to the Operator's installation
+
 {{% /notice %}}
 
 ## Obtaining Operator Ansible Role

--- a/hugo/content/Installation/operator-install.md
+++ b/hugo/content/Installation/operator-install.md
@@ -83,6 +83,8 @@ created as part of the default installation.
 
 However, if the user wishes to add a new watched namespace after installation, where the user would normally use pgo create namespace to add the new namespace, they should instead run the add-targeted-namespace.sh script or they may give themselves cluster-admin privileges instead of having to run setupnamespaces.sh script. Again, this is only required when running on a Kuberenetes distribution whose version is below 1.12. In Kubernetes version 1.12+ the pgo create namespace command works as expected.
 
+add-targeted-namespace.sh requires the additional environment variable PGO_INSTALLATION_NAME set to the unique name given to the Operator's installation
+
 {{% /notice %}}
 
 The *PGO_OPERATOR_NAMESPACE* environment variable is a comma separated list


### PR DESCRIPTION
add-targeted-namespace.sh has a sinister failure case if
PGO_INSTALLATION_NAME is unset in that the pgo-installation-name label
does not get set correctly. This causes later failures in selectors
built upon the assumption of that label's existence.

This change updates add-targeted-namespace.sh to fail if its expected
environment variables do not exist and updates the references to the
script to warn about needing to ensure its definition.

[ch5543]

**Checklist:**

 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

