### PR TITLE
Sync Ansible & Bash Templates

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/backrest-restore-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/backrest-restore-job.json
@@ -86,7 +86,9 @@
                         }
                     }]
                 }],
+                "affinity": {
         {{.NodeSelector}}
+                },
                 "restartPolicy": "Never"
             }
         }

--- a/ansible/roles/pgo-operator/files/pgo-configs/collect.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/collect.json
@@ -25,8 +25,7 @@
         {
             "name": "JOB_NAME",
             "value": "{{.JobName}}"
-        },
-        {
+        },{
             "name": "POSTGRES_EXPORTER_PORT",
             "value": "{{.ExporterPort}}"
         }

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
@@ -19,6 +19,7 @@
                 "crunchy-pgbouncer": "true",
                 "pg-cluster": "{{.ClusterName}}",
                 "service-name": "{{.Name}}",
+                "{{.PodAntiAffinityLabelName}}": "{{.PodAntiAffinityLabelValue}}",
                 "vendor": "crunchydata"
             }
         },
@@ -29,6 +30,7 @@
                     "crunchy-pgbouncer": "true",
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
+                    "{{.PodAntiAffinityLabelName}}": "{{.PodAntiAffinityLabelValue}}",
                     "vendor": "crunchydata"
                 }
             },

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
@@ -19,6 +19,7 @@
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
                     "vendor": "crunchydata",
+                    "{{.PodAntiAffinityLabelName}}": "{{.PodAntiAffinityLabelValue}}",
                     "pgo-backrest-repo": "true"
             }
         },
@@ -29,6 +30,7 @@
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
                     "vendor": "crunchydata",
+                    "{{.PodAntiAffinityLabelName}}": "{{.PodAntiAffinityLabelValue}}",
                     "pgo-backrest-repo": "true"
                 }
             },

--- a/conf/postgres-operator/pgo-target-role.json
+++ b/conf/postgres-operator/pgo-target-role.json
@@ -74,17 +74,6 @@
             "verbs": [
                 "*"
             ]
-        },
-        {
-            "apiGroups": [
-                "apps"
-            ],
-            "resources": [
-                "deployments"
-            ],
-            "verbs": [
-                "patch"
-            ]
         }
     ]
 }


### PR DESCRIPTION
Sync the backrest restore, collect, pgbouncer and backrest repo templates in the Ansible installer with those in the bash installer.  Also, sync the pgo target role template in the bash installer with the same template in the Ansible installer.  This ensures all template are in sync between the bash and Ansible installers.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Ansible and bash templates are out of sync.

**What is the new behavior (if this is a feature change)?**

Ansible and bash templates are in sync.

**Other information**:

N/A