### PR TITLE
[ch6702] Remove # backups from `pgo status`

### DIFF
--- a/apiserver/statusservice/statusimpl.go
+++ b/apiserver/statusservice/statusimpl.go
@@ -49,7 +49,6 @@ func getStatus(results *msgs.StatusDetail, ns string) error {
 
 	var err error
 	results.OperatorStartTime = getOperatorStart(apiserver.PgoNamespace)
-	results.NumBackups = getNumBackups(ns)
 	results.NumClaims = getNumClaims(ns)
 	results.NumDatabases = getNumDatabases(ns)
 	results.VolumeCap = getVolumeCap(ns)
@@ -75,16 +74,6 @@ func getOperatorStart(ns string) string {
 	log.Error("a running postgres-operator pod is not found")
 
 	return "error"
-}
-
-func getNumBackups(ns string) int {
-	//count the number of Jobs with pgbackup=true and completionTime not nil
-	jobs, err := kubeapi.GetJobs(apiserver.Clientset, config.LABEL_PGBACKUP, ns)
-	if err != nil {
-		log.Error(err)
-		return 0
-	}
-	return len(jobs.Items)
 }
 
 func getNumClaims(ns string) int {

--- a/apiservermsgs/statusmsgs.go
+++ b/apiservermsgs/statusmsgs.go
@@ -39,7 +39,6 @@ type KeyValue struct {
 type StatusDetail struct {
 	OperatorStartTime string
 	NumDatabases      int
-	NumBackups        int
 	NumClaims         int
 	VolumeCap         string
 	DbTags            map[string]int

--- a/pgo/cmd/status.go
+++ b/pgo/cmd/status.go
@@ -74,7 +74,6 @@ func printSummary(status *msgs.StatusDetail) {
 	WID := 25
 	fmt.Printf("%s%s\n", util.Rpad("Operator Start:", " ", WID), status.OperatorStartTime)
 	fmt.Printf("%s%d\n", util.Rpad("Databases:", " ", WID), status.NumDatabases)
-	fmt.Printf("%s%d\n", util.Rpad("Backups:", " ", WID), status.NumBackups)
 	fmt.Printf("%s%d\n", util.Rpad("Claims:", " ", WID), status.NumClaims)
 	fmt.Printf("%s%s\n", util.Rpad("Total Volume Size:", " ", WID), util.Rpad(status.VolumeCap, " ", 10))
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The way that the statistics on the individual cluster are gathered (i.e.
`pgo show backup`), the Operator performs a `kubectl exec` into the
primary instance of a  PostgreSQL cluster and executes the
`pgbackrest info`. This info is then forwarded along to a user.

**What is the new behavior (if this is a feature change)?**

The good news: there is a `pgbackrest info --output=json` that can be
used to get the number of backups in a parseable format that can be used
to get this total.

The bad news: we would have to exec into every pod in order to provide
this statistics.

The solution: We should remove this statistic until there is a better
way for us to track total backups.