### PR TITLE
Report errors in SQL policies at apply time

### DIFF
--- a/util/policy.go
+++ b/util/policy.go
@@ -93,9 +93,12 @@ func ExecPolicy(clientset *kubernetes.Clientset, restclient *rest.RESTClient, re
 	}
 
 	// execute the command! if it fails, return the error
-	if _, _, err := kubeapi.ExecToPodThroughAPI(restconfig, clientset,
-		command, pod.Spec.Containers[0].Name, pod.Name, namespace, stdin); err != nil {
-		return err
+	if _, stderr, err := kubeapi.ExecToPodThroughAPI(restconfig, clientset,
+		command, pod.Spec.Containers[0].Name, pod.Name, namespace, stdin); err != nil || stderr != "" {
+		// log the error from the pod and stderr, but return the stderr
+		log.Error(err, stderr)
+
+		return fmt.Errorf(stderr)
 	}
 
 	return nil


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

A change introduced into PostgreSQL 4.2 by yours truly accidentally
broke the ability to report back in real-time if there were SQL syntax
errors when attempting to add a policy to a managed PostgreSQL cluster.

**What is the new behavior (if this is a feature change)?**

This fixes the issue by reading the error from STDERR input and relaying
it back to the user.

**Other information**:

Issue: #1266