### PR TITLE
Sync Ansible & Bash Templates

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/backrest-restore-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/backrest-restore-job.json
@@ -86,7 +86,9 @@
                         }
                     }]
                 }],
+                "affinity": {
         {{.NodeSelector}}
+                },
                 "restartPolicy": "Never"
             }
         }

--- a/ansible/roles/pgo-operator/files/pgo-configs/cluster-service.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/cluster-service.json
@@ -35,10 +35,25 @@
     "port": {{.ExporterPort}},
     "targetPort": {{.ExporterPort}},
     "nodePort": 0
+    }, {
+    "name": "patroni",
+    "protocol": "TCP",
+    "port": 8009,
+    "targetPort": 8009,
+    "nodePort": 0
     }
     ],
         "selector": {
+            {{ if or (eq .Name .ClusterName) (eq .Name (printf "%s%s" .ClusterName "-replica")) }}
+            "pg-cluster": "{{.ClusterName}}",
+            {{ if eq .Name (printf "%s%s" .ClusterName "-replica") }}
+            "role": "replica"
+            {{else}}
+            "role": "master"
+            {{end}}
+            {{else}}
             "service-name": "{{.ServiceName}}"
+            {{end}}
         },
         "type": "{{.ServiceType}}",
         "sessionAffinity": "None"

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
@@ -19,6 +19,7 @@
                 "crunchy-pgbouncer": "true",
                 "pg-cluster": "{{.ClusterName}}",
                 "service-name": "{{.Name}}",
+                "{{.PodAntiAffinityLabelName}}": "{{.PodAntiAffinityLabelValue}}",
                 "vendor": "crunchydata"
             }
         },
@@ -29,6 +30,7 @@
                     "crunchy-pgbouncer": "true",
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
+                    "{{.PodAntiAffinityLabelName}}": "{{.PodAntiAffinityLabelValue}}",
                     "vendor": "crunchydata"
                 }
             },

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
@@ -19,6 +19,7 @@
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
                     "vendor": "crunchydata",
+                    "{{.PodAntiAffinityLabelName}}": "{{.PodAntiAffinityLabelValue}}",
                     "pgo-backrest-repo": "true"
             }
         },
@@ -29,6 +30,7 @@
                     "pg-cluster": "{{.ClusterName}}",
                     "service-name": "{{.Name}}",
                     "vendor": "crunchydata",
+                    "{{.PodAntiAffinityLabelName}}": "{{.PodAntiAffinityLabelValue}}",
                     "pgo-backrest-repo": "true"
                 }
             },

--- a/ansible/roles/pgo-operator/files/pgo-configs/postgres-ha.yaml
+++ b/ansible/roles/pgo-operator/files/pgo-configs/postgres-ha.yaml
@@ -1,0 +1,10 @@
+---
+bootstrap:
+  dcs:
+    postgresql:
+      parameters:
+        archive_timeout: {{.ArchiveTimeout}} 
+        log_min_duration_statement: {{.LogMinDurationStatement}}
+        log_statement: {{.LogStatement}}
+  initdb:
+  - encoding: UTF8

--- a/conf/postgres-operator/collect.json
+++ b/conf/postgres-operator/collect.json
@@ -25,7 +25,8 @@
         {
             "name": "JOB_NAME",
             "value": "{{.JobName}}"
-        },{
+        },
+        {
             "name": "POSTGRES_EXPORTER_PORT",
             "value": "{{.ExporterPort}}"
         }

--- a/conf/postgres-operator/pgo-target-role.json
+++ b/conf/postgres-operator/pgo-target-role.json
@@ -74,17 +74,6 @@
             "verbs": [
                 "*"
             ]
-        },
-        {
-            "apiGroups": [
-                "apps"
-            ],
-            "resources": [
-                "deployments"
-            ],
-            "verbs": [
-                "patch"
-            ]
         }
     ]
 }


### PR DESCRIPTION
This change syncs the templates between both the Ansible and bash installers to ensure they match.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The following templates are out of sync between the Ansible and bash installers:

- backrest-restore-job.json
- cluster-service.json
- pgbouncer-template.json
- pgo-backrest-repo-template.json
- postgres-ha.yaml
- collect.json
- pgo-target-role.json

**What is the new behavior (if this is a feature change)?**

The following templates are now in sync between the Ansible and bash installers:

- backrest-restore-job.json
- cluster-service.json
- pgbouncer-template.json
- pgo-backrest-repo-template.json
- postgres-ha.yaml
- collect.json
- pgo-target-role.json

**Other information**:

N/A