### PR TITLE
prevents misleading error-level logs

### DIFF
--- a/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -29,12 +29,20 @@
                             { "containerPort": {{ pgo_apiserver_port }} }
                         ],
                         "readinessProbe": {
-                            "tcpSocket": { "port": {{ pgo_apiserver_port }} },
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": {{ pgo_apiserver_port }},
+                                "scheme": "HTTPS"
+                            },
                             "initialDelaySeconds": 15,
                             "periodSeconds": 5
                         },
                         "livenessProbe": {
-                            "tcpSocket": { "port": {{ pgo_apiserver_port }} },
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": {{ pgo_apiserver_port }},
+                                "scheme": "HTTPS"
+                            },
                             "initialDelaySeconds": 15,
                             "periodSeconds": 5
                         },
@@ -183,13 +191,11 @@
                         "image": "{% if pgo_event_image | default('') != '' %}{{ pgo_event_image }}
                                 {%- else %}{{ pgo_image_prefix }}/pgo-event:{{ pgo_image_tag }}
                                 {%- endif %}",
-                        "readinessProbe": {
-                            "tcpSocket": { "port": 4150 },
-                            "initialDelaySeconds": 15,
-                            "periodSeconds": 5
-                        },
                         "livenessProbe": {
-                            "tcpSocket": { "port": 4150 },
+                            "httpGet": {
+                                "path": "/ping",
+                                "port": 4151,
+                            },
                             "initialDelaySeconds": 15,
                             "periodSeconds": 5
                         },

--- a/apiserver/middleware.go
+++ b/apiserver/middleware.go
@@ -33,7 +33,8 @@ type certEnforcer struct {
 func NewCertEnforcer(reqRoutes []string) (*certEnforcer, error) {
 	allowed := map[string]struct{}{
 		// List of allowed routes is part of the published documentation
-		"/health": struct{}{},
+		"/health":  struct{}{},
+		"/healthz": struct{}{},
 	}
 
 	ce := &certEnforcer{

--- a/apiserver/versionservice/versionservice.go
+++ b/apiserver/versionservice/versionservice.go
@@ -75,3 +75,20 @@ func HealthHandler(w http.ResponseWriter, r *http.Request) {
 
 	json.NewEncoder(w).Encode(resp)
 }
+
+// HealthyHandler follows the health endpoint convention of HTTP/200 and
+// body "ok" used by other cloud services, typically on /healthz
+func HealthyHandler(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation GET /healthz versionservice healthz
+	/*```
+
+	 */
+	// ---
+	//  produces:
+	//  - text/plain
+	//  responses:
+	//    '200':
+	//      description: Healthy: server is responding as expected
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}

--- a/bin/pgo-event/pgo-event.sh
+++ b/bin/pgo-event/pgo-event.sh
@@ -31,7 +31,7 @@ sleep 3
 
 echo "pgo-event starting nsqd"
 
-/usr/local/bin/nsqd --data-path=/tmp --http-address=0.0.0.0:4151 --tcp-address=0.0.0.0:4150 &
+/usr/local/bin/nsqd --data-path=/tmp --http-address=0.0.0.0:4151 --tcp-address=0.0.0.0:4150 --log-level=warn &
 
 echo "pgo-event waiting till sigterm"
 

--- a/deploy/deployment.json
+++ b/deploy/deployment.json
@@ -27,12 +27,20 @@
                             { "containerPort": $PGO_APISERVER_PORT }
                         ],
                         "readinessProbe": {
-                            "tcpSocket": { "port": $PGO_APISERVER_PORT },
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": $PGO_APISERVER_PORT,
+                                "scheme": "HTTPS"
+                            },
                             "initialDelaySeconds": 15,
                             "periodSeconds": 5
                         },
                         "livenessProbe": {
-                            "tcpSocket": { "port": $PGO_APISERVER_PORT },
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": $PGO_APISERVER_PORT,
+                                "scheme": "HTTPS"
+                            },
                             "initialDelaySeconds": 15,
                             "periodSeconds": 5
                         },
@@ -175,13 +183,11 @@
                     }, {
                         "name": "event",
                         "image": "$PGO_IMAGE_PREFIX/pgo-event:$PGO_IMAGE_TAG",
-                        "readinessProbe": {
-                            "tcpSocket": { "port": 4150 },
-                            "initialDelaySeconds": 15,
-                            "periodSeconds": 5
-                        },
                         "livenessProbe": {
-                            "tcpSocket": { "port": 4150 },
+                            "httpGet": {
+                                "path": "/ping",
+                                "port": 4151
+                            },
                             "initialDelaySeconds": 15,
                             "periodSeconds": 5
                         },

--- a/hugo/content/Configuration/configuration.md
+++ b/hugo/content/Configuration/configuration.md
@@ -96,9 +96,8 @@ this setting:
 /health
 ```
 
-If the health route has its authentication disabled, the existing readiness
-and liveness probes for the apiserver container could be enhanced by
-configuring them with HTTP-based checks against the health route.
+The `/healthz` route is used by kubernetes probes and has its authentication
+disabed without requiring NOAUTH_ROUTES.
 
 
 ## Security


### PR DESCRIPTION
The apiserver and nsqd processes do not gracefully handle the
empty TCP connections generated by kubelet as part of probe
execution, causing misleading error messages to accumulate
in the logs at the probe polling intervals.

For the nsqd process, there exists an HTTP endpoint that can
be used for liveness testing, but it not useful for readiness
testing as the `/ping` endpoint does not reflect readiness
for connections on port 4150. Thus, the liveness test is moved
to an HTTP test of the `/ping` endpoint and the readiness test
is removed.

Furthermore, each access to `/ping` is logged as an INFO level
log in the nsqd log files. While this is not as misleading as
ERROR level logging, it still represents unnecessary logging
and the log level for the nsqd process has been moved up to
WARNING.

For the pgo-apiserver, a new lightweight route is added to
the conventional location of `/healthz` with a simple `ok`
response with the HTTP 200.

As a result, NOAUTH_ROUTES no longer optionally activates
deferred certificate checking - it is required to support
`/healthz` as kubelet does not present a certificate when
performing HTTPS checks.

NOAUTH_ROUTES may still be used to enable unauthenticated
access to the existing whitelist of routes.

[ch6359]
[ch6452]

Related Issues:
#1111, #1119 

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
