### PR TITLE
Ensure all failover/scaledown targets are listed

### DIFF
--- a/util/failover.go
+++ b/util/failover.go
@@ -69,7 +69,11 @@ const (
 	instanceReplicationInfoTypePrimary = "Leader"
 	// pgPodNamePattern pattern is a pattern used by regexp to look up the
 	// name of the pod
-	pgPodNamePattern = "%s-[0-9a-z]{10}-[0-9a-z]{5}"
+	// The character classes are derived from the Kubernetes random generator
+	// "SafeEncodeString"
+	//
+	// https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/rand/rand.go#L121-L127
+	pgPodNamePattern = "%s-[bcdfghjklmnpqrstvwxz2456789]+-[0-9a-z]{5}$"
 )
 
 var (


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The previous commit to address this issue (323c3749) solved most of the
cases, but pod names with shorter random characters at the end would
not be included in the `pgo scaledown --query` / `pgo failover --query`
lists.

**What is the new behavior (if this is a feature change)?**

This patch uses the character classes that are employed by the Kuernetes
random string generation (i.e. the [SafeEncodeString function](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/rand/rand.go)) to
detect the name of the Pod to appropriately display the PostgreSQL
instance name in a cluster.

**Other information**:

Issue: #1247
Issue: [ch6955]
Issue: [ch7072]