### PR TITLE
Remove additional references to apiextensions.k8s.io/v1beta1

### DIFF
--- a/ansible/roles/pgo-operator/files/crds/pgbackups-crd.yaml
+++ b/ansible/roles/pgo-operator/files/crds/pgbackups-crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apps/v1
 kind: CustomResourceDefinition
 metadata:
   name: pgbackups.crunchydata.com

--- a/ansible/roles/pgo-operator/files/crds/pgclusters-crd.yaml
+++ b/ansible/roles/pgo-operator/files/crds/pgclusters-crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apps/v1
 kind: CustomResourceDefinition
 metadata:
   name: pgclusters.crunchydata.com

--- a/ansible/roles/pgo-operator/files/crds/pgpolicies-crd.yaml
+++ b/ansible/roles/pgo-operator/files/crds/pgpolicies-crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apps/v1
 kind: CustomResourceDefinition
 metadata:
   name: pgpolicies.crunchydata.com

--- a/ansible/roles/pgo-operator/files/crds/pgreplicas-crd.yaml
+++ b/ansible/roles/pgo-operator/files/crds/pgreplicas-crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apps/v1
 kind: CustomResourceDefinition
 metadata:
   name: pgreplicas.crunchydata.com

--- a/ansible/roles/pgo-operator/files/crds/pgtasks-crd.yaml
+++ b/ansible/roles/pgo-operator/files/crds/pgtasks-crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apps/v1
 kind: CustomResourceDefinition
 metadata:
   name: pgtasks.crunchydata.com

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apps/v1
 kind: CustomResourceDefinition
 metadata:
   name: pgbackups.crunchydata.com
@@ -13,7 +13,7 @@ spec:
   scope: Namespaced
   version: v1
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apps/v1
 kind: CustomResourceDefinition
 metadata:
   name: pgclusters.crunchydata.com
@@ -27,7 +27,7 @@ spec:
   scope: Namespaced
   version: v1
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apps/v1
 kind: CustomResourceDefinition
 metadata:
   name: pgpolicies.crunchydata.com
@@ -41,7 +41,7 @@ spec:
   scope: Namespaced
   version: v1
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apps/v1
 kind: CustomResourceDefinition
 metadata:
   name: pgreplicas.crunchydata.com
@@ -55,7 +55,7 @@ spec:
   scope: Namespaced
   version: v1
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apps/v1
 kind: CustomResourceDefinition
 metadata:
   name: pgtasks.crunchydata.com


### PR DESCRIPTION
This was not a term I had grepped for originally, so there remained a few
apiVersion that still referenced it.