### PR TITLE
update service ports for pgo-event nsqadmin

### DIFF
--- a/ansible/roles/pgo-operator/templates/service.json.j2
+++ b/ansible/roles/pgo-operator/templates/service.json.j2
@@ -18,8 +18,8 @@
 	        {
                 "name": "nsqadmin",
                 "protocol": "TCP",
-                "port": 4151,
-                "targetPort": 4151
+                "port": 4171,
+                "targetPort": 4171
             },
 	        {
                 "name": "nsqd",

--- a/bin/pgo-event/pgo-event.sh
+++ b/bin/pgo-event/pgo-event.sh
@@ -23,7 +23,7 @@ echo "pgo-event starting"
 
 trap 'trap_sigterm' SIGINT SIGTERM
 
-echo "pgo-event starting nsqadminy"
+echo "pgo-event starting nsqadmin"
 
 /usr/local/bin/nsqadmin  --http-address=0.0.0.0:4171  --nsqd-http-address=0.0.0.0:4151 &
 

--- a/deploy/service.json
+++ b/deploy/service.json
@@ -18,8 +18,8 @@
 	{
             "name": "nsqadmin",
             "protocol": "TCP",
-            "port": 4151,
-            "targetPort": 4151
+            "port": 4171,
+            "targetPort": 4171
         },
 	{
             "name": "nsqd",


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

Currently, the kubernetes service port for nsqadmin is set to the http port configured for nsqd.

**What is the new behavior (if this is a feature change)?**

Kubernetes service port for nsqadmin is now set to the properly configured port for nsqadmin.

**Other information**: