### PR TITLE
Fix ansible kubernetes_context issue

### DIFF
--- a/ansible/roles/pgo-metrics/tasks/kubernetes_auth.yml
+++ b/ansible/roles/pgo-metrics/tasks/kubernetes_auth.yml
@@ -1,4 +1,4 @@
 ---
 - name: Set the Kubernetes Context
-  shell: "kubectl config set-context {{ kubernetes_context }}"
+  shell: "kubectl config use-context {{ kubernetes_context }}"
   tags: always

--- a/ansible/roles/pgo-operator/tasks/kubernetes_auth.yml
+++ b/ansible/roles/pgo-operator/tasks/kubernetes_auth.yml
@@ -1,4 +1,4 @@
 ---
 - name: Set the Kubernetes Context
-  shell: "kubectl config set-context {{ kubernetes_context }}"
+  shell: "kubectl config use-context {{ kubernetes_context }}"
   tags: always


### PR DESCRIPTION
Ansible installer was not using the configured kubernetes context as specified in the `inventory` file. These changes resolve it.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Ansible installer ignores `kubernetes_context` configuration.

**What is the new behavior (if this is a feature change)?**

Ansible installer honors `kubernetes_context` configuration.

**Other information**: