### PR TITLE
Set the pgo-backrest-repo container to run as OS user "2000"

### DIFF
--- a/centos7/Dockerfile.pgo-backrest-repo.centos7
+++ b/centos7/Dockerfile.pgo-backrest-repo.centos7
@@ -36,7 +36,7 @@ RUN chmod g=u /etc/passwd && \
 
 RUN mkdir /.ssh && chown pgbackrest:pgbackrest /.ssh && chmod o+rwx /.ssh
 
-USER pgbackrest
+USER 2000
 
 ENTRYPOINT ["/opt/cpm/bin/uid_pgbackrest.sh"]
 

--- a/rhel7/Dockerfile.pgo-backrest-repo.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-repo.rhel7
@@ -41,7 +41,7 @@ RUN chmod g=u /etc/passwd && \
 #RUN ln -s /sshd /.ssh && chown 26:26 /.ssh && chmod 400 /.ssh/
 RUN mkdir /.ssh && chown pgbackrest:pgbackrest /.ssh && chmod o+rwx /.ssh
 
-USER pgbackrest
+USER 2000
 
 ENTRYPOINT ["/opt/cpm/bin/uid_pgbackrest.sh"]
 VOLUME ["/sshd", "/backrestrepo" ]

--- a/ubi7/Dockerfile.pgo-backrest-repo.ubi7
+++ b/ubi7/Dockerfile.pgo-backrest-repo.ubi7
@@ -38,7 +38,7 @@ RUN chmod g=u /etc/passwd && \
 #RUN ln -s /sshd /.ssh && chown 26:26 /.ssh && chmod 400 /.ssh/
 RUN mkdir /.ssh && chown pgbackrest:pgbackrest /.ssh && chmod o+rwx /.ssh
 
-USER pgbackrest
+USER 2000
 
 ENTRYPOINT ["/opt/cpm/bin/uid_pgbackrest.sh"]
 VOLUME ["/sshd", "/backrestrepo" ]


### PR DESCRIPTION
A container instantiated with the "runAsNonRoot" is unable to
verify that the "pgbackrest"  user is a non-root OS user. The fix for
this is to explicitly specify the numeric ID associated with the user
account in order for "runAsNonRoot" to verify that this is not a root
account.

Issue: [ch6248]