### PR TITLE
Fix typo

### DIFF
--- a/deploy/cleannamespaces.sh
+++ b/deploy/cleannamespaces.sh
@@ -17,7 +17,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ -z $PGO_OPERATOR_NAMESPACE ];
 then
-	echo "error: \$PGO_OPERATOR_NAME must be set"
+	echo "error: \$PGO_OPERATOR_NAMESPACE must be set"
 	exit 1
 fi
 


### PR DESCRIPTION
The error output leads the user to think that the PGO_OPERATOR_NAME env variable should be set. This change fixes the the error output to reference the actual env variable of PGO_OPERATOR_NAMESPACE.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable? NA
 - [ ] Have you tested your changes on all related environments with successful results, as applicable? NA



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
