### PR TITLE
Add pg1-path to pgbackrest.conf in pgBackRest Repo Container

### DIFF
--- a/bin/pgo-backrest-repo/pgo-backrest-repo.sh
+++ b/bin/pgo-backrest-repo/pgo-backrest-repo.sh
@@ -37,6 +37,20 @@ if [ ! -d $PGBACKREST_REPO_PATH ]; then
 	mkdir -p $PGBACKREST_REPO_PATH
 fi
 
+# This is a workaround for changes introduced in pgBackRest v2.24.  Specifically, a pg1-path
+# setting must now be visible when another container executes a pgBackRest command via SSH.
+# Since env vars, and therefore the PGBACKREST_DB_PATH setting, is not visible when another
+# container executes a command via SSH, this adds the pg1-path setting to the pgBackRest config
+# file instead, ensuring the setting is always available in the environment during SSH calls.
+# Additionally, since the value for pg1-path setting in the repository container is irrelevant 
+# (i.e. the value specified by the container running the command via SSH is used instead), it is
+# simply set to a dummy directory within the config file.
+mkdir -p /tmp/pg1path
+if ! grep -Fxq "[${PGBACKREST_STANZA}]" "/etc/pgbackrest/pgbackrest.conf" 
+then
+    printf "[%s]\npg1-path=/tmp/pg1path\n" "$PGBACKREST_STANZA" > /etc/pgbackrest/pgbackrest.conf
+fi
+
 mkdir ~/.ssh/
 cp $CONFIG/config ~/.ssh/
 #cp $CONFIG/authorized_keys ~/.ssh/

--- a/centos7/Dockerfile.pgo-backrest-repo.centos7
+++ b/centos7/Dockerfile.pgo-backrest-repo.centos7
@@ -23,13 +23,15 @@ RUN yum -y install \
 RUN groupadd pgbackrest -g 2000 && useradd pgbackrest -u 2000 -g 2000
 ADD bin/pgo-backrest-repo /usr/local/bin
 RUN chmod +x /usr/local/bin/pgo-backrest-repo.sh /usr/local/bin/archive-push-s3.sh \
-    && mkdir -p /opt/cpm/bin \
-    && chown -R pgbackrest:pgbackrest /opt/cpm
+    && mkdir -p /opt/cpm/bin /etc/pgbackrest \
+    && chown -R pgbackrest:pgbackrest /opt/cpm \
+    && chown -R pgbackrest /etc/pgbackrest
 
 ADD bin/uid_pgbackrest.sh /opt/cpm/bin
 
-RUN chmod g=u /etc/passwd && \
-        chmod g=u /etc/group
+RUN chmod g=u /etc/passwd \
+    && chmod g=u /etc/group \
+    && chmod -R g=u /etc/pgbackrest
 
 RUN mkdir /.ssh && chown pgbackrest:pgbackrest /.ssh && chmod o+rwx /.ssh
 

--- a/rhel7/Dockerfile.pgo-backrest-repo.rhel7
+++ b/rhel7/Dockerfile.pgo-backrest-repo.rhel7
@@ -21,13 +21,15 @@ RUN yum -y install \
 RUN groupadd pgbackrest -g 2000 && useradd pgbackrest -u 2000 -g 2000
 ADD bin/pgo-backrest-repo /usr/local/bin
 RUN chmod +x /usr/local/bin/pgo-backrest-repo.sh /usr/local/bin/archive-push-s3.sh \
-    && mkdir -p /opt/cpm/bin \
-    && chown -R pgbackrest:pgbackrest /opt/cpm
+    && mkdir -p /opt/cpm/bin /etc/pgbackrest \
+    && chown -R pgbackrest:pgbackrest /opt/cpm \
+    && chown -R pgbackrest /etc/pgbackrest
 
 ADD bin/uid_pgbackrest.sh /opt/cpm/bin
 
-RUN chmod g=u /etc/passwd && \
-        chmod g=u /etc/group
+RUN chmod g=u /etc/passwd \
+    && chmod g=u /etc/group \
+    && chmod -R g=u /etc/pgbackrest
 
 RUN mkdir /.ssh && chown pgbackrest:pgbackrest /.ssh && chmod o+rwx /.ssh
 


### PR DESCRIPTION
With the upgrade to `pgBackRest v2.24`, it is now necessary to ensure a configuration setting for `pg1-path` is available in the `pgBackRest` repository host environment when a `pgBackRest` restore is initiated from a PG host (e.g. a replica when bootstrapping).  However, being that the actual value for this setting in the `pgBackRest` repository host is irrelevant when performing a restore from a PG host (specifically because the  setting from the PG host is utilized instead), a dummy value can be provided that simply ensures a valid directory is set for `pg1-path`.  This PR therefore adds a dummy pg1-path setting to the default `pgbackrest.conf` file in the `pgBackRest` repo container, which ensures a valid `pg1-path` is configured on the repo host as needed to support restores from other PG hosts and containers.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Replicas cannot be created using `pgBackRest v2.24`.  Specifically, the following error is thrown when attempting to perform a restore to create a replica:

`ERROR: [037]: restore command requires option: pg1-path`

**What is the new behavior (if this is a feature change)?**

Replicas can be created using `pgBackRest v2.24`.

**Other information**:

N/A