### PR TITLE
Updated Job Controller to Not Process Backrest Jobs that are Being Deleted

### DIFF
--- a/controller/jobcontroller.go
+++ b/controller/jobcontroller.go
@@ -260,7 +260,8 @@ func (c *JobController) onUpdate(oldObj, newObj interface{}) {
 	}
 
 	//handle the case of a backrest job being added
-	if labels[config.LABEL_BACKREST] == "true" && labels[config.LABEL_BACKREST_COMMAND] == "backup" {
+	if !isForegroundDeletion && labels[config.LABEL_BACKREST] == "true" &&
+		labels[config.LABEL_BACKREST_COMMAND] == "backup" {
 		log.Debugf("jobController onUpdate backrest job case")
 		log.Debugf("got a backrest job status=%d", job.Status.Succeeded)
 		if job.Status.Succeeded == 1 {
@@ -305,7 +306,7 @@ func (c *JobController) onUpdate(oldObj, newObj interface{}) {
 					}
 					if clusterStatus == crv1.PgclusterStateRestore {
 						pgreplica.Spec.Status = "restore"
-					} else { 
+					} else {
 						pgreplica.Annotations[config.ANNOTATION_PGHA_BOOTSTRAP_REPLICA] = "true"
 					}
 					err = kubeapi.Updatepgreplica(c.JobClient, &pgreplica, pgreplica.Name, job.ObjectMeta.Namespace)


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The job controller does not check to see if a backrest job is currently being deleted prior to processing it.

**What is the new behavior (if this is a feature change)?**

The job controller checks to see if a backrest job is currently being deleted prior to processing it.

**Other information**:

N/A
