### PR TITLE
Add the postgres-ha.yaml template to the Ansible Installer

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/postgres-ha.yaml
+++ b/ansible/roles/pgo-operator/files/pgo-configs/postgres-ha.yaml
@@ -1,0 +1,10 @@
+---
+bootstrap:
+  dcs:
+    postgresql:
+      parameters:
+        archive_timeout: {{.ArchiveTimeout}} 
+        log_min_duration_statement: {{.LogMinDurationStatement}}
+        log_statement: {{.LogStatement}}
+  initdb:
+  - encoding: UTF8


### PR DESCRIPTION
Add the `postgres-ha.yaml` template to the Ansible installer.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `postgres-ha.yaml` is not included in the Ansible installer, resulting in the use of the the `postgres-ha.yaml` file baked into the image.

**What is the new behavior (if this is a feature change)?**

The `postgres-ha.yaml` is now included in the Ansible installer.

**Other information**:

N/A