### PR TITLE
Update documentation for how to add a CRL file

### DIFF
--- a/apis/cr/v1/cluster.go
+++ b/apis/cr/v1/cluster.go
@@ -130,7 +130,8 @@ type PodAntiAffinitySpec struct {
 type TLSSpec struct {
 	// CASecret contains the name of the secret to use as the trusted CA for the
 	// TLSSecret
-	// This is our own format and should contain one key: "ca.crt"
+	// This is our own format and should contain at least one key: "ca.crt"
+	// It can also contain a key "ca.crl" which is the certificate revocation list
 	CASecret string `json:"caSecret"`
 	// TLSSecret contains the name of the secret to use that contains the TLS
 	// keypair for the PostgreSQL server

--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -894,8 +894,25 @@ as a generic Secret, and note that the following requirements **must** be met:
 your PostgreSQL cluster
 - The `name` of the key that is holding the CA **must** be `ca.crt`
 
+There are optional settings for setting up the CA secret:
+
+- You can pass in a certificate revocation list (CRL) for the CA secret by
+passing in the CRL using the `ca.crl` key name in the Secret.
+
+For example, to create a CA Secret with the trusted CA to use for the PostgreSQL
+clusters, you could execute the following command:
+
 ```shell
-kubectl create secret generic postgresql-ca --from-file=ca.crt=/patho/to/ca.crt
+kubectl create secret generic postgresql-ca --from-file=ca.crt=/path/to/ca.crt
+```
+
+To create a CA Secret that includes a CRL, you could execute the following
+command:
+
+```shell
+kubectl create secret generic postgresql-ca \
+  --from-file=ca.crt=/path/to/ca.crt \
+  --from-file=ca.crl=/path/to/ca.crl
 ```
 
 Note that you can reuse this CA Secret for other PostgreSQL clusters deployed by
@@ -908,7 +925,9 @@ a TLS Secret, and note the following requirement must be met:
 your PostgreSQL cluster
 
 ```shell
-kubectl create secret tls hacluster-tls-keypair --cert=/path/to/server.crt --key=/path/to/server.key
+kubectl create secret tls hacluster-tls-keypair \
+  --cert=/path/to/server.crt \
+  --key=/path/to/server.key
 ```
 
 Now you can create a TLS-enabled PostgreSQL cluster!
@@ -920,7 +939,8 @@ accept both TLS and non-TLS connections, execute the following command:
 
 ```shell
 pgo create cluster hacluster-tls \
-  --server-ca-secret=hacluster-tls-keypair --server-tls-secret=postgresql-ca
+  --server-ca-secret=hacluster-tls-keypair \
+  --server-tls-secret=postgresql-ca
 ```
 
 Including the `--server-ca-secret` and `--server-tls-secret` flags automatically


### PR DESCRIPTION
This ties in with the change to the base crunchy-postgres-ha container
for supporting the optional CRL file for TLS-enabled PostgreSQL clusters.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the new behavior (if this is a feature change)?**

A CRL file can now be included with the CA secret for a PostgreSQL cluster that is leveraging TLS authentication