### PR TITLE
Ensure Node Labels are Properly Applied when Performing a Restore

### DIFF
--- a/conf/postgres-operator/backrest-restore-job.json
+++ b/conf/postgres-operator/backrest-restore-job.json
@@ -86,7 +86,9 @@
                         }
                     }]
                 }],
+                "affinity": {
         {{.NodeSelector}}
+                },
                 "restartPolicy": "Never"
             }
         }

--- a/operator/backrest/restore.go
+++ b/operator/backrest/restore.go
@@ -16,6 +16,7 @@ package backrest
 */
 
 import (
+	"strings"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -313,7 +314,10 @@ func CreateRestoredDeployment(restclient *rest.RESTClient, cluster *crv1.Pgclust
 		if err != nil {
 			log.Error("unable to marshall affinity obtained from restore job spec")
 		}
-		affinityStr = "\"affinity\":" + string(affinityBytes) + ","
+		// Since the template for a cluster deployment contains the braces for the json
+		// defining any affinity rules, we trim them here from the affinity json obtained
+		// directly from the restore job (which also has the same braces)
+		affinityStr = strings.Trim(string(affinityBytes), "{}")
 	} else {
 		affinityStr = operator.GetAffinity(cluster.Spec.UserLabels["NodeLabelKey"], cluster.Spec.UserLabels["NodeLabelValue"], "In")
 	}


### PR DESCRIPTION
This change ensures that node labels specified for a restore (e.g. those specified via the `node-label` flag when initiating a restore using the `pgo restore` command) are properly applied to both the `pgBackRest` restore job, and subsequently the restored primary PG deployment.  This includes ensuring the template for a pgBackRest restore job is properly structured for applying node affinity rules based on any node label specified, while also ensuring the node affinity rules applied to the new primary are properly structured.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Specifiying a node label when performing a restore results in an error in the restore job, preventing a successful restore.

#1206

**What is the new behavior (if this is a feature change)?**

Node labels are properly applied to a `pgBackRest` restore job and subsequent primary PG deployment, resulting in a successful restore when a node label is specified.

**Other information**:

N/A