### PR TITLE
[ch6494] Update `pgo scaledown --query` / `pgo failover --query`

### DIFF
--- a/apiserver/clusterservice/scaleimpl.go
+++ b/apiserver/clusterservice/scaleimpl.go
@@ -16,9 +16,7 @@ limitations under the License.
 */
 
 import (
-	"encoding/json"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -30,33 +28,9 @@ import (
 	"github.com/crunchydata/postgres-operator/util"
 
 	log "github.com/sirupsen/logrus"
-	apps_v1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/apps/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-// instance info is a struct used to store the results of a query to find out
-// information about an instance in a cluster
-type instanceInfo struct {
-	Name           string `json:"Member"`
-	Type           string `json:"Role"`
-	ReplicationLag int    `json:"Lag in MB"`
-	State          string
-	Timeline       int `json:"TL"`
-}
-
-// instanceInfoPrimary is the label used by Patroni to indicate that an instance
-// is indeed a primary PostgreSQL instance
-const instanceInfoPrimary = "Leader"
-
-var (
-	// instanceNamePattern is a regular expression usd to get the cluster instance
-	instanceNamePattern = regexp.MustCompile("^([a-zA-Z0-9]+(-[a-zA-Z0-9]{4})?)-")
-	// instanceInfoCommand is the command used to get information about the status
-	// and other statistics about the instances in a PostgreSQL cluster, e.g.
-	// replication lag
-	instanceInfoCommand = []string{"patronictl", "list", "-f", "json"}
 )
 
 // ScaleCluster ...
@@ -218,8 +192,10 @@ func ScaleCluster(name, replicaCount, resourcesConfig, storageConfig, nodeLabel,
 func ScaleQuery(name, ns string) msgs.ScaleQueryResponse {
 	var err error
 
-	response := msgs.ScaleQueryResponse{}
-	response.Status = msgs.Status{Code: msgs.Ok, Msg: ""}
+	response := msgs.ScaleQueryResponse{
+		Results: make([]msgs.ScaleQueryTargetSpec, 0),
+		Status:  msgs.Status{Code: msgs.Ok, Msg: ""},
+	}
 
 	cluster := crv1.Pgcluster{}
 	err = apiserver.RESTClient.Get().
@@ -243,13 +219,20 @@ func ScaleQuery(name, ns string) msgs.ScaleQueryResponse {
 		return response
 	}
 
-	//get replica pods using selector pg-cluster=clusterName-replica,role=replica
-	selector := config.LABEL_PG_CLUSTER + "=" + name + "," + config.LABEL_PGHA_ROLE + "=replica"
-	log.Debugf(`searching for pods with "%s"`, selector)
+	// Get information about the current status of all of the replicas. This is
+	// handled by a helper function, that will return the information in a struct
+	// with the key elements to help the user understand the current state of the
+	// replicas in a cluster
+	replicationStatusRequest := util.ReplicationStatusRequest{
+		RESTConfig:  apiserver.RESTConfig,
+		Clientset:   apiserver.Clientset,
+		Namespace:   ns,
+		ClusterName: name,
+	}
 
-	pods, err := kubeapi.GetPods(apiserver.Clientset, selector, ns)
+	replicationStatusResponse, err := util.ReplicationStatus(replicationStatusRequest)
 
-	// If there is an error trying to get the pods, return here
+	// if an error is return, log the message, and return the response
 	if err != nil {
 		log.Error(err.Error())
 		response.Status.Code = msgs.Error
@@ -257,55 +240,21 @@ func ScaleQuery(name, ns string) msgs.ScaleQueryResponse {
 		return response
 	}
 
-	// Begin to prepare returning the results
-	response.Results = make([]msgs.ScaleQueryTargetSpec, 0)
-
-	log.Debugf(`pods found "%d"`, len(pods.Items))
-
-	// if no replicas are found, then return here
-	if len(pods.Items) == 0 {
+	// if there are no results, return the response as is
+	if len(replicationStatusResponse.Instances) == 0 {
 		return response
 	}
 
-	// First, we need to create a quick map of "instance name" => node name
-	// We will iterate through the pod list once to extract the name we refere to
-	// the specific instance as, as well as which node it is deployed on
-	instanceNodeMap := createInstanceNodeMap(pods)
-
-	// Now get the statistics about the current state of the replicas, which we
-	// can delegate to Patroni vis-a-vis the information that it collects
-	instanceInfoList, err := createInstanceInfoList(ns, pods)
-
-	// if there is an error, record it here and return
-	if err != nil {
-		log.Error(err.Error())
-		response.Status.Code = msgs.Error
-		response.Status.Msg = err.Error()
-		return response
-	}
-
-	// iterate through the results of the raw data, pick out any replicas,
-	// and add them to the array
-	for _, instance := range instanceInfoList {
-		// if this is a primary, skip it
-		if instance.Type == instanceInfoPrimary {
-			continue
-		}
-
-		// create an result for the response
+	// iterate through response results to create the API response
+	for _, instance := range replicationStatusResponse.Instances {
+		// create a result for the response
 		result := msgs.ScaleQueryTargetSpec{
-			Status:         instance.State,
+			Name:           instance.Name,
+			Node:           instance.Node,
+			Status:         instance.Status,
 			ReplicationLag: instance.ReplicationLag,
 			Timeline:       instance.Timeline,
 		}
-
-		// get the instance name that is recognize by the Operator, which is the
-		// first part of the name
-		result.Name = instanceNamePattern.FindStringSubmatch(instance.Name)[1]
-
-		// get the node that the replica is on based on the "replica name" for this
-		// instance
-		result.Node = instanceNodeMap[result.Name]
 
 		// append the result to the response list
 		response.Results = append(response.Results, result)
@@ -344,7 +293,7 @@ func ScaleDown(deleteData bool, clusterName, replicaName, ns string) msgs.ScaleD
 	}
 
 	//if this was the last replica then remove the replica service
-	var replicaList *apps_v1.DeploymentList
+	var replicaList *v1.DeploymentList
 	selector := config.LABEL_PG_CLUSTER + "=" + clusterName + "," + config.LABEL_SERVICE_NAME + "=" + clusterName + "-replica"
 	replicaList, err = kubeapi.GetDeployments(apiserver.Clientset, selector, ns)
 	if err != nil {
@@ -387,52 +336,4 @@ func ScaleDown(deleteData bool, clusterName, replicaName, ns string) msgs.ScaleD
 
 	response.Results = append(response.Results, "deleted Pgreplica "+replicaName)
 	return response
-}
-
-// makeInstanceNodeMap creates an mapping between the names of the PostgreSQL
-// instances to the Nodes that they run on, based upon the output from a
-// Kubernetes API query
-func createInstanceNodeMap(pods *v1.PodList) map[string]string {
-	instanceNodeMap := map[string]string{}
-
-	// Iterate through each pod that is return and get the mapping between the
-	// PostgreSQL instance name and the node it is scheduled on
-	for _, pod := range pods.Items {
-		// get the replica name from the metadata on the pod
-		// for legacy purposes, we are using the "deployment name" label
-		replicaName := pod.ObjectMeta.Labels[config.LABEL_DEPLOYMENT_NAME]
-		// get the node name from the spec on the pod
-		nodeName := pod.Spec.NodeName
-		// add them to the map
-		instanceNodeMap[replicaName] = nodeName
-	}
-
-	return instanceNodeMap
-}
-
-// createInstanceInfo execs into a single pod that is returned in the collection
-// and looks up the information that Patroni gives about each instance in the
-// PostgreSQL cluster. This is returned to us in a JSON-parseable string,
-// which, if valid, we can process and create a list of "instanceInfo` structs
-func createInstanceInfoList(namespace string, pods *v1.PodList) ([]instanceInfo, error) {
-	instanceInfoList := []instanceInfo{}
-
-	// We can get the statistics about the current state of the managed instance
-	// From executing and running a command in the first pod
-	pod := pods.Items[0]
-
-	commandStdOut, _, err := kubeapi.ExecToPodThroughAPI(
-		apiserver.RESTConfig, apiserver.Clientset, instanceInfoCommand,
-		pod.Spec.Containers[0].Name, pod.Name, namespace, nil)
-
-	// if there is an error, return. We will log the error at a higher level
-	if err != nil {
-		return instanceInfoList, err
-	}
-
-	// parse the JSON and plast it into instanceInfoList
-	json.Unmarshal([]byte(commandStdOut), &instanceInfoList)
-
-	// return the list here
-	return instanceInfoList, nil
 }

--- a/apiservermsgs/clustermsgs.go
+++ b/apiservermsgs/clustermsgs.go
@@ -249,17 +249,17 @@ type ClusterTestResponse struct {
 // ScaleQueryTargetSpec
 // swagger:model
 type ScaleQueryTargetSpec struct {
-	Name        string
-	ReadyStatus string
-	Node        string
-	RepStatus   string
+	Name           string // the name of the PostgreSQL instance
+	Node           string // the node that the instance is running on
+	ReplicationLag int    // how far behind the instance is behind the primary, in MB
+	Status         string // the current status of the instance
+	Timeline       int    // the timeline the replica is on; timelines are adjusted after failover events
 }
 
 // ScaleQueryResponse
 // swagger:model
 type ScaleQueryResponse struct {
-	Results []string
-	Targets []ScaleQueryTargetSpec
+	Results []ScaleQueryTargetSpec
 	Status
 }
 

--- a/apiservermsgs/failovermsgs.go
+++ b/apiservermsgs/failovermsgs.go
@@ -17,23 +17,21 @@ limitations under the License.
 
 import ()
 
-// FailoverTargetSpec ...
+// FailoverTargetSpec
 // swagger:model
 type FailoverTargetSpec struct {
-	Name            string
-	ReadyStatus     string
-	Node            string
-	PreferredNode   bool
-	RepStatus       string
-	ReceiveLocation uint64
-	ReplayLocation  uint64
+	Name           string // the name of the PostgreSQL instance
+	Node           string // the node that the instance is running on
+	PreferredNode  bool   // if stored in the Operator configuration, a preferred node to failover to
+	ReplicationLag int    // how far behind the instance is behind the primary, in MB
+	Status         string // the current status of the instance
+	Timeline       int    // the timeline the replica is on; timelines are adjusted after failover events
 }
 
 // QueryFailoverResponse ...
 // swagger:model
 type QueryFailoverResponse struct {
-	Results []string
-	Targets []FailoverTargetSpec
+	Results []FailoverTargetSpec
 	Status
 }
 

--- a/util/failover.go
+++ b/util/failover.go
@@ -80,47 +80,6 @@ var (
 	instanceNamePattern = regexp.MustCompile("^([a-zA-Z0-9]+(-[a-zA-Z0-9]{4})?)-")
 )
 
-// GetBestTarget
-func GetBestTarget(clientset *kubernetes.Clientset, clusterName, namespace string) (*v1.Pod, *appsv1.Deployment, error) {
-
-	var err error
-
-	//get all the replica deployment pods for this cluster
-	var pod v1.Pod
-	var deployment appsv1.Deployment
-
-	//get all the deployments that are replicas for this clustername
-
-	var pods *v1.PodList
-
-	selector := config.LABEL_PG_CLUSTER + "=" + clusterName + "," + config.LABEL_SERVICE_NAME + "=" + clusterName + "-replica"
-
-	pods, err = kubeapi.GetPods(clientset, selector, namespace)
-	if err != nil {
-		return &pod, &deployment, err
-	}
-
-	if len(pods.Items) == 0 {
-		return &pod, &deployment, errors.New("no replica pods found for cluster " + clusterName)
-	}
-
-	for _, p := range pods.Items {
-		pod = p
-		log.Debugf("pod found for replica %s", pod.Name)
-		if len(pods.Items) == 1 {
-			log.Debug("only 1 pod found for failover best match..using it by default")
-			return &pod, &deployment, err
-		}
-
-		for _, c := range pod.Spec.Containers {
-			log.Debugf("container %s found in pod", c.Name)
-		}
-
-	}
-
-	return &pod, &deployment, err
-}
-
 // GetPod determines the best target to fail to
 func GetPod(clientset *kubernetes.Clientset, deploymentName, namespace string) (*v1.Pod, error) {
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The original genesis of this was to fix a bug that was shown in 053387c to ensure that a replica that was not currently matched with a primary could still have its information displayed without breaking the `pgo scaledown --query` and `pgo failover --query` commands.

However, this turned into an inspection of the information that these commands are returning and it was decided to make it a bit more helpful.

The commands provided information that could help a
user make a decision about which instance in a PostgreSQL cluster they
would want to fail over to, it could be challenging to decipher as not
everyone is versed in PostgreSQL log sequence numbers (LSN).

**What is the new behavior (if this is a feature change)?**

This updates the output for both `pgo scaledown --query` and `pgo failover --query` to give the user information that can help them make a better decision around these actions.

This changes leverages the information that is being collected by the
new HA system in order to provide better feedback about the status of
the replicas available. This information includes:

- NAME: the name of the replica
- STATUS: the current status of the replica
- NODE: the node that the replica resides on
- REPLICATION LAG: how far behind the replica is behind the primary

Additionally, "TIMELINE" is available in the API but is not currently
displayed to the user.

This also cleans out some now unused code.

Issue: [ch6494]

**Other information**:

The original bug fix is still kept as part of this commit in case the other changes are rejected.

This does make modifications to the API returns for the `--query` commands on `scaledown` + `failover`.

Issue: [ch6494]