### PR TITLE
Updated Operator logging to use Golang RFC3339

### DIFF
--- a/logging/loglib.go
+++ b/logging/loglib.go
@@ -60,12 +60,8 @@ func CrunchyLogger(logDetails LogValues) {
 			}
 			return fmt.Sprintf("%s()", function), fmt.Sprintf("%s:%d", filename, f.Line)
 		},
-		//ForceColors: true,
 		FullTimestamp: true,
-		//DisableTruncation: true,
 	}
-
-	crunchyTextFormatter.TimestampFormat = "2006-01-02 15:04:05 -0700"
 
 	log.SetFormatter(&formatter{
 		fields: log.Fields{


### PR DESCRIPTION
This should make it easier to use a standard to parse/filter over
Kubernetes logs.

Also removed some dead code.