### PR TITLE
Update prometheus-config.yaml.j2

### DIFF
--- a/ansible/roles/pgo-metrics/templates/prometheus-config.yaml.j2
+++ b/ansible/roles/pgo-metrics/templates/prometheus-config.yaml.j2
@@ -50,7 +50,7 @@ data:
         regex: (^[^-]*).*
         target_label: instance
         replacement: '$1'
-      - source_labels: [__meta_kubernetes_namespace,__meta_kubernetes_pod_label_name]
+      - source_labels: [__meta_kubernetes_namespace,__meta_kubernetes_pod_label_service_name]
         target_label: job
         separator: ': '
         replacement: '$1$2'


### PR DESCRIPTION
Source label must be service_name instead of pod_name otherwise after failover (pod name is still *-replica but the service is primary), Grafana is not changing the PostgreSQL Overview so even though the replica pod becomes primary, it shows it as replica and primary as down...

Tested on Openshift 3.10 env.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
After failover Grafana shows new primary as Replica and Primary as being Down


**What is the new behavior (if this is a feature change)?**
After failover, replica pod becomes primary and refers to primary service which is being monitored by prometheus


**Other information**:
