### PR TITLE
Only delete namespaces of specific installation with Ansible

### DIFF
--- a/ansible/roles/pgo-operator/tasks/cleanup.yml
+++ b/ansible/roles/pgo-operator/tasks/cleanup.yml
@@ -8,8 +8,8 @@
 
 - name: Find watched namespaces
   shell: |
-    {{ kubectl_or_oc }} get namespaces -o json --selector=vendor=crunchydata
-  register: ns_result 
+    {{ kubectl_or_oc }} get namespaces -o json --selector=vendor=crunchydata,pgo-installation-name={{ pgo_installation_name }}
+  register: ns_result
   tags:
   - uninstall
   - update
@@ -238,6 +238,7 @@
   shell: |
     {{ kubectl_or_oc }} label namespace {{ item }} vendor- pgo-created-by- pgo-installation-name-
   ignore_errors: yes
+  when: not (delete_watched_namespaces|bool)
   with_items:
   - "{{ watched_namespaces }}"
   no_log: false

--- a/deploy/cleannamespaces.sh
+++ b/deploy/cleannamespaces.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 # Copyright 2019 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,14 +14,21 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-IFS=', ' read -r -a array <<< "$PGO_OPERATOR_NAMESPACE"
+if [ -z $PGO_OPERATOR_NAMESPACE ];
+then
+	echo "error: \$PGO_OPERATOR_NAME must be set"
+	exit 1
+fi
 
-echo "deleting the namespaces the operator is deployed into..."
-for ns in "${array[@]}"
-do
-	$PGO_CMD delete namespace $ns > /dev/null 2> /dev/null
-	echo namespace $ns deleted
-done
+if [ -z $PGO_INSTALLATION_NAME ];
+then
+	echo "error: \$PGO_INSTALLATION_NAME must be set"
+	exit 1
+fi
+
+echo "deleting the namespaces the operator is deployed into ($PGO_OPERATOR_NAMESPACE)..."
+$PGO_CMD delete namespace $PGO_OPERATOR_NAMESPACE > /dev/null 2> /dev/null
+echo "namespace $PGO_OPERATOR_NAMESPACE deleted"
 
 echo ""
 echo "deleting the watched namespaces..."

--- a/deploy/setupnamespaces.sh
+++ b/deploy/setupnamespaces.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 # Copyright 2019 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,27 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-IFS=', ' read -r -a array <<< "$PGO_OPERATOR_NAMESPACE"
+if [ -z $PGO_OPERATOR_NAMESPACE ];
+then
+	echo "error: \$PGO_OPERATOR_NAME must be set"
+	exit 1
+fi
 
-echo "creating namespaces to deploy the Operator into..."
-for ns in "${array[@]}"
-do
-	$PGO_CMD get namespace $ns > /dev/null 2> /dev/null
-	if [ $? -eq 0 ]
-	then
-		echo namespace $ns is already created
-	else
-		$PGO_CMD create namespace $ns > /dev/null
-		echo namespace $ns created
-	fi
-done
+if [ -z $PGO_INSTALLATION_NAME ];
+then
+	echo "error: \$PGO_INSTALLATION_NAME must be set"
+	exit 1
+fi
+
+echo "creating "$PGO_OPERATOR_NAMESPACE" namespace to deploy the Operator into..."
+$PGO_CMD get namespace $PGO_OPERATOR_NAMESPACE > /dev/null 2> /dev/null
+if [ $? -eq 0 ]
+then
+	echo namespace $PGO_OPERATOR_NAMESPACE is already created
+else
+	$PGO_CMD create namespace $PGO_OPERATOR_NAMESPACE > /dev/null
+	echo namespace $PGO_OPERATOR_NAMESPACE created
+fi
 
 IFS=', ' read -r -a array <<< "$NAMESPACE"
 

--- a/hugo/content/Installation/operator-install.md
+++ b/hugo/content/Installation/operator-install.md
@@ -88,9 +88,9 @@ However, if the user wishes to add a new watched namespace after installation, w
 
 {{% /notice %}}
 
-The *PGO_OPERATOR_NAMESPACE* environment variable is a comma separated list
-of namespace values that the Operator itself will be deployed into.  For
-the installation example, this value is set as follows:
+The *PGO_OPERATOR_NAMESPACE* environment variable is the name of the namespace
+that the Operator will be installed into.  For the installation example, this
+value is set as follows:
 
     export PGO_OPERATOR_NAMESPACE=pgo
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

There existed a bug using the Ansible uninstaller that would clear out
all namespaces that had the "vendor=crunchydata" label, and not accounting
for the "pgo-installation-name" label.

**What is the new behavior (if this is a feature change)?**

This ensures the Ansible uninstaller checks for this label.

**Other information**:
