### PR TITLE
Return pgBackRest backup info in structured output

### DIFF
--- a/apiservermsgs/backrestmsgs.go
+++ b/apiservermsgs/backrestmsgs.go
@@ -32,11 +32,79 @@ type CreateBackrestBackupRequest struct {
 	BackrestStorageType string
 }
 
+// PgBackRestInfo and its associated structs are available for parsing the info
+// that comes from the output of the "pgbackrest info --output json" command
+type PgBackRestInfo struct {
+	Archives []PgBackRestInfoArchive `json:"archive"`
+	Backups  []PgBackRestInfoBackup  `json:"backup"`
+	Cipher   string                  `json:"cipher"`
+	DBs      []PgBackRestInfoDB      `json:"db"`
+	Name     string                  `json:"name"`
+	Status   PgBackRestInfoStatus    `json:"status"`
+}
+
+type PgBackRestInfoArchive struct {
+	DB  PgBackRestInfoDB `json:"db"`
+	ID  string           `json:"id"`
+	Max string           `json:"max"`
+	Min string           `json:"min"`
+}
+
+type PgBackRestInfoBackup struct {
+	Archive   PgBackRestInfoBackupArchive   `json:"archive"`
+	Backrest  PgBackRestInfoBackupBackrest  `json:"backrest"`
+	Database  PgBackRestInfoDB              `json:"database"`
+	Info      PgBackRestInfoBackupInfo      `json:"info"`
+	Label     string                        `json:"label"`
+	Prior     string                        `json:"prior"`
+	Reference []string                      `json:"reference"`
+	Timestamp PgBackRestInfoBackupTimestamp `json:"timestamp"`
+	Type      string                        `json:"type"`
+}
+
+type PgBackRestInfoBackupArchive struct {
+	Start string `json:"start"`
+	Stop  string `json:"stop"`
+}
+
+type PgBackRestInfoBackupBackrest struct {
+	Format  int    `json:"format"`
+	Version string `json:"version"`
+}
+
+type PgBackRestInfoBackupInfo struct {
+	Delta      int64                              `json:"delta"`
+	Repository PgBackRestInfoBackupInfoRepository `json:"repository"`
+	Size       int64                              `json:"size"`
+}
+
+type PgBackRestInfoBackupInfoRepository struct {
+	Delta int64 `json:"delta"`
+	Size  int64 `json:"size"`
+}
+
+type PgBackRestInfoBackupTimestamp struct {
+	Start int64 `json:"start"`
+	Stop  int64 `json:"stop"`
+}
+
+type PgBackRestInfoDB struct {
+	ID       int    `json:"id"`
+	SystemID int64  `json:"system-id,omitempty"`
+	Version  string `json:"version,omitempty"`
+}
+
+type PgBackRestInfoStatus struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
 // ShowBackrestDetail ...
 // swagger:model
 type ShowBackrestDetail struct {
-	Name string
-	Info string
+	Name        string
+	Info        []PgBackRestInfo
+	StorageType string
 }
 
 // ShowBackrestResponse ...

--- a/pgo/cmd/backrest.go
+++ b/pgo/cmd/backrest.go
@@ -19,6 +19,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
+	"time"
 
 	msgs "github.com/crunchydata/postgres-operator/apiservermsgs"
 	"github.com/crunchydata/postgres-operator/pgo/api"
@@ -85,15 +87,49 @@ func showBackrest(args []string, ns string) {
 		for _, backup := range response.Items {
 			printBackrest(&backup)
 		}
-
 	}
-
 }
 
 // printBackrest
 func printBackrest(result *msgs.ShowBackrestDetail) {
 	fmt.Printf("%s%s\n", "", "")
-	fmt.Printf("%s%s\n", "", "backrest : "+result.Name)
-	fmt.Printf("%s%s\n", "", result.Info)
+	fmt.Printf("cluster: %s\n", result.Name)
+	fmt.Printf("storage type: %s\n\n", result.StorageType)
 
+	for _, info := range result.Info {
+		fmt.Printf("stanza: %s\n", info.Name)
+		fmt.Printf("    status: %s\n", info.Status.Message)
+		fmt.Printf("    cipher: %s\n\n", info.Cipher)
+
+		for _, archive := range info.Archives {
+			// this is the quick way of getting the name...alternatively we could look
+			// it up by ID
+			fmt.Printf("    %s (current)\n", info.Name)
+			fmt.Printf("        wal archive min/max (%s)\n\n", archive.ID)
+
+			// iterate trhough the the backups and list out all the information
+			for _, backup := range info.Backups {
+				databaseSize, databaseUnit := getSizeAndUnit(backup.Info.Size)
+				databaseBackupSize, databaseBackupUnit := getSizeAndUnit(backup.Info.Delta)
+				repositorySize, repositoryUnit := getSizeAndUnit(backup.Info.Repository.Size)
+				repositoryBackupSize, repositoryBackupUnit := getSizeAndUnit(backup.Info.Repository.Delta)
+
+				// this matches the output format of pgbackrest info
+				fmt.Printf("        %s backup: %s\n", backup.Type, backup.Label)
+				fmt.Printf("            timestamp start/stop: %s / %s\n",
+					time.Unix(backup.Timestamp.Start, 0),
+					time.Unix(backup.Timestamp.Stop, 0))
+				fmt.Printf("            wal start/stop: %s / %s\n",
+					backup.Archive.Start, backup.Archive.Stop)
+				fmt.Printf("            database size: %.1f%s, backup size: %.1f%s\n",
+					databaseSize, getUnitString(databaseUnit),
+					databaseBackupSize, getUnitString(databaseBackupUnit))
+				fmt.Printf("            repository size: %.1f%s, repository backup size: %.1f%s\n",
+					repositorySize, getUnitString(repositoryUnit),
+					repositoryBackupSize, getUnitString(repositoryBackupUnit))
+				fmt.Printf("            backup reference list: %s\n\n",
+					strings.Join(backup.Reference, ", "))
+			}
+		}
+	}
 }

--- a/pgo/cmd/common.go
+++ b/pgo/cmd/common.go
@@ -21,6 +21,9 @@ import (
 	"reflect"
 )
 
+// unitType is used to group together the unit types
+type unitType int
+
 // values for the headings
 const (
 	headingCapacity     = "CAPACITY"
@@ -40,6 +43,35 @@ const (
 	headingUsed         = "USED"
 	headingUsername     = "USERNAME"
 )
+
+// unitSize recommends the unit we will use to size things
+const unitSize = 1024
+
+// the collection of unittypes, from byte to yottabyte
+const (
+	unitB unitType = iota
+	unitKB
+	unitMB
+	unitGB
+	unitTB
+	unitPB
+	unitEB
+	unitZB
+	unitYB
+)
+
+// unitTypeToString converts the unit types to strings
+var unitTypeToString = map[unitType]string{
+	unitB:  "B",
+	unitKB: "KiB",
+	unitMB: "MiB",
+	unitGB: "GiB",
+	unitTB: "TiB",
+	unitPB: "PiB",
+	unitEB: "EiB",
+	unitZB: "ZiB",
+	unitYB: "YiB",
+}
 
 // getHeaderLength returns the length of any value in a list, so that
 // the maximum length of the header can be determined
@@ -64,6 +96,33 @@ func getMaxLength(results []interface{}, title, fieldName string) int {
 	}
 
 	return maxLength + 1
+}
+
+// getSizeAndUnit determines the best size to return based on the best unit
+// where unit is KB, MB, GB, etc...
+func getSizeAndUnit(size int64) (float64, unitType) {
+	// set the unit
+	var unit unitType
+	// iterate through each tier, which we will initialize as "bytes"
+	normalizedSize := float64(size)
+
+	// We keep dividing by "unitSize" which is 1024. Once it is less than the unit
+	// size, that is the normalized unit we will use.
+	// The astute observer will note that "du" returns in units of 1024, but we
+	// want to attempt to keep thigns in the 3-digit area
+	//
+	// of course, eventually this will get too big...so bail after yotta bytes
+	for unit = unitB; normalizedSize > unitSize && unit < unitYB; unit++ {
+		normalizedSize /= unitSize
+	}
+
+	return normalizedSize, unit
+}
+
+// getUnitString maps the raw value of the unit to its corresponding
+// abbreviation
+func getUnitString(unit unitType) string {
+	return unitTypeToString[unit]
 }
 
 // printJSON renders a JSON response

--- a/pgo/cmd/df.go
+++ b/pgo/cmd/df.go
@@ -40,9 +40,6 @@ type dfTextPadding struct {
 	Used        int
 }
 
-// unitType is used to group together the unit types
-type unitType int
-
 // the different capacity levels and when to warn. Perhaps at some point one
 // can configure this
 const (
@@ -58,40 +55,11 @@ const (
 	dfTextPaddingPercentUsed = 7
 )
 
-// unitSize recommends the unit we will use to size things
-const unitSize = 1000
-
-// the collection of unittypes, from byte to yottabyte
-const (
-	unitB unitType = iota
-	unitKB
-	unitMB
-	unitGB
-	unitTB
-	unitPB
-	unitEB
-	unitZB
-	unitYB
-)
-
 // pvcTypeToString contains the human readable strings of the PVC types
 var pvcTypeToString = map[msgs.DfPVCType]string{
 	msgs.PVCTypePostgreSQL: "data",
 	msgs.PVCTypepgBackRest: "pgbackrest",
 	msgs.PVCTypeTablespace: "tablespace",
-}
-
-//unitTypeToString converts the unit types to strings
-var unitTypeToString = map[unitType]string{
-	unitB:  "B",
-	unitKB: "KB",
-	unitMB: "MB",
-	unitGB: "GB",
-	unitTB: "TB",
-	unitPB: "PB",
-	unitEB: "EB",
-	unitZB: "ZB",
-	unitYB: "YB",
 }
 
 var dfCmd = &cobra.Command{
@@ -149,33 +117,6 @@ func init() {
 // getPVCType returns a "human readable" form of the PVC
 func getPVCType(pvcType msgs.DfPVCType) string {
 	return pvcTypeToString[pvcType]
-}
-
-// getSizeAndUnit determines the best size to return based on the best unit
-// where unit is KB, MB, GB, etc...
-func getSizeAndUnit(size int64) (float64, unitType) {
-	// set the unit
-	var unit unitType
-	// iterate through each tier, which we will initialize as "bytes"
-	normalizedSize := float64(size)
-
-	// We keep dividing by "unitSize" which is 1000. Once it is less than the unit
-	// size, that is the normalized unit we will use.
-	// The astute observer will note that "du" returns in units of 1024, but we
-	// want to attempt to keep thigns in the 3-digit area
-	//
-	// of course, eventually this will get too big...so bail after yotta bytes
-	for unit = unitB; normalizedSize > unitSize && unit < unitYB; unit++ {
-		normalizedSize /= unitSize
-	}
-
-	return normalizedSize, unit
-}
-
-// getUnitString maps the raw value of the unit to its corresponding
-// abbreviation
-func getUnitString(unit unitType) string {
-	return unitTypeToString[unit]
 }
 
 // getUtilizationColor returns the appropriate color to use on the terminal


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The pgBackRest info was being trasnmitted entirely in text format
directly from the pgBackRest info command. This makes it difficult to
parse this data directly from API calls, which can be helpful for
monitoring pgBackRest clusters.

**What is the new behavior (if this is a feature change)?**

This patch returns the pgBackRest info via its JSON output, effectively
mirroring a call resembling "pgbackrest info --output json". The print
display remains the same: it implements a similar, if not identical,
structure to what "pgbackrest info" provides, though notes that the
data returned is in "ibibytes"

**Other information**:

Issue: [ch7508]