### PR TITLE
Add Support for Synchronous Replication in PG Clusters

### DIFF
--- a/ansible/inventory
+++ b/ansible/inventory
@@ -107,6 +107,8 @@ auto_failover='false'
 backrest='true'
 badger='false'
 metrics='false'
+pod_anti_affinity='preferred'
+sync_replication='false'
 
 # pgbadger Defaults
 pgbadgerport='10000'

--- a/ansible/roles/pgo-operator/defaults/main.yml
+++ b/ansible/roles/pgo-operator/defaults/main.yml
@@ -20,6 +20,7 @@ cleanup: "false"
 common_name: "crunchydata"
 crunchy_debug: "false"
 enable_crunchyadm: "false"
+disable_replica_start_fail_reinit: "false"
 
 pgo_client_install: "true"
 pgo_client_container_install: "false"

--- a/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -88,7 +88,10 @@
                     }, {
                         "name": "PGHA_REPLICA_REINIT_ON_START_FAIL",
                         "value": "{{.ReplicaReinitOnStartFail}}"
-                    }, {
+                    },  {
+                        "name": "PGHA_SYNC_REPLICATION",
+                        "value": "{{.SyncReplication}}"
+                    },  {
                         "name": "PATRONI_KUBERNETES_NAMESPACE",
                         "valueFrom": {
                             "fieldRef": {

--- a/ansible/roles/pgo-operator/templates/pgo.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/pgo.yaml.j2
@@ -27,6 +27,9 @@ Cluster:
   LogStatement: {{ log_statement }}
   LogMinDurationStatement:  {{ log_min_duration_statement }}
   EnableCrunchyadm:  {{ enable_crunchyadm }}
+  DisableReplicaStartFailReinit:  {{ disable_replica_start_fail_reinit }}
+  PodAntiAffinity:  {{ pod_anti_affinity }}
+  SyncReplication:  {{ sync_replication }}
 PrimaryStorage: {{ primary_storage }}
 BackupStorage: {{ backup_storage }}
 ReplicaStorage: {{ replica_storage }}

--- a/apis/cr/v1/cluster.go
+++ b/apis/cr/v1/cluster.go
@@ -68,6 +68,7 @@ type PgclusterSpec struct {
 	CustomConfig       string               `json:"customconfig"`
 	UserLabels         map[string]string    `json:"userlabels"`
 	PodAntiAffinity    string               `json:"podPodAntiAffinity"`
+	SyncReplication    *bool                `json:"syncReplication"`
 }
 
 // PgclusterList is the CRD that defines a Crunchy PG Cluster List

--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -719,6 +719,12 @@ func CreateCluster(request *msgs.CreateClusterRequest, ns, pgouser string) msgs.
 			userLabelsMap[config.LABEL_POD_ANTI_AFFINITY] = ""
 		}
 
+		// if synchronous replication has been enabled, then add to user labels
+		if request.SyncReplication != nil {
+			userLabelsMap[config.LABEL_SYNC_REPLICATION] =
+				string(strconv.FormatBool(*request.SyncReplication))
+		}
+
 		// Create an instance of our CRD
 		newInstance := getClusterParams(request, clusterName, userLabelsMap, ns)
 		newInstance.ObjectMeta.Labels[config.LABEL_PGOUSER] = pgouser
@@ -949,8 +955,8 @@ func getClusterParams(request *msgs.CreateClusterRequest, name string, userLabel
 	}
 
 	spec.CustomConfig = request.CustomConfig
-
 	spec.PodAntiAffinity = request.PodAntiAffinity
+	spec.SyncReplication = request.SyncReplication
 
 	labels := make(map[string]string)
 	labels[config.LABEL_NAME] = name

--- a/apiservermsgs/clustermsgs.go
+++ b/apiservermsgs/clustermsgs.go
@@ -75,6 +75,7 @@ type CreateClusterRequest struct {
 	// required: true
 	ClientVersion   string
 	PodAntiAffinity string
+	SyncReplication *bool
 }
 
 // CreateClusterResponse

--- a/conf/postgres-operator/cluster-deployment.json
+++ b/conf/postgres-operator/cluster-deployment.json
@@ -88,7 +88,10 @@
                     }, {
                         "name": "PGHA_REPLICA_REINIT_ON_START_FAIL",
                         "value": "{{.ReplicaReinitOnStartFail}}"
-                    }, {
+                    },  {
+                        "name": "PGHA_SYNC_REPLICATION",
+                        "value": "{{.SyncReplication}}"
+                    },  {
                         "name": "PATRONI_KUBERNETES_NAMESPACE",
                         "valueFrom": {
                             "fieldRef": {

--- a/conf/postgres-operator/pgo.yaml
+++ b/conf/postgres-operator/pgo.yaml
@@ -27,6 +27,7 @@ Cluster:
   LogStatement:  none
   LogMinDurationStatement:  60000
   PodAntiAffinity: preferred
+  SyncReplication: false
 PrimaryStorage: storageos
 BackupStorage: storageos
 ReplicaStorage: storageos

--- a/config/labels.go
+++ b/config/labels.go
@@ -48,6 +48,7 @@ const LABEL_CCP_IMAGE_TAG_KEY = "ccp-image-tag"
 const LABEL_CCP_IMAGE_KEY = "ccp-image"
 const LABEL_SERVICE_TYPE = "service-type"
 const LABEL_POD_ANTI_AFFINITY = "pg-pod-anti-affinity"
+const LABEL_SYNC_REPLICATION = "sync-replication"
 
 const LABEL_REPLICA_COUNT = "replica-count"
 const LABEL_RESOURCES_CONFIG = "resources-config"

--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -229,6 +229,7 @@ type ClusterStruct struct {
 	EnableCrunchyadm              bool   `yaml:"EnableCrunchyadm"`
 	DisableReplicaStartFailReinit bool   `yaml:"DisableReplicaStartFailReinit"`
 	PodAntiAffinity               string `yaml:"PodAntiAffinity"`
+	SyncReplication               bool   `yaml:"SyncReplication"`
 }
 
 type StorageStruct struct {

--- a/hugo/content/Configuration/pgo-yaml-configuration.md
+++ b/hugo/content/Configuration/pgo-yaml-configuration.md
@@ -37,7 +37,9 @@ The *pgo.yaml* file is broken into major sections as described below:
 |Backrest        | optional, if set, will cause clusters to have the pgbackrest volume PVC provisioned during cluster creation
 |BackrestPort        | currently required to be port 2022
 |DisableAutofail        | optional, if set, will disable autofail capabilities by default in any newly created cluster
-|DisableReplicaStartFailReinit | if set to "true" will disable the detection of a "start failed" states in PG replicas, which results in the re-initialization of the replica in an attempt to bring it back online
+|DisableReplicaStartFailReinit | if set to `true` will disable the detection of a "start failed" states in PG replicas, which results in the re-initialization of the replica in an attempt to bring it back online
+|PodAntiAffinity        | either `preferred`, `required` or `disabled` to either specify the type of affinity that should be utilized for the default pod anti-affinity applied to PG clusters, or to disable default pod anti-affinity all together (default `preferred`)
+|SyncReplication | boolean, if set to `true` will automatically enable synchronous replication in new PostgreSQL clusters (default `false`)
 
 ## Storage
 | Setting|Definition  |
@@ -54,7 +56,6 @@ The *pgo.yaml* file is broken into major sections as described below:
 |Fsgroup        | optional, if set, will cause a *SecurityContext* and *fsGroup* attributes to be added to generated Pod and Deployment definitions
 |SupplementalGroups        | optional, if set, will cause a SecurityContext to be added to generated Pod and Deployment definitions
 |MatchLabels        | optional, if set, will cause the PVC to add a *matchlabels* selector in order to match a PV, only useful when the StorageType is *create*, when specified a label of *key=value* is added to the PVC as a match criteria
-|PodAntiAffinity        | either `preferred`, `required` or `disabled` to either specify the type of affinity that should be utilized for the default pod anti-affinity applied to PG clusters, or to disable default pod anti-affinity all together  (default `preferred`)
 
 ## Storage Configuration Examples
 In *pgo.yaml*, you will need to configure your storage configurations

--- a/operator/backrest/restore.go
+++ b/operator/backrest/restore.go
@@ -458,6 +458,7 @@ func CreateRestoredDeployment(restclient *rest.RESTClient, cluster *crv1.Pgclust
 			cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], clientset, namespace),
 		EnableCrunchyadm:         operator.Pgo.Cluster.EnableCrunchyadm,
 		ReplicaReinitOnStartFail: !operator.Pgo.Cluster.DisableReplicaStartFailReinit,
+		SyncReplication:         operator.GetSyncReplication(cluster.Spec.SyncReplication),
 	}
 
 	log.Debug("collectaddon value is [" + deploymentFields.CollectAddon + "]")

--- a/operator/cluster/clusterlogic.go
+++ b/operator/cluster/clusterlogic.go
@@ -145,6 +145,7 @@ func AddCluster(clientset *kubernetes.Clientset, client *rest.RESTClient, cl *cr
 			cl.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], clientset, namespace),
 		EnableCrunchyadm:         operator.Pgo.Cluster.EnableCrunchyadm,
 		ReplicaReinitOnStartFail: !operator.Pgo.Cluster.DisableReplicaStartFailReinit,
+		SyncReplication:          operator.GetSyncReplication(cl.Spec.SyncReplication),
 	}
 
 	// create the default configuration file for crunchy-postgres-ha if custom config file not provided
@@ -382,6 +383,7 @@ func Scale(clientset *kubernetes.Clientset, client *rest.RESTClient, replica *cr
 			cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], clientset, namespace),
 		EnableCrunchyadm:         operator.Pgo.Cluster.EnableCrunchyadm,
 		ReplicaReinitOnStartFail: !operator.Pgo.Cluster.DisableReplicaStartFailReinit,
+		SyncReplication:          operator.GetSyncReplication(cluster.Spec.SyncReplication),
 	}
 
 	switch replica.Spec.ReplicaStorage.StorageType {

--- a/operator/clusterutilities.go
+++ b/operator/clusterutilities.go
@@ -149,6 +149,7 @@ type DeploymentTemplateFields struct {
 	EnableCrunchyadm         bool
 	ReplicaReinitOnStartFail bool
 	PodAntiAffinity          string
+	SyncReplication          bool
 }
 
 type PostgresHaTemplateFields struct {
@@ -585,4 +586,17 @@ func UpdatePghaDefaultConfigInitFlag(clientset *kubernetes.Clientset, initVal bo
 	configMap.Data["init"] = strconv.FormatBool(initVal)
 
 	kubeapi.UpdateConfigMap(clientset, configMap, namespace)
+}
+
+// GetSyncReplication returns true if synchronous replication has been enabled using either the
+// pgcluster CR specification or the pgo.yaml configuration file.  Otherwise, if synchronous
+// mode has not been enabled, it returns false.
+func GetSyncReplication(specSyncReplication *bool) bool {
+	// alawys use the value from the CR if explicitly provided
+	if specSyncReplication != nil {
+		return *specSyncReplication
+	} else if Pgo.Cluster.SyncReplication {
+		return true
+	}
+	return false
 }

--- a/pgo/cmd/cluster.go
+++ b/pgo/cmd/cluster.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"github.com/crunchydata/postgres-operator/pgo/api"
 	"github.com/crunchydata/postgres-operator/pgo/util"
@@ -184,7 +186,7 @@ func printPolicies(d *msgs.ShowClusterDeployment) {
 }
 
 // createCluster ....
-func createCluster(args []string, ns string) {
+func createCluster(args []string, ns string, createClusterCmd *cobra.Command) {
 	var err error
 
 	if len(args) != 1 {
@@ -224,6 +226,11 @@ func createCluster(args []string, ns string) {
 	r.ContainerResources = ContainerResources
 	r.ClientVersion = msgs.PGO_VERSION
 	r.PodAntiAffinity = PodAntiAffinity
+
+	// only set SyncReplication in the request if actually provided via the CLI
+	if createClusterCmd.Flag("sync-replication").Changed {
+		r.SyncReplication = &SyncReplication
+	}
 
 	if !(len(PgBouncerUser) > 0) {
 		r.PgbouncerUser = "pgbouncer"

--- a/pgo/cmd/create.go
+++ b/pgo/cmd/create.go
@@ -51,6 +51,7 @@ var Secret string
 var PgouserPassword, PgouserRoles, PgouserNamespaces string
 var Permissions string
 var PodAntiAffinity string
+var SyncReplication bool
 
 var Series int
 
@@ -116,7 +117,7 @@ var createClusterCmd = &cobra.Command{
 		if len(args) != 1 {
 			fmt.Println(`Error: A single cluster name is required for this command.`)
 		} else {
-			createCluster(args, Namespace)
+			createCluster(args, Namespace, cmd)
 		}
 	},
 }
@@ -256,6 +257,8 @@ func init() {
 	createClusterCmd.Flags().StringVarP(&PodAntiAffinity, "pod-anti-affinity", "", "",
 		"Specifies the type of anti-affinity that should be utilized when applying  "+
 			"default pod anti-affinity rules to PG clusters (default \"preferred\")")
+	createClusterCmd.Flags().BoolVarP(&SyncReplication, "sync-replication", "", false,
+		"Enables synchronous replication for the cluster")
 
 	createPolicyCmd.Flags().StringVarP(&PolicyURL, "url", "u", "", "The url to use for adding a policy.")
 	createPolicyCmd.Flags().StringVarP(&PolicyFile, "in-file", "i", "", "The policy file path to use for adding a policy.")


### PR DESCRIPTION
Adds the ability to enable synchronous replication for a PG cluster created using the PostgreSQL
Operator. Synchronous replication is enabled by setting the `PGHA_SYNC_REPLICATION` environment variable to `true` in the `crunchy-postgres-ha` (or GIS equivalent) container, which in turn sets the following configuration settings in the Patroni configuration file utilized to bootstrap and initialize the cluster: 

- `synchronous_commit: "on"`
- `synchronous_standby_names: "*"`
- `synchronous_mode: true`

With these settings in place, PostgreSQL will confirm that all changes made by a
transaction have been successfully transferred to a replica. Further, Patroni will not promote a replica unless it is certain that the standby contains all transactions.

Synchronous mode can be specifically enabled by specifying either the `--sync-replication` flag when creating a new cluster via the `pgo create` CLI command, by setting `SyncReplication` to
true in the `pgo.yaml` configuration file, or by setting `syncReplication` to `true` in the `pgcluster`
`CustomResourceDefinition`.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

A setting does not exist within the PostgreSQL Operator to enable synchronous replication for PG cluster.

[ch6635]

**What is the new behavior (if this is a feature change)?**

It is now possible to enable synchronous for PG clusters created using the PostgreSQL Operator.

**Other information**:

N/A