### PR TITLE
[ch6369] Ensure RBAC functions use "rbac.authorization.k8s.io/v1" API

### DIFF
--- a/ansible/roles/pgo-metrics/templates/prometheus-rbac.json.j2
+++ b/ansible/roles/pgo-metrics/templates/prometheus-rbac.json.j2
@@ -1,5 +1,5 @@
 {
-    "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+    "apiVersion": "rbac.authorization.k8s.io/v1",
     "kind": "ClusterRole",
     "metadata": {
         "name": "{{ metrics_namespace }}-prometheus-sa"
@@ -33,7 +33,7 @@
 }
 
 {
-    "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+    "apiVersion": "rbac.authorization.k8s.io/v1",
     "kind": "ClusterRoleBinding",
     "metadata": {
         "name": "{{ metrics_namespace }}-prometheus-sa"

--- a/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ pgo_operator_namespace }}
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-cluster-role
 rules:
@@ -20,7 +20,7 @@ rules:
       - roles
       - rolebindings
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pgo-cluster-role

--- a/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
@@ -1,6 +1,6 @@
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-role
   namespace: {{ pgo_operator_namespace }}
@@ -57,7 +57,7 @@ rules:
     resources:
       - deployments
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pgo-role

--- a/deploy/cluster-role-bindings.yaml
+++ b/deploy/cluster-role-bindings.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pgo-cluster-role

--- a/deploy/cluster-roles-readonly.yaml
+++ b/deploy/cluster-roles-readonly.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-cluster-role
 rules:
@@ -14,4 +14,3 @@ rules:
       - serviceaccounts
       - roles
       - rolebindings
-

--- a/deploy/cluster-roles.yaml
+++ b/deploy/cluster-roles.yaml
@@ -1,6 +1,6 @@
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-cluster-role
 rules:

--- a/deploy/role-bindings.yaml
+++ b/deploy/role-bindings.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pgo-role

--- a/deploy/roles.yaml
+++ b/deploy/roles.yaml
@@ -1,6 +1,6 @@
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-role
   namespace: $PGO_OPERATOR_NAMESPACE


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Some of the RBAC rules were still using rbac.authorization.k8s.io/v1beta1,
which becomes deprecated in Kubernetes 1.17.

**What is the new behavior (if this is a feature change)?**

Ensure RBAC functions use "rbac.authorization.k8s.io/v1" API As the V1 API was introduced in Kubernetes 1.8, we can just move forward to using it.

**Other information**:

Issue: [ch6369]