### PR TITLE
Remove 30 Second Sleep that Currently Occurs Prior to Creating the pgBackRest Stanza

### DIFF
--- a/pgo-backrest/pgo-backrest.go
+++ b/pgo-backrest/pgo-backrest.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/kubeapi"
@@ -104,8 +103,6 @@ func main() {
 	switch COMMAND {
 	case crv1.PgtaskBackrestStanzaCreate:
 		log.Info("backrest stanza-create command requested")
-		time.Sleep(time.Second * time.Duration(30))
-		log.Info("sleeping 30 seconds to avoid race with PG during startup")
 		cmdStrs = append(cmdStrs, backrestCommand)
 		cmdStrs = append(cmdStrs, backrestStanzaCreateCommand)
 		cmdStrs = append(cmdStrs, COMMAND_OPTS)


### PR DESCRIPTION
Removes the 30 second sleep that occurs prior to running the `pgbackrest stanza-create` command in the `pgo-backrest` container.  Sleeping is no longer necessary since stanza creation will not be executed before the cluster has been fully initialized (i.e. there is no longer the potential for a race condition with PG startup).  This change should reduce cluster creation time by approximately 30 seconds.



**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

A 30 second sleep occurs before pgBackRest stanza creation for a new PG cluster.

**What is the new behavior (if this is a feature change)?**

There is no longer any sleep prior to creating the stanza for a new PG cluster.

**Other information**:

N/A