### PR TITLE
[ch6369] Migrate "extensions/v1beta1" API usage to modern apiGroups

### DIFF
--- a/ansible/roles/pgo-metrics/templates/grafana-deployment.json.j2
+++ b/ansible/roles/pgo-metrics/templates/grafana-deployment.json.j2
@@ -1,11 +1,17 @@
 {
-    "apiVersion": "extensions/v1beta1",
+    "apiVersion": "apps/v1",
     "kind": "Deployment",
     "metadata": {
         "name": "crunchy-grafana"
     },
     "spec": {
         "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "name": "{{ grafana_service_name }}",
+            "vendor": "crunchydata"
+          }
+        },
         "template": {
             "metadata": {
                 "labels": {

--- a/ansible/roles/pgo-metrics/templates/prometheus-deployment.json.j2
+++ b/ansible/roles/pgo-metrics/templates/prometheus-deployment.json.j2
@@ -1,11 +1,17 @@
 {
-    "apiVersion": "extensions/v1beta1",
+    "apiVersion": "apps/v1",
     "kind": "Deployment",
     "metadata": {
         "name": "crunchy-prometheus"
     },
     "spec": {
         "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "name": "{{ prometheus_service_name }}",
+            "vendor": "crunchydata"
+          }
+        },
         "template": {
             "metadata": {
                 "labels": {

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo-target-role.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo-target-role.json
@@ -66,25 +66,13 @@
         },
         {
             "apiGroups": [
-                "batch",
-                "extensions"
+                "batch"
             ],
             "resources": [
                 "jobs"
             ],
             "verbs": [
                 "*"
-            ]
-        },
-        {
-            "apiGroups": [
-                "extensions"
-            ],
-            "resources": [
-                "deployments"
-            ],
-            "verbs": [
-                "patch"
             ]
         }
     ]

--- a/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -1,5 +1,5 @@
 {
-    "apiVersion": "extensions/v1beta1",
+    "apiVersion": "apps/v1",
     "kind": "Deployment",
     "metadata": {
         "name": "postgres-operator",
@@ -9,6 +9,12 @@
     },
     "spec": {
         "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "name": "postgres-operator",
+                "vendor": "crunchydata"
+            }
+        },
         "template": {
             "metadata": {
                 "labels": {

--- a/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
@@ -47,15 +47,8 @@ rules:
       - '*'
     apiGroups:
       - 'batch'
-      - 'extensions'
     resources:
       - jobs
-  - verbs:
-      - 'patch'
-    apiGroups:
-      - 'extensions'
-    resources:
-      - deployments
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/apiserver/labelservice/labelimpl.go
+++ b/apiserver/labelservice/labelimpl.go
@@ -212,7 +212,7 @@ func updateLabels(deployment *v1.Deployment, clusterName string, newLabels map[s
 		return err
 	}
 
-	_, err = apiserver.Clientset.ExtensionsV1beta1().Deployments(ns).Patch(clusterName, types.MergePatchType, patchBytes, "")
+	_, err = apiserver.Clientset.AppsV1().Deployments(ns).Patch(clusterName, types.MergePatchType, patchBytes, "")
 	if err != nil {
 		log.Debugf("error updating patching deployment %s", err.Error())
 	}
@@ -475,7 +475,7 @@ func deleteTheLabel(deployment *v1.Deployment, clusterName string, labelsMap map
 		return err
 	}
 
-	_, err = apiserver.Clientset.ExtensionsV1beta1().Deployments(ns).Patch(deployment.Name, types.MergePatchType, patchBytes, "")
+	_, err = apiserver.Clientset.AppsV1().Deployments(ns).Patch(deployment.Name, types.MergePatchType, patchBytes, "")
 	if err != nil {
 		log.Debugf("error patching deployment ", err.Error())
 	}

--- a/conf/postgres-operator/pgo-target-role.json
+++ b/conf/postgres-operator/pgo-target-role.json
@@ -66,8 +66,7 @@
         },
         {
             "apiGroups": [
-                "batch",
-                "extensions"
+                "batch"
             ],
             "resources": [
                 "jobs"
@@ -78,7 +77,7 @@
         },
         {
             "apiGroups": [
-                "extensions"
+                "apps"
             ],
             "resources": [
                 "deployments"

--- a/deploy/deployment.json
+++ b/deploy/deployment.json
@@ -1,5 +1,5 @@
 {
-    "apiVersion": "extensions/v1beta1",
+    "apiVersion": "apps/v1",
     "kind": "Deployment",
     "metadata": {
         "name": "postgres-operator",
@@ -9,6 +9,12 @@
     },
     "spec": {
         "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "name": "postgres-operator",
+                "vendor": "crunchydata"
+            }
+        },
         "template": {
             "metadata": {
                 "labels": {
@@ -180,7 +186,8 @@
                         "volumeMounts": [],
                         "resources": {},
                         "imagePullPolicy": "IfNotPresent"
-                    }, {
+                    },
+                    {
                         "name": "event",
                         "image": "$PGO_IMAGE_PREFIX/pgo-event:$PGO_IMAGE_TAG",
                         "livenessProbe": {

--- a/deploy/ingress.yml
+++ b/deploy/ingress.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: postgres-operator

--- a/deploy/roles.yaml
+++ b/deploy/roles.yaml
@@ -47,12 +47,5 @@ rules:
       - '*'
     apiGroups:
       - 'batch'
-      - 'extensions'
     resources:
       - jobs
-  - verbs:
-      - 'patch'
-    apiGroups:
-      - 'extensions'
-    resources:
-      - deployments

--- a/examples/olm/bundle/zip-metadata/postgresoperator.v4.0.0-rc10.csv.yaml
+++ b/examples/olm/bundle/zip-metadata/postgresoperator.v4.0.0-rc10.csv.yaml
@@ -132,7 +132,7 @@ metadata:
               "namespace": "test-operator"
           },
           "spec": {}
-      }] 
+      }]
     categories: Database
     capabilities: Full Lifecycle
     certified: "true"
@@ -478,10 +478,8 @@ spec:
           - '*'
         - apiGroups:
           - batch
-          - extensions
           resources:
           - jobs
-          - deployments
           verbs:
           - '*'
         serviceAccountName: postgres-operator

--- a/kubeapi/deployment.go
+++ b/kubeapi/deployment.go
@@ -22,7 +22,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/apps/v1"
 
-	//	"k8s.io/api/extensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/util/util.go
+++ b/util/util.go
@@ -134,7 +134,7 @@ func DrainDeployment(clientset *kubernetes.Clientset, name string, namespace str
 	}
 	log.Debug(string(patchBytes))
 
-	_, err = clientset.ExtensionsV1beta1().Deployments(namespace).Patch(name, types.JSONPatchType, patchBytes, "")
+	_, err = clientset.AppsV1().Deployments(namespace).Patch(name, types.JSONPatchType, patchBytes, "")
 	if err != nil {
 		log.Error("error patching deployment " + err.Error())
 	}
@@ -198,7 +198,7 @@ func ScaleDeployment(clientset *kubernetes.Clientset, deploymentName, namespace 
 	}
 	log.Debug(string(patchBytes))
 
-	_, err = clientset.ExtensionsV1beta1().Deployments(namespace).Patch(deploymentName, types.JSONPatchType, patchBytes)
+	_, err = clientset.AppsV1().Deployments(namespace).Patch(deploymentName, types.JSONPatchType, patchBytes)
 	if err != nil {
 		log.Error("error creating primary Deployment " + err.Error())
 		return err

--- a/util/waituntil.go
+++ b/util/waituntil.go
@@ -111,7 +111,7 @@ func WaitUntilDeploymentIsDeleted(clientset *kubernetes.Clientset, depname strin
 	var fw watch.Interface
 
 	lo := meta_v1.ListOptions{LabelSelector: "name=" + depname}
-	fw, err = clientset.ExtensionsV1beta1().Deployments(namespace).Watch(lo)
+	fw, err = clientset.AppsV1().Deployments(namespace).Watch(lo)
 	if err != nil {
 		log.Error("error watching deployments " + err.Error())
 		return err


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

Kubernetes 1.16 removes the "extensions/v1beta1" apiGroup in favors of various
other apiGroups, including "apps/v1", "networking.k8s.io/v1", et al.

**What is the new behavior (if this is a feature change)?**

This removes all of the existing calls and reliance upon "extensions/v1beta1"
and ensures compatibility with Kubernetes 1.16 and beyond from this standpoint,
while still keeping compatibility with Kubernetes 1.11.

**Other information**:

Original Pull Request: #1023 
Issue: [ch6369]