### PR TITLE
The add-targeted-namespace.sh Script Now Only Recreates SA pgo-pg If Not Currently in Use

### DIFF
--- a/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
+++ b/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
@@ -23,6 +23,9 @@ PGO_IMAGE_PULL_SECRET='{{ pgo_image_pull_secret }}'
 PGO_IMAGE_PULL_SECRET_MANIFEST='{{ pgo_image_pull_secret_manifest }}'
 TARGET_NAMESPACE='{{ item }}'
 
+# the name of the service account utilized by the PG pods
+PG_SA="pgo-pg"
+
 # create the namespace if necessary
 {{ kubectl_or_oc }} get ns {{ item }}  > /dev/null
 if [ $? -eq 0 ]; then
@@ -37,10 +40,26 @@ fi
 {{ kubectl_or_oc }} label namespace/{{ item }} vendor=crunchydata
 {{ kubectl_or_oc }} label namespace/{{ item }} pgo-installation-name={{ pgo_installation_name }}
 
+# determine if an existing pod is using the 'pgo-pg' service account.  if so, do not delete
+# and recreate the SA or its associated role and role binding.  this is to avoid any undesired
+# behavior with existing PG clusters that are actively utilizing the SA.
+{{ kubectl_or_oc }} -n {{ item }} get pods -o yaml | grep "serviceAccount: ${PG_SA}"  > /dev/null
+if [ $? -ne 0 ]; then
+	{{ kubectl_or_oc }} -n {{ item }} delete --ignore-not-found sa pgo-pg
+	{{ kubectl_or_oc }} -n {{ item }} delete --ignore-not-found role pgo-pg-role
+	{{ kubectl_or_oc }} -n {{ item }} delete --ignore-not-found rolebinding pgo-pg-role-binding
+
+	cat {{ role_path }}/files/pgo-configs/pgo-pg-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
+	cat {{ role_path }}/files/pgo-configs/pgo-pg-role.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
+	cat {{ role_path }}/files/pgo-configs/pgo-pg-role-binding.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
+else
+	echo "Running pods found using SA '${PG_SA}' in namespace {{ item }}, will not recreate"
+fi
+
 # create RBAC
-{{ kubectl_or_oc }} -n {{ item }} delete --ignore-not-found sa pgo-backrest pgo-default pgo-pg pgo-target
-{{ kubectl_or_oc }} -n {{ item }} delete --ignore-not-found role pgo-backrest-role pgo-pg-role pgo-target-role
-{{ kubectl_or_oc }} -n {{ item }} delete --ignore-not-found rolebinding pgo-backrest-role-binding pgo-pg-role-binding pgo-target-role-binding
+{{ kubectl_or_oc }} -n {{ item }} delete --ignore-not-found sa pgo-backrest pgo-default pgo-target
+{{ kubectl_or_oc }} -n {{ item }} delete --ignore-not-found role pgo-backrest-role pgo-target-role
+{{ kubectl_or_oc }} -n {{ item }} delete --ignore-not-found rolebinding pgo-backrest-role-binding pgo-target-role-binding
 
 cat {{ role_path }}/files/pgo-configs/pgo-default-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-target-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
@@ -49,9 +68,6 @@ cat {{ role_path }}/files/pgo-configs/pgo-target-role-binding.json | sed 's/{{ t
 cat {{ role_path }}/files/pgo-configs/pgo-backrest-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-backrest-role.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 cat {{ role_path }}/files/pgo-configs/pgo-backrest-role-binding.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
-cat {{ role_path }}/files/pgo-configs/pgo-pg-sa.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
-cat {{ role_path }}/files/pgo-configs/pgo-pg-role.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
-cat {{ role_path }}/files/pgo-configs/pgo-pg-role-binding.json | sed 's/{{ target_namespace }}/'"{{ item }}"'/' | {{ kubectl_or_oc }} -n {{ item }} create -f -
 
 if [ -r "$PGO_IMAGE_PULL_SECRET_MANIFEST" ]; then
 	$PGO_CMD -n "$TARGET_NAMESPACE" create -f "$PGO_IMAGE_PULL_SECRET_MANIFEST"


### PR DESCRIPTION
The `add-targeted-namespace.sh` script now only creates (or recreates) the `pgo-pg` service
account, along with the role and role binding for that service account, if there aren't any pods (i.e. PG DB pods) already running in the namespace utilizing the `pgo-pg` `ServiceAccount`.  This is to prevent undesired behavior with any PG DB pods that are relying on this SA to effectively communicate with the Kuburnetes API, i.e. the Patroni DCS (e.g. if the connection is broken the primary will not be able to renew the leader lock).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- The `add-targeted-namespace.sh` script always deletes and creates the `pgo-pg` service account and associated role and role binding

[ch6810]

**What is the new behavior (if this is a feature change)?**

- The `add-targeted-namespace.sh` script only deletes and creates the `pgo-pg` service account and associated role and role binding if there are not any pods in the namespace actively using the service account

**Other information**:
