### PR TITLE
changes default CA exclusion for Win pgo clients

### DIFF
--- a/hugo/content/Configuration/tls.md
+++ b/hugo/content/Configuration/tls.md
@@ -117,7 +117,8 @@ setip()
 By default, the pgo client will trust certificates issued by one of the
 Certificate Authorities listed in the operating system's default CA trust
 store. To prevent their inclusion, two configuation methods are available:
-either the Bash environment variable
+either the Bash environment variable. Windows clients have no default CA
+trust and thus have this setting configured to `true` by default.
 
 ```bash
 EXCLUDE_OS_TRUST=true

--- a/hugo/content/Configuration/tls.md
+++ b/hugo/content/Configuration/tls.md
@@ -116,15 +116,13 @@ setip()
 
 By default, the pgo client will trust certificates issued by one of the
 Certificate Authorities listed in the operating system's default CA trust
-store. To prevent their inclusion, two configuation methods are available:
-either the Bash environment variable. Windows clients have no default CA
-trust and thus have this setting configured to `true` by default.
+store, if any. To exclude them, either use the environment variable
 
 ```bash
 EXCLUDE_OS_TRUST=true
 ```
 
-or the --exclude-os-trust can be included during client use
+or use the --exclude-os-trust flag
 
 ```bash
 pgo version --exclude-os-trust

--- a/hugo/content/Installation/common-env.md
+++ b/hugo/content/Installation/common-env.md
@@ -34,7 +34,7 @@ Variable | Ansible Inventory | Example | Description
 `TLS_CA_TRUST` | pgo_tls_ca_store | /var/pki/my_cas.crt | PEM-encoded list of trusted CA certificates
 `ADD_OS_TRUSTSTORE` | pgo_add_os_ca_store | false | Adds OS root trust collection to apiserver
 `NOAUTH_ROUTES` | pgo_noauth_routes | "/health" | Disable mTLS and HTTP BasicAuth for listed routes
-`EXCLUDE_OS_TRUST` |  | false | Excludes OS root trust from pgo client
+`EXCLUDE_OS_TRUST` |  | false* | Excludes OS root trust from pgo client (defaults to true for windows clients)
 
 {{% notice tip %}}
 `examples/envs.sh` contains the above variable definitions as well

--- a/hugo/content/Upgrade/upgrade4xto42_bash.md
+++ b/hugo/content/Upgrade/upgrade4xto42_bash.md
@@ -84,9 +84,6 @@ export TLS_CA_TRUST=""
 export ADD_OS_TRUSTSTORE=false
 export NOAUTH_ROUTES=""
 
-# Disable default inclusion of OS trust in PGO clients
-export EXCLUDE_OS_TRUST=false
-
 # for disabling the Operator eventing
 export DISABLE_EVENTING=false
 ```
@@ -103,7 +100,6 @@ If you are upgrading from Postgres Operator 4.1.0 or 4.1.1, you will only need t
 export TLS_CA_TRUST=""
 export ADD_OS_TRUSTSTORE=false
 export NOAUTH_ROUTES=""
-export EXCLUDE_OS_TRUST=false
 ```
 
 Finally source the updated bash file:

--- a/pgo/cmd/root.go
+++ b/pgo/cmd/root.go
@@ -56,7 +56,7 @@ func init() {
 	RED = color.New(color.FgRed).SprintFunc()
 
 	// Go currently guarantees an error when attempting to load OS_TRUST for
-	// windows-based systems (see crypto/x509/cert_pool.go)
+	// windows-based systems (see https://golang.org/issue/16736) 
 	defExclOSTrust := (runtime.GOOS == "windows")
 
 	RootCmd.PersistentFlags().StringVarP(&Namespace, "namespace", "n", "", "The namespace to use for pgo requests.")

--- a/pgo/cmd/root.go
+++ b/pgo/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 
 	"github.com/fatih/color"
@@ -54,13 +55,17 @@ func init() {
 	GREEN = color.New(color.FgGreen).SprintFunc()
 	RED = color.New(color.FgRed).SprintFunc()
 
+	// Go currently guarantees an error when attempting to load OS_TRUST for
+	// windows-based systems (see crypto/x509/cert_pool.go)
+	defExclOSTrust := (runtime.GOOS == "windows")
+
 	RootCmd.PersistentFlags().StringVarP(&Namespace, "namespace", "n", "", "The namespace to use for pgo requests.")
 	RootCmd.PersistentFlags().StringVar(&APIServerURL, "apiserver-url", "", "The URL for the PostgreSQL Operator apiserver that will process the request from the pgo client.")
 	RootCmd.PersistentFlags().StringVar(&PGO_CA_CERT, "pgo-ca-cert", "", "The CA Certificate file path for authenticating to the PostgreSQL Operator apiserver.")
 	RootCmd.PersistentFlags().StringVar(&PGO_CLIENT_KEY, "pgo-client-key", "", "The Client Key file path for authenticating to the PostgreSQL Operator apiserver.")
 	RootCmd.PersistentFlags().StringVar(&PGO_CLIENT_CERT, "pgo-client-cert", "", "The Client Certificate file path for authenticating to the PostgreSQL Operator apiserver.")
 	RootCmd.PersistentFlags().BoolVar(&PGO_DISABLE_TLS, "disable-tls", false, "Disable TLS authentication to the Postgres Operator.")
-	RootCmd.PersistentFlags().BoolVar(&EXCLUDE_OS_TRUST, "exclude-os-trust", false, "Exclude CA certs from OS default trust store")
+	RootCmd.PersistentFlags().BoolVar(&EXCLUDE_OS_TRUST, "exclude-os-trust", defExclOSTrust, "Exclude CA certs from OS default trust store")
 	RootCmd.PersistentFlags().BoolVar(&DebugFlag, "debug", false, "Enable additional output for debugging.")
 
 }


### PR DESCRIPTION
x509.SystemCertPool has an exclusion for Windows environments
that results in an error being returned for those.
https://golang.org/src/crypto/x509/cert_pool.go?s=1351:1391#L45

This change makes the default behavior more pleasant than
immediately erroring out on Windows clients.

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable? (Don't have access to a Win terminal)


 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

