### PR TITLE
Do not panic if PGHA_PGBACKREST_LOCAL_S3_STORAGE is not set

### DIFF
--- a/pgo-backrest/pgo-backrest.go
+++ b/pgo-backrest/pgo-backrest.go
@@ -79,10 +79,10 @@ func main() {
 	REPO_TYPE := os.Getenv("PGBACKREST_REPO_TYPE")
 	log.Debugf("setting REPO_TYPE to %s", REPO_TYPE)
 
-	PGHA_PGBACKREST_LOCAL_S3_STORAGE, err := strconv.ParseBool(os.Getenv("PGHA_PGBACKREST_LOCAL_S3_STORAGE"))
-	if err != nil {
-		panic(err)
-	}
+	// determine the setting of PGHA_PGBACKREST_LOCAL_S3_STORAGE
+	// we will discard the error and treat the value as "false" if it is not
+	// explicitly set
+	PGHA_PGBACKREST_LOCAL_S3_STORAGE, _ := strconv.ParseBool(os.Getenv("PGHA_PGBACKREST_LOCAL_S3_STORAGE"))
 	log.Debugf("setting PGHA_PGBACKREST_LOCAL_S3_STORAGE to %s", PGHA_PGBACKREST_LOCAL_S3_STORAGE)
 
 	config, err := buildConfig(*kubeconfig)


### PR DESCRIPTION


**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

`PGHA_PGBACKREST_LOCAL_S3_STORAGE` causes `pgo-backrest` to PANIC and exit if it is unset.

**What is the new behavior (if this is a feature change)?**

This could happen for a variety of reasons, i.e. it is simply just
not set in one's environment. The default is to set this value to
"false" as it is using strconv.ParseBool, therefore if it errors,
it's okay.
