### PR TITLE
Add disable TLS functionality to the PGO Client

### DIFF
--- a/hugo/content/Installation/install-with-ansible/installing-operator.md
+++ b/hugo/content/Installation/install-with-ansible/installing-operator.md
@@ -71,6 +71,12 @@ oc get pods -n <NAMESPACE_NAME>
 After the Crunchy PostgreSQL Operator has successfully been installed we will need 
 to configure local environment variables before using the `pgo` client.
 
+{{% notice info %}}
+
+If TLS authentication was disabled during installation, please see the [TLS Configuration Page] ({{< relref "gettingstarted/Design/tls.md" >}}) for additional configuration information.
+
+{{% / notice %}}
+
 To configure the environment variables used by `pgo` run the following command:
 
 Note: `<PGO_NAMESPACE>` should be replaced with the namespace the Crunchy PostgreSQL

--- a/hugo/content/Installation/operator-install.md
+++ b/hugo/content/Installation/operator-install.md
@@ -253,6 +253,12 @@ The *pgo* client is provided in Mac, Windows, and Linux binary formats,
 download the appropriate client to your local laptop or workstation to work 
 with a remote Operator.
 
+{{% notice info %}}
+
+If TLS authentication was disabled during installation, please see the [TLS Configuration Page] ({{< relref "gettingstarted/Design/tls.md" >}}) for additional configuration information.
+
+{{% / notice %}}
+
 Prior to using *pgo*, users testing the Operator on a single host can specify the
 *postgres-operator* URL as follows:
 

--- a/hugo/content/gettingstarted/Design/tls.md
+++ b/hugo/content/gettingstarted/Design/tls.md
@@ -8,25 +8,87 @@ weight: 6
 ## TLS Configuration
 
 Should you desire to alter the default TLS settings for the Postgres Operator, you can set the
-following variables in bash:
+following variables as described below.
+
+### Server Settings
 
 To disable TLS and make an unsecured connection on port 8080 instead of connecting securely over
 the default port, 8443, set:
 
 Bash environment variables    
 
-    DISABLE_TLS=true
-    PGO_APISERVER_PORT=8080		
+```bash
+DISABLE_TLS=true
+PGO_APISERVER_PORT=8080		
+```
 
 Or inventory variables if using Ansible
 
-    pgo_disable_tls='true'
-    pgo_apiserver_port=8080
+```
+pgo_disable_tls='true'
+pgo_apiserver_port=8080
+```
 
 To disable TLS verifcation, set the follwing as a Bash environment variable
 
-    export TLS_NO_VERIFY=false
+```bash
+export TLS_NO_VERIFY=false
+```
 
 Or the following in the inventory file is using Ansible
 
-    pgo_tls_no_verify='false'
+```
+pgo_tls_no_verify='false'
+```
+
+### Connection Settings
+
+If TLS authentication has been disabled, or if the Operator's apiserver port is changed, be sure to 
+update the PGO_APISERVER_URL accordingly. 
+
+For example with an Ansible installation, 
+
+```bash
+export PGO_APISERVER_URL='https://<apiserver IP>:8443'
+```
+
+would become
+
+```bash
+export PGO_APISERVER_URL='http://<apiserver IP>:8080'
+```
+
+With a Bash installation,
+
+```bash
+setip()
+{
+   export PGO_APISERVER_URL=https://`$PGO_CMD -n "$PGO_OPERATOR_NAMESPACE" get service postgres-operator -o=jsonpath="{.spec.clusterIP}"`:8443
+}
+```
+
+would become
+
+```bash
+setip()
+{
+   export PGO_APISERVER_URL=http://`$PGO_CMD -n "$PGO_OPERATOR_NAMESPACE" get service postgres-operator -o=jsonpath="{.spec.clusterIP}"`:8080
+}
+```
+
+### Client Settings
+
+Finally, if TLS has been disabled for the Operator's apiserver, the PGO client connection must be set to match
+the given settings.
+
+Two options are available, either the Bash environment variable
+
+```bash
+DISABLE_TLS=true
+```
+
+must be configured, or the --disable-tls flag must be included when using the client, i.e.
+
+```bash
+pgo version --disable-tls
+```

--- a/pgo/cmd/auth.go
+++ b/pgo/cmd/auth.go
@@ -38,6 +38,7 @@ const httpTimeout = 60
 
 // BasicAuthUsername and BasicAuthPassword are for BasicAuth, they are fetched from a file
 
+// SessionCredentials stores the PGO user, PGO password and the PGO APIServer URL
 var SessionCredentials msgs.BasicAuthCredentials
 
 var caCertPool *x509.CertPool
@@ -58,7 +59,9 @@ func StatusCheck(resp *http.Response) {
 	}
 }
 
-func UserHomeDir() string {
+// userHomeDir updates the env variable with the appropriate home directory
+// depending on the host operating system the PGO client is running on.
+func userHomeDir() string {
 	env := "HOME"
 	if runtime.GOOS == "windows" {
 		env = "USERPROFILE"
@@ -99,9 +102,12 @@ func parseCredentials(dat string) msgs.BasicAuthCredentials {
 	return creds
 }
 
-func GetCredentialsFromFile() msgs.BasicAuthCredentials {
+// getCredentialsFromFile reads the pgouser and password from the .pgouser file,
+// checking in the various locations that file can be expected, and then returns
+// the credentials
+func getCredentialsFromFile() msgs.BasicAuthCredentials {
 	found := false
-	dir := UserHomeDir()
+	dir := userHomeDir()
 	fullPath := dir + "/" + ".pgouser"
 	var creds msgs.BasicAuthCredentials
 
@@ -158,7 +164,10 @@ func GetCredentialsFromFile() msgs.BasicAuthCredentials {
 	return creds
 }
 
-func GetCredentialsFromEnvironment() msgs.BasicAuthCredentials {
+// getCredentialsFromEnvironment reads the pgouser and password from relevant environment
+// variables and then returns a created BasicAuthCredentials object with both values,
+// as well as the APIServer URL.
+func getCredentialsFromEnvironment() msgs.BasicAuthCredentials {
 	pgoUser := os.Getenv(pgoUserNameEnvVar)
 	pgoPass := os.Getenv(pgoUserPasswordEnvVar)
 
@@ -184,10 +193,10 @@ func GetCredentialsFromEnvironment() msgs.BasicAuthCredentials {
 func SetSessionUserCredentials() {
 	log.Debug("GetSessionCredentials called")
 
-	SessionCredentials = GetCredentialsFromEnvironment()
+	SessionCredentials = getCredentialsFromEnvironment()
 
 	if !SessionCredentials.HasUsernameAndPassword() {
-		SessionCredentials = GetCredentialsFromFile()
+		SessionCredentials = getCredentialsFromFile()
 	}
 }
 

--- a/pgo/cmd/flags.go
+++ b/pgo/cmd/flags.go
@@ -40,3 +40,4 @@ var Namespace string
 var PGONamespace string
 var APIServerURL string
 var PGO_CA_CERT, PGO_CLIENT_CERT, PGO_CLIENT_KEY string
+var PGO_DISABLE_TLS bool


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The Postgres Operator's apiserver currently supports the
disabling of TLS authentication when receiving client connections.
However, the PGO client did not have a method for disabling
the necessary resource checks that are then unnecessary, meaning
the unneeded certificates and keys were still required to be
present.

**What is the new behavior (if this is a feature change)?**
This update allows the PGO client to skip the relevant configuration
setup when using an unauthenticated connection. This can be done in
one of two ways. Either by an environment variable:

DISABLE_TLS=true

(As is used by the Postgres Operator to disable TLS when performing
a Bash install)

Or by using the '--disable-tls' flag with the PGO client, for example:

pgo version --disable-tls

In the event that the DISABLE_TLS variable is set to 'false' and the
--disable-tls is used, the flag is authoritative.

Additionally, this commit includes documenationupdates to the main
TLS configuration page to explain how to properly set the new PGO
CLI configuration variables depending on installation method.

Notes with links to the main page were also added to both
the Bash and Ansible installation sections.

This PR was tested using an Ansible installation of the Postgres Operator with Kubernetes
and using a Bash installation of the Postgres Operator with Openshift.


**Other information**:
For testing, as this update does not add any new functions, unit testing is not ideal. The following steps can be followed to validate the appropriate behavior.

First, install the Postgres Operator with TLS enabled (the default setting) as described here: https://access.crunchydata.com/documentation/postgres-operator/4.1.0/installation/

Validate that commands work as expected, for instance

pgo version

returns the client and server versions

Now, either set the environment variable, DISABLE_TLS=true, or use

pgo version --disable-tls

The command should now fail.

At this point, update the PGO installation to disable TLS authentication (as described here https://access.crunchydata.com/documentation/postgres-operator/4.1.0/gettingstarted/design/tls/) and unset the TLS specific environment variables:

unset PGO_CA_CERT
unset PGO_CLIENT_CERT
unset PGO_CLIENT_KEY

Now running 'pgo version' without setting either the DISABLE_TLS variable or using the --disable-tls flag should result in an error and failure to return the expected values.

Issue: [ch6127]