### PR TITLE
pgo-client deployment file missing fields

### DIFF
--- a/ansible/roles/pgo-operator/templates/pgo-client.json.j2
+++ b/ansible/roles/pgo-operator/templates/pgo-client.json.j2
@@ -9,12 +9,12 @@
     },
     "spec": {
         "replicas": 1,
-	"selector": {
-		"matchLabels": {
-			"name": "pgo-client",
-			"vendor": "crunchydata"
-		}	
-	},
+        "selector": {
+                "matchLabels": {
+                        "name": "pgo-client",
+                        "vendor": "crunchydata"
+                }
+        },
         "template": {
             "metadata": {
                 "labels": {

--- a/ansible/roles/pgo-operator/templates/pgo-client.json.j2
+++ b/ansible/roles/pgo-operator/templates/pgo-client.json.j2
@@ -9,6 +9,12 @@
     },
     "spec": {
         "replicas": 1,
+	"selector": {
+		"matchLabels": {
+			"name": "pgo-client",
+			"vendor": "crunchydata"
+		}	
+	},
         "template": {
             "metadata": {
                 "labels": {


### PR DESCRIPTION
The deployment file was updated to `apps/v1` instead of `extensions/v1beta` in a
previous commit. This change required a new field in the deployment json file
under `spec.selector`. The field has been added to the ansible deployment
template to user `spec.selector.matchLabels` which is set to match the
`spec.template.labels`. This is based on Kubernetes API requirements that the two must match.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the new behavior (if this is a feature change)?**
Adds label selectors to pods. 


**Other information**:
[ch6738]