### PR TITLE
[ch5485] Ensure Schedules are deleted when a Cluster is deleted

### DIFF
--- a/kubeapi/configmap.go
+++ b/kubeapi/configmap.go
@@ -85,6 +85,28 @@ func DeleteConfigMap(clientset *kubernetes.Clientset, name, namespace string) er
 
 }
 
+// DeleteConfigMaps deletes a ConfigMap by a selector
+func DeleteConfigMaps(clientset *kubernetes.Clientset, selector, namespace string) error {
+	log.Debugf("deleting configmaps with selector '%s'", selector)
+
+	deleteOptions := meta_v1.DeleteOptions{}
+	listOptions := meta_v1.ListOptions{
+		LabelSelector: selector,
+	}
+
+	err := clientset.CoreV1().ConfigMaps(namespace).DeleteCollection(
+		&deleteOptions, listOptions)
+
+	if err != nil {
+		log.Error("error deleting ConfigMap " + err.Error())
+		return err
+	}
+
+	log.Debugf("deleted configmaps with selector '%s'", selector)
+
+	return nil
+}
+
 // UpdateConfigMap updates a configMap by name
 func UpdateConfigMap(clientset *kubernetes.Clientset, configMap *v1.ConfigMap, namespace string) error {
 	_, err := clientset.Core().ConfigMaps(namespace).Update(configMap)

--- a/pgo-rmdata/rmdata/process.go
+++ b/pgo-rmdata/rmdata/process.go
@@ -83,6 +83,11 @@ func Delete(request Request) {
 	}
 
 	log.Info("rmdata.Process cluster use case")
+
+	// first, clear out any of the scheduled jobs that may occur, as this would be
+	// executing asynchronously against any stale data
+	removeSchedules(request)
+
 	//the user had done something like:
 	//pgo delete cluster mycluster --delete-data
 	if request.RemoveData {
@@ -606,4 +611,23 @@ func removeReplicaServices(request Request) {
 		}
 	}
 
+}
+
+// removeSchedules removes any of the ConfigMap objects that were created to
+// execute schedule tasks, such as backups
+// As these are consistently labeled, we can leverage Kuernetes selectors to
+// delete all of them
+func removeSchedules(request Request) {
+	log.Debugf("removing schedules for '%s'", request.ClusterName)
+
+	// a ConfigMap used for the schedule uses the following label selector:
+	// crunchy-scheduler=true,<config.LABEL_PG_CLUSTER>=<request.ClusterName>
+	selector := fmt.Sprintf("crunchy-scheduler=true,%s=%s",
+		config.LABEL_PG_CLUSTER, request.ClusterName)
+
+	// run the query the deletes all of the scheduled configmaps
+	// if there is an error, log it, but continue on without making a big stink
+	if err := kubeapi.DeleteConfigMaps(request.Clientset, selector, request.Namespace); err != nil {
+		log.Error(err)
+	}
 }

--- a/pgo-rmdata/rmdata/process.go
+++ b/pgo-rmdata/rmdata/process.go
@@ -66,10 +66,6 @@ func Delete(request Request) {
 		return
 	}
 
-	pvcList, err := getPVCs(request)
-	if err != nil {
-		log.Error(err)
-	}
 	if request.IsBackup {
 		log.Info("rmdata.Process backup use case")
 		//the case of removing a backup using
@@ -106,21 +102,22 @@ func Delete(request Request) {
 
 	//handle the case of 'pgo delete cluster mycluster'
 	removeCluster(request)
-	err = kubeapi.Deletepgcluster(request.RESTClient,
-		request.ClusterName, request.Namespace)
-	if err != nil {
+	if err := kubeapi.Deletepgcluster(request.RESTClient, request.ClusterName, request.Namespace); err != nil {
 		log.Error(err)
 	}
 	removeServices(request)
 	removeAddons(request)
 	removePgreplicas(request)
 	removePgtasks(request)
+	removeClusterConfigmaps(request)
 	//removeClusterJobs(request)
 	if request.RemoveData {
+		pvcList, err := getPVCs(request)
+		if err != nil {
+			log.Error(err)
+		}
 		removePVCs(pvcList, request)
 	}
-
-	removeClusterConfigmaps(request)
 }
 
 func removeBackups(request Request) {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

This closes out two issues.

The first issue is that PVCs are being deleted multiple times during the rmdata task, which would lead to the final `removePVCs` call to potentially fail. This became evident in #1120 as `removeConfigMaps` call was moved after this block.

The second issue is that the pgo-rmdata job was not set up to delete the ConfigMap objects that are managed by the scheduler for scheduled tasks.

**What is the new behavior (if this is a feature change)?**

For the issue with the PVC removal, the list of available PVCs is refreshed before the final removal is called.

The second fix corrects that issue for the scheduled task configmaps not being removed, and ensures any scheduled task for a cluster being deleted is also removed.

**Other information**:

Issue: [ch5485]
Issue: [ch5485]