### PR TITLE
No pgBackRest Repo Restarts, Schedule Backup Opts & Restore Workflow Updates

### DIFF
--- a/apis/cr/v1/task.go
+++ b/apis/cr/v1/task.go
@@ -85,6 +85,10 @@ const (
 	BackupTypeBootstrap string = "bootstrap"
 )
 
+// BackrestStorageTypes defines the valid types of storage that can be utilized
+// with pgBackRest
+var BackrestStorageTypes = []string{"local", "s3"}
+
 // PgtaskSpec ...
 // swagger:ignore
 type PgtaskSpec struct {

--- a/apiserver/backrestservice/backrestimpl.go
+++ b/apiserver/backrestservice/backrestimpl.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/crunchydata/postgres-operator/apiserver/backupoptions"
+	"github.com/crunchydata/postgres-operator/util"
 
 	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
 	"github.com/crunchydata/postgres-operator/apiserver"
@@ -103,7 +104,7 @@ func CreateBackup(request *msgs.CreateBackrestBackupRequest, ns, pgouser string)
 			return resp
 		}
 
-		err = apiserver.ValidateBackrestStorageTypeOnBackupRestore(request.BackrestStorageType,
+		err = util.ValidateBackrestStorageTypeOnBackupRestore(request.BackrestStorageType,
 			cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], false)
 		if err != nil {
 			resp.Status.Code = msgs.Error
@@ -437,7 +438,7 @@ func Restore(request *msgs.RestoreRequest, ns, pgouser string) msgs.RestoreRespo
 
 	// ensure the backrest storage type specified for the backup is valid and enabled in the
 	// cluster
-	err = apiserver.ValidateBackrestStorageTypeOnBackupRestore(request.BackrestStorageType,
+	err = util.ValidateBackrestStorageTypeOnBackupRestore(request.BackrestStorageType,
 		cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], true)
 	if err != nil {
 		resp.Status.Code = msgs.Error

--- a/apiserver/backupoptions/backupoptionsutil.go
+++ b/apiserver/backupoptions/backupoptionsutil.go
@@ -151,6 +151,10 @@ func createBackupOptionsStruct(backupOpts string, request interface{}) (backupOp
 		}
 	case *msgs.PgRestoreRequest:
 		return &pgRestoreOptions{}, "pg_restore", nil
+	case *msgs.CreateScheduleRequest:
+		if request.(*msgs.CreateScheduleRequest).ScheduleType == "pgbackrest" {
+			return &pgBackRestBackupOptions{}, "pgBackRest", nil
+		}
 	}
 	return nil, "", errors.New("Request type not recognized. Unable to create struct for backup opts")
 }

--- a/apiserver/cloneservice/cloneimpl.go
+++ b/apiserver/cloneservice/cloneimpl.go
@@ -108,7 +108,7 @@ func Clone(request *msgs.CloneRequest, namespace, pgouser string) msgs.CloneResp
 	}
 
 	// clone is a form of restore, so validate using ValidateBackrestStorageTypeOnBackupRestore
-	err = apiserver.ValidateBackrestStorageTypeOnBackupRestore(request.BackrestStorageSource,
+	err = util.ValidateBackrestStorageTypeOnBackupRestore(request.BackrestStorageSource,
 		sourcePgcluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], true)
 	if err != nil {
 		response.Status.Code = msgs.Error

--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -1420,7 +1420,7 @@ func validateBackrestStorageTypeOnCreate(request *msgs.CreateClusterRequest) err
 
 	requestBackRestStorageType := request.BackrestStorageType
 
-	if requestBackRestStorageType != "" && !apiserver.IsValidBackrestStorageType(requestBackRestStorageType) {
+	if requestBackRestStorageType != "" && !util.IsValidBackrestStorageType(requestBackRestStorageType) {
 		return fmt.Errorf("Invalid value provided for pgBackRest storage type. The following values are allowed: %s",
 			"\""+strings.Join(apiserver.GetBackrestStorageTypes(), "\", \"")+"\"")
 	} else if strings.Contains(requestBackRestStorageType, "s3") && isMissingS3Config(request) {

--- a/apiserver/scheduleservice/scheduleimpl.go
+++ b/apiserver/scheduleservice/scheduleimpl.go
@@ -41,7 +41,7 @@ type scheduleRequest struct {
 func (s scheduleRequest) createBackRestSchedule(cluster *crv1.Pgcluster, ns string) *PgScheduleSpec {
 	name := fmt.Sprintf("%s-%s-%s", cluster.Name, s.Request.ScheduleType, s.Request.PGBackRestType)
 
-	err := apiserver.ValidateBackrestStorageTypeOnBackupRestore(s.Request.BackrestStorageType,
+	err := util.ValidateBackrestStorageTypeOnBackupRestore(s.Request.BackrestStorageType,
 		cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE], false)
 	if err != nil {
 		s.Response.Status.Code = msgs.Error

--- a/apiserver/scheduleservice/scheduleservice.go
+++ b/apiserver/scheduleservice/scheduleservice.go
@@ -46,12 +46,12 @@ type Policy struct {
 }
 
 type PGBackRest struct {
-	Deployment  string    `json:"deployment,omitempty"`
-	Label       string    `json:"label,omitempty"`
-	Container   string    `json:"container,omitempty"`
-	Type        string    `json:"type,omitempty"`
-	StorageType string    `json:"storageType,omitempty"`
-	Options     []Options `json:"options,omitempty"`
+	Deployment  string `json:"deployment,omitempty"`
+	Label       string `json:"label,omitempty"`
+	Container   string `json:"container,omitempty"`
+	Type        string `json:"type,omitempty"`
+	StorageType string `json:"storageType,omitempty"`
+	Options     string `json:"options,omitempty"`
 }
 
 type PGBaseBackup struct {
@@ -64,11 +64,6 @@ type PGBaseBackup struct {
 	ImageTag        string `json:"imageTag,omitempty"`
 	Secret          string `json:"secret,omitempty"`
 	SecurityContext `json:"securityContext,omitempty"`
-}
-
-type Options struct {
-	Name  string `json:"name,omitempty"`
-	Value string `json:"value,omitempty"`
 }
 
 type SecurityContext struct {

--- a/bin/push-to-gcr.sh
+++ b/bin/push-to-gcr.sh
@@ -18,6 +18,7 @@ GCR_IMAGE_PREFIX=gcr.io/crunchy-dev-test
 IMAGES=(
 pgo-event
 pgo-backrest-repo
+pgo-backrest-repo-sync
 pgo-backrest-restore
 pgo-scheduler
 pgo-sqlrunner

--- a/controller/podcontroller.go
+++ b/controller/podcontroller.go
@@ -140,14 +140,15 @@ func (c *PodController) onUpdate(oldObj, newObj interface{}) {
 			pgcluster.Status.State == crv1.PgclusterStateInitialized {
 
 			//look up the backrest-repo pod name
-			selector := config.LABEL_PG_CLUSTER + "=" + clusterName + "," +
-				config.LABEL_PGO_BACKREST_REPO + "=true"
+			selector := fmt.Sprintf("%s=%s,%s=true", config.LABEL_PG_CLUSTER, 
+				clusterName, config.LABEL_PGO_BACKREST_REPO)
 			pods, err := kubeapi.GetPods(c.PodClientset, selector, newpod.ObjectMeta.Namespace)
 			if len(pods.Items) != 1 {
 				log.Errorf("pods len != 1 for cluster %s", clusterName)
 				return
 			} else if err != nil {
 				log.Error(err)
+				return
 			}
 
 			err = backrest.CleanBackupResources(c.PodClient, c.PodClientset,
@@ -236,6 +237,7 @@ func (c *PodController) checkReadyStatus(oldpod, newpod *apiv1.Pod, cluster *crv
 						}
 						if err != nil {
 							log.Error(err)
+							return
 						}
 						err = backrest.CleanBackupResources(c.PodClient, c.PodClientset,
 							newpod.ObjectMeta.Namespace, clusterName)

--- a/operator/backrest/backup.go
+++ b/operator/backrest/backup.go
@@ -56,6 +56,9 @@ type backrestJobTemplateFields struct {
 	PgbackrestRestoreVolumeMounts string
 }
 
+var backrestPgHostRegex = regexp.MustCompile("--db-host|--pg1-host")
+var backrestPgPathRegex = regexp.MustCompile("--db-path|--pg1-path")
+
 // Backrest ...
 func Backrest(namespace string, clientset *kubernetes.Clientset, task *crv1.Pgtask) {
 
@@ -90,8 +93,7 @@ func Backrest(namespace string, clientset *kubernetes.Clientset, task *crv1.Pgta
 	jobFields.CommandOpts = jobFields.CommandOpts + " " + podCommandOpts
 
 	var doc2 bytes.Buffer
-	err = config.BackrestjobTemplate.Execute(&doc2, jobFields)
-	if err != nil {
+	if err := config.BackrestjobTemplate.Execute(&doc2, jobFields); err != nil {
 		log.Error(err.Error())
 		return
 	}
@@ -295,8 +297,6 @@ func getCommandOptsFromPod(clientset *kubernetes.Clientset, task *crv1.Pgtask,
 	pod := pods.Items[0]
 
 	var cmdOpts []string
-	var backrestPgHostRegex = regexp.MustCompile("--db-host|--pg1-host")
-	var backrestPgPathRegex = regexp.MustCompile("--db-path|--pg1-path")
 
 	if !backrestPgHostRegex.MatchString(task.Spec.Parameters[config.LABEL_BACKREST_OPTS]) {
 		cmdOpts = append(cmdOpts, fmt.Sprintf("--db-host=%s", pod.Status.PodIP))

--- a/operator/backrest/stanza.go
+++ b/operator/backrest/stanza.go
@@ -38,6 +38,7 @@ func StanzaCreate(namespace, clusterName string, clientset *kubernetes.Clientset
 	}
 	if err != nil {
 		log.Error(err)
+		return
 	}
 
 	podName := pods.Items[0].Name

--- a/operator/cluster/clone.go
+++ b/operator/cluster/clone.go
@@ -221,7 +221,8 @@ func cloneStep1(clientset *kubernetes.Clientset, client *rest.RESTClient, namesp
 	// if 's3' storage was selected for the clone, ensure it is enabled in the current pg cluster.
 	// also, if 'local' was selected, or if no storage type was selected, ensure the cluster is using
 	// local storage
-	err = validateBackrestStorageTypeClone(sourceClusterBackrestStorageType, cloneBackrestStorageType)
+	err = util.ValidateBackrestStorageTypeOnBackupRestore(cloneBackrestStorageType, 
+		sourceClusterBackrestStorageType, true)
 	if err != nil {
 		log.Error(err)
 		PublishCloneEvent(events.EventCloneClusterFailure, namespace, task, err.Error())
@@ -944,19 +945,6 @@ func waitForDeploymentReady(clientset *kubernetes.Clientset, namespace, deployme
 			}
 		}
 	}
-}
-
-// validateBackrestStorageTypeClone verifies that 's3' is enabled in the cluster being cloned
-// when 's3' is selected as the storage type for the new/cloned cluster
-func validateBackrestStorageTypeClone(sourceClusterBackrestStorageType,
-	cloneBackrestStorageType string) error {
-
-	if !strings.Contains(sourceClusterBackrestStorageType, cloneBackrestStorageType) {
-		return fmt.Errorf("The backrest storage source '%s' selected for the cloned cluster does "+
-			"not match a storage type in source cluster storage type '%s'",
-			cloneBackrestStorageType, sourceClusterBackrestStorageType)
-	}
-	return nil
 }
 
 // getS3Param returns either the value provided by 'sourceClusterS3param' if not en empty string,

--- a/pgo-scheduler/scheduler/pgbackrest.go
+++ b/pgo-scheduler/scheduler/pgbackrest.go
@@ -35,6 +35,7 @@ type BackRestBackupJob struct {
 	container   string
 	cluster     string
 	storageType string
+	options     string
 }
 
 func (s *ScheduleTemplate) NewBackRestSchedule() BackRestBackupJob {
@@ -47,6 +48,7 @@ func (s *ScheduleTemplate) NewBackRestSchedule() BackRestBackupJob {
 		container:   s.PGBackRest.Container,
 		cluster:     s.Cluster,
 		storageType: s.PGBackRest.StorageType,
+		options:     s.Options,
 	}
 }
 
@@ -146,7 +148,7 @@ func (b BackRestBackupJob) Run() {
 		taskName:      taskName,
 		podName:       pods.Items[0].Name,
 		containerName: "database",
-		backupOptions: fmt.Sprintf("--type=%s", b.backupType),
+		backupOptions: fmt.Sprintf("--type=%s %s", b.backupType, b.options),
 		stanza:        b.stanza,
 		storageType:   b.storageType,
 	}

--- a/pgo-scheduler/scheduler/types.go
+++ b/pgo-scheduler/scheduler/types.go
@@ -58,12 +58,12 @@ type PGBaseBackup struct {
 }
 
 type PGBackRest struct {
-	Deployment  string    `json:"deployment"`
-	Label       string    `json:"label"`
-	Container   string    `json:"container"`
-	Type        string    `json:"type"`
-	StorageType string    `json:"storageType,omitempty"`
-	Options     []Options `json:"options"`
+	Deployment  string `json:"deployment"`
+	Label       string `json:"label"`
+	Container   string `json:"container"`
+	Type        string `json:"type"`
+	StorageType string `json:"storageType,omitempty"`
+	Options     string `json:"options"`
 }
 
 type Policy struct {
@@ -72,11 +72,6 @@ type Policy struct {
 	ImagePrefix string `json:"imagePrefix"`
 	ImageTag    string `json:"imageTag"`
 	Database    string `json:"database"`
-}
-
-type Options struct {
-	Name  string `json:"name,omitempty"`
-	Value string `json:"value,omitempty"`
 }
 
 type SecurityContext struct {

--- a/util/backrest.go
+++ b/util/backrest.go
@@ -1,0 +1,73 @@
+package util
+
+/*
+ Copyright 2019 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	crv1 "github.com/crunchydata/postgres-operator/apis/cr/v1"
+)
+
+// ValidateBackrestStorageTypeOnBackupRestore checks to see if the pgbackrest storage type provided
+// when performing either pgbackrest backup or restore is valid.  This includes ensuring the value
+// provided is a valid storage type (e.g. "s3" and/or "local").  This also includes ensuring the
+// storage type specified (e.g. "s3" or "local") is enabled in the current cluster.  And finally,
+// validation is ocurring for a restore, the ensure only one storage type is selected.
+func ValidateBackrestStorageTypeOnBackupRestore(newBackRestStorageType,
+	currentBackRestStorageType string, restore bool) error {
+
+	if newBackRestStorageType != "" && !IsValidBackrestStorageType(newBackRestStorageType) {
+		return fmt.Errorf("Invalid value provided for pgBackRest storage type. The following "+
+			"values are allowed: %s", "\""+strings.Join(crv1.BackrestStorageTypes, "\", \"")+"\"")
+	} else if newBackRestStorageType != "" &&
+		strings.Contains(newBackRestStorageType, "s3") &&
+		!strings.Contains(currentBackRestStorageType, "s3") {
+		return errors.New("Storage type 's3' not allowed. S3 storage is not enabled for " +
+			"pgBackRest in thiscluster")
+	} else if (newBackRestStorageType == "" ||
+		strings.Contains(newBackRestStorageType, "local")) &&
+		(currentBackRestStorageType != "" &&
+			!strings.Contains(currentBackRestStorageType, "local")) {
+		return errors.New("Storage type 'local' not allowed. Local storage is not enabled for " +
+			"pgBackRest in this cluster. If this cluster uses S3 storage only, specify 's3' " +
+			"for the pgBackRest storage type.")
+	}
+
+	// storage type validation that is only applicable for restores
+	if restore && newBackRestStorageType != "" &&
+		len(strings.Split(newBackRestStorageType, ",")) > 1 {
+		return fmt.Errorf("Multiple storage types cannot be selected cannot be select when "+
+			"performing a restore. Please select one of the following: %s",
+			"\""+strings.Join(crv1.BackrestStorageTypes, "\", \"")+"\"")
+	}
+
+	return nil
+}
+
+// IsValidBackrestStorageType determines if the storage source string contains valid pgBackRest
+// storage type values
+func IsValidBackrestStorageType(storageType string) bool {
+	isValid := true
+	for _, storageType := range strings.Split(storageType, ",") {
+		if !IsStringOneOf(storageType, crv1.BackrestStorageTypes...) {
+			isValid = false
+			break
+		}
+	}
+	return isValid
+}

--- a/util/util.go
+++ b/util/util.go
@@ -374,3 +374,16 @@ func NewClient(cfg *rest.Config) (*rest.RESTClient, *runtime.Scheme, error) {
 
 	return client, scheme, nil
 }
+
+// IsStringOneOf tests to see string testVal is included in the list
+// of strings provided using acceptedVals
+func IsStringOneOf(testVal string, acceptedVals ...string) bool {
+	isOneOf := false
+	for _, val := range acceptedVals {
+		if testVal == val {
+			isOneOf = true
+			break
+		}
+	}
+	return isOneOf
+}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- The `pgBackRest` dedicated repository host is reconfigured with the `PGDATA` directory of the new primary following a failover event, forcing a restart of the repository host container
- The `pgBackRest` CLI options specified using the `--schedule-options` parameter when creating a new backup schedule (e.g. using `pgo create schedule`) are not actually utilized when running the scheduled backup
- A backup is not taken following a restore executed using the `pgo restore` command, which means replicas are created using a backup from the cluster prior to the restore
- Validation logic for validating the `pgBackRest` storage type specified during a restore is located in the API server, and therefore cannot be utilized in the Operator (e.g. by clone functionality in the Operator when validating the `pgBackRest` storage source on incoming `pgtask` clone CR's)
- The `pgo-backrest-repo-sync` container is missing from the `push-to-gcr.sh` script

[ch494]

**What is the new behavior (if this is a feature change)?**

- The `PGDATA` directory of the current primary is injected into all `pgBackRest` stanza-create and backup jobs, ensuring the proper `PGDATA` directory is always utilized when running `pgBackRest` command (even though the location might change over time as failovers occur and the primary changes)
- The `pgBackRest` CLI options specified using the `--schedule-options` parameter when creating a backup schedule are utilized when running the scheduled `pgBackRest` backup
- A backup is now taken following a restore executed using the `pgo restore` command, which means replicas are created using a fresh backup of the newly  restored cluster
- Validation logic for validating the `pgBackRest` storage type specified during a restore has refactored so that it can be utilized by the API server _*and*_ the Operator (e.g. by clone functionality in the Operator when validating the `pgBackRest` storage source on incoming `pgtask` CR's)
- The `pgo-backrest-repo-sync` container is included in the `push-to-gcr.sh` script

**Other information**:

N/A
