### PR TITLE
Update NFS PV creation script to mimic "production" environments

### DIFF
--- a/pv/create-pv-nfs-legacy.sh
+++ b/pv/create-pv-nfs-legacy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2017 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo "create the test PV and PVC using the NFS dir"
+for i in {1..160}
+do
+   	echo "creating PV crunchy-pv$i"
+	export COUNTER=$i
+	$PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE delete pv crunchy-pv$i
+	expenv -f $DIR/crunchy-pv-nfs.json | $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create -f -
+done

--- a/pv/create-pv-nfs.sh
+++ b/pv/create-pv-nfs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017 Crunchy Data Solutions, Inc.
+# Copyright 2017-2020 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,14 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+# NOTE: this is script is intended for setting up development environments to
+# use NFS as the persistent volume storage area. It is **not** intended for
+# production.
+#
+# This script makes some assumptions, i.e:
+#
+# - You have sudo
+# - You have your NFS filesystem mounted to the location you are running this
+#   script
+# - Your NFS filesystem is mounted to /nfsfileshare
+# - Your PV names will be one of "crunchy-pvNNN" where NNN is a natural number
+# - Your NFS UID:GID is "nfsnobody:nfsnobody", which correspunds to "65534:65534"
+#
+# And awaaaay we go...
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo "create the test PV and PVC using the NFS dir"
 for i in {1..160}
 do
-   	echo "creating PV crunchy-pv$i"
-	export COUNTER=$i
-	$PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE delete pv crunchy-pv$i
-	expenv -f $DIR/crunchy-pv-nfs.json | $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create -f -
+  PV_NAME="crunchy-pv${i}"
+  NFS_PV_PATH="/nfsfileshare/${PV_NAME}"
+
+  echo "deleting PV ${PV_NAME}"
+	$PGO_CMD delete pv "${PV_NAME}"
+  sudo rm -rf "${NFS_PV_PATH}"
+
+  # this is the manifest used to create the persistent volumes
+  MANIFEST=$(cat <<EOF
+    {
+      "apiVersion": "v1",
+      "kind": "PersistentVolume",
+      "metadata": {
+        "name": "${PV_NAME}"
+      },
+      "spec": {
+        "capacity": {
+            "storage": "1Gi"
+        },
+        "accessModes": [ "ReadWriteMany" ],
+        "nfs": {
+            "path": "${NFS_PV_PATH}",
+            "server": "${PGO_NFS_IP}"
+        },
+        "persistentVolumeReclaimPolicy": "Retain"
+      }
+    }
+EOF
+)
+
+  # create the new directory and set the permissions
+  sudo mkdir "${NFS_PV_PATH}"
+  sudo chown 65534:65534 "${NFS_PV_PATH}"
+  sudo chmod ugo=rwx "${NFS_PV_PATH}"
+
+  # create the new persistent volume
+  echo $MANIFEST | $PGO_CMD create -f -
 done


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The legacy NFS PV (persistent volume) creation script would expect
all of the PVs to exist in the same directory on the NFS mount point.
While this provides certain conveniences when developing and debugging
the Operator, it does not necessarily mimic production environments, and
could lead to creating some weird situations when trying to plan out
new features. Additionally, most PV provisioners do not do this as well,
for convenience and security as well.

**What is the new behavior (if this is a feature change)?**

This updates the "create-pv-nfs.sh" script to create a directory for
each PV that is created on the NFS filesystem. The script is very
opinionated (and could use a few more guardrails) and is still not
recommend for production use.

The legacy version of the script has been renamed to
"create-pv-nfs-legacy.sh" and is still available should one want to use
it. Likely, this will be removed in the future as we remove reliance on
"expenv"