### PR TITLE
Add service account to every pod

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/backup-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/backup-job.json
@@ -28,6 +28,7 @@
 
         {{.SecurityContext}}
 
+                "serviceAccountName": "pgo-default",
                 "containers": [{
                     "name": "backup",
                     "image": "{{.CCPImagePrefix}}/crunchy-backup:{{.CCPImageTag}}",

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbasebackup-restore-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbasebackup-restore-job.json
@@ -26,6 +26,7 @@
             },
             "spec":{
                 {{.SecurityContext}}
+                "serviceAccountName": "pgo-default",
                 "containers":[
                     {
                         "name":"pgbasebackup-restore",

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbench-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbench-job.json
@@ -9,7 +9,7 @@
             "pgo-benchmark": "true",
             "pg-cluster": "{{.ClusterName}}",
             "created": "{{.Created}}",
-            "workflowname": "{{.WorkflowName}}"
+            "workflowName": "{{.WorkflowName}}"
         }
     },
     "spec": {
@@ -22,7 +22,7 @@
                     "pgo-benchmark": "true",
                     "pg-cluster": "{{.ClusterName}}",
                     "created": "{{.Created}}",
-                    "workflowname": "{{.WorkflowName}}"
+                    "workflowName": "{{.WorkflowName}}"
                 }
             },
             "spec": {

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbench-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbench-job.json
@@ -26,6 +26,7 @@
                 }
             },
             "spec": {
+                "serviceAccountName": "pgo-default",
                 "containers": [
                     {
                         "name": "pgbench",

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
@@ -33,7 +33,7 @@
                 }
             },
             "spec": {
-
+                "serviceAccountName": "pgo-default",
                 "containers": [{
                     "name": "pgbouncer",
                     "image": "{{.CCPImagePrefix}}/crunchy-pgbouncer:{{.CCPImageTag}}",

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgdump-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgdump-job.json
@@ -33,6 +33,7 @@
 
                 {{.SecurityContext}}
 
+                "serviceAccountName": "pgo-default",
                 "containers": [{
                         "name": "pgdump",
                         "image": "{{.CCPImagePrefix}}/crunchy-pgdump:{{.CCPImageTag}}",

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
@@ -34,6 +34,7 @@
             },
             "spec": {
                 {{.SecurityContext}}
+                "serviceAccountName": "pgo-default",
                 "containers": [{
                     "name": "database",
                     "image": "{{.PGOImagePrefix}}/pgo-backrest-repo:{{.PGOImageTag}}",

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo-default-sa.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo-default-sa.json
@@ -1,0 +1,9 @@
+{
+    "apiVersion": "v1",
+    "kind": "ServiceAccount",
+    "metadata": {
+        "name": "pgo-default",
+        "namespace": "{{.TargetNamespace}}"
+    },
+    "automountServiceAccountToken": false
+}

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo.lspvc-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo.lspvc-template.json
@@ -15,6 +15,7 @@
         {{.NodeSelector}}
 
         "restartPolicy": "Never",
+        "serviceAccountName": "pgo-default",
         "containers": [{
             "name": "lspvc",
             "securityContext": {

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
@@ -21,6 +21,7 @@
                 }
             },
             "spec": {
+                "serviceAccountName": "pgo-default",
                 "containers": [
                     {
                         "name": "sqlrunner",

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
@@ -32,6 +32,7 @@
 
                     {{.SecurityContext}}
 
+                "serviceAccountName": "pgo-default",
                 "containers": [
                     {
                         "name": "pgrestore",

--- a/ansible/roles/pgo-operator/tasks/cleanup.yml
+++ b/ansible/roles/pgo-operator/tasks/cleanup.yml
@@ -133,7 +133,7 @@
 
 - name: Delete existing Service Accounts (Watched Namespaces)
   shell: |
-    {{ kubectl_or_oc }} delete serviceaccount pgo-backrest pgo-pg pgo-target -n {{ item }}
+    {{ kubectl_or_oc }} delete serviceaccount pgo-backrest pgo-default pgo-pg pgo-target -n {{ item }}
   with_items:
   - "{{ watched_namespaces }}"
   ignore_errors: yes

--- a/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
+++ b/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
@@ -34,14 +34,15 @@ fi
 {{ kubectl_or_oc }} label namespace/{{ item }} pgo-installation-name={{ pgo_installation_name }}
 
 # create RBAC
-{{ kubectl_or_oc }} -n {{ item }} delete sa pgo-backrest pgo-pg pgo-target
-{{ kubectl_or_oc }} -n {{ item }} delete role pgo-backrest-role pgo-pg-role pgo-target-role
-{{ kubectl_or_oc }} -n {{ item }} delete rolebinding pgo-backrest-role-binding pgo-pg-role-binding pgo-target-role-binding
+{{ kubectl_or_oc }} -n {{ item }} delete --ignore-not-found sa pgo-backrest pgo-default pgo-pg pgo-target
+{{ kubectl_or_oc }} -n {{ item }} delete --ignore-not-found role pgo-backrest-role pgo-pg-role pgo-target-role
+{{ kubectl_or_oc }} -n {{ item }} delete --ignore-not-found rolebinding pgo-backrest-role-binding pgo-pg-role-binding pgo-target-role-binding
 
-cat {{ role_path }}/files/pgo-configs/pgo-backrest-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
+cat {{ role_path }}/files/pgo-configs/pgo-default-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-target-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-target-role.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-target-role-binding.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | sed 's/{{ operator_namespace }}/'"{{ pgo_operator_namespace }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
+cat {{ role_path }}/files/pgo-configs/pgo-backrest-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-backrest-role.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-backrest-role-binding.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-pg-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -

--- a/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
+++ b/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
@@ -34,10 +34,9 @@ fi
 {{ kubectl_or_oc }} label namespace/{{ item }} pgo-installation-name={{ pgo_installation_name }}
 
 # create RBAC
-{{ kubectl_or_oc }} -n {{ item }} delete sa pgo-backrest
-{{ kubectl_or_oc }} -n {{ item }} delete sa pgo-target
-{{ kubectl_or_oc }} -n {{ item }} delete role pgo-target-role pgo-backrest-role
-{{ kubectl_or_oc }} -n {{ item }} delete rolebinding pgo-target-role-binding pgo-backrest-role-binding
+{{ kubectl_or_oc }} -n {{ item }} delete sa pgo-backrest pgo-pg pgo-target
+{{ kubectl_or_oc }} -n {{ item }} delete role pgo-backrest-role pgo-pg-role pgo-target-role
+{{ kubectl_or_oc }} -n {{ item }} delete rolebinding pgo-backrest-role-binding pgo-pg-role-binding pgo-target-role-binding
 
 cat {{ role_path }}/files/pgo-configs/pgo-backrest-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-target-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -

--- a/conf/postgres-operator/backup-job.json
+++ b/conf/postgres-operator/backup-job.json
@@ -28,6 +28,7 @@
 
         {{.SecurityContext}}
 
+                "serviceAccountName": "pgo-default",
                 "containers": [{
                     "name": "backup",
                     "image": "{{.CCPImagePrefix}}/crunchy-backup:{{.CCPImageTag}}",

--- a/conf/postgres-operator/pgbasebackup-restore-job.json
+++ b/conf/postgres-operator/pgbasebackup-restore-job.json
@@ -26,6 +26,7 @@
             },
             "spec":{
                 {{.SecurityContext}}
+                "serviceAccountName": "pgo-default",
                 "containers":[
                     {
                         "name":"pgbasebackup-restore",

--- a/conf/postgres-operator/pgbench-job.json
+++ b/conf/postgres-operator/pgbench-job.json
@@ -26,6 +26,7 @@
                 }
             },
             "spec": {
+                "serviceAccountName": "pgo-default",
                 "containers": [
                     {
                         "name": "pgbench",

--- a/conf/postgres-operator/pgbouncer-template.json
+++ b/conf/postgres-operator/pgbouncer-template.json
@@ -33,7 +33,7 @@
                 }
             },
             "spec": {
-
+                "serviceAccountName": "pgo-default",
                 "containers": [{
                     "name": "pgbouncer",
                     "image": "{{.CCPImagePrefix}}/crunchy-pgbouncer:{{.CCPImageTag}}",

--- a/conf/postgres-operator/pgdump-job.json
+++ b/conf/postgres-operator/pgdump-job.json
@@ -33,6 +33,7 @@
 
                 {{.SecurityContext}}
 
+                "serviceAccountName": "pgo-default",
                 "containers": [{
                         "name": "pgdump",
                         "image": "{{.CCPImagePrefix}}/crunchy-pgdump:{{.CCPImageTag}}",

--- a/conf/postgres-operator/pgo-backrest-repo-template.json
+++ b/conf/postgres-operator/pgo-backrest-repo-template.json
@@ -34,6 +34,7 @@
             },
             "spec": {
                 {{.SecurityContext}}
+                "serviceAccountName": "pgo-default",
                 "containers": [{
                     "name": "database",
                     "image": "{{.PGOImagePrefix}}/pgo-backrest-repo:{{.PGOImageTag}}",

--- a/conf/postgres-operator/pgo-default-sa.json
+++ b/conf/postgres-operator/pgo-default-sa.json
@@ -1,0 +1,9 @@
+{
+    "apiVersion": "v1",
+    "kind": "ServiceAccount",
+    "metadata": {
+        "name": "pgo-default",
+        "namespace": "{{.TargetNamespace}}"
+    },
+    "automountServiceAccountToken": false
+}

--- a/conf/postgres-operator/pgo.lspvc-template.json
+++ b/conf/postgres-operator/pgo.lspvc-template.json
@@ -15,6 +15,7 @@
         {{.NodeSelector}}
 
         "restartPolicy": "Never",
+        "serviceAccountName": "pgo-default",
         "containers": [{
             "name": "lspvc",
             "securityContext": {

--- a/conf/postgres-operator/pgo.sqlrunner-template.json
+++ b/conf/postgres-operator/pgo.sqlrunner-template.json
@@ -21,6 +21,7 @@
                 }
             },
             "spec": {
+                "serviceAccountName": "pgo-default",
                 "containers": [
                     {
                         "name": "sqlrunner",

--- a/conf/postgres-operator/pgrestore-job.json
+++ b/conf/postgres-operator/pgrestore-job.json
@@ -32,6 +32,7 @@
 
                     {{.SecurityContext}}
 
+                "serviceAccountName": "pgo-default",
                 "containers": [
                     {
                         "name": "pgrestore",

--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -37,6 +37,10 @@ const CustomConfigMapName = "pgo-config"
 const DefaultConfigsPath = "/default-pgo-config/"
 const CustomConfigsPath = "/pgo-config/"
 
+var PgoDefaultServiceAccountTemplate *template.Template
+
+const PGODefaultServiceAccountPath = "pgo-default-sa.json"
+
 var PgoTargetRoleBindingTemplate *template.Template
 
 const PGOTargetRoleBindingPath = "pgo-target-role-binding.json"
@@ -605,6 +609,10 @@ func (c *PgoConfig) GetConfig(clientset *kubernetes.Clientset, namespace string)
 	c.CheckEnv()
 
 	//load up all the templates
+	PgoDefaultServiceAccountTemplate, err = c.LoadTemplate(cMap, rootPath, PGODefaultServiceAccountPath)
+	if err != nil {
+		return err
+	}
 	PgoBackrestServiceAccountTemplate, err = c.LoadTemplate(cMap, rootPath, PGOBackrestServiceAccountPath)
 	if err != nil {
 		return err

--- a/deploy/add-targeted-namespace.sh
+++ b/deploy/add-targeted-namespace.sh
@@ -40,14 +40,15 @@ $PGO_CMD label namespace/$1 vendor=crunchydata
 $PGO_CMD label namespace/$1 pgo-installation-name=$PGO_INSTALLATION_NAME
 
 # create RBAC
-$PGO_CMD -n $1 delete sa pgo-backrest pgo-pg pgo-target
-$PGO_CMD -n $1 delete role pgo-backrest-role pgo-pg-role pgo-target-role
-$PGO_CMD -n $1 delete rolebinding pgo-backrest-role-binding pgo-pg-role-binding pgo-target-role-binding
+$PGO_CMD -n $1 delete --ignore-not-found sa pgo-backrest pgo-default pgo-pg pgo-target
+$PGO_CMD -n $1 delete --ignore-not-found role pgo-backrest-role pgo-pg-role pgo-target-role
+$PGO_CMD -n $1 delete --ignore-not-found rolebinding pgo-backrest-role-binding pgo-pg-role-binding pgo-target-role-binding
 
-cat $PGOROOT/conf/postgres-operator/pgo-backrest-sa.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
+cat $PGOROOT/conf/postgres-operator/pgo-default-sa.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
 cat $PGOROOT/conf/postgres-operator/pgo-target-sa.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
 cat $PGOROOT/conf/postgres-operator/pgo-target-role.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
 cat $PGOROOT/conf/postgres-operator/pgo-target-role-binding.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | sed 's/{{.OperatorNamespace}}/'"$PGO_OPERATOR_NAMESPACE"'/' | $PGO_CMD -n $1 create -f -
+cat $PGOROOT/conf/postgres-operator/pgo-backrest-sa.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
 cat $PGOROOT/conf/postgres-operator/pgo-backrest-role.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
 cat $PGOROOT/conf/postgres-operator/pgo-backrest-role-binding.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
 cat $PGOROOT/conf/postgres-operator/pgo-pg-sa.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -

--- a/deploy/add-targeted-namespace.sh
+++ b/deploy/add-targeted-namespace.sh
@@ -40,10 +40,9 @@ $PGO_CMD label namespace/$1 vendor=crunchydata
 $PGO_CMD label namespace/$1 pgo-installation-name=$PGO_INSTALLATION_NAME
 
 # create RBAC
-$PGO_CMD -n $1 delete sa pgo-backrest 
-$PGO_CMD -n $1 delete sa pgo-target
-$PGO_CMD -n $1 delete role pgo-target-role pgo-backrest-role
-$PGO_CMD -n $1 delete rolebinding pgo-target-role-binding pgo-backrest-role-binding
+$PGO_CMD -n $1 delete sa pgo-backrest pgo-pg pgo-target
+$PGO_CMD -n $1 delete role pgo-backrest-role pgo-pg-role pgo-target-role
+$PGO_CMD -n $1 delete rolebinding pgo-backrest-role-binding pgo-pg-role-binding pgo-target-role-binding
 
 cat $PGOROOT/conf/postgres-operator/pgo-backrest-sa.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
 cat $PGOROOT/conf/postgres-operator/pgo-target-sa.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -


### PR DESCRIPTION
This attaches a Service Account to every Pod deployed by the operator. A new account, `pgo-default`, is used for pods that don't need access to the Kubernetes API. This account provides a way to configure [image pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account) for each namespace.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
