### PR TITLE
Correct typo in quickstart

### DIFF
--- a/hugo/content/quickstart/_index.md
+++ b/hugo/content/quickstart/_index.md
@@ -284,7 +284,7 @@ This will create a PostgreSQL cluster named `hippo`. It may take a few moments f
 pgo test -n pgouser1 hippo
 ```
 
-When everything is up and running, you should seet output similar to this:
+When everything is up and running, you should see output similar to this:
 
 ```
 cluster : hippo


### PR DESCRIPTION
I noticed the word "seet" in this document. Looks like it should be "see," instead.
This commit fixes that typo.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Typo renders in docs. 


**What is the new behavior (if this is a feature change)?**
Typo is fixed.

