### PR TITLE
Image pull secrets and private image registries

### DIFF
--- a/ansible/inventory
+++ b/ansible/inventory
@@ -68,6 +68,11 @@ ccp_image_tag='centos7-12.1-4.2.0'
 pgo_image_prefix='crunchydata'
 pgo_image_tag='centos7-4.2.0'
 
+# Name of a Secret containing credentials for container image registries.
+# Provide a path to the Secret manifest to be installed in each namespace. (optional)
+#pgo_image_pull_secret=''
+#pgo_image_pull_secret_manifest=''
+
 # PGO Client Install
 pgo_client_install='true'
 pgo_client_version='v4.2.0'

--- a/ansible/roles/pgo-operator/defaults/main.yml
+++ b/ansible/roles/pgo-operator/defaults/main.yml
@@ -28,6 +28,8 @@ pgo_disable_tls: "false"
 pgo_tls_no_verify: "false"
 pgo_disable_eventing: "false"
 pgo_apiserver_port: 8443
+pgo_image_pull_secret: ""
+pgo_image_pull_secret_manifest: ""
 
 namespace: ""
 

--- a/ansible/roles/pgo-operator/tasks/main.yml
+++ b/ansible/roles/pgo-operator/tasks/main.yml
@@ -94,6 +94,13 @@
       tags: [install, update]
       when: create_rbac|bool
 
+    - name: Create Image Pull Secret
+      command: "{{ kubectl_or_oc }} create -f {{ pgo_image_pull_secret_manifest }} -n {{ pgo_operator_namespace }}"
+      tags: [install, update]
+      when:
+        - create_rbac | bool
+        - pgo_image_pull_secret_manifest != ''
+
     - name: Create cluster-admin Cluster Role Binding for PGO Service Account
       command: | 
         {{ kubectl_or_oc }} create clusterrolebinding pgo-cluster-admin \

--- a/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
+++ b/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
@@ -18,6 +18,10 @@ if [[ -z "{{ item }}" ]]; then
 	exit
 fi
 
+PGO_CMD='{{ kubectl_or_oc }}'
+PGO_IMAGE_PULL_SECRET='{{ pgo_image_pull_secret }}'
+PGO_IMAGE_PULL_SECRET_MANIFEST='{{ pgo_image_pull_secret_manifest }}'
+TARGET_NAMESPACE='{{ item }}'
 
 # create the namespace if necessary
 {{ kubectl_or_oc }} get ns {{ item }}  > /dev/null
@@ -48,3 +52,16 @@ cat {{ role_path }}/files/pgo-configs/pgo-backrest-role-binding.json | sed 's/{{
 cat {{ role_path }}/files/pgo-configs/pgo-pg-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-pg-role.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-pg-role-binding.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
+
+if [ -r "$PGO_IMAGE_PULL_SECRET_MANIFEST" ]; then
+	$PGO_CMD -n "$TARGET_NAMESPACE" create -f "$PGO_IMAGE_PULL_SECRET_MANIFEST"
+fi
+
+if [ -n "$PGO_IMAGE_PULL_SECRET" ]; then
+	patch='{"imagePullSecrets": [{ "name": "'"$PGO_IMAGE_PULL_SECRET"'" }]}'
+
+	$PGO_CMD -n "$TARGET_NAMESPACE" patch --type=strategic --patch="$patch" serviceaccount/pgo-backrest
+	$PGO_CMD -n "$TARGET_NAMESPACE" patch --type=strategic --patch="$patch" serviceaccount/pgo-default
+	$PGO_CMD -n "$TARGET_NAMESPACE" patch --type=strategic --patch="$patch" serviceaccount/pgo-pg
+	$PGO_CMD -n "$TARGET_NAMESPACE" patch --type=strategic --patch="$patch" serviceaccount/pgo-target
+fi

--- a/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: postgres-operator
   namespace: {{ pgo_operator_namespace }}
+{% if pgo_image_pull_secret %}
+imagePullSecrets:
+  - name: {{ pgo_image_pull_secret }}
+{% endif %}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/add-targeted-namespace.sh
+++ b/deploy/add-targeted-namespace.sh
@@ -54,3 +54,16 @@ cat $PGOROOT/conf/postgres-operator/pgo-backrest-role-binding.json | sed 's/{{.T
 cat $PGOROOT/conf/postgres-operator/pgo-pg-sa.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
 cat $PGOROOT/conf/postgres-operator/pgo-pg-role.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
 cat $PGOROOT/conf/postgres-operator/pgo-pg-role-binding.json | sed 's/{{.TargetNamespace}}/'"$1"'/' | $PGO_CMD -n $1 create -f -
+
+if [ -r "$PGO_IMAGE_PULL_SECRET_MANIFEST" ]; then
+	$PGO_CMD -n $1 create -f "$PGO_IMAGE_PULL_SECRET_MANIFEST"
+fi
+
+if [ -n "$PGO_IMAGE_PULL_SECRET" ]; then
+	patch='{"imagePullSecrets": [{ "name": "'"$PGO_IMAGE_PULL_SECRET"'" }]}'
+
+	$PGO_CMD -n $1 patch --type=strategic --patch="$patch" serviceaccount/pgo-backrest
+	$PGO_CMD -n $1 patch --type=strategic --patch="$patch" serviceaccount/pgo-default
+	$PGO_CMD -n $1 patch --type=strategic --patch="$patch" serviceaccount/pgo-pg
+	$PGO_CMD -n $1 patch --type=strategic --patch="$patch" serviceaccount/pgo-target
+fi

--- a/deploy/install-rbac.sh
+++ b/deploy/install-rbac.sh
@@ -38,6 +38,16 @@ expenv -f $DIR/cluster-roles.yaml | $PGO_CMD create -f -
 # create the Operator service accounts
 expenv -f $DIR/service-accounts.yaml | $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create -f -
 
+if [ -r "$PGO_IMAGE_PULL_SECRET_MANIFEST" ]; then
+	$PGO_CMD -n $PGO_OPERATOR_NAMESPACE create -f "$PGO_IMAGE_PULL_SECRET_MANIFEST"
+fi
+
+if [ -n "$PGO_IMAGE_PULL_SECRET" ]; then
+	patch='{"imagePullSecrets": [{ "name": "'"$PGO_IMAGE_PULL_SECRET"'" }]}'
+
+	$PGO_CMD -n $PGO_OPERATOR_NAMESPACE patch --type=strategic --patch="$patch" serviceaccount/postgres-operator
+fi
+
 # create the cluster role bindings to the Operator service accounts
 # postgres-operator and pgo-backrest, here we are assuming a single
 # Operator in the PGO_OPERATOR_NAMESPACE env variable


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**
To authenticate to private registries, one must configure kubelet or manually update service accounts with image pull secrets.


**What is the new behavior (if this is a feature change)?**
- Operator installation can install and configure image pull secrets.
- Scripts for static namespaces can configure image pull secrets.
- Operator API for dynamic namespaces configures image pull secrets.

While I was in the dynamic namespace code, I unexported all the functions that weren't used outside the package.