### PR TITLE
Update `pgo test` to check connectivity on instances & endpoints ([ch5712])

### DIFF
--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -405,7 +405,7 @@ func TestCluster(name, selector, ns, pgouser string, allFlag bool) msgs.ClusterT
 				Timestamp: time.Now(),
 				EventType: events.EventTestCluster,
 			},
-			Clustername:       c.Name,
+			Clustername: c.Name,
 		}
 
 		err = events.Publish(f)

--- a/apiservermsgs/clustermsgs.go
+++ b/apiservermsgs/clustermsgs.go
@@ -168,16 +168,31 @@ type ClusterTestRequest struct {
 	AllFlag       bool
 }
 
-// ClusterTestDetail ...
+// a collection of constants used to enumerate the output for
+// ClusterTestDetail => InstanceType
+const (
+	ClusterTestInstanceTypePrimary   = "primary"
+	ClusterTestInstanceTypeReplica   = "replica"
+	ClusterTestInstanceTypePGBouncer = "pgbouncer"
+	ClusterTestInstanceTypeBackups   = "backups"
+)
+
+// ClusterTestDetail provides the output of an individual test that is performed
+// on either a PostgreSQL instance (i.e. pod) or a service endpoint that is used
+// to connect to the instances
 type ClusterTestDetail struct {
-	PsqlString string
-	Working    bool
+	Available    bool   // true if the object being tested is available (ready)
+	Message      string // a descriptive message that can be displayed with
+	InstanceType string // an enumerated set of what this instance can be, e.g. "primary"
 }
 
-// ClusterTestResult ...
+// ClusterTestResult contains the output for a test on a single PostgreSQL
+// cluster. This includes the endpoints (i.e. how to connect to instances
+// in a cluster) and the instances themselves (which are pods)
 type ClusterTestResult struct {
 	ClusterName string
-	Items       []ClusterTestDetail
+	Endpoints   []ClusterTestDetail // a list of endpoints
+	Instances   []ClusterTestDetail // a list of instances (pods)
 }
 
 // ClusterTestResponse ...

--- a/events/eventtype.go
+++ b/events/eventtype.go
@@ -50,7 +50,6 @@ const (
 	EventUpgradeClusterCompleted  = "UpgradeClusterCompleted"
 	EventDeleteCluster            = "DeleteCluster"
 	EventDeleteClusterCompleted   = "DeleteClusterCompleted"
-	EventTestCluster              = "TestCluster"
 	EventCreateLabel              = "CreateLabel"
 	EventLoad                     = "Load"
 	EventLoadCompleted            = "LoadCompleted"
@@ -305,20 +304,6 @@ func (p EventDeleteClusterCompletedFormat) GetHeader() EventHeader {
 
 func (lvl EventDeleteClusterCompletedFormat) String() string {
 	msg := fmt.Sprintf("Event %s (delete completed) - clustername %s", lvl.EventHeader, lvl.Clustername)
-	return msg
-}
-
-//----------------------------
-type EventTestClusterFormat struct {
-	EventHeader `json:"eventheader"`
-	Clustername string `json:"clustername"`
-}
-
-func (p EventTestClusterFormat) GetHeader() EventHeader {
-	return p.EventHeader
-}
-func (lvl EventTestClusterFormat) String() string {
-	msg := fmt.Sprintf("Event %s (test) - clustername %s", lvl.EventHeader, lvl.Clustername)
 	return msg
 }
 

--- a/kubeapi/endpoints.go
+++ b/kubeapi/endpoints.go
@@ -1,0 +1,69 @@
+package kubeapi
+
+/*
+ Copyright 2019 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import (
+	log "github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GetEndpointRequest is used for the GetEndpoint function, which includes the
+// current Kubernetes request context, as well as the namespace / endpoint name
+// being requested
+type GetEndpointRequest struct {
+	Clientset *kubernetes.Clientset // Kubernetes Clientset that interfaces with the Kubernetes cluster
+	Name      string                // Name of the endpoint that is being queried
+	Namespace string                // Namespace the endpoint being queried resides in
+}
+
+// GetEndpointResponse contains the results from a successful request to the
+// endpoint API, including the Kubernetes Endpoint as well as the original
+// request data
+type GetEndpointResponse struct {
+	Endpoint  *v1.Endpoints // Kubernetes Endpoint object that specifics about the endpoint
+	Name      string        // Name of the endpoint
+	Namespace string        // Namespace that the endpoint is in
+}
+
+// GetEndpoint tries to find an individual endpoint in a namespace. Returns the
+// endpoint object if it can be IsNotFound
+// If no endpoint can be found, then an error is returned
+func GetEndpoint(request *GetEndpointRequest) (*GetEndpointResponse, error) {
+	log.Debugf("GetEndpointResponse Called: (%s,%s,%s)", request.Clientset, request.Name, request.Namespace)
+	// set the endpoints interfaces that will be used to make the query
+	endpointsInterface := request.Clientset.CoreV1().Endpoints(request.Namespace)
+	// make the query to Kubernetes to see if the specific endpoint exists
+	endpoint, err := endpointsInterface.Get(request.Name, meta_v1.GetOptions{})
+	// return at this point if there is an error
+	if err != nil {
+		log.Errorf("GetEndpointResponse(%s,%s): Endpoint Not Found: %s",
+			request.Name, request.Namespace, err.Error())
+		return nil, err
+	}
+	// create a response and return
+	response := &GetEndpointResponse{
+		Endpoint:  endpoint,
+		Name:      request.Name,
+		Namespace: request.Namespace,
+	}
+
+	log.Debugf("GetEndpointResponse Response: (%s,%s,%s)",
+		response.Namespace, response.Name, response.Endpoint)
+
+	return response, nil
+}

--- a/testing/events/event_test.go
+++ b/testing/events/event_test.go
@@ -23,7 +23,6 @@ func TestEventCreate(t *testing.T) {
 	tryEventFailoverCluster(t)
 	tryEventFailoverClusterCompleted(t)
 	tryEventDeleteCluster(t)
-	tryEventTestCluster(t)
 	tryEventCreateLabel(t)
 	tryEventLoad(t)
 	tryEventLoadCompleted(t)
@@ -238,27 +237,6 @@ func tryEventDeleteCluster(t *testing.T) {
 			Username:  TestUsername,
 			Topic:     topics,
 			EventType: events.EventDeleteCluster,
-		},
-		Clustername: TestClusterName,
-	}
-
-	err := events.Publish(f)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	t.Log(f.String())
-}
-func tryEventTestCluster(t *testing.T) {
-
-	topics := make([]string, 1)
-	topics[0] = events.EventTopicCluster
-
-	f := events.EventTestClusterFormat{
-		EventHeader: events.EventHeader{
-			Namespace: Namespace,
-			Username:  TestUsername,
-			Topic:     topics,
-			EventType: events.EventTestCluster,
 		},
 		Clustername: TestClusterName,
 	}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

Previously, `pgo test` would check if each individual user available to a PostgreSQL cluster could authenticate with its credentials. While this certainly determines that one can make a connection to a PostgreSQL database managed by the Operator, it also presents several issues:

- If one has many users available to the Operator, the number of connections made can rapidly multiply. Imagine 10 users across 5 replicas
- This also means that the user's credentials must be stored in the Operator. Currently this is a plaintext password. If the connections are _not_ being made over SSL, this creates the risk of password leakage.

**What is the new behavior (if this is a feature change)?**

Update the `pgo test` to do the following:

- Provide an instance (pod) level readiness check. The pod readiness check already calls `pg_isready`, which checks to see if a PostgreSQL instance is available to accept connections
- Check the service endpoints to see if they are ready to accept connections.

These two checks provide the equivalent behavior of what is currently happening today with `pgo test` but in a more efficient manner with less potential for information leakage.

The API endpoint now also serves content that is in a structured format.

Additionally, the event that was fired when "test event" is called is removed. This does not affect any lifecycle activity of a PostgreSQL cluster and as it is fired ad-hoc by a user, does not need to be propagated downstream.

**Other information**:

Here is a test case:

### Client #1:
```bash
watch pgo test -n jkatz jkatz
```

### Client #2:
```bash
pgo create namespace -n jkatz
# observe Client #1
pgo create cluster -n jkatz jkatz
# observe Client #1
pgo scale cluster -n jkatz jkatz
# observe Client #1
```