### PR TITLE
Fix typos in Operator installation documentation

### DIFF
--- a/hugo/content/Installation/operator-install.md
+++ b/hugo/content/Installation/operator-install.md
@@ -60,16 +60,16 @@ for deploying the Operator into and for holding Postgres clusters
 created by the Operator.
 
 Creating Kubernetes namespaces is typically something that only a
-priviledged Kubernetes user can perform so log into your Kubernetes cluster as a user
-that has the necessary priviledges.
+privileged Kubernetes user can perform so log into your Kubernetes cluster as a user
+that has the necessary privileges.
 
 On Openshift if you do not want to install the Operator as the system
-administrator, you can grant cluster-admin priviledges to a user
+administrator, you can grant cluster-admin privileges to a user
 as follows:
 
     oc adm policy add-cluster-role-to-user cluster-admin pgoinstaller
 
-In the above command, you are granting cluster-admin priviledges
+In the above command, you are granting cluster-admin privileges
 to a user named pgoinstaller.  
 
 The *NAMESPACE* environment variable is a comma separated list
@@ -198,7 +198,7 @@ Adjust these settings to meet your local requirements.
 ## Default Installation - Create Kubernetes RBAC Controls
 
 The Operator installation requires Kubernetes administrators to create Resources required by the Operator.  These resources are only allowed to be created by a cluster-admin user.  To install on Google Cloud, you will need a user
-account with cluster-admin priviledges.  If you own the GKE cluster you
+account with cluster-admin privileges.  If you own the GKE cluster you
 are installing on, you can add cluster-admin role to your account as
 follows:
 


### PR DESCRIPTION
When reading through the Bash installation instructions I noticed "priviledge(s)" was used multiple times in the document. This commit changes those occurrences to "privilege(s)".

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable? 

    - As this is only a documentation edit there was no testing done.



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

This is a documentation edit, not a code change.

**What is the current behavior? (link to any open issues here)**

n / a

**What is the new behavior (if this is a feature change)?**

n / a

**Other information**:
