### PR TITLE
updates yaml to min v2.2.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -505,12 +505,12 @@
   revision = "be2e0b0deed5a68ffee390b4583a13aff8321535"
 
 [[projects]]
-  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
+  digest = "1:ab9547706f32a7535bb4f25d6b58ad00436630593cd3e3ed4602f1613ed84783"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = ""
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "f221b8435cfb71e54062f6c6e99e9ade30b124d5"
+  version = "v2.2.4"
 
 [[projects]]
   digest = "1:024b1a40b80fa42c406575cf0f0bfebecc1ddf7faef4b64a52b805afadb86797"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,3 +21,8 @@ name = "gopkg.in/robfig/cron.v2"
 [[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "v1.4.0"
+
+[[override]]
+  name = "gopkg.in/yaml.v2"
+  version = ">=v2.2.3" # < 2.2.3 has a DoS vuln
+

--- a/vendor/gopkg.in/yaml.v2/benchmark_test.go
+++ b/vendor/gopkg.in/yaml.v2/benchmark_test.go
@@ -1,0 +1,123 @@
+package yaml_test
+
+import (
+	"strings"
+	"testing"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type testcase struct {
+	name  string
+	data  []byte
+	error string
+}
+
+func testcases() []testcase {
+	return []testcase{
+		{
+			name:  "1000kb of maps with 100 aliases",
+			data:  []byte(`{a: &a [{a}` + strings.Repeat(`,{a}`, 1000*1024/4-100) + `], b: &b [*a` + strings.Repeat(`,*a`, 99) + `]}`),
+			error: "yaml: document contains excessive aliasing",
+		},
+		{
+			name:  "1000kb of deeply nested slices",
+			data:  []byte(strings.Repeat(`[`, 1000*1024)),
+			error: "yaml: exceeded max depth of 10000",
+		},
+		{
+			name:  "1000kb of deeply nested maps",
+			data:  []byte("x: " + strings.Repeat(`{`, 1000*1024)),
+			error: "yaml: exceeded max depth of 10000",
+		},
+		{
+			name:  "1000kb of deeply nested indents",
+			data:  []byte(strings.Repeat(`- `, 1000*1024)),
+			error: "yaml: exceeded max depth of 10000",
+		},
+		{
+			name: "1000kb of 1000-indent lines",
+			data: []byte(strings.Repeat(strings.Repeat(`- `, 1000)+"\n", 1024/2)),
+		},
+		{name: "1kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 1*1024/4-1) + `]`)},
+		{name: "10kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 10*1024/4-1) + `]`)},
+		{name: "100kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 100*1024/4-1) + `]`)},
+		{name: "1000kb of maps", data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 1000*1024/4-1) + `]`)},
+	}
+}
+
+func (s *S) TestLimits(c *C) {
+	if testing.Short() {
+		return
+	}
+	for _, tc := range testcases() {
+		var v interface{}
+		err := yaml.Unmarshal(tc.data, &v)
+		if len(tc.error) > 0 {
+			c.Assert(err, ErrorMatches, tc.error, Commentf("testcase: %s", tc.name))
+		} else {
+			c.Assert(err, IsNil, Commentf("testcase: %s", tc.name))
+		}
+	}
+}
+
+func Benchmark1000KB100Aliases(b *testing.B) {
+	benchmark(b, "1000kb of maps with 100 aliases")
+}
+func Benchmark1000KBDeeplyNestedSlices(b *testing.B) {
+	benchmark(b, "1000kb of deeply nested slices")
+}
+func Benchmark1000KBDeeplyNestedMaps(b *testing.B) {
+	benchmark(b, "1000kb of deeply nested maps")
+}
+func Benchmark1000KBDeeplyNestedIndents(b *testing.B) {
+	benchmark(b, "1000kb of deeply nested indents")
+}
+func Benchmark1000KB1000IndentLines(b *testing.B) {
+	benchmark(b, "1000kb of 1000-indent lines")
+}
+func Benchmark1KBMaps(b *testing.B) {
+	benchmark(b, "1kb of maps")
+}
+func Benchmark10KBMaps(b *testing.B) {
+	benchmark(b, "10kb of maps")
+}
+func Benchmark100KBMaps(b *testing.B) {
+	benchmark(b, "100kb of maps")
+}
+func Benchmark1000KBMaps(b *testing.B) {
+	benchmark(b, "1000kb of maps")
+}
+
+func benchmark(b *testing.B, name string) {
+	var tc testcase
+	for _, t := range testcases() {
+		if t.name == name {
+			tc = t
+			break
+		}
+	}
+	if tc.name != name {
+		b.Errorf("testcase %q not found", name)
+		return
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var v interface{}
+		err := yaml.Unmarshal(tc.data, &v)
+		if len(tc.error) > 0 {
+			if err == nil {
+				b.Errorf("expected error, got none")
+			} else if err.Error() != tc.error {
+				b.Errorf("expected error '%s', got '%s'", tc.error, err.Error())
+			}
+		} else {
+			if err != nil {
+				b.Errorf("unexpected error: %v", err)
+			}
+		}
+	}
+}

--- a/vendor/gopkg.in/yaml.v2/decode.go
+++ b/vendor/gopkg.in/yaml.v2/decode.go
@@ -229,6 +229,10 @@ type decoder struct {
 	mapType reflect.Type
 	terrors []string
 	strict  bool
+
+	decodeCount int
+	aliasCount  int
+	aliasDepth  int
 }
 
 var (
@@ -314,7 +318,39 @@ func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unm
 	return out, false, false
 }
 
+const (
+	// 400,000 decode operations is ~500kb of dense object declarations, or ~5kb of dense object declarations with 10000% alias expansion
+	alias_ratio_range_low = 400000
+	// 4,000,000 decode operations is ~5MB of dense object declarations, or ~4.5MB of dense object declarations with 10% alias expansion
+	alias_ratio_range_high = 4000000
+	// alias_ratio_range is the range over which we scale allowed alias ratios
+	alias_ratio_range = float64(alias_ratio_range_high - alias_ratio_range_low)
+)
+
+func allowedAliasRatio(decodeCount int) float64 {
+	switch {
+	case decodeCount <= alias_ratio_range_low:
+		// allow 99% to come from alias expansion for small-to-medium documents
+		return 0.99
+	case decodeCount >= alias_ratio_range_high:
+		// allow 10% to come from alias expansion for very large documents
+		return 0.10
+	default:
+		// scale smoothly from 99% down to 10% over the range.
+		// this maps to 396,000 - 400,000 allowed alias-driven decodes over the range.
+		// 400,000 decode operations is ~100MB of allocations in worst-case scenarios (single-item maps).
+		return 0.99 - 0.89*(float64(decodeCount-alias_ratio_range_low)/alias_ratio_range)
+	}
+}
+
 func (d *decoder) unmarshal(n *node, out reflect.Value) (good bool) {
+	d.decodeCount++
+	if d.aliasDepth > 0 {
+		d.aliasCount++
+	}
+	if d.aliasCount > 100 && d.decodeCount > 1000 && float64(d.aliasCount)/float64(d.decodeCount) > allowedAliasRatio(d.decodeCount) {
+		failf("document contains excessive aliasing")
+	}
 	switch n.kind {
 	case documentNode:
 		return d.document(n, out)
@@ -353,7 +389,9 @@ func (d *decoder) alias(n *node, out reflect.Value) (good bool) {
 		failf("anchor '%s' value contains itself", n.value)
 	}
 	d.aliases[n] = true
+	d.aliasDepth++
 	good = d.unmarshal(n.alias, out)
+	d.aliasDepth--
 	delete(d.aliases, n)
 	return good
 }

--- a/vendor/gopkg.in/yaml.v2/decode_test.go
+++ b/vendor/gopkg.in/yaml.v2/decode_test.go
@@ -691,13 +691,13 @@ var unmarshalTests = []struct {
 		M{"ñoño": "very yes 🟔"},
 	},
 
-	// YAML Float regex shouldn't match this
+	// This *is* in fact a float number, per the spec. #171 was a mistake.
 	{
 		"a: 123456e1\n",
-		M{"a": "123456e1"},
+		M{"a": 123456e1},
 	}, {
 		"a: 123456E1\n",
-		M{"a": "123456E1"},
+		M{"a": 123456E1},
 	},
 	// yaml-test-suite 3GZX: Spec Example 7.1. Alias Nodes
 	{
@@ -713,6 +713,14 @@ var unmarshalTests = []struct {
 	{
 		"---\nhello\n...\n}not yaml",
 		"hello",
+	},
+	{
+		"a: 5\n",
+		&struct{ A jsonNumberT }{"5"},
+	},
+	{
+		"a: 5.5\n",
+		&struct{ A jsonNumberT }{"5.5"},
 	},
 }
 
@@ -846,6 +854,18 @@ var unmarshalErrorTests = []struct {
 	{"{{.}}", `yaml: invalid map key: map\[interface\ \{\}\]interface \{\}\{".":interface \{\}\(nil\)\}`},
 	{"b: *a\na: &a {c: 1}", `yaml: unknown anchor 'a' referenced`},
 	{"%TAG !%79! tag:yaml.org,2002:\n---\nv: !%79!int '1'", "yaml: did not find expected whitespace"},
+	{
+		"a: &a [00,00,00,00,00,00,00,00,00]\n" +
+		"b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]\n" +
+		"c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]\n" +
+		"d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]\n" +
+		"e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]\n" +
+		"f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]\n" +
+		"g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]\n" +
+		"h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]\n" +
+		"i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]\n",
+		"yaml: document contains excessive aliasing",
+	},
 }
 
 func (s *S) TestUnmarshalErrors(c *C) {

--- a/vendor/gopkg.in/yaml.v2/encode_test.go
+++ b/vendor/gopkg.in/yaml.v2/encode_test.go
@@ -15,6 +15,24 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type jsonNumberT string
+
+func (j jsonNumberT) Int64() (int64, error) {
+	val, err := strconv.Atoi(string(j))
+	if err != nil {
+		return 0, err
+	}
+	return int64(val), nil
+}
+
+func (j jsonNumberT) Float64() (float64, error) {
+	return strconv.ParseFloat(string(j), 64)
+}
+
+func (j jsonNumberT) String() string {
+	return string(j)
+}
+
 var marshalIntTest = 123
 
 var marshalTests = []struct {
@@ -366,6 +384,18 @@ var marshalTests = []struct {
 	{
 		map[string]string{"a": "你好 #comment"},
 		"a: '你好 #comment'\n",
+	},
+	{
+		map[string]interface{}{"a": jsonNumberT("5")},
+		"a: 5\n",
+	},
+	{
+		map[string]interface{}{"a": jsonNumberT("100.5")},
+		"a: 100.5\n",
+	},
+	{
+		map[string]interface{}{"a": jsonNumberT("bogus")},
+		"a: bogus\n",
 	},
 }
 

--- a/vendor/gopkg.in/yaml.v2/resolve.go
+++ b/vendor/gopkg.in/yaml.v2/resolve.go
@@ -81,7 +81,7 @@ func resolvableTag(tag string) bool {
 	return false
 }
 
-var yamlStyleFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)?$`)
+var yamlStyleFloat = regexp.MustCompile(`^[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?$`)
 
 func resolve(tag string, in string) (rtag string, out interface{}) {
 	if !resolvableTag(tag) {

--- a/vendor/gopkg.in/yaml.v2/scannerc.go
+++ b/vendor/gopkg.in/yaml.v2/scannerc.go
@@ -906,6 +906,9 @@ func yaml_parser_remove_simple_key(parser *yaml_parser_t) bool {
 	return true
 }
 
+// max_flow_level limits the flow_level
+const max_flow_level = 10000
+
 // Increase the flow level and resize the simple key list if needed.
 func yaml_parser_increase_flow_level(parser *yaml_parser_t) bool {
 	// Reset the simple key on the next level.
@@ -913,6 +916,11 @@ func yaml_parser_increase_flow_level(parser *yaml_parser_t) bool {
 
 	// Increase the flow level.
 	parser.flow_level++
+	if parser.flow_level > max_flow_level {
+		return yaml_parser_set_scanner_error(parser,
+			"while increasing flow level", parser.simple_keys[len(parser.simple_keys)-1].mark,
+			fmt.Sprintf("exceeded max depth of %d", max_flow_level))
+	}
 	return true
 }
 
@@ -924,6 +932,9 @@ func yaml_parser_decrease_flow_level(parser *yaml_parser_t) bool {
 	}
 	return true
 }
+
+// max_indents limits the indents stack size
+const max_indents = 10000
 
 // Push the current indentation level to the stack and set the new level
 // the current column is greater than the indentation level.  In this case,
@@ -939,6 +950,11 @@ func yaml_parser_roll_indent(parser *yaml_parser_t, column, number int, typ yaml
 		// indentation level.
 		parser.indents = append(parser.indents, parser.indent)
 		parser.indent = column
+		if len(parser.indents) > max_indents {
+			return yaml_parser_set_scanner_error(parser,
+				"while increasing indent level", parser.simple_keys[len(parser.simple_keys)-1].mark,
+				fmt.Sprintf("exceeded max depth of %d", max_indents))
+		}
 
 		// Create a token and insert it into the queue.
 		token := yaml_token_t{


### PR DESCRIPTION
The go yaml package is the root cause for a Kubernetes CVE
regarding the "Billion Laughs" DoS attack. (CVE-2019-11253)

This update constrains usage of the go yaml package to the patched
version or later.

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

[ch6122]