### PR TITLE
Add Default Pod Anti-Affinity Rules to PG Cluster Deployments

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/affinity.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/affinity.json
@@ -1,7 +1,6 @@
-        "affinity": {
             "nodeAffinity": {
             "preferredDuringSchedulingIgnoredDuringExecution": [{
-                "weight": 1,
+                "weight": 10,
                 "preference": {
                 "matchExpressions": [{
                     "key": "{{.NodeLabelKey}}",
@@ -13,4 +12,3 @@
                 }
             }]
             }
-        },

--- a/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -37,13 +37,20 @@
                     "readinessProbe": {
                         "exec": {
                             "command": [
-                                "/bin/bash",
-                                "-c",
-                                "[ -f /crunchyadm/pgha_initialized ] && exec pg_isready -h /crunchyadm -U crunchyready"
-                             ]
+                                "/opt/cpm/bin/pgha-readiness.sh"
+                            ]
                         },
-                        "initialDelaySeconds": 15,
-                        "timeoutSeconds": 8
+                        "initialDelaySeconds": 15
+                    },
+                    "livenessProbe": {
+                        "exec": {
+                            "command": [
+                                "/opt/cpm/bin/pgha-liveness.sh"
+                            ]
+                        },
+                        "initialDelaySeconds": 30,
+                        "periodSeconds": 15,
+                        "timeoutSeconds": 10
                     },
 
             {{.ContainerResources }}
@@ -78,6 +85,9 @@
                     }, {
                         "name": "PGHA_CRUNCHYADM",
                         "value": "true"
+                    }, {
+                        "name": "PGHA_REPLICA_REINIT_ON_START_FAIL",
+                        "value": "{{.ReplicaReinitOnStartFail}}"
                     }, {
                         "name": "PATRONI_KUBERNETES_NAMESPACE",
                         "valueFrom": {
@@ -161,13 +171,11 @@
                     "readinessProbe": {
                         "exec": {
                             "command": [
-                                "/bin/bash",
-                                "-c",
-                                "[ -f /crunchyadm/pgha_initialized ] && exec pg_isready -h /crunchyadm -U crunchyready"
-                             ]
+                                "/opt/cpm/bin/crunchyadm-readiness.sh"
+                            ]
                         },
-                        "initialDelaySeconds": 15,
-                        "timeoutSeconds": 8
+                        "initialDelaySeconds": 30,
+                        "timeoutSeconds": 10
                     },
                     "env": [
                         {
@@ -253,9 +261,11 @@
                     }
 
                 ],
-
+                "affinity": {
         {{.NodeSelector}}
-
+        {{if and .NodeSelector .PodAntiAffinity}},{{end}}
+        {{.PodAntiAffinity}}
+                },
                 "restartPolicy": "Always",
                 "dnsPolicy": "ClusterFirst"
             }

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
@@ -78,6 +78,9 @@
                     "defaultMode": 511
                     }
                 }],
+                "affinity": {
+        {{.PodAntiAffinity}}
+                },
                 "restartPolicy": "Always",
                 "dnsPolicy": "ClusterFirst"
             }

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
@@ -91,6 +91,9 @@
                         "claimName": "{{.BackrestRepoClaimName}}"
                     }
                 }],
+                "affinity": {
+        {{.PodAntiAffinity}}
+                },
                 "restartPolicy": "Always",
                 "dnsPolicy": "ClusterFirst"
             }

--- a/ansible/roles/pgo-operator/files/pgo-configs/pod-anti-affinity.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pod-anti-affinity.json
@@ -1,0 +1,36 @@
+                "podAntiAffinity": {
+                    "{{.AffinityType}}": [
+                        {
+                            {{if eq .AffinityType "preferredDuringSchedulingIgnoredDuringExecution"}}                
+                            "weight": 1,
+                            "podAffinityTerm": {
+                            {{end}}
+                                "labelSelector": {
+                                    "matchExpressions": [
+                                        {
+                                            "key": "{{.VendorLabelKey}}",
+                                            "operator": "In",
+                                            "values": [
+                                                "{{.VendorLabelValue}}"
+                                            ]
+                                        },
+                                        {
+                                            "key": "{{.PodAntiAffinityLabelKey}}",
+                                            "operator": "Exists"
+                                        },
+                                        {
+                                            "key": "pg-cluster",
+                                            "operator": "In",
+                                            "values": [
+                                                "{{.ClusterName}}"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "topologyKey": "kubernetes.io/hostname"
+                            {{if eq .AffinityType "preferredDuringSchedulingIgnoredDuringExecution"}}     
+                            }
+                            {{end}}
+                        }
+                    ]
+                }

--- a/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
@@ -19,6 +19,13 @@ rules:
       - serviceaccounts
       - roles
       - rolebindings
+  - verbs:
+      - 'list'
+      - 'get'
+    apiGroups:
+      - '*'
+    resources:
+      - nodes
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/apis/cr/v1/cluster.go
+++ b/apis/cr/v1/cluster.go
@@ -16,6 +16,8 @@ package v1
 */
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -65,6 +67,7 @@ type PgclusterSpec struct {
 	PswLastUpdate      string               `json:"pswlastupdate"`
 	CustomConfig       string               `json:"customconfig"`
 	UserLabels         map[string]string    `json:"userlabels"`
+	PodAntiAffinity    string               `json:"podPodAntiAffinity"`
 }
 
 // PgclusterList is the CRD that defines a Crunchy PG Cluster List
@@ -88,6 +91,14 @@ type PgclusterStatus struct {
 // swagger:ignore
 type PgclusterState string
 
+// PodAntiAffinityType defines the different types of type of anti-affinity rules applied to pg
+// clusters when utilizing the default pod anti-affinity rules provided by the PostgreSQL Operator,
+// which are enabled for a new pg cluster by default.  Valid Values include "required" for
+// requiredDuringSchedulingIgnoredDuringExecution anti-affinity, "preferred" for
+// preferredDuringSchedulingIgnoredDuringExecution anti-affinity, and "disabled" to disable the
+// default pod anti-affinity rules for the pg cluster all together.
+type PodAntiAffinityType string
+
 const (
 	// PgclusterStateCreated ...
 	PgclusterStateCreated PgclusterState = "pgcluster Created"
@@ -97,4 +108,29 @@ const (
 	PgclusterStateInitialized PgclusterState = "pgcluster Initialized"
 	// PgclusterStateRestore ...
 	PgclusterStateRestore PgclusterState = "pgcluster Restoring"
+
+	// PodAntiAffinityRequired results in requiredDuringSchedulingIgnoredDuringExecution for any
+	// default pod anti-affinity rules applied to pg custers
+	PodAntiAffinityRequired PodAntiAffinityType = "required"
+
+	// PodAntiAffinityPreffered results in preferredDuringSchedulingIgnoredDuringExecution for any
+	// default pod anti-affinity rules applied to pg custers
+	PodAntiAffinityPreffered PodAntiAffinityType = "preferred"
+
+	// PodAntiAffinityDisabled disables any default pod anti-affinity rules applied to pg custers
+	PodAntiAffinityDisabled PodAntiAffinityType = "disabled"
 )
+
+// ValidatePodAntiAffinityType is responsible for validating whether or not the type of pod
+// anti-affinity specified is valid
+func (p PodAntiAffinityType) ValidatePodAntiAffinityType() error {
+	switch p {
+	case
+		PodAntiAffinityRequired,
+		PodAntiAffinityPreffered,
+		PodAntiAffinityDisabled:
+		return nil
+	}
+	return fmt.Errorf("Invalid pod anti-affinity type.  Valid values are '%s', '%s' or '%s'",
+		PodAntiAffinityRequired, PodAntiAffinityPreffered, PodAntiAffinityDisabled)
+}

--- a/apis/cr/v1/cluster.go
+++ b/apis/cr/v1/cluster.go
@@ -123,7 +123,7 @@ const (
 
 // ValidatePodAntiAffinityType is responsible for validating whether or not the type of pod
 // anti-affinity specified is valid
-func (p PodAntiAffinityType) ValidatePodAntiAffinityType() error {
+func (p PodAntiAffinityType) Validate() error {
 	switch p {
 	case
 		PodAntiAffinityRequired,

--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -705,6 +705,21 @@ func CreateCluster(request *msgs.CreateClusterRequest, ns, pgouser string) msgs.
 			}
 		}
 
+		// if a value is provided in the request for PodAntiAffinity, then ensure is valid.  If
+		// it is, then set the user label for pod anti-affinity to the request value.  Otherwise,
+		// return the validation error.
+		if request.PodAntiAffinity != "" {
+			podAntiAffinityType := crv1.PodAntiAffinityType(request.PodAntiAffinity)
+			if err := podAntiAffinityType.ValidatePodAntiAffinityType(); err != nil {
+				resp.Status.Code = msgs.Error
+				resp.Status.Msg = err.Error()
+				return resp
+			} 
+			userLabelsMap[config.LABEL_POD_ANTI_AFFINITY] = request.PodAntiAffinity
+		} else {
+			userLabelsMap[config.LABEL_POD_ANTI_AFFINITY] = ""
+		}
+
 		// Create an instance of our CRD
 		newInstance := getClusterParams(request, clusterName, userLabelsMap, ns)
 		newInstance.ObjectMeta.Labels[config.LABEL_PGOUSER] = pgouser
@@ -935,6 +950,8 @@ func getClusterParams(request *msgs.CreateClusterRequest, name string, userLabel
 	}
 
 	spec.CustomConfig = request.CustomConfig
+
+	spec.PodAntiAffinity = request.PodAntiAffinity
 
 	labels := make(map[string]string)
 	labels[config.LABEL_NAME] = name

--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -710,7 +710,7 @@ func CreateCluster(request *msgs.CreateClusterRequest, ns, pgouser string) msgs.
 		// return the validation error.
 		if request.PodAntiAffinity != "" {
 			podAntiAffinityType := crv1.PodAntiAffinityType(request.PodAntiAffinity)
-			if err := podAntiAffinityType.ValidatePodAntiAffinityType(); err != nil {
+			if err := podAntiAffinityType.Validate(); err != nil {
 				resp.Status.Code = msgs.Error
 				resp.Status.Msg = err.Error()
 				return resp

--- a/apiservermsgs/clustermsgs.go
+++ b/apiservermsgs/clustermsgs.go
@@ -73,7 +73,8 @@ type CreateClusterRequest struct {
 	ContainerResources   string
 	// Version of API client
 	// required: true
-	ClientVersion string
+	ClientVersion   string
+	PodAntiAffinity string
 }
 
 // CreateClusterResponse

--- a/conf/postgres-operator/affinity.json
+++ b/conf/postgres-operator/affinity.json
@@ -1,7 +1,6 @@
-        "affinity": {
             "nodeAffinity": {
             "preferredDuringSchedulingIgnoredDuringExecution": [{
-                "weight": 1,
+                "weight": 10,
                 "preference": {
                 "matchExpressions": [{
                     "key": "{{.NodeLabelKey}}",
@@ -13,4 +12,3 @@
                 }
             }]
             }
-        },

--- a/conf/postgres-operator/cluster-deployment.json
+++ b/conf/postgres-operator/cluster-deployment.json
@@ -261,9 +261,11 @@
                     }
 
                 ],
-
+                "affinity": {
         {{.NodeSelector}}
-
+        {{if and .NodeSelector .PodAntiAffinity}},{{end}}
+        {{.PodAntiAffinity}}
+                },
                 "restartPolicy": "Always",
                 "dnsPolicy": "ClusterFirst"
             }

--- a/conf/postgres-operator/pgbouncer-template.json
+++ b/conf/postgres-operator/pgbouncer-template.json
@@ -19,6 +19,7 @@
                 "crunchy-pgbouncer": "true",
                 "pg-cluster": "{{.ClusterName}}",
                 "service-name": "{{.Name}}",
+                "{{.PodAntiAffinityLabelName}}": "{{.PodAntiAffinityLabelValue}}",
                 "vendor": "crunchydata"
             }
         },
@@ -29,6 +30,7 @@
                     "crunchy-pgbouncer": "true",
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
+                    "{{.PodAntiAffinityLabelName}}": "{{.PodAntiAffinityLabelValue}}",
                     "vendor": "crunchydata"
                 }
             },
@@ -78,6 +80,9 @@
                     "defaultMode": 511
                     }
                 }],
+                "affinity": {
+        {{.PodAntiAffinity}}
+                },
                 "restartPolicy": "Always",
                 "dnsPolicy": "ClusterFirst"
             }

--- a/conf/postgres-operator/pgo-backrest-repo-template.json
+++ b/conf/postgres-operator/pgo-backrest-repo-template.json
@@ -19,6 +19,7 @@
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
                     "vendor": "crunchydata",
+                    "{{.PodAntiAffinityLabelName}}": "{{.PodAntiAffinityLabelValue}}",
                     "pgo-backrest-repo": "true"
             }
         },
@@ -29,6 +30,7 @@
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
                     "vendor": "crunchydata",
+                    "{{.PodAntiAffinityLabelName}}": "{{.PodAntiAffinityLabelValue}}",
                     "pgo-backrest-repo": "true"
                 }
             },
@@ -91,6 +93,9 @@
                         "claimName": "{{.BackrestRepoClaimName}}"
                     }
                 }],
+                "affinity": {
+        {{.PodAntiAffinity}}
+                },
                 "restartPolicy": "Always",
                 "dnsPolicy": "ClusterFirst"
             }

--- a/conf/postgres-operator/pgo.yaml
+++ b/conf/postgres-operator/pgo.yaml
@@ -26,6 +26,7 @@ Cluster:
   AutofailReplaceReplica:  false
   LogStatement:  none
   LogMinDurationStatement:  60000
+  PodAntiAffinity: preferred
 PrimaryStorage: storageos
 BackupStorage: storageos
 ReplicaStorage: storageos

--- a/conf/postgres-operator/pod-anti-affinity.json
+++ b/conf/postgres-operator/pod-anti-affinity.json
@@ -1,0 +1,36 @@
+                "podAntiAffinity": {
+                    "{{.AffinityType}}": [
+                        {
+                            {{if eq .AffinityType "preferredDuringSchedulingIgnoredDuringExecution"}}                
+                            "weight": 1,
+                            "podAffinityTerm": {
+                            {{end}}
+                                "labelSelector": {
+                                    "matchExpressions": [
+                                        {
+                                            "key": "{{.VendorLabelKey}}",
+                                            "operator": "In",
+                                            "values": [
+                                                "{{.VendorLabelValue}}"
+                                            ]
+                                        },
+                                        {
+                                            "key": "{{.PodAntiAffinityLabelKey}}",
+                                            "operator": "Exists"
+                                        },
+                                        {
+                                            "key": "pg-cluster",
+                                            "operator": "In",
+                                            "values": [
+                                                "{{.ClusterName}}"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "topologyKey": "kubernetes.io/hostname"
+                            {{if eq .AffinityType "preferredDuringSchedulingIgnoredDuringExecution"}}     
+                            }
+                            {{end}}
+                        }
+                    ]
+                }

--- a/config/labels.go
+++ b/config/labels.go
@@ -47,6 +47,7 @@ const LABEL_REPLICA_NAME = "replica-name"
 const LABEL_CCP_IMAGE_TAG_KEY = "ccp-image-tag"
 const LABEL_CCP_IMAGE_KEY = "ccp-image"
 const LABEL_SERVICE_TYPE = "service-type"
+const LABEL_POD_ANTI_AFFINITY = "pg-pod-anti-affinity"
 
 const LABEL_REPLICA_COUNT = "replica-count"
 const LABEL_RESOURCES_CONFIG = "resources-config"

--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -498,7 +498,7 @@ func (c *PgoConfig) Validate() error {
 
 	// if provided, ensure that the type of pod anti-affinity specified is valid
 	podAntiAffinityType := crv1.PodAntiAffinityType(c.Cluster.PodAntiAffinity)
-	if err := podAntiAffinityType.ValidatePodAntiAffinityType(); podAntiAffinityType != "" && err != nil {
+	if err := podAntiAffinityType.Validate(); podAntiAffinityType != "" && err != nil {
 		return errors.New(errPrefix + "Invalid value provided for Cluster.PodAntiAffinityType")
 	}
 

--- a/controller/podcontroller.go
+++ b/controller/podcontroller.go
@@ -157,10 +157,10 @@ func (c *PodController) onUpdate(oldObj, newObj interface{}) {
 			log.Error(err)
 			return
 		}
-		
-		// if the backrest repo pod is ready, then see if is reporting ready following an configuration
-		// update due to a failover over (i.e. to point the pgbackrest repo to the new primary).  if it
-		// is again ready following a failover event, the initiate a backup
+
+		// if the backrest repo pod is ready, then see if it is reporting ready following a
+		// configuration update due to a failover over (i.e. to point the pgbackrest repo to the
+		// new primary).  if it is again ready following a failover event, then initiate a backup
 		if isBackrestRepo && isPrimaryOnRoleChange(c.PodClientset, pgcluster,
 			newpod.ObjectMeta.Namespace) && isBackrestRepoReady(oldpod, newpod) {
 
@@ -547,8 +547,7 @@ func isPrimaryOnRoleChange(clientset *kubernetes.Clientset, pgcluster crv1.Pgclu
 	var err error
 
 	// return false right away if scope isn't set
-	if _, valExists := pgcluster.ObjectMeta.Labels[config.LABEL_PGHA_SCOPE]; 
-		!valExists {
+	if _, valExists := pgcluster.ObjectMeta.Labels[config.LABEL_PGHA_SCOPE]; !valExists {
 		return false
 	}
 

--- a/deploy/cluster-roles-readonly.yaml
+++ b/deploy/cluster-roles-readonly.yaml
@@ -14,3 +14,4 @@ rules:
       - serviceaccounts
       - roles
       - rolebindings
+      - nodes

--- a/deploy/cluster-roles.yaml
+++ b/deploy/cluster-roles.yaml
@@ -13,3 +13,10 @@ rules:
       - serviceaccounts
       - roles
       - rolebindings
+  - verbs:
+      - 'list'
+      - 'get'
+    apiGroups:
+      - '*'
+    resources:
+      - nodes

--- a/hugo/content/Configuration/pgo-yaml-configuration.md
+++ b/hugo/content/Configuration/pgo-yaml-configuration.md
@@ -53,7 +53,8 @@ The *pgo.yaml* file is broken into major sections as described below:
 |Storage.storage1.StorageType        |supported values are either *dynamic*,  *create*,  if not supplied, *create* is used
 |Fsgroup        | optional, if set, will cause a *SecurityContext* and *fsGroup* attributes to be added to generated Pod and Deployment definitions
 |SupplementalGroups        | optional, if set, will cause a SecurityContext to be added to generated Pod and Deployment definitions
-|MatchLabels        | optional, if set, will cause the PVC to add a *matchlabels* selector in order to match a PV, only useful when the StorageType is *create*, when specified a label of *key=value* is added to the PVC as a match criteria
+|MatchLabels        | optional, if set, will cause the PVC to add a *matchlabels* selector in order to match a PV, only useful when the StorageType is *create*, when specified a label of
+|PodAntiAffinity        | either `preferred`, `require` or `disable` to either specify the type of affinity that should be utilized for the default pod anti-affinity applied to PG clusters, or to disable default pod anti-affinity all together  (default `preferred`)
 
 ## Storage Configuration Examples
 In *pgo.yaml*, you will need to configure your storage configurations

--- a/hugo/content/Configuration/pgo-yaml-configuration.md
+++ b/hugo/content/Configuration/pgo-yaml-configuration.md
@@ -53,8 +53,8 @@ The *pgo.yaml* file is broken into major sections as described below:
 |Storage.storage1.StorageType        |supported values are either *dynamic*,  *create*,  if not supplied, *create* is used
 |Fsgroup        | optional, if set, will cause a *SecurityContext* and *fsGroup* attributes to be added to generated Pod and Deployment definitions
 |SupplementalGroups        | optional, if set, will cause a SecurityContext to be added to generated Pod and Deployment definitions
-|MatchLabels        | optional, if set, will cause the PVC to add a *matchlabels* selector in order to match a PV, only useful when the StorageType is *create*, when specified a label of
-|PodAntiAffinity        | either `preferred`, `require` or `disable` to either specify the type of affinity that should be utilized for the default pod anti-affinity applied to PG clusters, or to disable default pod anti-affinity all together  (default `preferred`)
+|MatchLabels        | optional, if set, will cause the PVC to add a *matchlabels* selector in order to match a PV, only useful when the StorageType is *create*, when specified a label of *key=value* is added to the PVC as a match criteria
+|PodAntiAffinity        | either `preferred`, `required` or `disabled` to either specify the type of affinity that should be utilized for the default pod anti-affinity applied to PG clusters, or to disable default pod anti-affinity all together  (default `preferred`)
 
 ## Storage Configuration Examples
 In *pgo.yaml*, you will need to configure your storage configurations

--- a/hugo/content/overview/pod-affinitiy-overview.md
+++ b/hugo/content/overview/pod-affinitiy-overview.md
@@ -17,11 +17,10 @@ the PostgreSQL Operator).  This includes:
 - The `pgBackrest` dedicated repostiory deployment
 - The `pgBouncer` deployment (if enabled for the cluster)
 
-With default pod anti-affinity enabled, Kubernetes will attempt to schedule the pods created
-by each individual deployment above on a unique node, but at the same time will not guarentee that
-each deployment will be scheduled on a unqiue node.  This therefore ensures that the various pods
-comprising the PG cluster can always be scheduled, even if though they might not end up on the 
-desired node.  This is specifically done using the following:
+With default pod anti-affinity enabled, Kubernetes will attempt to schedule pods created by each of
+the separate deployments above on a unique node, but will not guarentee that this will ocurr. This
+ensures that the pods comprising the PG cluster can always be scheduled, though perhaps not always
+on the desired node.  This is specifically done using the following:
 
 - The `preferredDuringSchedulingIgnoredDuringExecution` affinity type, (as defined by the Kubernetes
 API), which defines an anti-affinity rule that Kubernetes will attempt to adhere to, but will not
@@ -52,8 +51,8 @@ the default pod anti-affinity, specifically by setting `pod-anti-affinity` to `r
 pgo create cluster mycluster --replica-count=2 --pod-anti-affinity=required
 ```
 
-Or similarly the `require` option can be enabled globally for all clusters by setting 
-`PodAntiAffinity` to `require` in the `pgo.yaml` configuration file.
+Or similarly the `required` option can be enabled globally for all clusters by setting 
+`PodAntiAffinity` to `required` in the `pgo.yaml` configuration file.
 
 When `require` is utilized for the default pod anti-affinity, a separate node is required for each
 deployment listed above comprising the PG cluster.  This ensures that the cluster remains 
@@ -73,4 +72,4 @@ pgo create cluster mycluster --replica-count=2 --pod-anti-affinity=disabled
 ```
 
 Or the same setting can be applied globally to all clusters created by setting `PodAntiAffinity` 
-to `require` in the `pgo.yaml` configuration file.
+to `disabled` in the `pgo.yaml` configuration file.

--- a/hugo/content/overview/pod-affinitiy-overview.md
+++ b/hugo/content/overview/pod-affinitiy-overview.md
@@ -1,0 +1,76 @@
+---
+title: "Pod Anti-Affinity in PostgreSQL Operator"
+date:
+draft: false
+weight: 3
+---
+
+## Pod Anti-Affinity in PostgreSQL Operator
+
+By default, when a new PostgreSQL cluster is created using the PostgreSQL Operator, pod 
+anti-affinity rules will be applied to any deployments comprising the full PG cluster
+(please note that default pod anti-affinity does not apply to any Kubernetes jobs created by
+the PostgreSQL Operator).  This includes:
+
+- The primary PG deployment
+- The deployments for each PG replica
+- The `pgBackrest` dedicated repostiory deployment
+- The `pgBouncer` deployment (if enabled for the cluster)
+
+With default pod anti-affinity enabled, Kubernetes will attempt to schedule the pods created
+by each individual deployment above on a unique node, but at the same time will not guarentee that
+each deployment will be scheduled on a unqiue node.  This therefore ensures that the various pods
+comprising the PG cluster can always be scheduled, even if though they might not end up on the 
+desired node.  This is specifically done using the following:
+
+- The `preferredDuringSchedulingIgnoredDuringExecution` affinity type, (as defined by the Kubernetes
+API), which defines an anti-affinity rule that Kubernetes will attempt to adhere to, but will not
+guarantee
+- A combination of labels that uniquely identify the pods created by the various deployments 
+listed above as those that the default pod anti-affinity should apply to
+- A topology key of `kubernetes.io/hostname`, which instructs Kubernetes to schedule a pod on
+specific node (i.e. host) only if there is not already another pod in the PG cluster
+scheduled on that same node
+
+While the pod anti-affinity rule discussed above will be enabled by default for all PG clusters,
+it can also be explicitly enabled via the `pgo` CLI by setting the `pod-anti-affinity` option
+to `preferred`:
+
+```bash
+pgo create cluster mycluster --replica-count=2 --pod-anti-affinity=preferred
+```
+
+Or it can also be explicitly enabled globally for all clusters by setting `PodAntiAffinity` to
+`preferred` in the `pgo.yaml` configuration file.
+
+In addition to providing the ability to set default pod anti-affinity using the `preferred`
+option, i.e. an affinity rule that utilizes the `preferredDuringSchedulingIgnoredDuringExecution`
+affinity type, it is also possible to use `requiredDuringSchedulingIgnoredDuringExecution` for
+the default pod anti-affinity, specifically by setting `pod-anti-affinity` to `required`:
+
+```bash
+pgo create cluster mycluster --replica-count=2 --pod-anti-affinity=required
+```
+
+Or similarly the `require` option can be enabled globally for all clusters by setting 
+`PodAntiAffinity` to `require` in the `pgo.yaml` configuration file.
+
+When `require` is utilized for the default pod anti-affinity, a separate node is required for each
+deployment listed above comprising the PG cluster.  This ensures that the cluster remains 
+highly-available by ensuring that node failures do not impact any other deployments in the cluster.
+However, this does mean that the PG primary, each PG replica, the `pgBackRestRepo` and `pgBouncer`,
+will each require a unique node, meaning the minimum number of nodes required for the Kubernetes 
+cluster will increase as more deployments (e.g. PG replicas) are added to the PG cluster.  Further,
+if an insufficient number of nodes are available to support this configuration, certain deployments 
+will fail, since it will not be possible for Kubernetes to successfully schedule the pods for each 
+deployment.
+
+And finally, it is also possible to disable the default pod anti-affinity settings all together.
+Using the `pgo` CLI this is done by setting `pod-anti-affinity` to `disabled`, e.g.:
+
+```bash
+pgo create cluster mycluster --replica-count=2 --pod-anti-affinity=disabled
+```
+
+Or the same setting can be applied globally to all clusters created by setting `PodAntiAffinity` 
+to `require` in the `pgo.yaml` configuration file.

--- a/operator/backrest/repo.go
+++ b/operator/backrest/repo.go
@@ -27,28 +27,31 @@ import (
 	"github.com/crunchydata/postgres-operator/operator/pvc"
 	"github.com/crunchydata/postgres-operator/util"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 type RepoDeploymentTemplateFields struct {
-	SecurityContext       string
-	PGOImagePrefix        string
-	PGOImageTag           string
-	ContainerResources    string
-	BackrestRepoClaimName string
-	SshdSecretsName       string
-	PGbackrestDBHost      string
-	PgbackrestRepoPath    string
-	PgbackrestDBPath      string
-	PgbackrestPGPort      string
-	SshdPort              int
-	PgbackrestStanza      string
-	PgbackrestRepoType    string
-	PgbackrestS3EnvVars   string
-	Name                  string
-	ClusterName           string
+	SecurityContext           string
+	PGOImagePrefix            string
+	PGOImageTag               string
+	ContainerResources        string
+	BackrestRepoClaimName     string
+	SshdSecretsName           string
+	PGbackrestDBHost          string
+	PgbackrestRepoPath        string
+	PgbackrestDBPath          string
+	PgbackrestPGPort          string
+	SshdPort                  int
+	PgbackrestStanza          string
+	PgbackrestRepoType        string
+	PgbackrestS3EnvVars       string
+	Name                      string
+	ClusterName               string
+	PodAntiAffinity           string
+	PodAntiAffinityLabelName  string
+	PodAntiAffinityLabelValue string
 }
 
 type RepoServiceTemplateFields struct {
@@ -109,6 +112,9 @@ func CreateRepoDeployment(clientset *kubernetes.Clientset, namespace string, clu
 		Name:            serviceName,
 		ClusterName:     cluster.Name,
 		SecurityContext: util.CreateSecContext(cluster.Spec.PrimaryStorage.Fsgroup, cluster.Spec.PrimaryStorage.SupplementalGroups),
+		PodAntiAffinity: operator.GetPodAntiAffinity(cluster.Spec.PodAntiAffinity, cluster.Spec.Name),
+		PodAntiAffinityLabelName: config.LABEL_POD_ANTI_AFFINITY,
+		PodAntiAffinityLabelValue: cluster.Spec.PodAntiAffinity,
 	}
 	log.Debugf(fields.Name)
 

--- a/operator/backrest/restore.go
+++ b/operator/backrest/restore.go
@@ -445,6 +445,7 @@ func CreateRestoredDeployment(restclient *rest.RESTClient, cluster *crv1.Pgclust
 		PrimarySecretName:  cluster.Spec.PrimarySecretName,
 		UserSecretName:     cluster.Spec.UserSecretName,
 		NodeSelector:       affinityStr,
+		PodAntiAffinity:    operator.GetPodAntiAffinity(cluster.Spec.PodAntiAffinity, cluster.Spec.Name),
 		ContainerResources: operator.GetContainerResourcesJSON(&cluster.Spec.ContainerResources),
 		ConfVolume:         operator.GetConfVolume(clientset, cluster, namespace),
 		CollectAddon:       operator.GetCollectAddon(clientset, namespace, &cluster.Spec),

--- a/operator/cluster/clusterlogic.go
+++ b/operator/cluster/clusterlogic.go
@@ -131,6 +131,7 @@ func AddCluster(clientset *kubernetes.Clientset, client *rest.RESTClient, cl *cr
 		PrimarySecretName:  cl.Spec.PrimarySecretName,
 		UserSecretName:     cl.Spec.UserSecretName,
 		NodeSelector:       operator.GetAffinity(cl.Spec.UserLabels["NodeLabelKey"], cl.Spec.UserLabels["NodeLabelValue"], "In"),
+		PodAntiAffinity:    operator.GetPodAntiAffinity(cl.Spec.PodAntiAffinity, cl.Spec.Name),
 		ContainerResources: operator.GetContainerResourcesJSON(&cl.Spec.ContainerResources),
 		ConfVolume:         operator.GetConfVolume(clientset, cl, namespace),
 		CollectAddon:       operator.GetCollectAddon(clientset, namespace, &cl.Spec),
@@ -160,7 +161,7 @@ func AddCluster(clientset *kubernetes.Clientset, client *rest.RESTClient, cl *cr
 			} else {
 				log.Debugf("Custom postgres-ha config file found in custom configMap, " +
 					"creating default configMap without default postgres-ha config file")
-				operator.AddDefaultPostgresHaConfigMap(clientset, cl, deploymentFields.IsInit, true, namespace)
+				operator.AddDefaultPostgresHaConfigMap(clientset, cl, deploymentFields.IsInit, false, namespace)
 			}
 		} else {
 			log.Error(err.Error())
@@ -369,6 +370,7 @@ func Scale(clientset *kubernetes.Clientset, client *rest.RESTClient, replica *cr
 		UserSecretName:     cluster.Spec.UserSecretName,
 		ContainerResources: operator.GetContainerResourcesJSON(&cs),
 		NodeSelector:       operator.GetReplicaAffinity(cluster.Spec.UserLabels, replica.Spec.UserLabels),
+		PodAntiAffinity:    operator.GetPodAntiAffinity(cluster.Spec.PodAntiAffinity, cluster.Spec.Name),
 		CollectAddon:       operator.GetCollectAddon(clientset, namespace, &cluster.Spec),
 		CollectVolume:      operator.GetCollectVolume(clientset, cluster, namespace),
 		BadgerAddon:        operator.GetBadgerAddon(clientset, namespace, cluster, replica.Spec.Name),

--- a/operator/cluster/pgbouncer.go
+++ b/operator/cluster/pgbouncer.go
@@ -55,15 +55,18 @@ type PgbouncerConfFields struct {
 }
 
 type PgbouncerTemplateFields struct {
-	Name               string
-	ClusterName        string
-	PGBouncerSecret    string
-	CCPImagePrefix     string
-	CCPImageTag        string
-	Port               string
-	PrimaryServiceName string
-	ReplicaServiceName string
-	ContainerResources string
+	Name                      string
+	ClusterName               string
+	PGBouncerSecret           string
+	CCPImagePrefix            string
+	CCPImageTag               string
+	Port                      string
+	PrimaryServiceName        string
+	ReplicaServiceName        string
+	ContainerResources        string
+	PodAntiAffinity           string
+	PodAntiAffinityLabelName  string
+	PodAntiAffinityLabelValue string
 }
 
 // connInfo ....
@@ -307,13 +310,16 @@ func AddPgbouncer(clientset *kubernetes.Clientset, restclient *rest.RESTClient, 
 
 	//create the pgbouncer deployment
 	fields := PgbouncerTemplateFields{
-		Name:               pgbouncerName,
-		ClusterName:        clusterName,
-		CCPImagePrefix:     operator.Pgo.Cluster.CCPImagePrefix,
-		CCPImageTag:        cl.Spec.CCPImageTag,
-		Port:               operator.Pgo.Cluster.Port,
-		PGBouncerSecret:    secretName,
-		ContainerResources: "",
+		Name:                      pgbouncerName,
+		ClusterName:               clusterName,
+		CCPImagePrefix:            operator.Pgo.Cluster.CCPImagePrefix,
+		CCPImageTag:               cl.Spec.CCPImageTag,
+		Port:                      operator.Pgo.Cluster.Port,
+		PGBouncerSecret:           secretName,
+		ContainerResources:        "",
+		PodAntiAffinity:           operator.GetPodAntiAffinity(cl.Spec.PodAntiAffinity, cl.Spec.Name),
+		PodAntiAffinityLabelName:  config.LABEL_POD_ANTI_AFFINITY,
+		PodAntiAffinityLabelValue: cl.Spec.PodAntiAffinity,
 	}
 
 	if operator.Pgo.DefaultPgbouncerResources != "" {

--- a/operator/clusterutilities.go
+++ b/operator/clusterutilities.go
@@ -50,7 +50,7 @@ type affinityType string
 
 const (
 	requireScheduleIgnoreExec affinityType = "requiredDuringSchedulingIgnoredDuringExecution"
-	preferScheduleIgnoreExec   affinityType = "preferredDuringSchedulingIgnoredDuringExecution"
+	preferScheduleIgnoreExec  affinityType = "preferredDuringSchedulingIgnoredDuringExecution"
 )
 
 type affinityTemplateFields struct {
@@ -454,13 +454,13 @@ func GetPodAntiAffinity(podAntiAffinityType string, clusterName string) string {
 		affinityTypeParam = crv1.PodAntiAffinityType(podAntiAffinityType)
 	} else if Pgo.Cluster.PodAntiAffinity != "" {
 		affinityTypeParam = crv1.PodAntiAffinityType(Pgo.Cluster.PodAntiAffinity)
-	} 
+	}
 
 	// verify that the affinity type provided is valid (i.e. 'required' or 'preffered'), and
 	// log an error and return an empty string if not
-	if err := affinityTypeParam.ValidatePodAntiAffinityType(); affinityTypeParam != "" &&
-	 	err != nil {
-		log.Error(fmt.Sprintf("Invalid affinity type '%s' specified when attempting to set " +
+	if err := affinityTypeParam.Validate(); affinityTypeParam != "" &&
+		err != nil {
+		log.Error(fmt.Sprintf("Invalid affinity type '%s' specified when attempting to set "+
 			"default pod anti-affinity for cluster %s.  Pod anti-affinity will not be applied.",
 			podAntiAffinityType, clusterName))
 		return ""
@@ -468,7 +468,7 @@ func GetPodAntiAffinity(podAntiAffinityType string, clusterName string) string {
 
 	// set requiredDuringSchedulingIgnoredDuringExecution or
 	// prefferedDuringSchedulingIgnoredDuringExecution depending on the pod anti-affinity type
-	// specified in the pgcluster CR.  Defaults to preffered if not explicitly specified 
+	// specified in the pgcluster CR.  Defaults to preffered if not explicitly specified
 	// in the CR or in the pgo.yaml configuration file
 	templateAffinityType := preferScheduleIgnoreExec
 	switch affinityTypeParam {

--- a/pgo/cmd/cluster.go
+++ b/pgo/cmd/cluster.go
@@ -223,6 +223,7 @@ func createCluster(args []string, ns string) {
 	r.ReplicaStorageConfig = ReplicaStorageConfig
 	r.ContainerResources = ContainerResources
 	r.ClientVersion = msgs.PGO_VERSION
+	r.PodAntiAffinity = PodAntiAffinity
 
 	if !(len(PgBouncerUser) > 0) {
 		r.PgbouncerUser = "pgbouncer"

--- a/pgo/cmd/create.go
+++ b/pgo/cmd/create.go
@@ -50,6 +50,7 @@ var PGBackRestType string
 var Secret string
 var PgouserPassword, PgouserRoles, PgouserNamespaces string
 var Permissions string
+var PodAntiAffinity string
 
 var Series int
 
@@ -252,6 +253,9 @@ func init() {
 	createClusterCmd.Flags().IntVarP(&Series, "series", "e", 1, "The number of clusters to create in a series.")
 	createClusterCmd.Flags().IntVarP(&ClusterReplicaCount, "replica-count", "", 0, "The number of replicas to create as part of the cluster.")
 	createClusterCmd.Flags().StringVarP(&ContainerResources, "resources-config", "r", "", "The name of a container resource configuration in pgo.yaml that holds CPU and memory requests and limits.")
+	createClusterCmd.Flags().StringVarP(&PodAntiAffinity, "pod-anti-affinity", "", "",
+		"Specifies the type of anti-affinity that should be utilized when applying  "+
+			"default pod anti-affinity rules to PG clusters (default \"preferred\")")
 
 	createPolicyCmd.Flags().StringVarP(&PolicyURL, "url", "u", "", "The url to use for adding a policy.")
 	createPolicyCmd.Flags().StringVarP(&PolicyFile, "in-file", "i", "", "The policy file path to use for adding a policy.")


### PR DESCRIPTION
Adds default pod ant-affinity rules to all deployment specifications utilized to deploy the various pods that comprise a full PG cluster. This includes the PG primary, each PG replica, the `pgBackRest` dedicated repository host, as well as `pgBouncer` (if enabled).

The default pod anti-affinity rules specifically attempt to schedule each pod created for the various deployments discussed above to a unique pod within the Kubernetes cluster.  By default, the anti affinity rules are applied using the `preferredDuringSchedulingIgnoredDuringExecution` affinity type, which means Kubernetes will attempt to adhere to the anti-affinity rules, but will not guarantee that they will be enforced.  This configuration therefore favors ensuring various pods comprising the PG cluster can always be scheduled, even if not always on the desired node.

It is also possible to use the `requiredDuringSchedulingIgnoredDuringExecution` affinity type when applying default pod anti-affinity.  The specific affinity type for a PG cluster can be specified by setting the`pod-anti-affinity` option available on the `pgo create cluster` command to either `required` (for `requiredDuringSchedulingIgnoredDuringExecution`) or `preferred` (for
`preferredDuringSchedulingIgnoredDuringExecution`). The same option can also be set globally
for all PG deployments by using the `PodAntiAffinity`setting in the `pgo.yaml` configuration file.

When the `required` option is utilized, a unique node will be required for each pod comprising the full PG cluster.  Therefore, as new deployments (e.g. `pgBouncer` and/or additional replicas) are
added, there must be enough nodes available without existing PG pods scheduled and deployed for the cluster, otherwise those deployments will not be successfully scheduled.  Therefore, while `required` supports a highly-available configuration by ensuring node failures only potentially impact
a single deployment in the cluster, it is necessary that the cluster has sufficient nodes
to support this configuration.

And lastly, pod anti-affinity can be disabled all together for all deployments by setting
either the `pod-anti-affinity` CLI option to `disable`, or by setting the `PodAntiAffinity`
setting in pgo.yaml to disabled.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Pod anti-affinity is not applied to the pods comprising a PG cluster.

[ch6372]

**What is the new behavior (if this is a feature change)?**

Default pod anti-affinity is applied to the pods comprising a PG cluster in order to schedule the pods comprising the PG cluster of different nodes.

**Other information**:

N/A