### PR TITLE
updated broken links

### DIFF
--- a/hugo/content/Configuration/configuration.md
+++ b/hugo/content/Configuration/configuration.md
@@ -121,7 +121,7 @@ command line flag.
 
 ## Namespace Configuration
 
-The Design [Design](/Design) section of this documentation talks further about
+The Design [Design](/gettingstarted/design) section of this documentation talks further about
 the use of namespaces within the Operator and configuring different
 deployment models of the Operator.
 

--- a/hugo/content/Installation/operator-install.md
+++ b/hugo/content/Installation/operator-install.md
@@ -31,7 +31,7 @@ The Operator follows a golang project structure, you can create a structure as f
     cd $HOME/odev/src/github.com/crunchydata
     git clone https://github.com/CrunchyData/postgres-operator.git
     cd postgres-operator
-	git checkout 4.1.0
+	git checkout v4.1.0
 
 
 This creates a directory structure under your HOME directory name *odev* and clones the current Operator version to that structure.  

--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -38,13 +38,13 @@ The Operator is developed and tested on CentOS and RHEL Linux platforms but is k
 ## Documentation
 The following documentation is provided:
 
- - [pgo CLI Syntax and Examples](/operator-cli)
+ - [pgo CLI Syntax and Examples](/operatorcli)
  - [Installation](/installation)
  - [Configuration](/configuration) 
  - [pgo.yaml Configuration](/configuration/pgo-yaml-configuration) 
  - [Security](/security) 
- - [Design Overview](/design) 
- - [Developing](/developer-setup) 
+ - [Design Overview](/gettingstarted/design/designoverview) 
+ - [Developing](/installation/developer-setup) 
  - [Upgrading the Operator](/upgrade)
  - [Contributing](/contributing/documentation-updates)
 

--- a/hugo/content/contributing/documentation-updates.md
+++ b/hugo/content/contributing/documentation-updates.md
@@ -17,7 +17,7 @@ If you would like to build the documentation locally, view the
 You can then start the server by running the following commands -
 
 ```
-cd $COROOT/hugo/
+cd $PGOROOT/hugo/
 hugo server
 ```
 

--- a/hugo/content/contributing/issues.md
+++ b/hugo/content/contributing/issues.md
@@ -6,7 +6,7 @@ weight: 902
 ---
 
 
-If you would like to submit an feature / issue for us to consider please submit an to the official [GitHub Repository](ttps://github.com/CrunchyData/crunchy-containers/issues/new/choose).
+If you would like to submit an feature / issue for us to consider please submit an to the official [GitHub Repository](https://github.com/CrunchyData/postgres-operator/issues/new/choose).
 
 If you would like to work the issue, please add that information in the issue so that we can confirm we are not already working no need to duplicate efforts.
 

--- a/hugo/content/gettingstarted/Design/namespace.md
+++ b/hugo/content/gettingstarted/Design/namespace.md
@@ -31,7 +31,7 @@ the namespaces which will be *watched* by the Operator.
 The format of the NAMESPACE value is modeled after the following
 document:
 
-https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/operatorgroups.md
+https://github.com/operator-framework/operator-lifecycle-manager/blob/0.12.0/doc/design/operatorgroups.md 
 
 
 ### OwnNamespace Example

--- a/hugo/content/gettingstarted/Design/olm.md
+++ b/hugo/content/gettingstarted/Design/olm.md
@@ -11,7 +11,7 @@ The PostgreSQL Operator supports Red Hat OLM (Operator Lifecycle Manager)
 to a degree starting with the PostgreSQL Operator 4.0 release.
 
 The PostgreSQL Operator supports the different deployment models
-as documented [here](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/operatorgroups.md)
+as documented [here](https://github.com/operator-framework/operator-lifecycle-manager/blob/0.12.0/doc/design/operatorgroups.md )
 
 The PostgreSQL Operator is available for download in [OperatorHub.io](https://www.operatorhub.io/operator/postgres-operator.v3.5.0)
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x ] Have you updated or added documentation for the change, as applicable?
 - [ x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
broken links found in the documentation.  added list below of what links were broken and what they were changed to.  


**What is the new behavior (if this is a feature change)?**
links are no longer broken in documentation
I also updated a tag typo and an old env var on the submitting and issue page

I ran hugo locally and verified newly updated links worked accordingly 

**Other information**:  

updated these broken links in the docs:

•  "pgo CLI Syntax and Examples" link on page https://crunchydata.github.io/postgres-operator/4.1.0/ should be https://crunchydata.github.io/postgres-operator/4.1.0/operatorcli/
•  "Design Overview" link on page https://crunchydata.github.io/postgres-operator/4.1.0/ should be https://crunchydata.github.io/postgres-operator/4.1.0/gettingstarted/design/designoverview/
•  "Developing" link on page https://crunchydata.github.io/postgres-operator/4.1.0/ should be https://crunchydata.github.io/postgres-operator/4.1.0/installation/developer-setup/
•  "https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/operatorgroups.md" link on page https://crunchydata.github.io/postgres-operator/4.1.0/gettingstarted/design/namespace/ should be https://github.com/operator-framework/operator-lifecycle-manager/blob/0.12.0/doc/design/operatorgroups.md 
•  "here" link on page https://crunchydata.github.io/postgres-operator/4.1.0/gettingstarted/design/olm/ should be https://github.com/operator-framework/operator-lifecycle-manager/blob/0.12.0/doc/design/operatorgroups.md
• "Design" link on page https://crunchydata.github.io/postgres-operator/4.1.0/configuration/configuration/ should be https://crunchydata.github.io/postgres-operator/4.1.0/gettingstarted/design/
• "GitHub Repository" link on page https://crunchydata.github.io/postgres-operator/4.1.0/contributing/issues/ should be https://github.com/CrunchyData/postgres-operator/issues/new/choose  

