### PR TITLE
Automatically set the Application icon during install

### DIFF
--- a/installers/gcp-marketplace/Dockerfile
+++ b/installers/gcp-marketplace/Dockerfile
@@ -38,9 +38,7 @@ COPY installers/gcp-marketplace/test-pod.yaml \
      /data-test/manifest/
 
 ARG PGO_VERSION
-RUN env OPERATOR_ICON_BASE64="$(base64 --wrap=0 /opt/postgres-operator/favicon.png)" envsubst '$OPERATOR_ICON_BASE64' \
-    < /data/manifest/application.yaml > /tmp/sponge && mv /tmp/sponge /data/manifest/application.yaml \
- && for file in \
+RUN for file in \
       /data/schema.yaml \
       /data/manifest/application.yaml \
     ; do envsubst '$PGO_VERSION' < "$file" > /tmp/sponge && mv /tmp/sponge "$file" ; done

--- a/installers/gcp-marketplace/application.yaml
+++ b/installers/gcp-marketplace/application.yaml
@@ -4,9 +4,6 @@ metadata:
   name: '${OPERATOR_NAME}'
   labels:
     app.kubernetes.io/name: '${OPERATOR_NAME}'
-  annotations:
-    kubernetes-engine.cloud.google.com/icon: >-
-      data:image/png;base64,${OPERATOR_ICON_BASE64}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
The manual installation instructions missed this step resulting in a broken icon. The icon source and tools needed to render it are already included in the installer image.

Backpatch of #1142.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)