### PR TITLE
[ch6204] Enable pgBouncer to connect to additional database

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer.ini
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer.ini
@@ -1,5 +1,5 @@
 [databases]
-{{.PG_PRIMARY_SERVICE_NAME}} = host={{.PG_PRIMARY_SERVICE_NAME}} port={{.PG_PORT}} auth_user={{.PG_USERNAME}} dbname={{.PG_DATABASE}}
+* = host={{.PG_PRIMARY_SERVICE_NAME}} port={{.PG_PORT}} auth_user={{.PG_USERNAME}}
 
 [pgbouncer]
 listen_port = 5432

--- a/conf/postgres-operator/pgbouncer.ini
+++ b/conf/postgres-operator/pgbouncer.ini
@@ -1,5 +1,5 @@
 [databases]
-{{.PG_PRIMARY_SERVICE_NAME}} = host={{.PG_PRIMARY_SERVICE_NAME}} port={{.PG_PORT}} auth_user={{.PG_USERNAME}} dbname={{.PG_DATABASE}}
+* = host={{.PG_PRIMARY_SERVICE_NAME}} port={{.PG_PORT}} auth_user={{.PG_USERNAME}}
 
 [pgbouncer]
 listen_port = 5432

--- a/operator/cluster/pgbouncer.go
+++ b/operator/cluster/pgbouncer.go
@@ -181,7 +181,7 @@ func AddPgbouncerFromTask(clientset *kubernetes.Clientset, restclient *rest.REST
 			Timestamp: time.Now(),
 			EventType: events.EventCreatePgbouncer,
 		},
-		Clustername:       clusterName,
+		Clustername: clusterName,
 	}
 
 	err = events.Publish(f)
@@ -250,7 +250,7 @@ func DeletePgbouncerFromTask(clientset *kubernetes.Clientset, restclient *rest.R
 			Timestamp: time.Now(),
 			EventType: events.EventDeletePgbouncer,
 		},
-		Clustername:       clusterName,
+		Clustername: clusterName,
 	}
 
 	err = events.Publish(f)
@@ -593,7 +593,7 @@ func getDatabaseListForCredentials(namespace, clusterName string, clientSet *kub
 
 	// get a list of database names from postgres
 	var rows *sql.Rows
-	querystr := "SELECT datname FROM pg_database WHERE datname NOT IN ('template0', 'template1')"
+	querystr := "SELECT datname FROM pg_database WHERE datname NOT IN ('template0')"
 	rows, err = conn.Query(querystr)
 	if err != nil {
 		log.Debug(err.Error())


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The previous configuration for pgBouncer would not allow it to work with
any PostgreSQL databases that were created after the initial deployment
of the Operator.

**What is the new behavior (if this is a feature change)?**

This leverages the "catch-all" feature of pgBouncer (i.e. "*") to point
to any database that is associated with the primary PostgreSQL service.

Additionally, this installs the pgBouncer "get_auth" function into
the "template1" database to ensure that it is available in any newly
created databases.

For existing deployments of the Operator, one needs to update their
"pgbouncer.ini" files. The installation templates for the pgBouncer
files are updated to support this chaange.

This change continues to work with the changes to the HA system as it
references the primary service only.

**Other information**:

Issue: [ch6204]