### PR TITLE
fixes oversight re: docker switch and pgo-base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ pgo-rmdata-image: pgo-rmdata-img-$(IMGBUILDER)
 pgo-sqlrunner-image: pgo-sqlrunner-img-$(IMGBUILDER)
 pgo-backrest-image: pgo-backrest-img-$(IMGBUILDER)
 
-pgo-base: check-go-vars
+pgo-base-buildah: check-go-vars
 	sudo --preserve-env buildah bud --layers $(SQUASH) \
 		-f $(PGOROOT)/$(PGO_BASEOS)/Dockerfile.pgo-base.$(PGO_BASEOS) \
 		-t $(PGO_IMAGE_PREFIX)/pgo-base:$(PGO_IMAGE_TAG) \
@@ -122,6 +122,16 @@ pgo-base: check-go-vars
 		$(PGOROOT)
 	sudo --preserve-env buildah push $(PGO_IMAGE_PREFIX)/pgo-base:$(PGO_IMAGE_TAG) docker-daemon:$(PGO_IMAGE_PREFIX)/pgo-base:$(PGO_IMAGE_TAG)
 	docker tag docker.io/$(PGO_IMAGE_PREFIX)/pgo-base:$(PGO_IMAGE_TAG)  $(PGO_IMAGE_PREFIX)/pgo-base:$(PGO_IMAGE_TAG)
+
+pgo-base-docker: check-go-vars
+	docker build \
+		-f $(PGOROOT)/$(PGO_BASEOS)/Dockerfile.pgo-base.$(PGO_BASEOS) \
+		-t $(PGO_IMAGE_PREFIX)/pgo-base:$(PGO_IMAGE_TAG) \
+		--build-arg RELVER=$(PGO_VERSION) \
+		$(PGOROOT)
+	docker tag docker.io/$(PGO_IMAGE_PREFIX)/pgo-base:$(PGO_IMAGE_TAG)  $(PGO_IMAGE_PREFIX)/pgo-base:$(PGO_IMAGE_TAG)
+
+pgo-base: pgo-base-$(IMGBUILDER)
 
 cli-docs:	check-go-vars
 	cd $(PGOROOT)/hugo/content/operatorcli/cli && go run $(PGOROOT)/pgo/generatedocs.go


### PR DESCRIPTION
Bugfix:
  When the docker build mode was added to the base
Makefile, a split for using docker was added to the
implicit pattern image build rules but not the pgo-base
rule. This change fixes that oversight

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
