### PR TITLE
Update to Allow pgBackrest Backup Repo Retention Options

### DIFF
--- a/apiserver/backupoptions/backupoptionsutil.go
+++ b/apiserver/backupoptions/backupoptionsutil.go
@@ -163,6 +163,13 @@ func isValidCompressLevel(compressLevel int) bool {
 	}
 }
 
+// isValidRetentionRange validates that pgBackrest Full, Diff or Archive
+// retention option value is set within the allowable range.
+// allowed: 1-9999999
+func isValidRetentionRange(retentionRange int) bool {
+	return (retentionRange >= 1 && retentionRange <= 9999999)
+}
+
 func isValidValue(vals []string, val string) bool {
 	isValid := false
 	for _, currVal := range vals {

--- a/apiserver/backupoptions/pgbackrestoptions.go
+++ b/apiserver/backupoptions/pgbackrestoptions.go
@@ -30,36 +30,40 @@ var pgBackRestOptsBlacklist = []string{"--archive-check", "--no-archive-check", 
 	"--pg-host-config-include-path", "--pg-host-config-path", "--pg-host-port", "--pg-host-user", "--pg-path", "--pg-port"}
 
 type pgBackRestBackupOptions struct {
-	ArchiveCopy           bool   `flag:"archive-copy"`
-	NoArchiveCopy         bool   `flag:"no-archive-copy"`
-	ArchiveTimeout        int    `flag:"archive-timeout"`
-	BackupStandby         bool   `flag:"backup-standby"`
-	NoBackupStandby       bool   `flag:"no-backup-standby"`
-	ChecksumPage          bool   `flag:"checksum-page"`
-	NoChecksumPage        bool   `flag:"no-checksum-page"`
-	Exclude               string `flag:"exclude"`
-	Force                 bool   `flag:"force"`
-	ManifestSaveThreshold string `flag:"manifest-save-threshold"`
-	Resume                bool   `flag:"resume"`
-	NoResume              bool   `flag:"no-resume"`
-	StartFast             bool   `flag:"start-fast"`
-	NoStartFast           bool   `flag:"no-start-fast"`
-	StopAuto              bool   `flag:"stop-auto"`
-	NoStopAuto            bool   `flag:"no-stop-auto"`
-	BackupType            string `flag:"type"`
-	BufferSize            string `flag:"buffer-size"`
-	Compress              bool   `flag:"compress"`
-	NoCompress            bool   `flag:"no-compress"`
-	CompressLevel         int    `flag:"compress-level"`
-	CompressLevelNetwork  int    `flag:"compress-level-network"`
-	DBTimeout             int    `flag:"db-timeout"`
-	Delta                 bool   `flag:"no-delta"`
-	ProcessMax            int    `flag:"process-max"`
-	ProtocolTimeout       int    `flag:"protocol-timeout"`
-	LogLevelConsole       string `flag:"log-level-console"`
-	LogLevelFile          string `flag:"log-level-file"`
-	LogLevelStderr        string `flag:"log-level-stderr"`
-	LogSubprocess         bool   `flag:"log-subprocess"`
+	ArchiveCopy              bool   `flag:"archive-copy"`
+	NoArchiveCopy            bool   `flag:"no-archive-copy"`
+	ArchiveTimeout           int    `flag:"archive-timeout"`
+	BackupStandby            bool   `flag:"backup-standby"`
+	NoBackupStandby          bool   `flag:"no-backup-standby"`
+	ChecksumPage             bool   `flag:"checksum-page"`
+	NoChecksumPage           bool   `flag:"no-checksum-page"`
+	Exclude                  string `flag:"exclude"`
+	Force                    bool   `flag:"force"`
+	ManifestSaveThreshold    string `flag:"manifest-save-threshold"`
+	Resume                   bool   `flag:"resume"`
+	NoResume                 bool   `flag:"no-resume"`
+	StartFast                bool   `flag:"start-fast"`
+	NoStartFast              bool   `flag:"no-start-fast"`
+	StopAuto                 bool   `flag:"stop-auto"`
+	NoStopAuto               bool   `flag:"no-stop-auto"`
+	BackupType               string `flag:"type"`
+	BufferSize               string `flag:"buffer-size"`
+	Compress                 bool   `flag:"compress"`
+	NoCompress               bool   `flag:"no-compress"`
+	CompressLevel            int    `flag:"compress-level"`
+	CompressLevelNetwork     int    `flag:"compress-level-network"`
+	DBTimeout                int    `flag:"db-timeout"`
+	Delta                    bool   `flag:"no-delta"`
+	ProcessMax               int    `flag:"process-max"`
+	ProtocolTimeout          int    `flag:"protocol-timeout"`
+	LogLevelConsole          string `flag:"log-level-console"`
+	LogLevelFile             string `flag:"log-level-file"`
+	LogLevelStderr           string `flag:"log-level-stderr"`
+	LogSubprocess            bool   `flag:"log-subprocess"`
+	RepoRetentionFull        int    `flag:"repo1-retention-full"`
+	RepoRetentionDiff        int    `flag:"repo1-retention-diff"`
+	RepoRetentionArchive     int    `flag:"repo1-retention-archive"`
+	RepoRetentionArchiveType string `flag:"repo1-retention-archive-type"`
 }
 
 type pgBackRestRestoreOptions struct {
@@ -88,8 +92,10 @@ type pgBackRestRestoreOptions struct {
 	LogSubprocess        bool   `flag:"log-subprocess"`
 }
 
+// validate method runs validation checks against any pgBackrest backup options given when executing
+// a pgBackrest backup. As it iterates through the options array, it will call the appropriate
+// function to ensure an allowed value has been set, otherwise it will produce an appropriate error
 func (backRestBackupOpts pgBackRestBackupOptions) validate(setFlagFieldNames []string) error {
-
 	var errstrings []string
 
 	for _, setFlag := range setFlagFieldNames {
@@ -123,6 +129,26 @@ func (backRestBackupOpts pgBackRestBackupOptions) validate(setFlagFieldNames []s
 		case "LogLevelStdErr":
 			if !isValidBackrestLogLevel(backRestBackupOpts.LogLevelStderr) {
 				err := errors.New("Invalid log level for pgBackRest backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "RepoRetentionFull":
+			if !isValidRetentionRange(backRestBackupOpts.RepoRetentionFull) {
+				err := errors.New("Invalid value for pgBackRest full backup retention. Allowed: 1-9999999")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "RepoRetentionDiff":
+			if !isValidRetentionRange(backRestBackupOpts.RepoRetentionDiff) {
+				err := errors.New("Invalid value for pgBackRest diff backup retention. Allowed: 1-9999999")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "RepoRetentionArchive":
+			if !isValidRetentionRange(backRestBackupOpts.RepoRetentionArchive) {
+				err := errors.New("Invalid value for pgBackRest archive retention. Allowed: 1-9999999")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "RepoRetentionArchiveType":
+			if !isValidValue([]string{"full", "diff", "incr"}, backRestBackupOpts.RepoRetentionArchiveType) {
+				err := errors.New("Invalid backup type for pgBackRest WAL retention. Allowed: \"full\", \"diff\", \"incr\"")
 				errstrings = append(errstrings, err.Error())
 			}
 		}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The backup options validator in the PGO apiserver does not currently allow options
--repo1-retention-full
--repo1-retention-diff
--repo1-retention-archive
--repo1-retention-archive-type
to be set when creating a pgBackRest backup. 

**What is the new behavior (if this is a feature change)?**
With this update, these option are whitelisted as allowed backup options 
that can be specified when creating a backup via the pgo create backup command. 
This allows users to set desired retention values when creating backups.

Additionally, this update creates a new function, isValidRetentionRange, to
ensure the 'full', 'diff', and 'archive' values are within the documented
allowable range, 1-9999999.
For the '--repo1-retention-archive-type' flag, the existing isValidValue function
is utilized to ensure that the value set is either 'full', 'diff' or 'incr', as
documented.

Finally, formatting was adjusted to accommodate new flags.

**Other information**:
Example usage:

pgo backup mycluster --backup-type="pgbackrest" --backup-opts="--type=incr --repo1-retention-diff=2 --repo1-retention-full=1"

pgo backup mycluster --backup-opts="--type=full --repo1-retention-full=2 --repo1-retention-archive=4 --repo1-retention-archive-type=diff"

Example for error handling:
pgo backup mycluster --backup-opts="--type=full --repo1-retention-full=0 --repo1-retention-diff=-2 --repo1-retention-archive=-4 --repo1-retention-archive-type=fake"

Issue: [ch4204]
