### PR TITLE
Update kubectl-ssh-wrapper.sh script to Ignore Terminating Pods & Properly Parse the pgBackRest SSH Command

### DIFF
--- a/bin/kube-ssh-wrapper.sh
+++ b/bin/kube-ssh-wrapper.sh
@@ -1,18 +1,29 @@
 #!/bin/bash
 
-# Determine if connecting to the backrest repo or primary db
+# Determine if connecting to the pgBackRest dedicated repository host or the primary database.  Specifically,
+# set the proper label to target one or the other when executing the kubectl command in place of SSH.
 if [[ "${PGO_BACKREST_REPO}" == "true" ]]
 then
+    # Add required env vars to environment. Specifically sets the CLUSTER_NAME when running on a dedicated
+    # pgBakcRest reposotiory host, as required to set variable CLUSTER_LABEL label below
     source "/tmp/pod_env.sh"
     TARGET_LABEL="role=master"
 else
     TARGET_LABEL="pgo-backrest-repo=true"
 fi
 
+# Set the name of the cluster the pgBackRest command is being executed for, as well as the name of the
+# container being targeted for the command
 CLUSTER_LABEL="pg-cluster=${CLUSTER_NAME}"
 CONTAINER_NAME="database"
 
-opts=$(echo "$@" | grep -o "\-\-c.*")
-pod=$(kubectl get pods --selector=${CLUSTER_LABEL},${TARGET_LABEL} --field-selector=status.phase=Running -o name)
+# Drop any SSH options to obtain the pgBackRest command only
+backrest_cmd=$(sed -n "s/^.*\(pgbackrest \)/\1/p" <<< "$@")
 
-exec kubectl exec -i "${pod}" -c ${CONTAINER_NAME} -- bash -c "pgbackrest ${opts}"
+# Find the pod to exec into using the labels defined above, and ensure the pod is running.  There might
+# still be a terminating pod with the same labels in certain situations, e.g. when an old pgBackRest repo 
+# pod is still terminating, and a new pgBackRest repo pod is up and running during a pgBackRest restore
+pod=$(kubectl get pods --selector="${CLUSTER_LABEL}","${TARGET_LABEL}" --no-headers | awk '/Running/ {print $1}')
+
+# Execute the kubectl command in place of SSH
+exec kubectl exec -i "${pod}" -c "${CONTAINER_NAME}" -- bash -c "${backrest_cmd}"


### PR DESCRIPTION
Updated the `kube-ssh-wrapper.sh` script to ensure the pod discovered when executing a backrest job (e.g. the `pgBackRest` dedicated repository host that must be discovered by the `pgBackRest` restore job when performing a restore) is running and not terminating.  This ensures that the proper pod is targeted in the event that a new pod is ready for use, but the old one is still terminating.  

For instance, during a `pgBackRest` restore, the `pgBackRest` dedicated repository host is patched in order to update its configuration for the restored deployment.  This results in a period in which the old dedicated repository host might still be terminating, while the new repository host is ready for use.  This change ensures that only the running repo pod is considered by the restore job when it is run, therefore preventing the restore job from attempting to communicate with the terminating pod.

Also streamlined the mechanism for parsing the `pgBackRest` options when executing a command via SSH.  This includes parsing the `pgBackRest` SSH command on 'pgbackrest' in order to cleanly
parse out the SSH options and retrieve the `pgBackRest` command only (which is then utilized by kubectl).  

Additionally, added additional comments to detail various steps in the script.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

A restore job can sometimes fail if an old `pgBackRest` dedicated repository pod is still terminating while the new pgBackRest repo pod is still online.  For instance, when performing a `pgBackRest` restore, the dedicated repository pod is scaled down to `0`, the configuration is then updated to point to the new/restored primary PostgreSQL database pod, and the pod is then scaled back up to `1`.  While this occurs, there can be a period in which the old repo pod is still terminating as a result of scaling to `0`, while the new pod is online and ready for use as a result of scaling back up to `1`.  If a `pgBackRest` restore job is then executed while both the terminating and running pods are visible to the Kubernetes API server (e.g. when viewing pods using `kubectl get pods`), the restore job will fail due to the inability to identify the proper pod. 

Also, depending on the `pgBackRest` command being executed, the current `kubectl-ssh-wrapper.sh` script sometimes incorrectly parses the `pgBackRest` SSH command.  For instance, when a backup is created, the `buffer-size` is currently being dropped.

[ch6320]

**What is the new behavior (if this is a feature change)?**

The `kube-ssh-wrapper.sh` script now ensures the pod discovered when executing a backrest job (e.g. the `pgBackRest` dedicated repository host that must be discovered by the `pgBackRest` restore job when performing a restore) is running and not terminating.  This ensures that the proper pod is targeted in the event that a new pod is ready for use, but the old one is still terminating.  

Also, the `kubectl-ssh-wrapper.sh` script now correctly parses the `pgBackRest` SSH command.

**Other information**:

N/A