### PR TITLE
execute policy: Check stderr to determine if sql statements were successfully executed…

### DIFF
--- a/kubeapi/exec.go
+++ b/kubeapi/exec.go
@@ -17,6 +17,7 @@ package kubeapi
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
 	log "github.com/sirupsen/logrus"
@@ -73,6 +74,13 @@ func ExecToPodThroughAPI(config *rest.Config, clientset *kubernetes.Clientset, c
 		Tty:    false,
 	})
 	if err != nil {
+		log.Error(err)
+		return stdout.String(), stderr.String(), err
+	}
+
+	// Here we check if something is written to stderr. If yes, we had a problem with the provided script
+	if stderr.String() != "" {
+		err = fmt.Errorf("error in provided sql cmd: %s", stderr.String())
 		log.Error(err)
 		return stdout.String(), stderr.String(), err
 	}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Since 4.2.x, execute Policy does not check anymore if the provided sql statements were successfully executed (as explained in issue #1266)


**What is the new behavior (if this is a feature change)?**
This update checks the content of stderr. If not empty, this means an error occurred. Therefore, an error is returned


**Other information**:
