### PR TITLE
Remove trailing spaces and indent consistently with spaces in config

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/affinity.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/affinity.json
@@ -8,9 +8,9 @@
                     "operator": "{{.OperatorValue}}",
                     "values": [
                         "{{.NodeLabelValue}}"
-                    ]   
-                }]  
-                }   
-            }]  
-            }   
+                    ]
+                }]
+                }
+            }]
+            }
         },

--- a/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
@@ -12,7 +12,7 @@
                 }
     },
     "spec": {
-	"backoffLimit": 0,
+        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",
@@ -26,16 +26,16 @@
             },
             "spec": {
                 "volumes": [
-		{{.PgbackrestRestoreVolumes}}
-			],
-		{{.SecurityContext}}
+                    {{.PgbackrestRestoreVolumes}}
+                ],
+                {{.SecurityContext}}
                 "serviceAccountName": "pgo-backrest",
                 "containers": [{
                     "name": "backrest",
                     "image": "{{.PGOImagePrefix}}/pgo-backrest:{{.PGOImageTag}}",
                     "volumeMounts": [
-		{{.PgbackrestRestoreVolumeMounts}}
-			    ],
+                        {{.PgbackrestRestoreVolumeMounts}}
+                    ],
                     "env": [{
                         "name": "COMMAND",
                         "value": "{{.Command}}"

--- a/ansible/roles/pgo-operator/files/pgo-configs/backrest-restore-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/backrest-restore-job.json
@@ -12,13 +12,13 @@
                 }
     },
     "spec": {
-	"backoffLimit": 0,
+        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",
                 "labels": {
                     "vendor": "crunchydata",
-		    "pgo-backrest-restore": "true",
+                    "pgo-backrest-restore": "true",
                     "backrest-restore-to-pvc": "{{.ToClusterPVCName}}",
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.ClusterName}}"
@@ -26,32 +26,32 @@
             },
             "spec": {
                 "volumes": [ {
-			"name": "pgdata",
-			"persistentVolumeClaim": {
-				"claimName": "{{.ToClusterPVCName}}"
-			}
-		}, {
-			"name": "sshd",
-			"secret": {
-				"secretName": "{{.ClusterName}}-backrest-repo-config",
-				"defaultMode": 511
-			}
-		} ],
+                    "name": "pgdata",
+                    "persistentVolumeClaim": {
+                        "claimName": "{{.ToClusterPVCName}}"
+                    }
+                }, {
+                    "name": "sshd",
+                    "secret": {
+                        "secretName": "{{.ClusterName}}-backrest-repo-config",
+                        "defaultMode": 511
+                    }
+                } ],
 
-		{{.SecurityContext}}
+                {{.SecurityContext}}
                 "serviceAccountName": "pgo-backrest",
                 "containers": [{
                     "name": "backrest",
                     "image": "{{.PGOImagePrefix}}/pgo-backrest-restore:{{.PGOImageTag}}",
                     "volumeMounts": [ {
-			"mountPath": "/pgdata",
-			"name": "pgdata",
-			"readOnly": false
-		    }, {
-			"mountPath": "/sshd",
-			"name": "sshd",
-			"readOnly": true
-		    } ],
+                        "mountPath": "/pgdata",
+                        "name": "pgdata",
+                        "readOnly": false
+                    }, {
+                        "mountPath": "/sshd",
+                        "name": "sshd",
+                        "readOnly": true
+                    } ],
                     "env": [{
             {{.PgbackrestS3EnvVars}}
                         "name": "COMMAND_OPTS",

--- a/ansible/roles/pgo-operator/files/pgo-configs/backup-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/backup-job.json
@@ -3,11 +3,11 @@
     "kind": "Job",
     "metadata": {
         "name": "{{.JobName}}",
-       	"labels": {
-       		"vendor": "crunchydata",
-               	"pgbackup": "true",
-                "pg-cluster": "{{.Name}}"
-	}
+        "labels": {
+            "vendor": "crunchydata",
+            "pgbackup": "true",
+            "pg-cluster": "{{.Name}}"
+        }
     },
     "spec": {
         "backoffLimit": 0,
@@ -15,9 +15,9 @@
             "metadata": {
                 "name": "{{.JobName}}",
                 "labels": {
-       			"vendor": "crunchydata",
-               		"pgbackup": "true",
-                    	"pg-cluster": "{{.Name}}"
+                    "vendor": "crunchydata",
+                    "pgbackup": "true",
+                    "pg-cluster": "{{.Name}}"
                 }
             },
             "spec": {
@@ -36,7 +36,7 @@
                         "name": "pgdata",
                         "readOnly": false
                     }],
-		    {{.ContainerResources }}
+                    {{.ContainerResources }}
                     "env": [{
                         "name": "BACKUP_HOST",
                         "value": "{{.BackupHost}}"

--- a/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -11,10 +11,10 @@
     "spec": {
         "replicas": {{.Replicas}},
         "selector": {
-		"matchLabels": {
-		    "vendor": "crunchydata",
-		    {{.DeploymentLabels }}
-		}
+        "matchLabels": {
+            "vendor": "crunchydata",
+            {{.DeploymentLabels }}
+        }
         },
         "template": {
             "metadata": {
@@ -29,8 +29,6 @@
                 {{.SecurityContext }}
 
                 "containers": [
-        
-
             {
                     "name": "database",
                     "image": "{{.CCPImagePrefix}}/{{.CCPImage}}:{{.CCPImageTag}}",
@@ -71,7 +69,7 @@
                         "name": "PGDATA_PATH_OVERRIDE",
                         "value": "{{.DataPathOverride}}"
                     }, {
-			{{.PgmonitorEnvVars}}
+            {{.PgmonitorEnvVars}}
             {{.PgbackrestEnvVars}}
             {{.PgbackrestS3EnvVars}}
                         "name": "PG_DATABASE",
@@ -115,7 +113,6 @@
                             "mountPath": "/recover",
                             "name": "recover-volume"
                         }
-
                     ],
 
                     "ports": [{
@@ -130,7 +127,7 @@
 
                 {{.BadgerAddon }}
 
-		],
+                ],
                 "volumes": [{
                         "name": "pgdata",
                         {{.PVCName}}
@@ -151,7 +148,7 @@
                         "name": "sshd",
                         "secret": {
                             "secretName": "{{.ClusterName}}-backrest-repo-config",
-			    "defaultMode": 511
+                            "defaultMode": 511
                         }
                     }, {
                         "name": "root-volume",

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbadger.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbadger.json
@@ -1,6 +1,6 @@
             ,{
                 "name": "pgbadger",
-		        "image": "{{.CCPImagePrefix}}/crunchy-pgbadger:{{.CCPImageTag}}",
+                "image": "{{.CCPImagePrefix}}/crunchy-pgbadger:{{.CCPImageTag}}",
                 "ports": [ {
                         "containerPort": {{.PGBadgerPort}},
                         "protocol": "TCP"
@@ -13,11 +13,11 @@
                     "initialDelaySeconds": 20,
                     "periodSeconds": 10
                 },
-		        {{.ContainerResources }}
+                {{.ContainerResources }}
                 "env": [ {
-		            "name": "BADGER_TARGET",
-		            "value": "{{.BadgerTarget}}"
-		        },{
+                    "name": "BADGER_TARGET",
+                    "value": "{{.BadgerTarget}}"
+                }, {
                     "name": "PGBADGER_SERVICE_PORT",
                     "value": "{{.PGBadgerPort}}"
                 } ],

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
@@ -14,14 +14,14 @@
     "spec": {
         "replicas": 1,
         "selector": {
-		"matchLabels": {
-            		"name": "{{.Name}}",
-            		"crunchy-pgbouncer": "true",
-            		"pg-cluster": "{{.ClusterName}}",
-            		"service-name": "{{.Name}}",
-            		"vendor": "crunchydata"
-		}
-	},
+            "matchLabels": {
+                "name": "{{.Name}}",
+                "crunchy-pgbouncer": "true",
+                "pg-cluster": "{{.ClusterName}}",
+                "service-name": "{{.Name}}",
+                "vendor": "crunchydata"
+            }
+        },
         "template": {
             "metadata": {
                 "labels": {
@@ -29,7 +29,7 @@
                     "crunchy-pgbouncer": "true",
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
-            	    "vendor": "crunchydata"
+                    "vendor": "crunchydata"
                 }
             },
             "spec": {
@@ -41,7 +41,7 @@
                         "containerPort": {{.Port}},
                         "protocol": "TCP"
                     }],
-		    {{.ContainerResources }}
+                    {{.ContainerResources }}
                     "env": [{
                         "name": "PG_USERNAME",
                         "valueFrom": {

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgdump-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgdump-job.json
@@ -7,18 +7,18 @@
                 "vendor": "crunchydata",
                 "pgdump": "true",
                 "pg-cluster": "{{.ClusterName}}",
-	        "pg-task": "{{.TaskName}}"
-	}
+                "pg-task": "{{.TaskName}}"
+        }
     },
     "spec": {
-	"backoffLimit": 0,
+        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",
                 "labels": {
                     "vendor":"crunchydata",
-		    "pgdump":"true",
-		    "pg-cluster":"{{.ClusterName}}"
+                    "pgdump":"true",
+                    "pg-cluster":"{{.ClusterName}}"
                 }
             },
             "spec": {
@@ -26,11 +26,11 @@
                     {
                         "name": "pgdata",
                         "persistentVolumeClaim": {
-                            "claimName": "{{.PgDumpPVC}}" 
+                            "claimName": "{{.PgDumpPVC}}"
                         }
                     }
                 ],
-		
+
                 {{.SecurityContext}}
 
                 "containers": [{
@@ -43,7 +43,7 @@
                                 "readOnly": false
                             }
                         ],
-		        {{.ContainerResources}}
+                        {{.ContainerResources}}
                         "env": [
                             {
                                 "name": "PGDUMP_HOST",
@@ -52,41 +52,41 @@
                             {
                                 "name": "PGDUMP_USER",
                                 "valueFrom": {
-				    "secretKeyRef": {
-					"name": "{{.PgDumpUserSecret}}",
-					"key": "username"
-				    }
-				}
+                                    "secretKeyRef": {
+                                        "name": "{{.PgDumpUserSecret}}",
+                                        "key": "username"
+                                    }
+                                }
                             },
                             {
                                 "name": "PGDUMP_PASS",
                                 "valueFrom": {
-				    "secretKeyRef": {
-					"name": "{{.PgDumpUserSecret}}",
-					"key": "password"
-				    }
-				}
+                                    "secretKeyRef": {
+                                        "name": "{{.PgDumpUserSecret}}",
+                                        "key": "password"
+                                    }
+                                }
                             },
                             {
                                 "name": "PGDUMP_DB",
                                 "value": "{{.PgDumpDB}}"
                             },
-			    {
-				"name": "PGDUMP_PORT",
-				"value": "{{.PgDumpPort}}"
-			    },
-			    {
-				"name": "PGDUMP_CUSTOM_OPTS",
-				"value": "{{.PgDumpOpts}}"
-			    },
-			    {
-				"name": "PGDUMP_FILENAME",
-				"value": "{{.PgDumpFilename}}"
-			    },
-			    {
-				"name": "PGDUMP_ALL",
-				"value": "{{.PgDumpAll}}"
-			    }
+                            {
+                                "name": "PGDUMP_PORT",
+                                "value": "{{.PgDumpPort}}"
+                            },
+                            {
+                                "name": "PGDUMP_CUSTOM_OPTS",
+                                "value": "{{.PgDumpOpts}}"
+                            },
+                            {
+                                "name": "PGDUMP_FILENAME",
+                                "value": "{{.PgDumpFilename}}"
+                            },
+                            {
+                                "name": "PGDUMP_ALL",
+                                "value": "{{.PgDumpAll}}"
+                            }
                         ]
                     }
                 ],

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
@@ -18,8 +18,8 @@
                     "name": "{{.Name}}",
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
-            	    "vendor": "crunchydata",
-           	    "pgo-backrest-repo": "true"
+                    "vendor": "crunchydata",
+                    "pgo-backrest-repo": "true"
             }
         },
         "template": {
@@ -28,12 +28,12 @@
                     "name": "{{.Name}}",
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
-            	    "vendor": "crunchydata",
-           	    "pgo-backrest-repo": "true"
+                    "vendor": "crunchydata",
+                    "pgo-backrest-repo": "true"
                 }
             },
             "spec": {
-		{{.SecurityContext}}
+                {{.SecurityContext}}
 
                 "containers": [{
                     "name": "database",
@@ -42,7 +42,7 @@
                         "containerPort": {{.SshdPort}},
                         "protocol": "TCP"
                     }],
-		    {{.ContainerResources }}
+                    {{.ContainerResources }}
                     "env": [{
             {{.PgbackrestS3EnvVars}}
                         "name": "PGBACKREST_STANZA",
@@ -77,16 +77,16 @@
                     }]
                 }],
                 "volumes": [{
-                	"name": "sshd",
-                	"secret": {
-                    		"secretName": "{{.ClusterName}}-backrest-repo-config",
-                    		"defaultMode": 511
-                    	}
+                    "name": "sshd",
+                    "secret": {
+                        "secretName": "{{.ClusterName}}-backrest-repo-config",
+                        "defaultMode": 511
+                    }
                 }, {
-                	"name": "backrestrepo",
-                	"persistentVolumeClaim": {
-                    		"claimName": "{{.BackrestRepoClaimName}}"
-                    	}
+                    "name": "backrestrepo",
+                    "persistentVolumeClaim": {
+                        "claimName": "{{.BackrestRepoClaimName}}"
+                    }
                 }],
                 "restartPolicy": "Always",
                 "dnsPolicy": "ClusterFirst"

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo-scc.yaml
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo-scc.yaml
@@ -10,7 +10,7 @@ apiVersion: security.openshift.io/v1
 defaultAddCapabilities: null
 fsGroup:
   type: MustRunAs
-  ranges: 
+  ranges:
   - max: 26
     min: 26
 groups:

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo.load-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo.load-template.json
@@ -5,7 +5,7 @@
         "name": "{{.Name}}"
     },
     "spec": {
-	"backoffLimit": 0,
+        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.Name}}",
@@ -34,7 +34,7 @@
                         "readOnly": true
                     }],
 
-		    {{.ContainerResources }}
+                    {{.ContainerResources }}
 
                     "env": [{
                         "name": "TABLE_TO_LOAD",

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo.lspvc-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo.lspvc-template.json
@@ -12,7 +12,7 @@
     },
     "spec": {
 
-	    {{.NodeSelector}}
+        {{.NodeSelector}}
 
         "restartPolicy": "Never",
         "containers": [{
@@ -21,7 +21,7 @@
                 "privileged": false
             },
             "image": "{{.PGOImagePrefix}}/pgo-lspvc:{{.PGOImageTag}}",
-	    {{.ContainerResources }}
+            {{.ContainerResources }}
             "env": [{
                 "name": "BACKUP_ROOT",
                 "value": "{{.BackupRoot}}"

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgpool-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgpool-template.json
@@ -8,20 +8,20 @@
             "pg-cluster": "{{.ClusterName}}",
             "crunchy-pgpool-pod": "true",
             "service-name": "{{.Name}}",
-	    "vendor": "crunchydata"
+            "vendor": "crunchydata"
         }
     },
     "spec": {
         "replicas": 1,
-	"selector": {
-		"matchLabels": {
-            		"name": "{{.Name}}",
-            		"pg-cluster": "{{.ClusterName}}",
-            		"crunchy-pgpool-pod": "true",
-            		"service-name": "{{.Name}}",
-	    		"vendor": "crunchydata"
-		}
-	},
+        "selector": {
+            "matchLabels": {
+                "name": "{{.Name}}",
+                "pg-cluster": "{{.ClusterName}}",
+                "crunchy-pgpool-pod": "true",
+                "service-name": "{{.Name}}",
+                "vendor": "crunchydata"
+            }
+        },
         "template": {
             "metadata": {
                 "labels": {
@@ -29,7 +29,7 @@
                     "pg-cluster": "{{.ClusterName}}",
                     "crunchy-pgpool-pod": "true",
                     "service-name": "{{.Name}}",
-	    	    "vendor": "crunchydata"
+                    "vendor": "crunchydata"
                 }
             },
             "spec": {
@@ -41,7 +41,7 @@
                         "containerPort": {{.Port}},
                         "protocol": "TCP"
                     }],
-		    {{.ContainerResources }}
+                    {{.ContainerResources }}
                     "env": [{
                         "name": "PG_USERNAME",
                         "valueFrom": {

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgpool.conf
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgpool.conf
@@ -316,8 +316,8 @@ follow_master_command = ''
                                    #   %H = hostname of the new master node
                                    #   %M = old master node id
                                    #   %P = old primary node id
-								   #   %r = new master port number
-								   #   %R = new master database cluster path
+                                   #   %r = new master port number
+                                   #   %R = new master database cluster path
                                    #   %% = '%' character
 
 
@@ -363,7 +363,7 @@ health_check_user = '{{.PG_USERNAME}}'
 health_check_password = '{{.PG_PASSWORD}}'
                                    # Password for health check user
 health_check_max_retries = 3
-connect_timeout = 10000 		# Timeout value in milliseconds before giving up to connect to backend.
+connect_timeout = 10000            # Timeout value in milliseconds before giving up to connect to backend.
 
                                    # Maximum number of times to retry a failed health check before giving up.
 health_check_retry_delay = 1
@@ -385,8 +385,8 @@ failover_command = ''
                                    #   %H = hostname of the new master node
                                    #   %M = old master node id
                                    #   %P = old primary node id
-								   #   %r = new master port number
-								   #   %R = new master database cluster path
+                                   #   %r = new master port number
+                                   #   %R = new master database cluster path
                                    #   %% = '%' character
 failback_command = ''
                                    # Executes this command at failback.
@@ -399,8 +399,8 @@ failback_command = ''
                                    #   %H = hostname of the new master node
                                    #   %M = old master node id
                                    #   %P = old primary node id
-								   #   %r = new master port number
-								   #   %R = new master database cluster path
+                                   #   %r = new master port number
+                                   #   %R = new master database cluster path
                                    #   %% = '%' character
 
 fail_over_on_backend_error = off
@@ -476,7 +476,7 @@ wd_authkey = ''
 
 delegate_IP = ''
                                     # delegate IP address
-                                    # If this is empty, virtual IP never bring up. 
+                                    # If this is empty, virtual IP never bring up.
                                     # (change requires restart)
 ifconfig_path = '/sbin'
                                     # ifconfig command path
@@ -508,7 +508,7 @@ wd_escalation_command = ''
                                     # Executes this command at escalation on new active pgpool.
                                     # (change requires restart)
 
-# - Lifecheck Setting - 
+# - Lifecheck Setting -
 
 # -- common --
 
@@ -534,7 +534,7 @@ heartbeat_destination0 = 'host0_ip1'
                                     # Host name or IP address of destination 0
                                     # for sending heartbeat signal.
                                     # (change requires restart)
-heartbeat_destination_port0 = 9694 
+heartbeat_destination_port0 = 9694
                                     # Port number of destination 0 for sending
                                     # heartbeat signal. Usually this is the
                                     # same as wd_heartbeat_port.
@@ -606,66 +606,66 @@ relcache_expire = 0
 relcache_size = 256
                                    # Number of relation cache
                                    # entry. If you see frequently:
-								   # "pool_search_relcache: cache replacement happend"
-								   # in the pgpool log, you might want to increate this number.
+                                   # "pool_search_relcache: cache replacement happend"
+                                   # in the pgpool log, you might want to increate this number.
 
 check_temp_table = on
                                    # If on, enable temporary table check in SELECT statements.
                                    # This initiates queries against system catalog of primary/master
-								   # thus increases load of master.
-								   # If you are absolutely sure that your system never uses temporary tables
-								   # and you want to save access to primary/master, you could turn this off.
-								   # Default is on.
+                                   # thus increases load of master.
+                                   # If you are absolutely sure that your system never uses temporary tables
+                                   # and you want to save access to primary/master, you could turn this off.
+                                   # Default is on.
 
 
 #------------------------------------------------------------------------------
 # ON MEMORY QUERY MEMORY CACHE
 #------------------------------------------------------------------------------
 memory_cache_enabled = off
-								   # If on, use the memory cache functionality, off by default
+                                   # If on, use the memory cache functionality, off by default
 memqcache_method = 'shmem'
-								   # Cache storage method. either 'shmem'(shared memory) or
-								   # 'memcached'. 'shmem' by default
+                                   # Cache storage method. either 'shmem'(shared memory) or
+                                   # 'memcached'. 'shmem' by default
                                    # (change requires restart)
 memqcache_memcached_host = 'localhost'
-								   # Memcached host name or IP address. Mandatory if
-								   # memqcache_method = 'memcached'.
-								   # Defaults to localhost.
+                                   # Memcached host name or IP address. Mandatory if
+                                   # memqcache_method = 'memcached'.
+                                   # Defaults to localhost.
                                    # (change requires restart)
 memqcache_memcached_port = 11211
-								   # Memcached port number. Mondatory if memqcache_method = 'memcached'.
-								   # Defaults to 11211.
+                                   # Memcached port number. Mondatory if memqcache_method = 'memcached'.
+                                   # Defaults to 11211.
                                    # (change requires restart)
 memqcache_total_size = 67108864
-								   # Total memory size in bytes for storing memory cache.
-								   # Mandatory if memqcache_method = 'shmem'.
-								   # Defaults to 64MB.
+                                   # Total memory size in bytes for storing memory cache.
+                                   # Mandatory if memqcache_method = 'shmem'.
+                                   # Defaults to 64MB.
                                    # (change requires restart)
 memqcache_max_num_cache = 1000000
-								   # Total number of cache entries. Mandatory
-								   # if memqcache_method = 'shmem'.
-								   # Each cache entry consumes 48 bytes on shared memory.
-								   # Defaults to 1,000,000(45.8MB).
+                                   # Total number of cache entries. Mandatory
+                                   # if memqcache_method = 'shmem'.
+                                   # Each cache entry consumes 48 bytes on shared memory.
+                                   # Defaults to 1,000,000(45.8MB).
                                    # (change requires restart)
 memqcache_expire = 0
-								   # Memory cache entry life time specified in seconds.
-								   # 0 means infinite life time. 0 by default.
+                                   # Memory cache entry life time specified in seconds.
+                                   # 0 means infinite life time. 0 by default.
                                    # (change requires restart)
 memqcache_auto_cache_invalidation = on
-								   # If on, invalidation of query cache is triggered by corresponding
-								   # DDL/DML/DCL(and memqcache_expire).  If off, it is only triggered
-								   # by memqcache_expire.  on by default.
+                                   # If on, invalidation of query cache is triggered by corresponding
+                                   # DDL/DML/DCL(and memqcache_expire).  If off, it is only triggered
+                                   # by memqcache_expire.  on by default.
                                    # (change requires restart)
 memqcache_maxcache = 409600
-								   # Maximum SELECT result size in bytes.
-								   # Must be smaller than memqcache_cache_block_size. Defaults to 400KB.
+                                   # Maximum SELECT result size in bytes.
+                                   # Must be smaller than memqcache_cache_block_size. Defaults to 400KB.
                                    # (change requires restart)
 memqcache_cache_block_size = 1048576
-								   # Cache block size in bytes. Mandatory if memqcache_method = 'shmem'.
-								   # Defaults to 1MB.
+                                   # Cache block size in bytes. Mandatory if memqcache_method = 'shmem'.
+                                   # Defaults to 1MB.
                                    # (change requires restart)
 memqcache_oiddir = '/var/log/pgpool/oiddir'
-				   				   # Temporary work directory to record table oids
+                                   # Temporary work directory to record table oids
                                    # (change requires restart)
 white_memqcache_table_list = ''
                                    # Comma separated list of table names to memcache

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
@@ -3,22 +3,21 @@
     "kind": "Job",
     "metadata": {
         "name": "{{.JobName}}",
-	"labels": {
-	    "vendor": "crunchydata",
-	    "pgrestore": "true",
-	    "pg-cluster": "{{.ClusterName}}",
-  	    "pg-task": "{{.TaskName}}"
-
-                }
+        "labels": {
+            "vendor": "crunchydata",
+            "pgrestore": "true",
+            "pg-cluster": "{{.ClusterName}}",
+            "pg-task": "{{.TaskName}}"
+        }
     },
     "spec": {
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",
                 "labels": {
-		    "vendor": "crunchydata",
-		    "pgrestore": "true",
-		    "pg-cluster": "{{.ClusterName}}"
+                    "vendor": "crunchydata",
+                    "pgrestore": "true",
+                    "pg-cluster": "{{.ClusterName}}"
                 }
             },
             "spec": {
@@ -30,9 +29,9 @@
                         }
                     }
                 ],
-		
+
                     {{.SecurityContext}}
-                
+
                 "containers": [
                     {
                         "name": "pgrestore",
@@ -48,22 +47,22 @@
                             {
                                 "name": "PGRESTORE_USER",
                                 "valueFrom": {
-				    "secretKeyRef": {
-					"name": "{{.PgRestoreUserSecret}}",
-					"key": "username"
-				    }
-				}
+                                    "secretKeyRef": {
+                                        "name": "{{.PgRestoreUserSecret}}",
+                                        "key": "username"
+                                    }
+                                }
                             },
                             {
                                 "name": "PGRESTORE_PASS",
                                 "valueFrom": {
-				   "secretKeyRef": {
-				       "name": "{{.PgRestoreUserSecret}}",
-				       "key": "password"
-				    }
-				}
+                                    "secretKeyRef": {
+                                        "name": "{{.PgRestoreUserSecret}}",
+                                        "key": "password"
+                                    }
+                                }
                             },
-			    {
+                            {
                                 "name": "PGRESTORE_HOST",
                                 "value": "{{.PgRestoreHost}}"
                             },
@@ -71,18 +70,18 @@
                                 "name": "PGRESTORE_DB",
                                 "value": "{{.PgRestoreDB}}"
                             },
-			    {
-				"name": "PG_PRIMARY_PORT",
-				"value": "5432"
-			    },
-			    {
-				"name": "PGRESTORE_CUSTOM_OPTS",
-				"value": "{{.PGRestoreOpts}}"
-			    },
-			    {
-				"name": "PGRESTORE_BACKUP_TIMESTAMP",
-				"value": "{{.PITRTarget}}"
-			    }
+                            {
+                                "name": "PG_PRIMARY_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "PGRESTORE_CUSTOM_OPTS",
+                                "value": "{{.PGRestoreOpts}}"
+                            },
+                            {
+                                "name": "PGRESTORE_BACKUP_TIMESTAMP",
+                                "value": "{{.PITRTarget}}"
+                            }
                         ]
                     }
                 ],

--- a/ansible/roles/pgo-operator/files/pgo-configs/rmdata-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/rmdata-job.json
@@ -3,14 +3,14 @@
     "kind": "Job",
     "metadata": {
         "name": "{{.JobName}}",
-	"labels": {
-        	"vendor": "crunchydata",
-               	"pgrmdata": "true",
-		"pg-cluster": "{{.ClusterName}}"
-	}
+        "labels": {
+            "vendor": "crunchydata",
+            "pgrmdata": "true",
+            "pg-cluster": "{{.ClusterName}}"
+        }
     },
     "spec": {
-	"backoffLimit": 0,
+        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",
@@ -21,11 +21,11 @@
                 }
             },
             "spec": {
-		"serviceAccountName": "pgo-target",
+                "serviceAccountName": "pgo-target",
                 "containers": [{
                     "name": "rmdata",
                     "image": "{{.PGOImagePrefix}}/pgo-rmdata:{{.PGOImageTag}}",
-		    {{.ContainerResources }}
+                    {{.ContainerResources }}
                     "env": [{
                         "name": "PG_CLUSTER",
                         "value": "{{.ClusterName}}"
@@ -46,11 +46,11 @@
                         "value": "{{.IsReplica}}"
                     }, {
                         "name": "NAMESPACE",
-			"valueFrom": {
-				"fieldRef": {
-					"fieldPath": "metadata.namespace"
-				}
-			}
+                        "valueFrom": {
+                            "fieldRef": {
+                                "fieldPath": "metadata.namespace"
+                            }
+                        }
                     }]
                 }],
                 "restartPolicy": "Never"

--- a/ansible/roles/pgo-operator/templates/pgo.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/pgo.yaml.j2
@@ -56,7 +56,7 @@ DefaultLoadResources: {{ default_pgpool_resources }}
 DefaultLspvcResources: {{ default_lspvc_resources }}
 DefaultRmdataResources: {{ default_rmdata_resources }}
 DefaultBackupResources: {{ default_backup_resources }}
-DefaultPgbouncerResources: {{ default_pgbouncer_resources }}  
+DefaultPgbouncerResources: {{ default_pgbouncer_resources }}
 DefaultPgpoolResources: {{ default_pgpool_resources }}
 ContainerResources:
 {% for i in range(1, max_resource_configs) %}
@@ -69,7 +69,7 @@ ContainerResources:
 {% endif %}
 {% endfor %}
 Pgo:
-  AutofailSleepSeconds:  {{ auto_failover_sleep_secs }} 
+  AutofailSleepSeconds:  {{ auto_failover_sleep_secs }}
   Audit:  false
   LSPVCTemplate:  /pgo-config/pgo.lspvc-template.json
   LoadTemplate:  /pgo-config/pgo.load-template.json

--- a/conf/postgres-operator/affinity.json
+++ b/conf/postgres-operator/affinity.json
@@ -8,9 +8,9 @@
                     "operator": "{{.OperatorValue}}",
                     "values": [
                         "{{.NodeLabelValue}}"
-                    ]   
-                }]  
-                }   
-            }]  
-            }   
+                    ]
+                }]
+                }
+            }]
+            }
         },

--- a/conf/postgres-operator/backrest-job.json
+++ b/conf/postgres-operator/backrest-job.json
@@ -12,7 +12,7 @@
                 }
     },
     "spec": {
-	"backoffLimit": 0,
+        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",
@@ -26,16 +26,16 @@
             },
             "spec": {
                 "volumes": [
-		{{.PgbackrestRestoreVolumes}}
-			],
-		{{.SecurityContext}}
+                    {{.PgbackrestRestoreVolumes}}
+                ],
+                {{.SecurityContext}}
                 "serviceAccountName": "pgo-backrest",
                 "containers": [{
                     "name": "backrest",
                     "image": "{{.PGOImagePrefix}}/pgo-backrest:{{.PGOImageTag}}",
                     "volumeMounts": [
-		{{.PgbackrestRestoreVolumeMounts}}
-			    ],
+                        {{.PgbackrestRestoreVolumeMounts}}
+                    ],
                     "env": [{
                         "name": "COMMAND",
                         "value": "{{.Command}}"

--- a/conf/postgres-operator/backrest-restore-job.json
+++ b/conf/postgres-operator/backrest-restore-job.json
@@ -12,13 +12,13 @@
                 }
     },
     "spec": {
-	"backoffLimit": 0,
+        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",
                 "labels": {
                     "vendor": "crunchydata",
-		    "pgo-backrest-restore": "true",
+                    "pgo-backrest-restore": "true",
                     "backrest-restore-to-pvc": "{{.ToClusterPVCName}}",
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.ClusterName}}"
@@ -26,32 +26,32 @@
             },
             "spec": {
                 "volumes": [ {
-			"name": "pgdata",
-			"persistentVolumeClaim": {
-				"claimName": "{{.ToClusterPVCName}}"
-			}
-		}, {
-			"name": "sshd",
-			"secret": {
-				"secretName": "{{.ClusterName}}-backrest-repo-config",
-				"defaultMode": 511
-			}
-		} ],
+                    "name": "pgdata",
+                    "persistentVolumeClaim": {
+                        "claimName": "{{.ToClusterPVCName}}"
+                    }
+                }, {
+                    "name": "sshd",
+                    "secret": {
+                        "secretName": "{{.ClusterName}}-backrest-repo-config",
+                        "defaultMode": 511
+                    }
+                } ],
 
-		{{.SecurityContext}}
+                {{.SecurityContext}}
                 "serviceAccountName": "pgo-backrest",
                 "containers": [{
                     "name": "backrest",
                     "image": "{{.PGOImagePrefix}}/pgo-backrest-restore:{{.PGOImageTag}}",
                     "volumeMounts": [ {
-			"mountPath": "/pgdata",
-			"name": "pgdata",
-			"readOnly": false
-		    }, {
-			"mountPath": "/sshd",
-			"name": "sshd",
-			"readOnly": true
-		    } ],
+                        "mountPath": "/pgdata",
+                        "name": "pgdata",
+                        "readOnly": false
+                    }, {
+                        "mountPath": "/sshd",
+                        "name": "sshd",
+                        "readOnly": true
+                    } ],
                     "env": [{
             {{.PgbackrestS3EnvVars}}
                         "name": "COMMAND_OPTS",

--- a/conf/postgres-operator/backup-job.json
+++ b/conf/postgres-operator/backup-job.json
@@ -3,11 +3,11 @@
     "kind": "Job",
     "metadata": {
         "name": "{{.JobName}}",
-       	"labels": {
-       		"vendor": "crunchydata",
-               	"pgbackup": "true",
-                "pg-cluster": "{{.Name}}"
-	}
+        "labels": {
+            "vendor": "crunchydata",
+            "pgbackup": "true",
+            "pg-cluster": "{{.Name}}"
+        }
     },
     "spec": {
         "backoffLimit": 0,
@@ -15,9 +15,9 @@
             "metadata": {
                 "name": "{{.JobName}}",
                 "labels": {
-       			"vendor": "crunchydata",
-               		"pgbackup": "true",
-                    	"pg-cluster": "{{.Name}}"
+                    "vendor": "crunchydata",
+                    "pgbackup": "true",
+                    "pg-cluster": "{{.Name}}"
                 }
             },
             "spec": {
@@ -36,7 +36,7 @@
                         "name": "pgdata",
                         "readOnly": false
                     }],
-		    {{.ContainerResources }}
+                    {{.ContainerResources }}
                     "env": [{
                         "name": "BACKUP_HOST",
                         "value": "{{.BackupHost}}"

--- a/conf/postgres-operator/cluster-deployment.json
+++ b/conf/postgres-operator/cluster-deployment.json
@@ -12,10 +12,10 @@
     "spec": {
         "replicas": {{.Replicas}},
         "selector": {
-		"matchLabels": {
-		    "vendor": "crunchydata",
-		    {{.DeploymentLabels }}
-		}
+        "matchLabels": {
+            "vendor": "crunchydata",
+            {{.DeploymentLabels }}
+        }
         },
         "template": {
             "metadata": {
@@ -31,8 +31,6 @@
                 {{.SecurityContext }}
                 "serviceAccountName": "pgo-pg",
                 "containers": [
-        
-
             {
                     "name": "database",
                     "image": "{{.CCPImagePrefix}}/{{.CCPImage}}:{{.CCPImageTag}}",
@@ -67,19 +65,19 @@
                                "key": "init"
                             }
                          }
-                    }, 
+                    },
                     {{ end }}
                     {{if not .IsInit}}
                     {
                         "name": "PGHA_PRIMARY_HOST",
                         "value": "{{.ClusterName}}"
-                    }, 
+                    },
                     {{ end }}
                     {
                         "name": "PATRONI_POSTGRESQL_DATA_DIR",
                         "value": "/pgdata/{{.Name}}"
                     }, {
-			{{.PgmonitorEnvVars}}
+            {{.PgmonitorEnvVars}}
             {{.PgbackrestEnvVars}}
             {{.PgbackrestS3EnvVars}}
                         "name": "PGHA_DATABASE",
@@ -156,7 +154,6 @@
                             "mountPath": "/crunchyadm",
                             "name": "crunchyadm"
                         }
-                        
                     ],
 
                     "ports": [{
@@ -206,7 +203,7 @@
 
                 {{.BadgerAddon }}
 
-		],
+                ],
                 "volumes": [{
                         "name": "pgdata",
                         {{.PVCName}}
@@ -227,7 +224,7 @@
                         "name": "sshd",
                         "secret": {
                             "secretName": "{{.ClusterName}}-backrest-repo-config",
-			    "defaultMode": 511
+                            "defaultMode": 511
                         }
                     }, {
                         "name": "root-volume",
@@ -255,13 +252,13 @@
                             "sources": [
                                 {{if .ConfVolume}}
                                 {
-                                    "configMap": { 
+                                    "configMap": {
                                         "name": {{.ConfVolume}}
                                     }
                                 },
                                 {{end}}
                                 {
-                                    "configMap": { 
+                                    "configMap": {
                                         "name": "{{.ClusterName}}-pgha-default-config",
                                         "optional": true
                                     }
@@ -287,4 +284,3 @@
         }
     }
 }
- 

--- a/conf/postgres-operator/pgbadger.json
+++ b/conf/postgres-operator/pgbadger.json
@@ -1,6 +1,6 @@
             ,{
                 "name": "pgbadger",
-		        "image": "{{.CCPImagePrefix}}/crunchy-pgbadger:{{.CCPImageTag}}",
+                "image": "{{.CCPImagePrefix}}/crunchy-pgbadger:{{.CCPImageTag}}",
                 "ports": [ {
                         "containerPort": {{.PGBadgerPort}},
                         "protocol": "TCP"
@@ -13,11 +13,11 @@
                     "initialDelaySeconds": 20,
                     "periodSeconds": 10
                 },
-		         {{.ContainerResources }}
+                {{.ContainerResources }}
                 "env": [ {
-		            "name": "BADGER_TARGET",
-		            "value": "{{.BadgerTarget}}"
-		        }, {
+                    "name": "BADGER_TARGET",
+                    "value": "{{.BadgerTarget}}"
+                }, {
                     "name": "PGBADGER_SERVICE_PORT",
                     "value": "{{.PGBadgerPort}}"
                 } ],

--- a/conf/postgres-operator/pgbouncer-template.json
+++ b/conf/postgres-operator/pgbouncer-template.json
@@ -14,14 +14,14 @@
     "spec": {
         "replicas": 1,
         "selector": {
-		"matchLabels": {
-            		"name": "{{.Name}}",
-            		"crunchy-pgbouncer": "true",
-            		"pg-cluster": "{{.ClusterName}}",
-            		"service-name": "{{.Name}}",
-            		"vendor": "crunchydata"
-		}
-	},
+            "matchLabels": {
+                "name": "{{.Name}}",
+                "crunchy-pgbouncer": "true",
+                "pg-cluster": "{{.ClusterName}}",
+                "service-name": "{{.Name}}",
+                "vendor": "crunchydata"
+            }
+        },
         "template": {
             "metadata": {
                 "labels": {
@@ -29,7 +29,7 @@
                     "crunchy-pgbouncer": "true",
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
-            	    "vendor": "crunchydata"
+                    "vendor": "crunchydata"
                 }
             },
             "spec": {
@@ -41,7 +41,7 @@
                         "containerPort": {{.Port}},
                         "protocol": "TCP"
                     }],
-		    {{.ContainerResources }}
+                    {{.ContainerResources }}
                     "env": [{
                         "name": "PG_USERNAME",
                         "valueFrom": {

--- a/conf/postgres-operator/pgdump-job.json
+++ b/conf/postgres-operator/pgdump-job.json
@@ -7,18 +7,18 @@
                 "vendor": "crunchydata",
                 "pgdump": "true",
                 "pg-cluster": "{{.ClusterName}}",
-	        "pg-task": "{{.TaskName}}"
-	}
+                "pg-task": "{{.TaskName}}"
+        }
     },
     "spec": {
-	"backoffLimit": 0,
+        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",
                 "labels": {
                     "vendor":"crunchydata",
-		    "pgdump":"true",
-		    "pg-cluster":"{{.ClusterName}}"
+                    "pgdump":"true",
+                    "pg-cluster":"{{.ClusterName}}"
                 }
             },
             "spec": {
@@ -26,11 +26,11 @@
                     {
                         "name": "pgdata",
                         "persistentVolumeClaim": {
-                            "claimName": "{{.PgDumpPVC}}" 
+                            "claimName": "{{.PgDumpPVC}}"
                         }
                     }
                 ],
-		
+
                 {{.SecurityContext}}
 
                 "containers": [{
@@ -43,7 +43,7 @@
                                 "readOnly": false
                             }
                         ],
-		        {{.ContainerResources}}
+                        {{.ContainerResources}}
                         "env": [
                             {
                                 "name": "PGDUMP_HOST",
@@ -52,41 +52,41 @@
                             {
                                 "name": "PGDUMP_USER",
                                 "valueFrom": {
-				    "secretKeyRef": {
-					"name": "{{.PgDumpUserSecret}}",
-					"key": "username"
-				    }
-				}
+                                    "secretKeyRef": {
+                                        "name": "{{.PgDumpUserSecret}}",
+                                        "key": "username"
+                                    }
+                                }
                             },
                             {
                                 "name": "PGDUMP_PASS",
                                 "valueFrom": {
-				    "secretKeyRef": {
-					"name": "{{.PgDumpUserSecret}}",
-					"key": "password"
-				    }
-				}
+                                    "secretKeyRef": {
+                                        "name": "{{.PgDumpUserSecret}}",
+                                        "key": "password"
+                                    }
+                                }
                             },
                             {
                                 "name": "PGDUMP_DB",
                                 "value": "{{.PgDumpDB}}"
                             },
-			    {
-				"name": "PGDUMP_PORT",
-				"value": "{{.PgDumpPort}}"
-			    },
-			    {
-				"name": "PGDUMP_CUSTOM_OPTS",
-				"value": "{{.PgDumpOpts}}"
-			    },
-			    {
-				"name": "PGDUMP_FILENAME",
-				"value": "{{.PgDumpFilename}}"
-			    },
-			    {
-				"name": "PGDUMP_ALL",
-				"value": "{{.PgDumpAll}}"
-			    }
+                            {
+                                "name": "PGDUMP_PORT",
+                                "value": "{{.PgDumpPort}}"
+                            },
+                            {
+                                "name": "PGDUMP_CUSTOM_OPTS",
+                                "value": "{{.PgDumpOpts}}"
+                            },
+                            {
+                                "name": "PGDUMP_FILENAME",
+                                "value": "{{.PgDumpFilename}}"
+                            },
+                            {
+                                "name": "PGDUMP_ALL",
+                                "value": "{{.PgDumpAll}}"
+                            }
                         ]
                     }
                 ],

--- a/conf/postgres-operator/pgo-backrest-repo-template.json
+++ b/conf/postgres-operator/pgo-backrest-repo-template.json
@@ -18,8 +18,8 @@
                     "name": "{{.Name}}",
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
-            	    "vendor": "crunchydata",
-           	    "pgo-backrest-repo": "true"
+                    "vendor": "crunchydata",
+                    "pgo-backrest-repo": "true"
             }
         },
         "template": {
@@ -28,12 +28,12 @@
                     "name": "{{.Name}}",
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
-            	    "vendor": "crunchydata",
-           	    "pgo-backrest-repo": "true"
+                    "vendor": "crunchydata",
+                    "pgo-backrest-repo": "true"
                 }
             },
             "spec": {
-		{{.SecurityContext}}
+                {{.SecurityContext}}
                 "serviceAccountName": "pgo-backrest",
                 "containers": [{
                     "name": "database",
@@ -42,7 +42,7 @@
                         "containerPort": {{.SshdPort}},
                         "protocol": "TCP"
                     }],
-		    {{.ContainerResources }}
+                    {{.ContainerResources }}
                     "env": [{
             {{.PgbackrestS3EnvVars}}
                         "name": "PGBACKREST_STANZA",
@@ -99,16 +99,16 @@
                     }]
                 }],
                 "volumes": [{
-                	"name": "sshd",
-                	"secret": {
-                    		"secretName": "{{.ClusterName}}-backrest-repo-config",
-                    		"defaultMode": 511
-                    	}
+                    "name": "sshd",
+                    "secret": {
+                        "secretName": "{{.ClusterName}}-backrest-repo-config",
+                        "defaultMode": 511
+                    }
                 }, {
-                	"name": "backrestrepo",
-                	"persistentVolumeClaim": {
-                    		"claimName": "{{.BackrestRepoClaimName}}"
-                    	}
+                    "name": "backrestrepo",
+                    "persistentVolumeClaim": {
+                        "claimName": "{{.BackrestRepoClaimName}}"
+                    }
                 }],
                 "restartPolicy": "Always",
                 "dnsPolicy": "ClusterFirst"

--- a/conf/postgres-operator/pgo.load-template.json
+++ b/conf/postgres-operator/pgo.load-template.json
@@ -5,7 +5,7 @@
         "name": "{{.Name}}"
     },
     "spec": {
-	"backoffLimit": 0,
+        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.Name}}",
@@ -34,7 +34,7 @@
                         "readOnly": true
                     }],
 
-		    {{.ContainerResources }}
+                    {{.ContainerResources }}
 
                     "env": [{
                         "name": "TABLE_TO_LOAD",

--- a/conf/postgres-operator/pgo.lspvc-template.json
+++ b/conf/postgres-operator/pgo.lspvc-template.json
@@ -12,7 +12,7 @@
     },
     "spec": {
 
-	    {{.NodeSelector}}
+        {{.NodeSelector}}
 
         "restartPolicy": "Never",
         "containers": [{
@@ -21,7 +21,7 @@
                 "privileged": false
             },
             "image": "{{.PGOImagePrefix}}/pgo-lspvc:{{.PGOImageTag}}",
-	    {{.ContainerResources }}
+            {{.ContainerResources }}
             "env": [{
                 "name": "BACKUP_ROOT",
                 "value": "{{.BackupRoot}}"

--- a/conf/postgres-operator/pgpool-template.json
+++ b/conf/postgres-operator/pgpool-template.json
@@ -8,20 +8,20 @@
             "pg-cluster": "{{.ClusterName}}",
             "crunchy-pgpool-pod": "true",
             "service-name": "{{.Name}}",
-	    "vendor": "crunchydata"
+            "vendor": "crunchydata"
         }
     },
     "spec": {
         "replicas": 1,
-	"selector": {
-		"matchLabels": {
-            		"name": "{{.Name}}",
-            		"pg-cluster": "{{.ClusterName}}",
-            		"crunchy-pgpool-pod": "true",
-            		"service-name": "{{.Name}}",
-	    		"vendor": "crunchydata"
-		}
-	},
+        "selector": {
+            "matchLabels": {
+                "name": "{{.Name}}",
+                "pg-cluster": "{{.ClusterName}}",
+                "crunchy-pgpool-pod": "true",
+                "service-name": "{{.Name}}",
+                "vendor": "crunchydata"
+            }
+        },
         "template": {
             "metadata": {
                 "labels": {
@@ -29,7 +29,7 @@
                     "pg-cluster": "{{.ClusterName}}",
                     "crunchy-pgpool-pod": "true",
                     "service-name": "{{.Name}}",
-	    	    "vendor": "crunchydata"
+                    "vendor": "crunchydata"
                 }
             },
             "spec": {
@@ -41,7 +41,7 @@
                         "containerPort": {{.Port}},
                         "protocol": "TCP"
                     }],
-		    {{.ContainerResources }}
+                    {{.ContainerResources }}
                     "env": [{
                         "name": "PG_USERNAME",
                         "valueFrom": {

--- a/conf/postgres-operator/pgpool.conf
+++ b/conf/postgres-operator/pgpool.conf
@@ -316,8 +316,8 @@ follow_master_command = ''
                                    #   %H = hostname of the new master node
                                    #   %M = old master node id
                                    #   %P = old primary node id
-								   #   %r = new master port number
-								   #   %R = new master database cluster path
+                                   #   %r = new master port number
+                                   #   %R = new master database cluster path
                                    #   %% = '%' character
 
 
@@ -363,7 +363,7 @@ health_check_user = '{{.PG_USERNAME}}'
 health_check_password = '{{.PG_PASSWORD}}'
                                    # Password for health check user
 health_check_max_retries = 3
-connect_timeout = 10000 		# Timeout value in milliseconds before giving up to connect to backend.
+connect_timeout = 10000            # Timeout value in milliseconds before giving up to connect to backend.
 
                                    # Maximum number of times to retry a failed health check before giving up.
 health_check_retry_delay = 1
@@ -385,8 +385,8 @@ failover_command = ''
                                    #   %H = hostname of the new master node
                                    #   %M = old master node id
                                    #   %P = old primary node id
-								   #   %r = new master port number
-								   #   %R = new master database cluster path
+                                   #   %r = new master port number
+                                   #   %R = new master database cluster path
                                    #   %% = '%' character
 failback_command = ''
                                    # Executes this command at failback.
@@ -399,8 +399,8 @@ failback_command = ''
                                    #   %H = hostname of the new master node
                                    #   %M = old master node id
                                    #   %P = old primary node id
-								   #   %r = new master port number
-								   #   %R = new master database cluster path
+                                   #   %r = new master port number
+                                   #   %R = new master database cluster path
                                    #   %% = '%' character
 
 fail_over_on_backend_error = off
@@ -476,7 +476,7 @@ wd_authkey = ''
 
 delegate_IP = ''
                                     # delegate IP address
-                                    # If this is empty, virtual IP never bring up. 
+                                    # If this is empty, virtual IP never bring up.
                                     # (change requires restart)
 ifconfig_path = '/sbin'
                                     # ifconfig command path
@@ -508,7 +508,7 @@ wd_escalation_command = ''
                                     # Executes this command at escalation on new active pgpool.
                                     # (change requires restart)
 
-# - Lifecheck Setting - 
+# - Lifecheck Setting -
 
 # -- common --
 
@@ -534,7 +534,7 @@ heartbeat_destination0 = 'host0_ip1'
                                     # Host name or IP address of destination 0
                                     # for sending heartbeat signal.
                                     # (change requires restart)
-heartbeat_destination_port0 = 9694 
+heartbeat_destination_port0 = 9694
                                     # Port number of destination 0 for sending
                                     # heartbeat signal. Usually this is the
                                     # same as wd_heartbeat_port.
@@ -606,66 +606,66 @@ relcache_expire = 0
 relcache_size = 256
                                    # Number of relation cache
                                    # entry. If you see frequently:
-								   # "pool_search_relcache: cache replacement happend"
-								   # in the pgpool log, you might want to increate this number.
+                                   # "pool_search_relcache: cache replacement happend"
+                                   # in the pgpool log, you might want to increate this number.
 
 check_temp_table = on
                                    # If on, enable temporary table check in SELECT statements.
                                    # This initiates queries against system catalog of primary/master
-								   # thus increases load of master.
-								   # If you are absolutely sure that your system never uses temporary tables
-								   # and you want to save access to primary/master, you could turn this off.
-								   # Default is on.
+                                   # thus increases load of master.
+                                   # If you are absolutely sure that your system never uses temporary tables
+                                   # and you want to save access to primary/master, you could turn this off.
+                                   # Default is on.
 
 
 #------------------------------------------------------------------------------
 # ON MEMORY QUERY MEMORY CACHE
 #------------------------------------------------------------------------------
 memory_cache_enabled = off
-								   # If on, use the memory cache functionality, off by default
+                                   # If on, use the memory cache functionality, off by default
 memqcache_method = 'shmem'
-								   # Cache storage method. either 'shmem'(shared memory) or
-								   # 'memcached'. 'shmem' by default
+                                   # Cache storage method. either 'shmem'(shared memory) or
+                                   # 'memcached'. 'shmem' by default
                                    # (change requires restart)
 memqcache_memcached_host = 'localhost'
-								   # Memcached host name or IP address. Mandatory if
-								   # memqcache_method = 'memcached'.
-								   # Defaults to localhost.
+                                   # Memcached host name or IP address. Mandatory if
+                                   # memqcache_method = 'memcached'.
+                                   # Defaults to localhost.
                                    # (change requires restart)
 memqcache_memcached_port = 11211
-								   # Memcached port number. Mondatory if memqcache_method = 'memcached'.
-								   # Defaults to 11211.
+                                   # Memcached port number. Mondatory if memqcache_method = 'memcached'.
+                                   # Defaults to 11211.
                                    # (change requires restart)
 memqcache_total_size = 67108864
-								   # Total memory size in bytes for storing memory cache.
-								   # Mandatory if memqcache_method = 'shmem'.
-								   # Defaults to 64MB.
+                                   # Total memory size in bytes for storing memory cache.
+                                   # Mandatory if memqcache_method = 'shmem'.
+                                   # Defaults to 64MB.
                                    # (change requires restart)
 memqcache_max_num_cache = 1000000
-								   # Total number of cache entries. Mandatory
-								   # if memqcache_method = 'shmem'.
-								   # Each cache entry consumes 48 bytes on shared memory.
-								   # Defaults to 1,000,000(45.8MB).
+                                   # Total number of cache entries. Mandatory
+                                   # if memqcache_method = 'shmem'.
+                                   # Each cache entry consumes 48 bytes on shared memory.
+                                   # Defaults to 1,000,000(45.8MB).
                                    # (change requires restart)
 memqcache_expire = 0
-								   # Memory cache entry life time specified in seconds.
-								   # 0 means infinite life time. 0 by default.
+                                   # Memory cache entry life time specified in seconds.
+                                   # 0 means infinite life time. 0 by default.
                                    # (change requires restart)
 memqcache_auto_cache_invalidation = on
-								   # If on, invalidation of query cache is triggered by corresponding
-								   # DDL/DML/DCL(and memqcache_expire).  If off, it is only triggered
-								   # by memqcache_expire.  on by default.
+                                   # If on, invalidation of query cache is triggered by corresponding
+                                   # DDL/DML/DCL(and memqcache_expire).  If off, it is only triggered
+                                   # by memqcache_expire.  on by default.
                                    # (change requires restart)
 memqcache_maxcache = 409600
-								   # Maximum SELECT result size in bytes.
-								   # Must be smaller than memqcache_cache_block_size. Defaults to 400KB.
+                                   # Maximum SELECT result size in bytes.
+                                   # Must be smaller than memqcache_cache_block_size. Defaults to 400KB.
                                    # (change requires restart)
 memqcache_cache_block_size = 1048576
-								   # Cache block size in bytes. Mandatory if memqcache_method = 'shmem'.
-								   # Defaults to 1MB.
+                                   # Cache block size in bytes. Mandatory if memqcache_method = 'shmem'.
+                                   # Defaults to 1MB.
                                    # (change requires restart)
 memqcache_oiddir = '/var/log/pgpool/oiddir'
-				   				   # Temporary work directory to record table oids
+                                   # Temporary work directory to record table oids
                                    # (change requires restart)
 white_memqcache_table_list = ''
                                    # Comma separated list of table names to memcache

--- a/conf/postgres-operator/pgrestore-job.json
+++ b/conf/postgres-operator/pgrestore-job.json
@@ -3,22 +3,21 @@
     "kind": "Job",
     "metadata": {
         "name": "{{.JobName}}",
-	"labels": {
-	    "vendor": "crunchydata",
-	    "pgrestore": "true",
-	    "pg-cluster": "{{.ClusterName}}",
-  	    "pg-task": "{{.TaskName}}"
-
-                }
+        "labels": {
+            "vendor": "crunchydata",
+            "pgrestore": "true",
+            "pg-cluster": "{{.ClusterName}}",
+            "pg-task": "{{.TaskName}}"
+        }
     },
     "spec": {
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",
                 "labels": {
-		    "vendor": "crunchydata",
-		    "pgrestore": "true",
-		    "pg-cluster": "{{.ClusterName}}"
+                    "vendor": "crunchydata",
+                    "pgrestore": "true",
+                    "pg-cluster": "{{.ClusterName}}"
                 }
             },
             "spec": {
@@ -30,9 +29,9 @@
                         }
                     }
                 ],
-		
+
                     {{.SecurityContext}}
-                
+
                 "containers": [
                     {
                         "name": "pgrestore",
@@ -48,22 +47,22 @@
                             {
                                 "name": "PGRESTORE_USER",
                                 "valueFrom": {
-				    "secretKeyRef": {
-					"name": "{{.PgRestoreUserSecret}}",
-					"key": "username"
-				    }
-				}
+                                    "secretKeyRef": {
+                                        "name": "{{.PgRestoreUserSecret}}",
+                                        "key": "username"
+                                    }
+                                }
                             },
                             {
                                 "name": "PGRESTORE_PASS",
                                 "valueFrom": {
-				   "secretKeyRef": {
-				       "name": "{{.PgRestoreUserSecret}}",
-				       "key": "password"
-				    }
-				}
+                                    "secretKeyRef": {
+                                        "name": "{{.PgRestoreUserSecret}}",
+                                        "key": "password"
+                                    }
+                                }
                             },
-			    {
+                            {
                                 "name": "PGRESTORE_HOST",
                                 "value": "{{.PgRestoreHost}}"
                             },
@@ -71,18 +70,18 @@
                                 "name": "PGRESTORE_DB",
                                 "value": "{{.PgRestoreDB}}"
                             },
-			    {
-				"name": "PG_PRIMARY_PORT",
-				"value": "5432"
-			    },
-			    {
-				"name": "PGRESTORE_CUSTOM_OPTS",
-				"value": "{{.PGRestoreOpts}}"
-			    },
-			    {
-				"name": "PGRESTORE_BACKUP_TIMESTAMP",
-				"value": "{{.PITRTarget}}"
-			    }
+                            {
+                                "name": "PG_PRIMARY_PORT",
+                                "value": "5432"
+                            },
+                            {
+                                "name": "PGRESTORE_CUSTOM_OPTS",
+                                "value": "{{.PGRestoreOpts}}"
+                            },
+                            {
+                                "name": "PGRESTORE_BACKUP_TIMESTAMP",
+                                "value": "{{.PITRTarget}}"
+                            }
                         ]
                     }
                 ],

--- a/conf/postgres-operator/rmdata-job.json
+++ b/conf/postgres-operator/rmdata-job.json
@@ -3,14 +3,14 @@
     "kind": "Job",
     "metadata": {
         "name": "{{.JobName}}",
-	"labels": {
-        	"vendor": "crunchydata",
-               	"pgrmdata": "true",
-		"pg-cluster": "{{.ClusterName}}"
-	}
+        "labels": {
+            "vendor": "crunchydata",
+            "pgrmdata": "true",
+            "pg-cluster": "{{.ClusterName}}"
+        }
     },
     "spec": {
-	"backoffLimit": 0,
+        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",
@@ -21,11 +21,11 @@
                 }
             },
             "spec": {
-		"serviceAccountName": "pgo-target",
+                "serviceAccountName": "pgo-target",
                 "containers": [{
                     "name": "rmdata",
                     "image": "{{.PGOImagePrefix}}/pgo-rmdata:{{.PGOImageTag}}",
-		    {{.ContainerResources }}
+                    {{.ContainerResources }}
                     "env": [{
                         "name": "PG_CLUSTER",
                         "value": "{{.ClusterName}}"
@@ -46,11 +46,11 @@
                         "value": "{{.IsReplica}}"
                     }, {
                         "name": "NAMESPACE",
-			"valueFrom": {
-				"fieldRef": {
-					"fieldPath": "metadata.namespace"
-				}
-			}
+                        "valueFrom": {
+                            "fieldRef": {
+                                "fieldPath": "metadata.namespace"
+                            }
+                        }
                     }]
                 }],
                 "restartPolicy": "Never"

--- a/deploy/pgo-scc.yaml
+++ b/deploy/pgo-scc.yaml
@@ -10,7 +10,7 @@ apiVersion: security.openshift.io/v1
 defaultAddCapabilities: null
 fsGroup:
   type: MustRunAs
-  ranges: 
+  ranges:
   - max: 26
     min: 26
 groups:


### PR DESCRIPTION
To preserve whitespace, Kubernetes renders ConfigMap values with these artifacts as double-quoted scalars in YAML. Removing them makes it possible to `kubectl edit cm/pgo-config` with some effectiveness.

The Ansible template for `pgo.yaml` still renders some trailing spaces when some variables are unset.

---

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**Other information**:

```shell
git show -p -w
```
```patch
commit a2716511c7dce0bdb3fc11fda787d82641807d65
Author: Chris Bandy <chris.bandy@crunchydata.com>
Date:   Wed Nov 20 22:46:02 2019 -0600

    Remove trailing spaces and indent consistently with spaces in config
    
    To preserve whitespace, Kubernetes renders ConfigMap values with these
    artifacts as double-quoted scalars in YAML. Removing them makes it
    possible to `kubectl edit cm/pgo-config` with some effectiveness.
    
    The Ansible template for `pgo.yaml` still renders some trailing spaces
    when some variables are unset.

diff --git ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
index cd85f7fd5..25bbf2f8c 100644
--- ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -29,8 +29,6 @@
                 {{.SecurityContext }}
 
                 "containers": [
-        
-
             {
                     "name": "database",
                     "image": "{{.CCPImagePrefix}}/{{.CCPImage}}:{{.CCPImageTag}}",
@@ -115,7 +113,6 @@
                             "mountPath": "/recover",
                             "name": "recover-volume"
                         }
-
                     ],
 
                     "ports": [{
diff --git ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
index 6b4dc8f0b..4f8594b84 100644
--- ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
+++ ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
@@ -8,7 +8,6 @@
             "pgrestore": "true",
             "pg-cluster": "{{.ClusterName}}",
             "pg-task": "{{.TaskName}}"
-
         }
     },
     "spec": {
diff --git conf/postgres-operator/cluster-deployment.json conf/postgres-operator/cluster-deployment.json
index 861437f8f..2a10827a8 100644
--- conf/postgres-operator/cluster-deployment.json
+++ conf/postgres-operator/cluster-deployment.json
@@ -31,8 +31,6 @@
                 {{.SecurityContext }}
                 "serviceAccountName": "pgo-pg",
                 "containers": [
-        
-
             {
                     "name": "database",
                     "image": "{{.CCPImagePrefix}}/{{.CCPImage}}:{{.CCPImageTag}}",
@@ -156,7 +154,6 @@
                             "mountPath": "/crunchyadm",
                             "name": "crunchyadm"
                         }
-                        
                     ],
 
                     "ports": [{
@@ -287,4 +284,3 @@
         }
     }
 }
- 
\ No newline at end of file
diff --git conf/postgres-operator/pgrestore-job.json conf/postgres-operator/pgrestore-job.json
index 6b4dc8f0b..4f8594b84 100644
--- conf/postgres-operator/pgrestore-job.json
+++ conf/postgres-operator/pgrestore-job.json
@@ -8,7 +8,6 @@
             "pgrestore": "true",
             "pg-cluster": "{{.ClusterName}}",
             "pg-task": "{{.TaskName}}"
-
         }
     },
     "spec": {
```