### PR TITLE
Updates add-targeted-namespace script

### DIFF
--- a/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
+++ b/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
@@ -29,15 +29,16 @@ PG_SA="pgo-pg"
 # create the namespace if necessary
 {{ kubectl_or_oc }} get ns {{ item }}  > /dev/null
 if [ $? -eq 0 ]; then
-	echo "namespace" {{ item }} "already exists, adding labels"
-	# set the labels so that existing namespace is owned by this installation
-	{{ kubectl_or_oc }} label namespace/{{ item }} pgo-created-by=add-script
-	{{ kubectl_or_oc }} label namespace/{{ item }} vendor=crunchydata
-	{{ kubectl_or_oc }} label namespace/{{ item }} pgo-installation-name={{ pgo_installation_name }}
+	echo "namespace" {{ item }} "already exists"
 else
 	echo "namespace" {{ item }} "is new"
 	{{ kubectl_or_oc }} create ns {{ item }}
 fi
+
+# set the labels so that this namespace is owned by this installation
+{{ kubectl_or_oc }} label namespace/{{ item }} pgo-created-by=add-script
+{{ kubectl_or_oc }} label namespace/{{ item }} vendor=crunchydata
+{{ kubectl_or_oc }} label namespace/{{ item }} pgo-installation-name={{ pgo_installation_name }}
 
 # determine if an existing pod is using the 'pgo-pg' service account.  if so, do not delete
 # and recreate the SA or its associated role and role binding.  this is to avoid any undesired

--- a/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
+++ b/ansible/roles/pgo-operator/templates/add-targeted-namespace.sh.j2
@@ -29,16 +29,15 @@ PG_SA="pgo-pg"
 # create the namespace if necessary
 {{ kubectl_or_oc }} get ns {{ item }}  > /dev/null
 if [ $? -eq 0 ]; then
-	echo "namespace" {{ item }} "already exists"
+	echo "namespace" {{ item }} "already exists, adding labels"
+	# set the labels so that existing namespace is owned by this installation
+	{{ kubectl_or_oc }} label namespace/{{ item }} pgo-created-by=add-script
+	{{ kubectl_or_oc }} label namespace/{{ item }} vendor=crunchydata
+	{{ kubectl_or_oc }} label namespace/{{ item }} pgo-installation-name={{ pgo_installation_name }}
 else
 	echo "namespace" {{ item }} "is new"
 	{{ kubectl_or_oc }} create ns {{ item }}
 fi
-
-# set the labels so that this namespace is owned by this installation
-{{ kubectl_or_oc }} label namespace/{{ item }} pgo-created-by=add-script
-{{ kubectl_or_oc }} label namespace/{{ item }} vendor=crunchydata
-{{ kubectl_or_oc }} label namespace/{{ item }} pgo-installation-name={{ pgo_installation_name }}
 
 # determine if an existing pod is using the 'pgo-pg' service account.  if so, do not delete
 # and recreate the SA or its associated role and role binding.  this is to avoid any undesired

--- a/deploy/add-targeted-namespace.sh
+++ b/deploy/add-targeted-namespace.sh
@@ -32,16 +32,15 @@ fi
 # create the namespace if necessary
 $PGO_CMD get ns $1  > /dev/null
 if [ $? -eq 0 ]; then
-	echo "namespace" $1 "already exists"
+	echo "namespace" $1 "already exists, adding labels"
+	# set the labels so that existing namespace is owned by this installation
+	$PGO_CMD label namespace/$1 pgo-created-by=add-script
+	$PGO_CMD label namespace/$1 vendor=crunchydata
+	$PGO_CMD label namespace/$1 pgo-installation-name=$PGO_INSTALLATION_NAME
 else
 	echo "namespace" $1 "is new"
-	TARGET_NAMESPACE=$1 expenv -f $DIR/target-namespace.yaml | $PGO_CMD create -f -
+	cat $DIR/target-namespace.yaml | sed -e 's/$TARGET_NAMESPACE/'"$1"'/' -e 's/$PGO_INSTALLATION_NAME/'"$PGO_INSTALLATION_NAME"'/' | $PGO_CMD create -f -
 fi
-
-# set the labels so that this namespace is owned by this installation
-$PGO_CMD label namespace/$1 pgo-created-by=add-script
-$PGO_CMD label namespace/$1 vendor=crunchydata
-$PGO_CMD label namespace/$1 pgo-installation-name=$PGO_INSTALLATION_NAME
 
 # determine if an existing pod is using the 'pgo-pg' service account.  if so, do not delete
 # and recreate the SA or its associated role and role binding.  this is to avoid any undesired


### PR DESCRIPTION
- Removes dependency on expenv by using sed to replace environment variables
- If a namespace exists in the environment we need to confirm that it has
the correct labels. This is done by blindly adding the labels to the existing
namespace. These commands are moved inside of the if statement so that they
are only called if the namespace exists. If the namespace doesn't exist it
is created with the labels so adding them again adds unnecessary errors.
Moving the lines also makes the script and the purpose of these commands
more clear.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable? tested both scripts using either the ansible installer or `make setupnamespaces` target


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**


**What is the new behavior (if this is a feature change)?**



**Other information**:
[ch5232]