### PR TITLE
Fix panic caused by RELATED_IMAGE_* environment

### DIFF
--- a/operator/common.go
+++ b/operator/common.go
@@ -40,7 +40,7 @@ var Pgo config.PgoConfig
 // ContainerImageOverrides contains a list of container images that are
 // overridden by the RELATED_IMAGE_* environmental variables that can be set by
 // people deploying the Operator
-var ContainerImageOverrides map[string]string
+var ContainerImageOverrides = map[string]string{}
 
 type containerResourcesTemplateFields struct {
 	RequestsMemory, RequestsCPU string


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

```
panic: assignment to entry in nil map
goroutine 1 [running]:
github.com/crunchydata/postgres-operator/operator.initializeContainerImageOverrides()
	/opt/cdev/src/github.com/crunchydata/postgres-operator/operator/common.go:201 +0x115
github.com/crunchydata/postgres-operator/operator.Initialize(0xc000210000)
	/opt/cdev/src/github.com/crunchydata/postgres-operator/operator/common.go:118 +0x5d3
main.main()
	/opt/cdev/src/github.com/crunchydata/postgres-operator/postgres-operator.go:84 +0x348 
```

**What is the new behavior (if this is a feature change)?**

No panic when overriding images via environment variable.
