### PR TITLE
Updates apiserver swagger comments for 4.2

### DIFF
--- a/apiserver/versionservice/versionservice.go
+++ b/apiserver/versionservice/versionservice.go
@@ -66,8 +66,6 @@ func HealthHandler(w http.ResponseWriter, r *http.Request) {
 	//  responses:
 	//    '200':
 	//      description: Output
-	//      schema:
-	//        "$ref": "#/definitions/UpdateNamespaceResponse"
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
@@ -88,7 +86,7 @@ func HealthyHandler(w http.ResponseWriter, r *http.Request) {
 	//  - text/plain
 	//  responses:
 	//    '200':
-	//      description: Healthy: server is responding as expected
+	//      description: "Healthy: server is responding as expected"
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("ok"))
 }


### PR DESCRIPTION
- Fixes yaml in healthz endpoint
- Removes invalid schema definition that was added with copy paste error

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently the yaml in the healthz endpoint is invalid so the swagger spec doesn't generate.  Yaml doesn't seem to like using a `:` in the description string
```
description: Healthy: server is responding as expected
```

```
swagger generate spec -w /home/vagrant/go/src/github.com/crunchydata/postgres-operator -o /sync_data/swagger.json --exclude-deps --scan-models
operation (healthz): yaml: line 6: mapping values are not allowed in this context
make: *** [spec] Error 1
```


**What is the new behavior (if this is a feature change)?**
This change adds quotes around the description to treat it as a string


**Other information**:
