### PR TITLE
Eliminate Logging of pgBackRest Environmental Variables with Sensitive information

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/backrest-restore-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/backrest-restore-job.json
@@ -56,8 +56,9 @@
                         "readOnly": true
                     }
                     {{.TablespaceVolumeMounts}}],
-                    "env": [{
+                    "env": [
                       {{.PgbackrestS3EnvVars}}
+                      {
                         "name": "COMMAND_OPTS",
                         "value": "{{.CommandOpts}}"
                     }, {

--- a/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -82,10 +82,10 @@
                         "name": "PATRONI_POSTGRESQL_DATA_DIR",
                         "value": "/pgdata/{{.Name}}"
                     },
+                    {{.PgbackrestEnvVars}}
                     {{.PgbackrestS3EnvVars}}
                     {{.PgmonitorEnvVars}}
                     {
-            {{.PgbackrestEnvVars}}
                         "name": "PGHA_DATABASE",
                         "value": "{{.Database}}"
                     }, {

--- a/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -81,10 +81,11 @@
                     {
                         "name": "PATRONI_POSTGRESQL_DATA_DIR",
                         "value": "/pgdata/{{.Name}}"
-                    }, {
+                    },
+                    {{.PgbackrestS3EnvVars}}
+                    {
             {{.PgmonitorEnvVars}}
             {{.PgbackrestEnvVars}}
-            {{.PgbackrestS3EnvVars}}
                         "name": "PGHA_DATABASE",
                         "value": "{{.Database}}"
                     }, {

--- a/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -83,8 +83,8 @@
                         "value": "/pgdata/{{.Name}}"
                     },
                     {{.PgbackrestS3EnvVars}}
+                    {{.PgmonitorEnvVars}}
                     {
-            {{.PgmonitorEnvVars}}
             {{.PgbackrestEnvVars}}
                         "name": "PGHA_DATABASE",
                         "value": "{{.Database}}"

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbackrest-env-vars.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbackrest-env-vars.json
@@ -1,36 +1,48 @@
-                        "name": "PGBACKREST_STANZA",
-                        "value": "{{.PgbackrestStanza}}"
-                    }, {
-                        "name": "PGBACKREST_REPO1_HOST",
-                        "value": "{{.PgbackrestRepo1Host}}"
-                    }, {
-                        "name": "BACKREST_SKIP_CREATE_STANZA",
-                        "value": "true"
-                    }, {
-                        "name": "PGHA_PGBACKREST",
-                        "value": "true"
-                    }, {
-                        "name": "PGBACKREST_REPO1_PATH",
-                        "value": "{{.PgbackrestRepo1Path}}"
-                    }, {
-                        "name": "PGBACKREST_DB_PATH",
-                        "value": "{{.PgbackrestDBPath}}"
-                    }, {
-                        "name": "ENABLE_SSHD",
-                        "value": "true"
-                    }, {
-                        "name": "PGBACKREST_LOG_PATH",
-                        "value": "/tmp"
-                    }, {
-                        "name": "PGBACKREST_PG1_SOCKET_PATH",
-                        "value": "/tmp"
-                    }, {
-                        "name": "PGBACKREST_PG1_PORT",
-                        "value": "{{.PgbackrestPGPort}}"
-                    }, {
-                        "name": "PGBACKREST_REPO_TYPE",
-                        "value": "{{.PgbackrestRepo1Type}}"
-                    }, {
-                        "name": "PGHA_PGBACKREST_LOCAL_S3_STORAGE",
-                        "value": "{{.PgbackrestLocalAndS3Storage}}"
-                    }, {
+{
+  "name": "PGBACKREST_STANZA",
+  "value": "{{.PgbackrestStanza}}"
+},
+{
+  "name": "PGBACKREST_REPO1_HOST",
+  "value": "{{.PgbackrestRepo1Host}}"
+},
+{
+  "name": "BACKREST_SKIP_CREATE_STANZA",
+  "value": "true"
+},
+{
+  "name": "PGHA_PGBACKREST",
+  "value": "true"
+},
+{
+  "name": "PGBACKREST_REPO1_PATH",
+  "value": "{{.PgbackrestRepo1Path}}"
+},
+{
+  "name": "PGBACKREST_DB_PATH",
+  "value": "{{.PgbackrestDBPath}}"
+},
+{
+  "name": "ENABLE_SSHD",
+  "value": "true"
+},
+{
+  "name": "PGBACKREST_LOG_PATH",
+  "value": "/tmp"
+},
+{
+  "name": "PGBACKREST_PG1_SOCKET_PATH",
+  "value": "/tmp"
+},
+{
+  "name": "PGBACKREST_PG1_PORT",
+  "value": "{{.PgbackrestPGPort}}"
+},
+{
+  "name": "PGBACKREST_REPO_TYPE",
+  "value": "{{.PgbackrestRepo1Type}}"
+},
+{
+  "name": "PGHA_PGBACKREST_LOCAL_S3_STORAGE",
+  "value": "{{.PgbackrestLocalAndS3Storage}}"
+},

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbackrest-s3-env-vars.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbackrest-s3-env-vars.json
@@ -11,12 +11,21 @@
   "value": "{{.PgbackrestS3Region}}"
 },
 {
-  "name": "PGBACKREST_REPO1_S3_KEY",
-  "value": "{{.PgbackrestS3Key}}"
+  "valueFrom": {
+    "secretKeyRef": {
+      "name": "{{.PgbackrestS3SecretName}}",
+      "key": "{{.PgbackrestS3Key}}"
+    }
+  }
 },
 {
   "name": "PGBACKREST_REPO1_S3_KEY_SECRET",
-  "value": "{{.PgbackrestS3KeySecret}}"
+  "valueFrom": {
+    "secretKeyRef": {
+      "name": "{{.PgbackrestS3SecretName}}",
+      "key": "{{.PgbackrestS3KeySecret}}"
+    }
+  }
 },
 {
   "name": "PGBACKREST_REPO1_S3_CA_FILE",

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgbackrest-s3-env-vars.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgbackrest-s3-env-vars.json
@@ -1,21 +1,28 @@
-                    "name": "PGBACKREST_REPO1_S3_BUCKET",
-                    "value": "{{.PgbackrestS3Bucket}}"
-                    }, {
-                    "name": "PGBACKREST_REPO1_S3_ENDPOINT",
-                    "value": "{{.PgbackrestS3Endpoint}}"
-                    }, {
-                    "name": "PGBACKREST_REPO1_S3_REGION",
-                    "value": "{{.PgbackrestS3Region}}"
-                    }, {
-                    "name": "PGBACKREST_REPO1_S3_KEY",
-                    "value": "{{.PgbackrestS3Key}}"
-                    }, {
-                    "name": "PGBACKREST_REPO1_S3_KEY_SECRET",
-                    "value": "{{.PgbackrestS3KeySecret}}"
-                    }, {
-                    "name": "PGBACKREST_REPO1_S3_CA_FILE",
-                    "value": "/sshd/aws-s3-ca.crt"
-                    }, {
-                    "name": "PGBACKREST_REPO1_HOST_CMD",
-                    "value": "/usr/local/bin/archive-push-s3.sh"
-                    }, {
+{
+  "name": "PGBACKREST_REPO1_S3_BUCKET",
+  "value": "{{.PgbackrestS3Bucket}}"
+},
+{
+  "name": "PGBACKREST_REPO1_S3_ENDPOINT",
+  "value": "{{.PgbackrestS3Endpoint}}"
+},
+{
+  "name": "PGBACKREST_REPO1_S3_REGION",
+  "value": "{{.PgbackrestS3Region}}"
+},
+{
+  "name": "PGBACKREST_REPO1_S3_KEY",
+  "value": "{{.PgbackrestS3Key}}"
+},
+{
+  "name": "PGBACKREST_REPO1_S3_KEY_SECRET",
+  "value": "{{.PgbackrestS3KeySecret}}"
+},
+{
+  "name": "PGBACKREST_REPO1_S3_CA_FILE",
+  "value": "/sshd/aws-s3-ca.crt"
+},
+{
+  "name": "PGBACKREST_REPO1_HOST_CMD",
+  "value": "/usr/local/bin/archive-push-s3.sh"
+},

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgmonitor-env-vars.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgmonitor-env-vars.json
@@ -1,3 +1,4 @@
-                        "name": "PGMONITOR_PASSWORD",
-                        "value": "{{.PgmonitorPassword}}"
-                    }, {
+{
+  "name": "PGMONITOR_PASSWORD",
+  "value": "{{.PgmonitorPassword}}"
+},

--- a/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
@@ -45,32 +45,41 @@
                         "protocol": "TCP"
                     }],
                     {{.ContainerResources }}
-                    "env": [{
-            {{.PgbackrestS3EnvVars}}
+                    "env": [
+                      {{.PgbackrestS3EnvVars}}
+                      {
                         "name": "PGBACKREST_STANZA",
                         "value": "{{.PgbackrestStanza}}"
-                    }, {
+                      },
+                      {
                         "name": "SSHD_PORT",
                         "value": "{{.SshdPort}}"
-                    }, {
+                      },
+                      {
                         "name": "PGBACKREST_DB_PATH",
                         "value": "{{.PgbackrestDBPath}}"
-                    }, {
+                      },
+                      {
                         "name": "PGBACKREST_REPO_PATH",
                         "value": "{{.PgbackrestRepoPath}}"
-                    }, {
+                      },
+                      {
                         "name": "PGBACKREST_PG1_PORT",
                         "value": "{{.PgbackrestPGPort}}"
-                    }, {
+                      },
+                      {
                         "name": "PGBACKREST_LOG_PATH",
                         "value": "/tmp"
-                    }, {
+                      },
+                      {
                         "name": "PGBACKREST_PG1_SOCKET_PATH",
                         "value": "/tmp"
-                    }, {
+                      },
+                      {
                         "name": "PGBACKREST_DB_HOST",
                         "value": "{{.PGbackrestDBHost}}"
-                    }],
+                      }
+                    ],
                     "volumeMounts": [{
                         "name": "sshd",
                         "mountPath": "/sshd",

--- a/ansible/roles/pgo-operator/tasks/main.yml
+++ b/ansible/roles/pgo-operator/tasks/main.yml
@@ -5,7 +5,7 @@
   tags: always
 
 - name: Ensure output directory exists
-  file: 
+  file:
     path: "{{ output_dir }}"
     state: directory
     mode: 0700
@@ -60,7 +60,7 @@
       tags:
         - install
         - update
-    
+
     - include_tasks: crds.yml
       tags:
         - install
@@ -134,7 +134,7 @@
         - pgo_image_pull_secret_manifest != ''
 
     - name: Create cluster-admin Cluster Role Binding for PGO Service Account
-      command: | 
+      command: |
         {{ kubectl_or_oc }} create clusterrolebinding pgo-cluster-admin \
           --clusterrole cluster-admin \
           --user system:serviceaccount:{{ pgo_operator_namespace }}:postgres-operator
@@ -142,7 +142,7 @@
       tags:
         - install
         - update
-      
+
     - name: Template PGO RBAC
       template:
         src: pgo-role-rbac.yaml.j2
@@ -187,22 +187,14 @@
         - install
         - update
 
-    - name: Template BackRest AWS S3 Configuration
-      template:
-        src: aws-s3-credentials.yaml.j2
-        dest: "{{ output_dir }}/aws-s3-credentials.yaml"
-        mode: '0600'
-      tags:
-        - install
-        - update
-
     - name: Create PGO BackRest Repo Secret
       command: |
         {{ kubectl_or_oc }} create secret generic pgo-backrest-repo-config \
           --from-file=config='{{ role_path }}/files/pgo-backrest-repo/config' \
           --from-file=sshd_config='{{ role_path }}/files/pgo-backrest-repo/sshd_config' \
           --from-file=aws-s3-ca.crt='{{ role_path }}/files/pgo-backrest-repo/aws-s3-ca.crt' \
-          --from-file=aws-s3-credentials.yaml='{{ output_dir }}/aws-s3-credentials.yaml' \
+          --from-literal=aws-s3-key='{{ backrest_aws_s3_key }}' \
+          --from-literal=aws-s3-key-secret='{{ backrest_aws_s3_key_secret }}' \
           -n {{ pgo_operator_namespace }}
       tags:
         - install

--- a/bin/pgo-backrest-repo-sync/pgo-backrest-repo-sync.sh
+++ b/bin/pgo-backrest-repo-sync/pgo-backrest-repo-sync.sh
@@ -23,14 +23,7 @@ trap 'trap_sigterm' SIGINT SIGTERM
 # First enable sshd prior to running rsync if using pgbackrest with a repository
 # host
 enable_sshd() {
-
-	echo "PGBACKREST env vars are set to:"
-	set | grep PGBACKREST
-
 	SSHD_CONFIG=/sshd
-
-	echo "SSHD_CONFIG is.."
-	ls $SSHD_CONFIG
 
 	mkdir ~/.ssh/
 	cp $SSHD_CONFIG/config ~/.ssh/
@@ -57,7 +50,6 @@ rsync_repo() {
 # location.  The this inlcudes syncing files between who s3 locations,
 # syncing a local directory to s3, or syncing from s3 to a local directory.
 aws_sync_repo() {
-
 	export AWS_CA_BUNDLE="${PGBACKREST_REPO1_S3_CA_FILE}"
 	export AWS_ACCESS_KEY_ID="${PGBACKREST_REPO1_S3_KEY}"
 	export AWS_SECRET_ACCESS_KEY="${PGBACKREST_REPO1_S3_KEY_SECRET}"

--- a/bin/pgo-backrest-repo/archive-push-s3.sh
+++ b/bin/pgo-backrest-repo/archive-push-s3.sh
@@ -1,20 +1,3 @@
 #!/bin/bash
 
-awsKeySecret() {
-    val=$(grep "$1" -m 1 /sshd/aws-s3-credentials.yaml | sed "s/^.*:\s*//")
-    # remove leading and trailing whitespace
-    val=$(echo -e "${val}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-    if [[ "$val" == "" ]]
-    then
-        echo "empty-$1"
-    else
-        echo "${val}"
-    fi
-}
-
-PGBACKREST_REPO1_S3_KEY=$(awsKeySecret "aws-s3-key")
-export PGBACKREST_REPO1_S3_KEY
-PGBACKREST_REPO1_S3_KEY_SECRET=$(awsKeySecret "aws-s3-key-secret")
-export PGBACKREST_REPO1_S3_KEY_SECRET
-
 pgbackrest "$@"

--- a/bin/pgo-backrest-repo/pgo-backrest-repo.sh
+++ b/bin/pgo-backrest-repo/pgo-backrest-repo.sh
@@ -24,14 +24,6 @@ trap 'trap_sigterm' SIGINT SIGTERM
 CONFIG=/sshd
 REPO=/backrestrepo
 
-echo "PGBACKREST env vars are set to:"
-set | grep PGBACKREST
-
-echo "CONFIG is.."
-ls $CONFIG
-echo "REPO is ..."
-ls $REPO
-
 if [ ! -d $PGBACKREST_REPO1_PATH ]; then
 	echo "creating " $PGBACKREST_REPO1_PATH
 	mkdir -p $PGBACKREST_REPO1_PATH
@@ -42,11 +34,11 @@ fi
 # Since env vars, and therefore the PGBACKREST_DB_PATH setting, is not visible when another
 # container executes a command via SSH, this adds the pg1-path setting to the pgBackRest config
 # file instead, ensuring the setting is always available in the environment during SSH calls.
-# Additionally, since the value for pg1-path setting in the repository container is irrelevant 
+# Additionally, since the value for pg1-path setting in the repository container is irrelevant
 # (i.e. the value specified by the container running the command via SSH is used instead), it is
 # simply set to a dummy directory within the config file.
 mkdir -p /tmp/pg1path
-if ! grep -Fxq "[${PGBACKREST_STANZA}]" "/etc/pgbackrest/pgbackrest.conf" 
+if ! grep -Fxq "[${PGBACKREST_STANZA}]" "/etc/pgbackrest/pgbackrest.conf"
 then
     printf "[%s]\npg1-path=/tmp/pg1path\n" "$PGBACKREST_STANZA" > /etc/pgbackrest/pgbackrest.conf
 fi

--- a/bin/pgo-backrest-repo/pgo-backrest-repo.sh
+++ b/bin/pgo-backrest-repo/pgo-backrest-repo.sh
@@ -41,6 +41,17 @@ mkdir -p /tmp/pg1path
 if ! grep -Fxq "[${PGBACKREST_STANZA}]" "/etc/pgbackrest/pgbackrest.conf"
 then
     printf "[%s]\npg1-path=/tmp/pg1path\n" "$PGBACKREST_STANZA" > /etc/pgbackrest/pgbackrest.conf
+
+		# Additionally, if the PGBACKREST S3 variables are set, add them here
+		if [[ "${PGBACKREST_REPO1_S3_KEY}" != "" ]]
+		then
+			printf "repo1-s3-key=%s\n" "${PGBACKREST_REPO1_S3_KEY}" >> /etc/pgbackrest/pgbackrest.conf
+		fi
+
+		if [[ "${PGBACKREST_REPO1_S3_KEY_SECRET}" != "" ]]
+		then
+			printf "repo1-s3-key-secret=%s\n" "${PGBACKREST_REPO1_S3_KEY_SECRET}" >> /etc/pgbackrest/pgbackrest.conf
+		fi
 fi
 
 mkdir ~/.ssh/

--- a/bin/pgo-backrest-restore/pgo-backrest-restore.sh
+++ b/bin/pgo-backrest-restore/pgo-backrest-restore.sh
@@ -23,14 +23,6 @@ trap 'trap_sigterm' SIGINT SIGTERM
 
 CONFIG=/sshd
 
-echo "PGBACKREST env vars are set to:"
-set | grep PGBACKREST
-
-echo "CONFIG is.."
-ls $CONFIG
-echo "REPO is ..."
-ls $REPO
-
 mkdir ~/.ssh/
 cp $CONFIG/config ~/.ssh/
 cp $CONFIG/id_ed25519 /tmp

--- a/bin/pgo-rmdata/start.sh
+++ b/bin/pgo-rmdata/start.sh
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-env
-
 /usr/local/bin/pgo-rmdata -pg-cluster=$PG_CLUSTER \
 	-replica-name=$REPLICA_NAME \
 	-namespace=$NAMESPACE \

--- a/conf/postgres-operator/backrest-restore-job.json
+++ b/conf/postgres-operator/backrest-restore-job.json
@@ -59,8 +59,9 @@
                       }
                       {{.TablespaceVolumeMounts}}
                     ],
-                    "env": [{
+                    "env": [
                       {{.PgbackrestS3EnvVars}}
+                      {
                         "name": "COMMAND_OPTS",
                         "value": "{{.CommandOpts}}"
                     },

--- a/conf/postgres-operator/cluster-deployment.json
+++ b/conf/postgres-operator/cluster-deployment.json
@@ -83,9 +83,9 @@
                         "value": "/pgdata/{{.Name}}"
                     },
                     {{.PgbackrestS3EnvVars}}
+                    {{.PgbackrestEnvVars}}
                     {{.PgmonitorEnvVars}}
                     {
-            {{.PgbackrestEnvVars}}
                         "name": "PGHA_DATABASE",
                         "value": "{{.Database}}"
                     }, {

--- a/conf/postgres-operator/cluster-deployment.json
+++ b/conf/postgres-operator/cluster-deployment.json
@@ -81,10 +81,11 @@
                     {
                         "name": "PATRONI_POSTGRESQL_DATA_DIR",
                         "value": "/pgdata/{{.Name}}"
-                    }, {
+                    },
+                    {{.PgbackrestS3EnvVars}}
+                    {
             {{.PgmonitorEnvVars}}
             {{.PgbackrestEnvVars}}
-            {{.PgbackrestS3EnvVars}}
                         "name": "PGHA_DATABASE",
                         "value": "{{.Database}}"
                     }, {

--- a/conf/postgres-operator/cluster-deployment.json
+++ b/conf/postgres-operator/cluster-deployment.json
@@ -83,8 +83,8 @@
                         "value": "/pgdata/{{.Name}}"
                     },
                     {{.PgbackrestS3EnvVars}}
+                    {{.PgmonitorEnvVars}}
                     {
-            {{.PgmonitorEnvVars}}
             {{.PgbackrestEnvVars}}
                         "name": "PGHA_DATABASE",
                         "value": "{{.Database}}"

--- a/conf/postgres-operator/pgbackrest-env-vars.json
+++ b/conf/postgres-operator/pgbackrest-env-vars.json
@@ -1,36 +1,48 @@
-                        "name": "PGBACKREST_STANZA",
-                        "value": "{{.PgbackrestStanza}}"
-                    }, {
-                        "name": "PGBACKREST_REPO1_HOST",
-                        "value": "{{.PgbackrestRepo1Host}}"
-                    }, {
-                        "name": "BACKREST_SKIP_CREATE_STANZA",
-                        "value": "true"
-                    }, {
-                        "name": "PGHA_PGBACKREST",
-                        "value": "true"
-                    }, {
-                        "name": "PGBACKREST_REPO1_PATH",
-                        "value": "{{.PgbackrestRepo1Path}}"
-                    }, {
-                        "name": "PGBACKREST_DB_PATH",
-                        "value": "{{.PgbackrestDBPath}}"
-                    }, {
-                        "name": "ENABLE_SSHD",
-                        "value": "true"
-                    }, {
-                        "name": "PGBACKREST_LOG_PATH",
-                        "value": "/tmp"
-                    }, {
-                        "name": "PGBACKREST_PG1_SOCKET_PATH",
-                        "value": "/tmp"
-                    }, {
-                        "name": "PGBACKREST_PG1_PORT",
-                        "value": "{{.PgbackrestPGPort}}"
-                    }, {
-                        "name": "PGBACKREST_REPO_TYPE",
-                        "value": "{{.PgbackrestRepo1Type}}"
-                    }, {
-                        "name": "PGHA_PGBACKREST_LOCAL_S3_STORAGE",
-                        "value": "{{.PgbackrestLocalAndS3Storage}}"
-                    }, {
+{
+  "name": "PGBACKREST_STANZA",
+  "value": "{{.PgbackrestStanza}}"
+},
+{
+  "name": "PGBACKREST_REPO1_HOST",
+  "value": "{{.PgbackrestRepo1Host}}"
+},
+{
+  "name": "BACKREST_SKIP_CREATE_STANZA",
+  "value": "true"
+},
+{
+  "name": "PGHA_PGBACKREST",
+  "value": "true"
+},
+{
+  "name": "PGBACKREST_REPO1_PATH",
+  "value": "{{.PgbackrestRepo1Path}}"
+},
+{
+  "name": "PGBACKREST_DB_PATH",
+  "value": "{{.PgbackrestDBPath}}"
+},
+{
+  "name": "ENABLE_SSHD",
+  "value": "true"
+},
+{
+  "name": "PGBACKREST_LOG_PATH",
+  "value": "/tmp"
+},
+{
+  "name": "PGBACKREST_PG1_SOCKET_PATH",
+  "value": "/tmp"
+},
+{
+  "name": "PGBACKREST_PG1_PORT",
+  "value": "{{.PgbackrestPGPort}}"
+},
+{
+  "name": "PGBACKREST_REPO_TYPE",
+  "value": "{{.PgbackrestRepo1Type}}"
+},
+{
+  "name": "PGHA_PGBACKREST_LOCAL_S3_STORAGE",
+  "value": "{{.PgbackrestLocalAndS3Storage}}"
+},

--- a/conf/postgres-operator/pgbackrest-s3-env-vars.json
+++ b/conf/postgres-operator/pgbackrest-s3-env-vars.json
@@ -12,11 +12,21 @@
 },
 {
   "name": "PGBACKREST_REPO1_S3_KEY",
-  "value": "{{.PgbackrestS3Key}}"
+  "valueFrom": {
+    "secretKeyRef": {
+      "name": "{{.PgbackrestS3SecretName}}",
+      "key": "{{.PgbackrestS3Key}}"
+    }
+  }
 },
 {
   "name": "PGBACKREST_REPO1_S3_KEY_SECRET",
-  "value": "{{.PgbackrestS3KeySecret}}"
+  "valueFrom": {
+    "secretKeyRef": {
+      "name": "{{.PgbackrestS3SecretName}}",
+      "key": "{{.PgbackrestS3KeySecret}}"
+    }
+  }
 },
 {
   "name": "PGBACKREST_REPO1_S3_CA_FILE",

--- a/conf/postgres-operator/pgbackrest-s3-env-vars.json
+++ b/conf/postgres-operator/pgbackrest-s3-env-vars.json
@@ -1,21 +1,28 @@
-                    "name": "PGBACKREST_REPO1_S3_BUCKET",
-                    "value": "{{.PgbackrestS3Bucket}}"
-                    }, {
-                    "name": "PGBACKREST_REPO1_S3_ENDPOINT",
-                    "value": "{{.PgbackrestS3Endpoint}}"
-                    }, {
-                    "name": "PGBACKREST_REPO1_S3_REGION",
-                    "value": "{{.PgbackrestS3Region}}"
-                    }, {
-                    "name": "PGBACKREST_REPO1_S3_KEY",
-                    "value": "{{.PgbackrestS3Key}}"
-                    }, {
-                    "name": "PGBACKREST_REPO1_S3_KEY_SECRET",
-                    "value": "{{.PgbackrestS3KeySecret}}"
-                    }, {
-                    "name": "PGBACKREST_REPO1_S3_CA_FILE",
-                    "value": "/sshd/aws-s3-ca.crt"
-                    }, {
-                    "name": "PGBACKREST_REPO1_HOST_CMD",
-                    "value": "/usr/local/bin/archive-push-s3.sh"
-                    }, {
+{
+  "name": "PGBACKREST_REPO1_S3_BUCKET",
+  "value": "{{.PgbackrestS3Bucket}}"
+},
+{
+  "name": "PGBACKREST_REPO1_S3_ENDPOINT",
+  "value": "{{.PgbackrestS3Endpoint}}"
+},
+{
+  "name": "PGBACKREST_REPO1_S3_REGION",
+  "value": "{{.PgbackrestS3Region}}"
+},
+{
+  "name": "PGBACKREST_REPO1_S3_KEY",
+  "value": "{{.PgbackrestS3Key}}"
+},
+{
+  "name": "PGBACKREST_REPO1_S3_KEY_SECRET",
+  "value": "{{.PgbackrestS3KeySecret}}"
+},
+{
+  "name": "PGBACKREST_REPO1_S3_CA_FILE",
+  "value": "/sshd/aws-s3-ca.crt"
+},
+{
+  "name": "PGBACKREST_REPO1_HOST_CMD",
+  "value": "/usr/local/bin/archive-push-s3.sh"
+},

--- a/conf/postgres-operator/pgmonitor-env-vars.json
+++ b/conf/postgres-operator/pgmonitor-env-vars.json
@@ -1,3 +1,4 @@
-                        "name": "PGMONITOR_PASSWORD",
-                        "value": "{{.PgmonitorPassword}}"
-                    }, {
+{
+  "name": "PGMONITOR_PASSWORD",
+  "value": "{{.PgmonitorPassword}}"
+},

--- a/conf/postgres-operator/pgo-backrest-repo-template.json
+++ b/conf/postgres-operator/pgo-backrest-repo-template.json
@@ -45,32 +45,41 @@
                         "protocol": "TCP"
                     }],
                     {{.ContainerResources }}
-                    "env": [{
-            {{.PgbackrestS3EnvVars}}
+                    "env": [
+                      {{.PgbackrestS3EnvVars}}
+                      {
                         "name": "PGBACKREST_STANZA",
                         "value": "{{.PgbackrestStanza}}"
-                    }, {
+                      },
+                      {
                         "name": "SSHD_PORT",
                         "value": "{{.SshdPort}}"
-                    }, {
+                      },
+                      {
                         "name": "PGBACKREST_DB_PATH",
                         "value": "{{.PgbackrestDBPath}}"
-                    }, {
+                      },
+                      {
                         "name": "PGBACKREST_REPO_PATH",
                         "value": "{{.PgbackrestRepoPath}}"
-                    }, {
+                      },
+                      {
                         "name": "PGBACKREST_PG1_PORT",
                         "value": "{{.PgbackrestPGPort}}"
-                    }, {
+                      },
+                      {
                         "name": "PGBACKREST_LOG_PATH",
                         "value": "/tmp"
-                    }, {
+                      },
+                      {
                         "name": "PGBACKREST_PG1_SOCKET_PATH",
                         "value": "/tmp"
-                    }, {
+                      },
+                      {
                         "name": "PGBACKREST_DB_HOST",
                         "value": "{{.PGbackrestDBHost}}"
-                    }],
+                      }
+                    ],
                     "volumeMounts": [{
                         "name": "sshd",
                         "mountPath": "/sshd",

--- a/installers/olm/openshift.description.md
+++ b/installers/olm/openshift.description.md
@@ -107,14 +107,15 @@ Create the pgo namespace if it does not exist already. This single namespace is 
 oc create namespace pgo
 ```
 
-Create the `pgo-backrest-repo-config` Secret that is used by the operator.
+Create the `pgo-backrest-repo-config` Secret that is used by the PostgreSQL Operator. You can omit the AWS S3 keys if you are not planning to use S3 storage with the Operator
 
 ```
 oc create secret generic -n pgo pgo-backrest-repo-config \
   --from-file=config=$PGOROOT/conf/pgo-backrest-repo/config \
   --from-file=sshd_config=$PGOROOT/conf/pgo-backrest-repo/sshd_config \
-  --from-file=aws-s3-credentials.yaml=$PGOROOT/conf/pgo-backrest-repo/aws-s3-credentials.yaml \
-  --from-file=aws-s3-ca.crt=$PGOROOT/conf/pgo-backrest-repo/aws-s3-ca.crt
+  --from-file=aws-s3-ca.crt=$PGOROOT/conf/pgo-backrest-repo/aws-s3-ca.crt \
+  --from-literal=aws-s3-key="<your-aws-s3-key>" \
+  --from-literal=aws-s3-key-secret="<your-aws-s3-key-secret>"
 ```
 
 Create the `pgo-auth-secret` Secret that is used by the operator.

--- a/installers/olm/postgresoperator.csv.description.md
+++ b/installers/olm/postgresoperator.csv.description.md
@@ -107,14 +107,15 @@ Create the pgo namespace if it does not exist already. This single namespace is 
 kubectl create namespace pgo
 ```
 
-Create the `pgo-backrest-repo-config` Secret that is used by the operator.
+Create the `pgo-backrest-repo-config` Secret that is used by the PostgreSQL Operator. You can omit the AWS S3 keys if you are not planning to use S3 storage with the Operator
 
 ```
 kubectl create secret generic -n pgo pgo-backrest-repo-config \
   --from-file=config=$PGOROOT/conf/pgo-backrest-repo/config \
   --from-file=sshd_config=$PGOROOT/conf/pgo-backrest-repo/sshd_config \
-  --from-file=aws-s3-credentials.yaml=$PGOROOT/conf/pgo-backrest-repo/aws-s3-credentials.yaml \
-  --from-file=aws-s3-ca.crt=$PGOROOT/conf/pgo-backrest-repo/aws-s3-ca.crt
+  --from-file=aws-s3-ca.crt=$PGOROOT/conf/pgo-backrest-repo/aws-s3-ca.crt \
+  --from-literal=aws-s3-key="<your-aws-s3-key>" \
+  --from-literal=aws-s3-key-secret="<your-aws-s3-key-secret>"
 ```
 
 Create the `pgo-auth-secret` Secret that is used by the operator.

--- a/operator/cluster/clone.go
+++ b/operator/cluster/clone.go
@@ -288,8 +288,7 @@ func cloneStep2(clientset *kubernetes.Clientset, client *rest.RESTClient, namesp
 	}
 
 	// Retrieve current S3 key & key secret
-	s3Creds, err := util.GetS3CredsFromBackrestRepoSecret(clientset, sourcePgcluster.Name,
-		namespace)
+	s3Creds, err := util.GetS3CredsFromBackrestRepoSecret(clientset, namespace, sourcePgcluster.Name)
 	if err != nil {
 		log.Error(err)
 		errorMessage := fmt.Sprintf("Unable to get S3 key and key secret from source cluster "+
@@ -617,8 +616,7 @@ func createPgBackRestRepoSyncJob(clientset *kubernetes.Clientset, namespace stri
 		&job.Spec.Template.Spec.Containers[0])
 
 	// Retrieve current S3 key & key secret
-	s3Creds, err := util.GetS3CredsFromBackrestRepoSecret(clientset, sourcePgcluster.Name,
-		namespace)
+	s3Creds, err := util.GetS3CredsFromBackrestRepoSecret(clientset, namespace, sourcePgcluster.Name)
 	if err != nil {
 		log.Error(err)
 		errorMessage := fmt.Sprintf("Unable to get S3 key and key secret from source cluster "+


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

Though the pgBackRest S3 credentials are stored in Kubernetes secrets, there were several cases of these credentials being logged in various Kubernetes resources or being made available in Kubernetes resources (e.g. `kubectl describe pod`), which ideally should not happen.

**What is the new behavior (if this is a feature change)?**

- The environmental variables are not printed out when certain containers load, which appeared to be legacy debugging code 
- The pgBackRest S3 credentials are now loaded into containers via "[environmental variables secrets](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables)" and are hidden by Kubernetes in its various resources.

There is a breaking change, in that the S3 credentials are no longer stored in a YAML file in the Secret, but rather get their own keys and key-value pairs.

**Other information**:

Issue: [ch7638]
Issue: #1306