### PR TITLE
Specify pgbackrest User ID Explicitly [ch5510]

### DIFF
--- a/centos7/Dockerfile.pgo-backrest-repo.centos7
+++ b/centos7/Dockerfile.pgo-backrest-repo.centos7
@@ -35,7 +35,7 @@ RUN chmod g=u /etc/passwd && \
 
 RUN mkdir /.ssh && chown pgbackrest:pgbackrest /.ssh && chmod o+rwx /.ssh
 
-USER pgbackrest
+USER 2000
 
 ENTRYPOINT ["/opt/cpm/bin/uid_pgbackrest.sh"]
 

--- a/rhel7/Dockerfile.pgo-backrest-repo.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-repo.rhel7
@@ -34,7 +34,7 @@ RUN chmod g=u /etc/passwd && \
 
 RUN mkdir /.ssh && chown pgbackrest:pgbackrest /.ssh && chmod o+rwx /.ssh
 
-USER pgbackrest
+USER 2000
 
 ENTRYPOINT ["/opt/cpm/bin/uid_pgbackrest.sh"]
 VOLUME ["/sshd", "/backrestrepo" ]

--- a/ubi7/Dockerfile.pgo-backrest-repo.ubi7
+++ b/ubi7/Dockerfile.pgo-backrest-repo.ubi7
@@ -34,7 +34,7 @@ RUN chmod g=u /etc/passwd && \
 
 RUN mkdir /.ssh && chown pgbackrest:pgbackrest /.ssh && chmod o+rwx /.ssh
 
-USER pgbackrest
+USER 2000
 
 ENTRYPOINT ["/opt/cpm/bin/uid_pgbackrest.sh"]
 VOLUME ["/sshd", "/backrestrepo" ]


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

A container instantiated with the "runAsNonRoot" is unable to
verify that the "pgbackrest"  user is a non-root OS user. The fix for
this is to explicitly specify the numeric ID associated with the user
account in order for "runAsNonRoot" to verify that this is not a root
account.