### PR TITLE
Limit logging of passwords in logs (4.1)

### DIFF
--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -625,9 +625,6 @@ func CreateCluster(request *msgs.CreateClusterRequest, ns, pgouser string) msgs.
 
 		}
 
-		log.Debug("userLabelsMap")
-		log.Debugf("%v", userLabelsMap)
-
 		if existsGlobalConfig(ns) {
 			userLabelsMap[config.LABEL_CUSTOM_CONFIG] = config.GLOBAL_CUSTOM_CONFIGMAP
 		}

--- a/apiserver/dfservice/dfimpl.go
+++ b/apiserver/dfservice/dfimpl.go
@@ -177,7 +177,6 @@ func getPGSize(port, host, databaseName, clusterName, ns string) (string, int, e
 		log.Error(err.Error())
 		return dbsizePretty, dbsize, err
 	}
-	//log.Debug("username=" + username + " password=" + password)
 
 	conn, err = sql.Open("postgres", "sslmode=disable user="+username+" host="+host+" port="+port+" dbname="+databaseName+" password="+password)
 	if err != nil {

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -232,7 +232,7 @@ func BasicAuthCheck(username, password string) bool {
 
 	psw := string(secret.Data["password"])
 	if psw != password {
-		log.Errorf("%s  %s password does not match for user %s ", psw, password, username)
+		log.Errorf("password does not match for user [%s]", username)
 		return false
 	}
 

--- a/operator/backrest/restore.go
+++ b/operator/backrest/restore.go
@@ -395,7 +395,7 @@ func CreateRestoredDeployment(restclient *rest.RESTClient, cluster *crv1.Pgclust
 		affinityStr = operator.GetAffinity(cluster.Spec.UserLabels["NodeLabelKey"], cluster.Spec.UserLabels["NodeLabelValue"], "In")
 	}
 
-	log.Debugf("creating restored PG deployment with bouncer pass of [%s]", cluster.Spec.UserLabels[config.LABEL_PGBOUNCER_PASS])
+	log.Debugf("creating restored postgresql deployment for cluster [%s]", restoreToName)
 
 	deploymentFields := operator.DeploymentTemplateFields{
 		Name:                    restoreToName,
@@ -483,7 +483,7 @@ func publishRestore(id, clusterName, username, namespace string) {
 			Timestamp: time.Now(),
 			EventType: events.EventRestoreCluster,
 		},
-		Clustername:       clusterName,
+		Clustername: clusterName,
 	}
 
 	err := events.Publish(f)

--- a/operator/cluster/pgbouncer.go
+++ b/operator/cluster/pgbouncer.go
@@ -275,7 +275,6 @@ func AddPgbouncer(clientset *kubernetes.Clientset, restclient *rest.RESTClient, 
 	err, secretUser, secretPass := createPgbouncerSecret(clientset, cl, primaryName, replicaName, primaryName, secretName, namespace)
 
 	log.Debugf("secretUser: %s", secretUser)
-	log.Debugf("secretPass: %s", secretPass)
 
 	if err != nil {
 		log.Error(err)
@@ -303,7 +302,6 @@ func AddPgbouncer(clientset *kubernetes.Clientset, restclient *rest.RESTClient, 
 
 	pgbouncerName := clusterName + PGBOUNCER_SUFFIX
 	log.Debugf("adding a pgbouncer %s", pgbouncerName)
-	//	log.Debugf("secretUser: %s, secretPass: %s", secretUser, secretPass)
 
 	//create the pgbouncer deployment
 	fields := PgbouncerTemplateFields{
@@ -435,7 +433,7 @@ func updatePgBouncerDBPassword(clusterName string, p connectionInfo, username, n
 	var err error
 	var conn *sql.DB
 
-	log.Debugf("Updating credentials for %s in %s with %s ", username, p.Database, newPassword)
+	log.Debugf("Updating credentials for %s in %s", username, p.Database)
 
 	conn, err = sql.Open("postgres", "sslmode=disable user="+p.Username+" host="+p.Hostip+" port="+p.Port+" dbname="+p.Database+" password="+p.Password)
 	if err != nil {

--- a/pgo/cmd/auth.go
+++ b/pgo/cmd/auth.go
@@ -91,8 +91,8 @@ func parseCredentials(dat string) msgs.BasicAuthCredentials {
 		fmt.Println("unable to parse credentials in pgouser file")
 		os.Exit(2) // TODO: graceful exit
 	}
-	log.Debugf("%v", fields)
-	log.Debugf("username=[%s] password=[%s]", fields[0], fields[1])
+
+	log.Debugf("username=[%s]", fields[0])
 
 	creds := msgs.BasicAuthCredentials{
 		Username:     fields[0],

--- a/util/failover.go
+++ b/util/failover.go
@@ -212,7 +212,7 @@ func GetReplicationInfo(target string) (*ReplicationInfo, error) {
 	conn, err := sql.Open("postgres", target)
 
 	if err != nil {
-		log.Errorf("Could not connect to: %s", target)
+		log.Error(err)
 		return nil, err
 	}
 
@@ -224,7 +224,7 @@ func GetReplicationInfo(target string) (*ReplicationInfo, error) {
 	rows, err := conn.Query("SELECT current_setting('server_version_num')")
 
 	if err != nil {
-		log.Errorf("Could not perform query for version: %s", target)
+		log.Error(err)
 		return nil, err
 	}
 
@@ -257,7 +257,7 @@ func GetReplicationInfo(target string) (*ReplicationInfo, error) {
 	rows, err = conn.Query(replicationInfoQuery)
 
 	if err != nil {
-		log.Errorf("Could not perform replication info query: %s", target)
+		log.Error(err)
 		return nil, err
 	}
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the new behavior (if this is a feature change)?**

Typically, one does not want to log PostgreSQL or PGO credentials
in logs, not even debug logs. There are other ways to retrieve
credentials if one is a Kubernetes administrator or has access to
the appropriate PostgreSQL Operator commands.

Issue: [ch7272]