### PR TITLE
Remove unused installation variables (4.2)

### DIFF
--- a/ansible/inventory
+++ b/ansible/inventory
@@ -111,7 +111,6 @@ pgo_client_version='v4.2.1'
 #pgo_cluster_admin='false'
 
 # This will set default enhancements for operator deployed PostgreSQL clusters
-auto_failover='false'
 backrest='true'
 badger='false'
 metrics='false'
@@ -131,8 +130,7 @@ log_statement='none'
 log_min_duration_statement=60000
 
 # Autofail Settings
-auto_failover_replace_replica=false
-auto_failover_sleep_secs=9
+disable_auto_failover='false'
 
 # Scheduler Settings
 scheduler_timeout=3600

--- a/ansible/roles/pgo-operator/templates/pgo.yaml.j2
+++ b/ansible/roles/pgo-operator/templates/pgo.yaml.j2
@@ -3,8 +3,7 @@ Cluster:
   ReplicaNodeLabel:
   CCPImagePrefix:  {{ ccp_image_prefix }}
   CCPImageTag:  {{ ccp_image_tag }}
-  Autofail:  {{ auto_failover }}
-  AutofailReplaceReplica:  {{ auto_failover_replace_replica }}
+  DisableAutofail:  {{ disable_auto_failover }}
   Backrest:  {{ backrest }}
   BackrestPort:  {{ backrest_port }}
   BackrestS3Bucket: {{ backrest_aws_s3_bucket }}
@@ -71,7 +70,6 @@ ContainerResources:
 {% endif %}
 {% endfor %}
 Pgo:
-  AutofailSleepSeconds:  {{ auto_failover_sleep_secs }}
   Audit:  false
   LoadTemplate:  /pgo-config/pgo.load-template.json
   PGOImagePrefix:  {{ pgo_image_prefix }}

--- a/ansible/roles/pgo-preflight/tasks/check_inventory.yml
+++ b/ansible/roles/pgo-preflight/tasks/check_inventory.yml
@@ -15,14 +15,12 @@
     - ccp_image_tag
     - pgo_image_prefix
     - pgo_image_tag
-    - auto_failover
+    - disable_auto_failover
     - backrest
     - badger
     - metrics
     - archive_mode
     - archive_timeout
-    - auto_failover_sleep_secs
-    - auto_failover_replace_replica
     - db_name
     - db_password_age_days
     - db_password_length

--- a/conf/postgres-operator/pgo.yaml
+++ b/conf/postgres-operator/pgo.yaml
@@ -23,7 +23,6 @@ Cluster:
   BackrestS3Endpoint:
   BackrestS3Region:
   DisableAutofail:  false
-  AutofailReplaceReplica:  false
   LogStatement:  none
   LogMinDurationStatement:  60000
   PodAntiAffinity: preferred
@@ -99,7 +98,6 @@ ContainerResources:
     LimitsMemory:  2Gi
     LimitsCPU:  4.0
 Pgo:
-  AutofailSleepSeconds:  9
   PreferredFailoverNode:
   Audit:  false
   PGOImagePrefix:  crunchydata

--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -224,7 +224,6 @@ type ClusterStruct struct {
 	BackrestS3Endpoint            string `yaml:"BackrestS3Endpoint"`
 	BackrestS3Region              string `yaml:"BackrestS3Region"`
 	DisableAutofail               bool   `yaml:"DisableAutofail"`
-	AutofailReplaceReplica        bool   `yaml:"AutofailReplaceReplica"`
 	PgmonitorPassword             string `yaml:"PgmonitorPassword"`
 	EnableCrunchyadm              bool   `yaml:"EnableCrunchyadm"`
 	DisableReplicaStartFailReinit bool   `yaml:"DisableReplicaStartFailReinit"`
@@ -250,12 +249,10 @@ type ContainerResourcesStruct struct {
 }
 
 type PgoStruct struct {
-	PreferredFailoverNode     string `yaml:"PreferredFailoverNode"`
-	AutofailSleepSeconds      string `yaml:"AutofailSleepSeconds"`
-	AutofailSleepSecondsValue int
-	Audit                     bool   `yaml:"Audit"`
-	PGOImagePrefix            string `yaml:"PGOImagePrefix"`
-	PGOImageTag               string `yaml:"PGOImageTag"`
+	PreferredFailoverNode string `yaml:"PreferredFailoverNode"`
+	Audit                 bool   `yaml:"Audit"`
+	PGOImagePrefix        string `yaml:"PGOImagePrefix"`
+	PGOImageTag           string `yaml:"PGOImageTag"`
 }
 
 type PgoConfig struct {
@@ -276,7 +273,6 @@ type PgoConfig struct {
 	DefaultPgbouncerResources string                              `yaml:"DefaultPgbouncerResources"`
 }
 
-const DEFAULT_AUTOFAIL_SLEEP_SECONDS = "30"
 const DEFAULT_SERVICE_TYPE = "ClusterIP"
 const LOAD_BALANCER_SERVICE_TYPE = "LoadBalancer"
 const NODEPORT_SERVICE_TYPE = "NodePort"
@@ -395,14 +391,6 @@ func (c *PgoConfig) Validate() error {
 	}
 	if c.Pgo.PGOImageTag == "" {
 		return errors.New(errPrefix + "Pgo.PGOImageTag is required")
-	}
-	if c.Pgo.AutofailSleepSeconds == "" {
-		log.Warn("Pgo.AutofailSleepSeconds not set, using default ")
-		c.Pgo.AutofailSleepSeconds = DEFAULT_AUTOFAIL_SLEEP_SECONDS
-	}
-	c.Pgo.AutofailSleepSecondsValue, err = strconv.Atoi(c.Pgo.AutofailSleepSeconds)
-	if err != nil {
-		return errors.New(errPrefix + "Pgo.AutofailSleepSeconds invalid int value found")
 	}
 
 	if c.DefaultContainerResources != "" {

--- a/hugo/content/Installation/install-with-ansible/prerequisites.md
+++ b/hugo/content/Installation/install-with-ansible/prerequisites.md
@@ -112,9 +112,6 @@ sets of variables cannot be used at the same time.
 
 * `archive_mode`
 * `archive_timeout`
-* `auto_failover`
-* `auto_failover_sleep_secs`
-* `auto_failover_replace_replica`
 * `backup_storage`
 * `backrest`
 * `backrest_storage`
@@ -128,6 +125,7 @@ sets of variables cannot be used at the same time.
 * `db_port`
 * `db_replicas`
 * `db_user`
+* `disable_auto_failover``
 * `exporterport`
 * `kubernetes_context` (Comment out if deploying to am OpenShift environment)
 * `metrics`
@@ -156,9 +154,6 @@ sets of variables cannot be used at the same time.
 |-----------------------------------|-------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `archive_mode`                    | true        | **Required** | Set to true enable archive logging on all newly created clusters.                                                                                                                |
 | `archive_timeout`                 | 60          | **Required** | Set to a value in seconds to configure the timeout threshold for archiving.                                                                                                      |
-| `auto_failover`                   | false       | **Required** | Set to true enable auto failover capabilities on all newly created cluster requests.  This can be disabled by the client.                                                        |
-| `auto_failover_replace_replica`   | false       | **Required** | Set to true to replace promoted replicas during failovers with a new replica on all newly created clusters.                                                                      |
-| `auto_failover_sleep_secs`        | 9           | **Required** | Set to a value in seconds to configure the sleep time before initiating a failover on all newly created clusters.                                                                |
 | `backrest`                        | false       | **Required** | Set to true enable pgBackRest capabilities on all newly created cluster request.  This can be disabled by the client.                                                            |
 | `backrest_aws_s3_bucket`          |             |          | Set to configure the bucket used by pgBackRest with Amazon Web Service S3 for backups and restoration in S3.                                                                     |
 | `backrest_aws_s3_endpoint`        |             |          | Set to configure the endpoint used by pgBackRest with Amazon Web Service S3 for backups and restoration in S3.                                                                   |
@@ -182,6 +177,7 @@ sets of variables cannot be used at the same time.
 | `db_port`                         | 5432        | **Required** | Set to configure the default port used on all newly created clusters.                                                                                                            |
 | `db_replicas`                     | 1           | **Required** | Set to configure the amount of replicas provisioned on all newly created clusters.                                                                                               |
 | `db_user`                         | testuser    | **Required** | Set to configure the username of the dedicated user account on all newly created clusters.                                                                                       |
+| `disable_failover`                | false       | **Required** | Set to true disable auto failover capabilities on all newly created cluster requests. This cannot be overriden by the client on a cluster create, but on a cluster update. Setting this is not generally recommend, as it disable high-availability capabilities.|
 | `exporterport`                    | 9187        | **Required** | Set to configure the default port used to connect to postgres exporter.  |
 | `grafana_admin_password`          |             |          | Set to configure the login password for the Grafana administrator. |
 | `grafana_admin_username`          | admin       |          | Set to configure the login username for the Grafana administrator. |

--- a/hugo/content/pgo-client/common-tasks.md
+++ b/hugo/content/pgo-client/common-tasks.md
@@ -132,7 +132,6 @@ Cluster:
   BackrestS3Endpoint: ""
   BackrestS3Region: ""
   DisableAutofail: false
-  AutofailReplaceReplica: false
   PgmonitorPassword: ""
   EnableCrunchyadm: false
   DisableReplicaStartFailReinit: false

--- a/installers/gcp-marketplace/inventory.ini
+++ b/installers/gcp-marketplace/inventory.ini
@@ -31,7 +31,6 @@ pgo_scheduler_image='${OPERATOR_IMAGE_SCHEDULER}'
 pgo_client_install='false'
 pgo_client_version='v4.2.1'
 
-auto_failover='true'
 backrest='true'
 badger='false'
 metrics='${POSTGRES_METRICS}'
@@ -50,8 +49,7 @@ log_statement='none'
 log_min_duration_statement=60000
 
 # Autofail Settings
-auto_failover_replace_replica=false
-auto_failover_sleep_secs=9
+disable_auto_failover='false'
 
 # Scheduler Settings
 scheduler_timeout=3600


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The changes to the HA system introduced in Operator 4.2 removed
the need for some global configuration settings. However, this
could cause some confusion as these artifacts are still present in
some of the configuration files and installers.

**What is the new behavior (if this is a feature change)?**

This removes those artifacts, and also introduces the
`disable_auto_failover` parameter to the Ansible installation method.

See #1275 