### PR TITLE
add namspace field to cluster create response

### DIFF
--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -862,6 +862,7 @@ func CreateCluster(request *msgs.CreateClusterRequest, ns, pgouser string) msgs.
 
 	// assign the cluster information to the result
 	resp.Result.Name = newInstance.Spec.Name
+	resp.Result.Namespace = newInstance.Spec.Namespace
 
 	// and return!
 	return resp

--- a/apiservermsgs/clustermsgs.go
+++ b/apiservermsgs/clustermsgs.go
@@ -118,6 +118,8 @@ type CreateClusterDetail struct {
 	Database string
 	// Name is the name of the PostgreSQL cluster
 	Name string
+	// Namespace is the name of the namespace where the cluster was created.
+	Namespace string
 	// Users contain an array of users along with their credentials
 	Users []CreateClusterDetailUser
 	// WorkflowID matches up to the WorkflowID of the cluster


### PR DESCRIPTION
Namespace was missing from the cluster create response. This field is
important to some external clients. These changes add the field to the
response as well as assigning its value by the service.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Currently, the namespace a cluster was created in is not returned as part of the response from the create cluster workflow.

**What is the new behavior (if this is a feature change)?**

Create cluster response now includes the namespace.

**Other information**:
