### PR TITLE
Monitoring & Recovery from Failed PG Starts on Replicas

### DIFF
--- a/apis/cr/v1/task.go
+++ b/apis/cr/v1/task.go
@@ -66,6 +66,15 @@ const PgtaskpgBasebackupRestore = "pgbasebackuprestore"
 
 const PgtaskBenchmark = "benchmark"
 
+// Defines the types of pgBackRest backups that are taken throughout a clusters
+// lifecycle
+const (
+	// this type of backup is taken following a failover event
+	BackupTypeFailover string = "failover"
+	// this type of backup is taken when a new cluster is being bootstrapped
+	BackupTypeBootstrap string = "bootstrap"
+)
+
 // PgtaskSpec ...
 // swagger:ignore
 type PgtaskSpec struct {

--- a/conf/postgres-operator/cluster-deployment.json
+++ b/conf/postgres-operator/cluster-deployment.json
@@ -37,13 +37,20 @@
                     "readinessProbe": {
                         "exec": {
                             "command": [
-                                "/bin/bash",
-                                "-c",
-                                "[ -f /crunchyadm/pgha_initialized ] && exec pg_isready -h /crunchyadm -U crunchyready"
-                             ]
+                                "/opt/cpm/bin/pgha-readiness.sh"
+                            ]
                         },
-                        "initialDelaySeconds": 15,
-                        "timeoutSeconds": 8
+                        "initialDelaySeconds": 15
+                    },
+                    "livenessProbe": {
+                        "exec": {
+                            "command": [
+                                "/opt/cpm/bin/pgha-liveness.sh"
+                            ]
+                        },
+                        "initialDelaySeconds": 30,
+                        "periodSeconds": 15,
+                        "timeoutSeconds": 10
                     },
 
             {{.ContainerResources }}
@@ -78,6 +85,9 @@
                     }, {
                         "name": "PGHA_CRUNCHYADM",
                         "value": "true"
+                    }, {
+                        "name": "PGHA_REPLICA_REINIT_ON_START_FAIL",
+                        "value": "{{.ReplicaReinitOnStartFail}}"
                     }, {
                         "name": "PATRONI_KUBERNETES_NAMESPACE",
                         "valueFrom": {
@@ -161,13 +171,11 @@
                     "readinessProbe": {
                         "exec": {
                             "command": [
-                                "/bin/bash",
-                                "-c",
-                                "[ -f /crunchyadm/pgha_initialized ] && exec pg_isready -h /crunchyadm -U crunchyready"
-                             ]
+                                "/opt/cpm/bin/crunchyadm-readiness.sh"
+                            ]
                         },
-                        "initialDelaySeconds": 15,
-                        "timeoutSeconds": 8
+                        "initialDelaySeconds": 30,
+                        "timeoutSeconds": 10
                     },
                     "env": [
                         {

--- a/config/labels.go
+++ b/config/labels.go
@@ -173,5 +173,5 @@ const GLOBAL_CUSTOM_CONFIGMAP = "pgo-custom-pg-config"
 
 const LABEL_PGHA_SCOPE = "crunchy-pgha-scope"
 const LABEL_PGHA_DEFAULT_CONFIGMAP = "pgha-default-config"
-const LABEL_PGHA_BOOTSTRAP_BACKUP = "pgha-bootstrap-backup"
+const LABEL_PGHA_BACKUP_TYPE = "pgha-backup-type"
 const LABEL_PGHA_ROLE = "role"

--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -198,35 +198,36 @@ var PostgresHaTemplate *template.Template
 const PostgresHaTemplatePath = "postgres-ha.yaml"
 
 type ClusterStruct struct {
-	CCPImagePrefix          string `yaml:"CCPImagePrefix"`
-	CCPImageTag             string `yaml:"CCPImageTag"`
-	PrimaryNodeLabel        string `yaml:"PrimaryNodeLabel"`
-	ReplicaNodeLabel        string `yaml:"ReplicaNodeLabel"`
-	Policies                string `yaml:"Policies"`
-	LogStatement            string `yaml:"LogStatement"`
-	LogMinDurationStatement string `yaml:"LogMinDurationStatement"`
-	Metrics                 bool   `yaml:"Metrics"`
-	Badger                  bool   `yaml:"Badger"`
-	Port                    string `yaml:"Port"`
-	PGBadgerPort            string `yaml:"PGBadgerPort"`
-	ExporterPort            string `yaml:"ExporterPort"`
-	User                    string `yaml:"User"`
-	ArchiveTimeout          string `yaml:"ArchiveTimeout"`
-	Database                string `yaml:"Database"`
-	PasswordAgeDays         string `yaml:"PasswordAgeDays"`
-	PasswordLength          string `yaml:"PasswordLength"`
-	Strategy                string `yaml:"Strategy"`
-	Replicas                string `yaml:"Replicas"`
-	ServiceType             string `yaml:"ServiceType"`
-	BackrestPort            int    `yaml:"BackrestPort"`
-	Backrest                bool   `yaml:"Backrest"`
-	BackrestS3Bucket        string `yaml:"BackrestS3Bucket"`
-	BackrestS3Endpoint      string `yaml:"BackrestS3Endpoint"`
-	BackrestS3Region        string `yaml:"BackrestS3Region"`
-	DisableAutofail         bool   `yaml:"DisableAutofail"`
-	AutofailReplaceReplica  bool   `yaml:"AutofailReplaceReplica"`
-	PgmonitorPassword       string `yaml:"PgmonitorPassword"`
-	EnableCrunchyadm        bool   `yaml:"EnableCrunchyadm"`
+	CCPImagePrefix                string `yaml:"CCPImagePrefix"`
+	CCPImageTag                   string `yaml:"CCPImageTag"`
+	PrimaryNodeLabel              string `yaml:"PrimaryNodeLabel"`
+	ReplicaNodeLabel              string `yaml:"ReplicaNodeLabel"`
+	Policies                      string `yaml:"Policies"`
+	LogStatement                  string `yaml:"LogStatement"`
+	LogMinDurationStatement       string `yaml:"LogMinDurationStatement"`
+	Metrics                       bool   `yaml:"Metrics"`
+	Badger                        bool   `yaml:"Badger"`
+	Port                          string `yaml:"Port"`
+	PGBadgerPort                  string `yaml:"PGBadgerPort"`
+	ExporterPort                  string `yaml:"ExporterPort"`
+	User                          string `yaml:"User"`
+	ArchiveTimeout                string `yaml:"ArchiveTimeout"`
+	Database                      string `yaml:"Database"`
+	PasswordAgeDays               string `yaml:"PasswordAgeDays"`
+	PasswordLength                string `yaml:"PasswordLength"`
+	Strategy                      string `yaml:"Strategy"`
+	Replicas                      string `yaml:"Replicas"`
+	ServiceType                   string `yaml:"ServiceType"`
+	BackrestPort                  int    `yaml:"BackrestPort"`
+	Backrest                      bool   `yaml:"Backrest"`
+	BackrestS3Bucket              string `yaml:"BackrestS3Bucket"`
+	BackrestS3Endpoint            string `yaml:"BackrestS3Endpoint"`
+	BackrestS3Region              string `yaml:"BackrestS3Region"`
+	DisableAutofail               bool   `yaml:"DisableAutofail"`
+	AutofailReplaceReplica        bool   `yaml:"AutofailReplaceReplica"`
+	PgmonitorPassword             string `yaml:"PgmonitorPassword"`
+	EnableCrunchyadm              bool   `yaml:"EnableCrunchyadm"`
+	DisableReplicaStartFailReinit bool   `yaml:"DisableReplicaStartFailReinit"`
 }
 
 type StorageStruct struct {
@@ -288,6 +289,7 @@ const DEFAULT_BACKREST_PORT = 2022
 const DEFAULT_PGBADGER_PORT = "10000"
 const DEFAULT_EXPORTER_PORT = "9187"
 const DEFAULT_POSTGRES_PORT = "5432"
+const DEFAULT_PATRONI_PORT = "8009"
 const DEFAULT_BACKREST_SSH_KEY_BITS = 2048
 
 func (c *PgoConfig) Validate() error {

--- a/hugo/content/Configuration/pgo-yaml-configuration.md
+++ b/hugo/content/Configuration/pgo-yaml-configuration.md
@@ -37,6 +37,7 @@ The *pgo.yaml* file is broken into major sections as described below:
 |Backrest        | optional, if set, will cause clusters to have the pgbackrest volume PVC provisioned during cluster creation
 |BackrestPort        | currently required to be port 2022
 |DisableAutofail        | optional, if set, will disable autofail capabilities by default in any newly created cluster
+|DisableReplicaStartFailReinit | if set to "true" will disable the detection of a "start failed" states in PG replicas, which results in the re-initialization of the replica in an attempt to bring it back online
 
 ## Storage
 | Setting|Definition  |

--- a/operator/cluster/clusterlogic.go
+++ b/operator/cluster/clusterlogic.go
@@ -142,7 +142,8 @@ func AddCluster(clientset *kubernetes.Clientset, client *rest.RESTClient, cl *cr
 			cl.Spec.Port, cl.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE]),
 		PgbackrestS3EnvVars: operator.GetPgbackrestS3EnvVars(cl.Labels[config.LABEL_BACKREST],
 			cl.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], clientset, namespace),
-		EnableCrunchyadm: operator.Pgo.Cluster.EnableCrunchyadm,
+		EnableCrunchyadm:         operator.Pgo.Cluster.EnableCrunchyadm,
+		ReplicaReinitOnStartFail: !operator.Pgo.Cluster.DisableReplicaStartFailReinit,
 	}
 
 	// create the default configuration file for crunchy-postgres-ha if custom config file not provided
@@ -377,7 +378,8 @@ func Scale(clientset *kubernetes.Clientset, client *rest.RESTClient, replica *cr
 			cluster.Spec.Port, cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE]),
 		PgbackrestS3EnvVars: operator.GetPgbackrestS3EnvVars(cluster.Labels[config.LABEL_BACKREST],
 			cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], clientset, namespace),
-		EnableCrunchyadm: operator.Pgo.Cluster.EnableCrunchyadm,
+		EnableCrunchyadm:         operator.Pgo.Cluster.EnableCrunchyadm,
+		ReplicaReinitOnStartFail: !operator.Pgo.Cluster.DisableReplicaStartFailReinit,
 	}
 
 	switch replica.Spec.ReplicaStorage.StorageType {

--- a/operator/cluster/failover.go
+++ b/operator/cluster/failover.go
@@ -24,7 +24,6 @@ import (
 	"github.com/crunchydata/postgres-operator/config"
 	"github.com/crunchydata/postgres-operator/events"
 	"github.com/crunchydata/postgres-operator/kubeapi"
-	"github.com/crunchydata/postgres-operator/operator/backrest"
 	jsonpatch "github.com/evanphx/json-patch"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
@@ -92,17 +91,6 @@ func FailoverBase(namespace string, clientset *kubernetes.Clientset, client *res
 	}
 
 	Failover(cluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER], clientset, client, clusterName, task, namespace, restconfig)
-
-	//if a backrest-repo exists, bounce it with the new
-	//DB_PATH set to the new primary deployment name
-	if cluster.ObjectMeta.Labels[config.LABEL_BACKREST] == "true" {
-		err = backrest.UpdateDBPath(clientset, &cluster, task.ObjectMeta.Labels[config.LABEL_TARGET], namespace)
-		if err != nil {
-			log.Error(err)
-			log.Error("error bouncing backrest-repo during failover")
-			return
-		}
-	}
 
 	//publish event for failover completed
 	topics = make([]string, 1)

--- a/operator/clusterutilities.go
+++ b/operator/clusterutilities.go
@@ -126,9 +126,10 @@ type DeploymentTemplateFields struct {
 	Replicas    string
 	PrimaryHost string
 	// PgBouncer deployment only
-	PgbouncerPass    string
-	IsInit           bool
-	EnableCrunchyadm bool
+	PgbouncerPass            string
+	IsInit                   bool
+	EnableCrunchyadm         bool
+	ReplicaReinitOnStartFail bool
 }
 
 type PostgresHaTemplateFields struct {

--- a/postgres-operator.go
+++ b/postgres-operator.go
@@ -145,6 +145,7 @@ func main() {
 		InformerNamespaces: make(map[string]struct{}),
 	}
 	jobcontroller := &controller.JobController{
+		JobConfig:          config,
 		JobClientset:       Clientset,
 		JobClient:          crdClient,
 		Ctx:                ctx,


### PR DESCRIPTION
This PR adds support for replica `start failed` detection, as implemented in the `crunchy-postges-ha` container.  Specifically, by setting the `PGHA_REPLICA_REINIT_ON_START_FAIL` environment variable to true in the `crunchy-postgres-ha` container for any PG deployment, the container will check for a 'start failed' state in a replica, and if detected will reinitialize the replica using the `reinitialize` REST endpoint deployed by Patroni on the replica.

Additionally, this commit adds additional support for the `start failed` detection process within the PGO itself by providing supporting functionality for the `on_role_change` Patroni callback, i.e. taking
certain actions post-failover after detecting that the role of a PG database has changed from `replica` to `master`, indicating promotion of a replica to primary due to a failover (or switchover).  This includes updating the `pgBackRest` dedicated repository to point to the `PGDATA` directory of the new/promoted primary, as well as taking a new backup of the database.  The creation of a new backup has the added benefit of ensuring any replicas created or re-initialized post-failover can successfully bootstrap (e.g. in the event that WAL is missing from the `pgBackRest` repo, resulting in the inability of a replica to otherwise recover).

While enabled by default, the replica `start failed` detection can be disabled by setting `DisableReplicaStartFailReinit` to `true` in `pgo.yaml`. And in addition to the above, also included in this commit are are updated readiness probes for both the database and crunchyadm containers. Specifically, both now utilize the new readiness scripts provided in the `crunchy-postgres-ha` container.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

If a `crunchy-postgres-ha` (or GIS equivalent) container identified as a replica ends up in a state where it is unable to start (i.e. the start failed state), it will remain stuck in this state until action is manually take (e.g. manually re-initializing the Patroni node).

Additionally, a backup is not automatically taken following a failover event.

**What is the new behavior (if this is a feature change)?**

A start failed state can now automatically be detected in a replica, followed by automatically reinitializing that replica.

Also, a backup is now automatically taken following a failure event to ensure the successful creation and/or re-initialization of replicas.

[ch6602]

**Other information**:

N/A