### PR TITLE
Sync the Cluster Service Template in the Ansible Installer with Bash

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/cluster-service.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/cluster-service.json
@@ -35,10 +35,25 @@
     "port": {{.ExporterPort}},
     "targetPort": {{.ExporterPort}},
     "nodePort": 0
+    }, {
+    "name": "patroni",
+    "protocol": "TCP",
+    "port": 8009,
+    "targetPort": 8009,
+    "nodePort": 0
     }
     ],
         "selector": {
+            {{ if or (eq .Name .ClusterName) (eq .Name (printf "%s%s" .ClusterName "-replica")) }}
+            "pg-cluster": "{{.ClusterName}}",
+            {{ if eq .Name (printf "%s%s" .ClusterName "-replica") }}
+            "role": "replica"
+            {{else}}
+            "role": "master"
+            {{end}}
+            {{else}}
             "service-name": "{{.ServiceName}}"
+            {{end}}
         },
         "type": "{{.ServiceType}}",
         "sessionAffinity": "None"


### PR DESCRIPTION
Sync the cluster service template in the Ansible installer with the cluster service template for a bash install.  This ensures that the proper ports and selectors are in place for any services (e.g. primary and replica services) created for a cluster.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Cluster service template for Ansible is out of sync.

**What is the new behavior (if this is a feature change)?**

Cluster service template for Ansible is now in sync

**Other information**:

N/A