### PR TITLE
restores explicit go binary build rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,13 +71,21 @@ build-pgo-apiserver:
 	go install apiserver.go
 	cp $(GOBIN)/apiserver bin/
 
+build-pgo-backrest:
+	go install pgo-backrest/pgo-backrest.go
+	mv $(GOBIN)/pgo-backrest bin/pgo-backrest/
+
+build-pgo-rmdata:
+	go install pgo-rmdata/pgo-rmdata.go
+	cp $(GOBIN)/pgo-rmdata bin/pgo-rmdata/
+
+build-pgo-scheduler:
+	go install pgo-scheduler/pgo-scheduler.go
+	mv $(GOBIN)/pgo-scheduler bin/pgo-scheduler/
+
 build-postgres-operator:
 	go install postgres-operator.go
 	cp $(GOBIN)/postgres-operator bin/postgres-operator/
-
-build-%: %/%.go
-	go install $*/$*.go
-	cp $(GOBIN)/$* ./bin/$*
 
 build-pgo-%:
 	$(info No binary build needed for $@)


### PR DESCRIPTION
The introduction of a second, similarly named implicit rule left
the "warning suppression" rule as the more explicit rule.
(PR #1137)
This had the negative effect of suppressing the binary builds.

This change reverts the removal of the explicit build rules,
leaving the implicit rule to only cover invocations of build-*
for unneeded binaries

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
