### PR TITLE
Add the exp_type='pg' Label to all crunchy-collect Targets

### DIFF
--- a/ansible/roles/pgo-metrics/templates/prometheus-config.yaml.j2
+++ b/ansible/roles/pgo-metrics/templates/prometheus-config.yaml.j2
@@ -54,3 +54,5 @@ data:
         target_label: job
         separator: ': '
         replacement: '$1$2'
+      - target_label: exp_type
+        replacement: 'pg'


### PR DESCRIPTION
Added the `exp_type='pg'` label to all targets discovered by the Prometheus `crunchy-collect` job.   This ensures that all crunchy-collect metrics have the `exp_type='pg'` label as required by the Grafana PG dashboards included in pgMonitor v3.2.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

PG metrics are not displayed in the Grafana dashboards.

[ch6044]

**What is the new behavior (if this is a feature change)?**

PG metrics are displayed in the Grafana dashboards.

**Other information**:

N/A