### PR TITLE
code change to allow choice of files to include in the cmap

### DIFF
--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -827,13 +827,13 @@ func (c *PgoConfig) LoadTemplate(cMap *v1.ConfigMap, rootPath, path string) (*te
 		if value == "" {
 			value, err = c.DefaultTemplate(path)
 			if err != nil {
-				return err
+				return nil, error
 			}
 		}
 	} else {
 		value, err = c.DefaultTemplate(path)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included? This can be found in the behavior questions below.
 - [ ] Have you updated or added documentation for the change, as applicable? 
As crunchy does not offer a Helm deploy/install I don't feel as though a documentation update is needed. I  feel as though this fix would only benefit a Helm deploy/install as we can control more easily what goes in to the configmap.
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently, when you want to customize the config files, all of the files need to be inserted in the configmap `pgo-config`


**What is the new behavior (if this is a feature change)?**
The new behavior allows for some of the config files to be put into the configmap and if they are not in the configmap, the default config files will be uesd.


**Other information**:
