### PR TITLE
[ch5479] Ensure `pgo test` shows instances in "unknown" state

### DIFF
--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -378,6 +378,8 @@ func TestCluster(name, selector, ns, pgouser string, allFlag bool) msgs.ClusterT
 				Message:   pod.Name,
 			}
 			switch pod.Type {
+			default:
+				instance.InstanceType = msgs.ClusterTestInstanceTypeUnknown
 			case msgs.PodTypePrimary:
 				instance.InstanceType = msgs.ClusterTestInstanceTypePrimary
 			case msgs.PodTypeReplica:

--- a/apiservermsgs/clustermsgs.go
+++ b/apiservermsgs/clustermsgs.go
@@ -218,6 +218,7 @@ const (
 	ClusterTestInstanceTypeReplica   = "replica"
 	ClusterTestInstanceTypePGBouncer = "pgbouncer"
 	ClusterTestInstanceTypeBackups   = "backups"
+	ClusterTestInstanceTypeUnknown   = "unknown"
 )
 
 // ClusterTestDetail provides the output of an individual test that is performed


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

When a PostgreSQL instance is in an indeterminate state, e.g. during
initialization or when healing after a failover event, the type of
instance is unknown. However, `pgo test`, and by extension the test
endpoint in the `apiserver`, were not returning the status of the
instances that were in this state.

**What is the new behavior (if this is a feature change)?**

This patch corrects this by allowing instances to have a type of
"unknown".

Issue: [ch5479]