### PR TITLE
Update Documentation for UBI

### DIFF
--- a/hugo/content/Configuration/compatibility.md
+++ b/hugo/content/Configuration/compatibility.md
@@ -74,10 +74,16 @@ dependency between the two projects at a specific version level.
 ## Operating Systems
 
 The Operator is developed on both Centos 7 and RHEL 7 operating systems.  The
-underlying containers are designed to use either Centos 7 or RHEL 7 as the base
-container image.
+underlying containers are designed to use either Centos 7 or Red Hat UBI 7 as 
+the base container image.
 
 Other Linux variants are possible but are not supported at this time.
+
+Also, please note that as of version 4.2.2 of the PostgreSQL Operator, Red Hat Univeral Base
+Image (UBI) 7 has replaced RHEL 7 as the base container image for the various PostgreSQL Operator
+containers.  For more information on Red Hat UBI, please see the following link:
+
+https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image
 
 ## Kubernetes Distributions
 


### PR DESCRIPTION
Now that the RHEL images have been replaced by UBI as of version 4.2.2 of the PostgreSQL Operator, this commit replaces all applicable references to 'RHEL' in the PostgreSQL Operator documentation with 'UBI'.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

RHEL 7 is referenced in the documentation.

**What is the new behavior (if this is a feature change)?**

UBI 7 is referenced in the documentation where applicable.

**Other information**:

N/A