### PR TITLE
Enable PAM for SSHD by Setting UsePAM to 'yes' in the SSHD Configuration File

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-backrest-repo/sshd_config
+++ b/ansible/roles/pgo-operator/files/pgo-backrest-repo/sshd_config
@@ -93,7 +93,7 @@ ChallengeResponseAuthentication yes
 # and ChallengeResponseAuthentication to 'no'.
 # WARNING: 'UsePAM no' is not supported in Red Hat Enterprise Linux and may cause several
 # problems.
-UsePAM no 
+UsePAM yes
 
 #AllowAgentForwarding yes
 #AllowTcpForwarding yes

--- a/conf/pgo-backrest-repo/sshd_config
+++ b/conf/pgo-backrest-repo/sshd_config
@@ -93,7 +93,7 @@ ChallengeResponseAuthentication yes
 # and ChallengeResponseAuthentication to 'no'.
 # WARNING: 'UsePAM no' is not supported in Red Hat Enterprise Linux and may cause several
 # problems.
-UsePAM no 
+UsePAM yes
 
 #AllowAgentForwarding yes
 #AllowTcpForwarding yes


### PR DESCRIPTION
Enable PAM authentication, account processing, and session processing for `SSHD` by changing
`UsePAM` from `no` to `yes` in the `sshd_config` configuration file in both the Ansible and Bash
installers.  With this change, PAM will now be utilized by `SSHD` when started within both the `crunchy-postgres-ha` and `pgo-backrest-repo` containers.  This ensures that the `SSHD` configuration utilized by the is PostgreSQL Operator is compatible with the latest version of Docker provided by RedHat, specifically version `1.13.1-108`, therefore ensuring proper SSH functionality with `pgBackRest` (successful stanza creation, backups, etc.).

This change has been tested with the following versions of Docker:

- `1.13.1-108`
- `1.13.1-104`
- `1.13.1-108`

Additionally, this change has been tested across various Kubernetes environments as follows:

- OCP v3.11 installed locally (tested with both CentOS and RHEL v4.2.1 containers)
- OCP v3.11 installed in Google Compute Engine (tested with CentOS and RHEL v4.2.1 containers)
- Google Kubernetes Engine (GKE) v1.13 (tested with CentOS v4.2.1 containers)
- Kubernetes v1.17 installed locally via `kubeadm` (tested with CentOS v4.2.1 containers)

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

When using version `1.13.1-108` of Docker with OpenShift 3.11, the following error is seen when a `pgBackRest` attempts to create a stanza:

```bash
time="2020-01-29T11:29:49Z" level=info msg="stderr=[WARN: unable to check pg-1: [UnknownError] remote-0 process on '10.129.1.228' terminated unexpectedly [255]: Permission denied (publickey,keyboard-interactive).\nERROR: [056]: unable to find primary cluster - cannot proceed\n]"
time="2020-01-29T11:29:49Z" level=error msg="command terminated with exit code 56"
```

**What is the new behavior (if this is a feature change)?**

When using version `1.13.1-108` of Docker with OpenShift 3.11, stanza creation, backups and all other `pgBackRest` commands work as expected.

**Other information**:

N/A