### PR TITLE
[ch6162] Ensure disabling BasicAuth skips Basic Authentication check.

### DIFF
--- a/hugo/content/Configuration/pgo-yaml-configuration.md
+++ b/hugo/content/Configuration/pgo-yaml-configuration.md
@@ -14,7 +14,7 @@ The *pgo.yaml* file is broken into major sections as described below:
 
 | Setting |Definition  |
 |---|---|
-|BasicAuth        | if set to *true* will enable Basic Authentication
+|BasicAuth        | If set to `"true"` will enable Basic Authentication. If set to `"false"`, will allow a valid Operator user to successfully authenticate regardless of the value of the password provided for Basic Authentication. Defaults to `"true".`
 |PrimaryNodeLabel        |newly created primary deployments will specify this node label if specified, unless you override it using the --node-label command line flag, if not set, no node label is specifed
 |ReplicaNodeLabel        |newly created replica deployments will specify this node label if specified, unless you override it using the --node-label command line flag, if not set, no node label is specifed
 |CCPImagePrefix        |newly created containers will be based on this image prefix (e.g. crunchydata), update this if you require a custom image prefix


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Presently, disabling BasicAuth in the pgo.yaml configuration file would
not actually disable the HTTP Basic Authentication from occuring, as
the check against authorization headers provided by the HTTP requests
would still be scanned.

**What is the new behavior (if this is a feature change)?**

This ensures this check is skipped when BasicAuth is set to `"false"`.

However, skipping Basic Authentication does not skip authorization, as
the Operator heavily leverages RBAC checks, and as such, a valid username
is required at all times even if BasicAuth is skipped. As such, this fix
only solves one type of error, i.e. the case where no HTTP Authorization
headers are sent to the Operator apiserver. And by "fix," I mean it just
moves the failure from the authentication check to the authorization
check.

**Other information**:

Issue: [ch6162]