### PR TITLE
Allow separate image pull secrets for container registry

### DIFF
--- a/ansible/inventory
+++ b/ansible/inventory
@@ -77,6 +77,11 @@ namespace='pgouser1,pgouser2'
 ccp_image_prefix='crunchydata'
 ccp_image_tag='centos7-12.1-4.2.0'
 
+# Name of a Secret containing credentials for container image registries.
+# Provide a path to the Secret manifest to be installed in each namespace. (optional)
+ccp_image_pull_secret=''
+ccp_image_pull_secret_manifest=''
+
 # Crunchy PostgreSQL Operator images to use.  The tags centos7 and rhel7 are acceptable.
 pgo_image_prefix='crunchydata'
 pgo_image_tag='centos7-4.2.0'

--- a/ansible/roles/pgo-metrics/tasks/grafana.yml
+++ b/ansible/roles/pgo-metrics/tasks/grafana.yml
@@ -35,6 +35,15 @@
       tags: [install-metrics]
       when: create_rbac|bool
 
+    - name: Create CCP Image Pull Secret
+      shell: >
+        {{ kubectl_or_oc }} -n {{ metrics_namespace }} get secret/{{ ccp_image_pull_secret }} -o jsonpath='{""}' 2> /dev/null ||
+        {{ kubectl_or_oc }} -n {{ metrics_namespace }} create -f {{ ccp_image_pull_secret_manifest }}
+      tags: [install-metrics]
+      when:
+        - create_rbac | bool
+        - ccp_image_pull_secret_manifest != ''
+
     - name: Template Grafana Secret
       template:
         src: "grafana-secret.json.j2"

--- a/ansible/roles/pgo-metrics/tasks/prometheus.yml
+++ b/ansible/roles/pgo-metrics/tasks/prometheus.yml
@@ -35,6 +35,15 @@
       tags: [install-metrics]
       when: create_rbac|bool
 
+    - name: Create CCP Image Pull Secret
+      shell: >
+        {{ kubectl_or_oc }} -n {{ metrics_namespace }} get secret/{{ ccp_image_pull_secret }} -o jsonpath='{""}' 2> /dev/null ||
+        {{ kubectl_or_oc }} -n {{ metrics_namespace }} create -f {{ ccp_image_pull_secret_manifest }}
+      tags: [install-metrics]
+      when:
+        - create_rbac | bool
+        - ccp_image_pull_secret_manifest != ''
+
     - name: Template Prometheus Objects
       template:
         src: "{{ item }}"

--- a/ansible/roles/pgo-metrics/templates/grafana-rbac.json.j2
+++ b/ansible/roles/pgo-metrics/templates/grafana-rbac.json.j2
@@ -5,5 +5,10 @@
         "name": "grafana",
         "namespace": "{{ metrics_namespace }}"
     },
-    "automountServiceAccountToken": false
+    "automountServiceAccountToken": false,
+    "imagePullSecrets": [
+{% if ccp_image_pull_secret %}
+        { "name": "{{ ccp_image_pull_secret }}" }
+{% endif %}
+    ]
 }

--- a/ansible/roles/pgo-metrics/templates/prometheus-rbac.json.j2
+++ b/ansible/roles/pgo-metrics/templates/prometheus-rbac.json.j2
@@ -29,7 +29,12 @@
     "metadata": {
         "name": "prometheus-sa",
         "namespace": "{{ metrics_namespace }}"
-    }
+    },
+    "imagePullSecrets": [
+{% if ccp_image_pull_secret %}
+        { "name": "{{ ccp_image_pull_secret }}" }
+{% endif %}
+    ]
 }
 
 {

--- a/ansible/roles/pgo-operator/tasks/main.yml
+++ b/ansible/roles/pgo-operator/tasks/main.yml
@@ -94,8 +94,19 @@
       tags: [install, update]
       when: create_rbac|bool
 
-    - name: Create Image Pull Secret
-      command: "{{ kubectl_or_oc }} create -f {{ pgo_image_pull_secret_manifest }} -n {{ pgo_operator_namespace }}"
+    - name: Create CCP Image Pull Secret
+      shell: >
+        {{ kubectl_or_oc }} -n {{ pgo_operator_namespace }} get secret/{{ ccp_image_pull_secret }} -o jsonpath='{""}' 2> /dev/null ||
+        {{ kubectl_or_oc }} -n {{ pgo_operator_namespace }} create -f {{ ccp_image_pull_secret_manifest }}
+      tags: [install-metrics]
+      when:
+        - create_rbac | bool
+        - ccp_image_pull_secret_manifest != ''
+
+    - name: Create PGO Image Pull Secret
+      shell: >
+        {{ kubectl_or_oc }} -n {{ pgo_operator_namespace }} get secret/{{ pgo_image_pull_secret }} -o jsonpath='{""}' 2> /dev/null ||
+        {{ kubectl_or_oc }} -n {{ pgo_operator_namespace }} create -f {{ pgo_image_pull_secret_manifest }}
       tags: [install, update]
       when:
         - create_rbac | bool

--- a/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
@@ -4,8 +4,11 @@ kind: ServiceAccount
 metadata:
   name: postgres-operator
   namespace: {{ pgo_operator_namespace }}
-{% if pgo_image_pull_secret %}
 imagePullSecrets:
+{% if ccp_image_pull_secret %}
+  - name: {{ ccp_image_pull_secret }}
+{% endif %}
+{% if pgo_image_pull_secret and ccp_image_pull_secret != pgo_image_pull_secret %}
   - name: {{ pgo_image_pull_secret }}
 {% endif %}
 ---


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the new behavior (if this is a feature change)?**

This adds `ccp_image_pull_secret` to complement `ccp_image_prefix` the same way `pgo_image_pull_secret` is available for `pgo_image_prefix`.

The two image prefixes could refer to different registries with different credentials. This also provides a way to specify image pull secrets for the `pgo-metrics` Ansible role.

Issue: [ch5511]