### PR TITLE
removing ui:label x-descriptor

### DIFF
--- a/installers/olm/postgresoperator.crd.descriptions.yaml
+++ b/installers/olm/postgresoperator.crd.descriptions.yaml
@@ -84,7 +84,6 @@
       description: Attributes that help set the primary storage of a PostgreSQL cluster
       x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PrimaryStorage'
-        - 'urn:alm:descriptor:com.tectonic.ui:label'
     - path: PrimaryStorage.name
       value: "hippo"
       displayName: PostgreSQL Primary Storage Name


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Fixes #1262 


**What is the new behavior (if this is a feature change)?**
The `label` descriptor here has been deprecated in favor of text. That said, from what I can see, it doesn't seem like we actually need to specify a value prompt for this field specifically, but rather the keys contained in this 

Tested in Openshift 4.3 by removing the value from the installed CSV for 4.2.1. 

**Other information**:

Made the PR here as I believe these are the sources of all the other locations where rendered CSVs eventually live (upstream-community-operators, community-operators, certified-operators, etc). Let me know if I can or need to push this somewhere else!