### PR TITLE
Ensure Successful Cluster Creation when Restoring After Scale Down

### DIFF
--- a/controller/jobcontroller.go
+++ b/controller/jobcontroller.go
@@ -562,15 +562,7 @@ func handleRmdata(job *apiv1.Job, restClient *rest.RESTClient, clientset *kubern
 	labels := job.GetObjectMeta().GetLabels()
 	clusterName := labels[config.LABEL_PG_CLUSTER]
 
-	//delete any pgtask for this cluster
-	log.Debugf("deleting pgtask for rmdata job name is %s", job.ObjectMeta.Name)
-	err = kubeapi.Deletepgtasks(restClient, config.LABEL_PG_CLUSTER+"="+clusterName, namespace)
-	if err != nil {
-		return err
-	}
-
-	err = kubeapi.DeleteJob(clientset, job.Name, namespace)
-	if err != nil {
+	if err = kubeapi.DeleteJob(clientset, job.Name, namespace); err != nil {
 		log.Error(err)
 	}
 

--- a/operator/backrest/backup.go
+++ b/operator/backrest/backup.go
@@ -233,19 +233,16 @@ func CleanBackupResources(restclient *rest.RESTClient, clientset *kubernetes.Cli
 		return err
 	}
 
-	// if the pgBackRest backup pgtask exits, then delete it so that a new pgBackRest backup
+	log.Debugf("pgtask %s found was %t when cleaning backup resources prior to creating a "+
+		"new backrest backup pgtask for cluster %s", taskName, found, clusterName)
+	// if the pgBackRest backup pgtask was found, then delete it so that a new pgBackRest backup
 	// pgtask can be created in order to initiate a new backup
 	if found {
-		log.Debugf("pgtask %s was found when cleaning backup resources prior to creating a new "+
-			"backrest backup pgtask and will be deleted", taskName)
+		log.Debugf("deleting pgtask %s for cluster %s", taskName, clusterName)
 		// delete the existing pgBackRest backup pgtask
-		err = kubeapi.Deletepgtask(restclient, taskName, namespace)
-		if err != nil {
+		if err = kubeapi.Deletepgtask(restclient, taskName, namespace); err != nil {
 			return err
 		}
-	} else {
-		log.Debugf("pgtask %s was not found when cleaning backup resources prior to creating a "+
-			"new backrest backup pgtask", taskName)
 	}
 
 	//remove previous backup job


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

If a cluster is scaled down prior to a restore (and without then taking a backup), then the initial cluster backup taken immediately following the restore will fail, and cluster replicas will not be bootstrapped.

Additionally, following the successful completion of any `rmdata` job, all `pgtasks` for the cluster are deleted.

[ch6991]

**What is the new behavior (if this is a feature change)?**

A restored cluster will now properly bootstrap and deploy regardless of whether or not it has been scaled down immediately prior to the restore.

**Other information**:

N/A