### PR TITLE
[ch6673] Fix for cluster names with "-" in scaledown/failover query

### DIFF
--- a/pgo/cmd/failover.go
+++ b/pgo/cmd/failover.go
@@ -132,6 +132,8 @@ func queryFailover(args []string, ns string) {
 	for i := 0; i < len(response.Results); i++ {
 		instance := response.Results[i]
 
+		log.Debugf("postgresql instance: %v", instance)
+
 		node := instance.Node
 		// check if this is a preferred node
 		if instance.PreferredNode {

--- a/pgo/cmd/scaledown.go
+++ b/pgo/cmd/scaledown.go
@@ -115,6 +115,8 @@ func queryCluster(args []string, ns string) {
 		for i := 0; i < len(response.Results); i++ {
 			instance := response.Results[i]
 
+			log.Debugf("postgresql instance: %v", instance)
+
 			fmt.Printf("%-20s\t%-10s\t%-10s\t%12d MB\n",
 				instance.Name, instance.Status, instance.Node, instance.ReplicationLag)
 		}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Cluster names that had dashes (e.g. "broken-cluster") would not properly
display replica names in the `pgo scaledown --query` and
`pgo failover --query` commands. This is due to us trying to leverage
the information in Patroni to calculate values that are made available
in the output of these commands (e.g. replication lag) so we don't
reinvent the wheel, but have to contend with Patroni get the names
from the pods themselves.

**What is the new behavior (if this is a feature change)?**

The fix uses the information we've collected in the instance-node map
to look for the instance name prefix, which will be less brittle than
the regular expression I had concocted in 4fbcd2239.

**Other information**:

Issue: [ch6673]