### PR TITLE
Expand access to POSIX shared memory for PostgreSQL container

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -112,6 +112,10 @@
                         }, {
                             "mountPath": "/recover",
                             "name": "recover-volume"
+                        },
+                        {
+                            "mountPath": "/dev/shm",
+                            "name": "dshm"
                         }
                     ],
 
@@ -166,8 +170,15 @@
             "emptyDir": { "medium": "Memory" }
                     }, {
                         "name": "backrestrepo",
-            "emptyDir": { "medium": "Memory" }
-                    }, {
+                        "emptyDir": { "medium": "Memory" }
+                    },
+                    {
+                      "name": "dshm",
+                      "emptyDir": {
+                        "medium": "Memory"
+                      }
+                    },
+                    {
                         "name": "pgconf-volume",
             {{.ConfVolume}}
                     }

--- a/conf/postgres-operator/cluster-deployment.json
+++ b/conf/postgres-operator/cluster-deployment.json
@@ -112,6 +112,10 @@
                         }, {
                             "mountPath": "/recover",
                             "name": "recover-volume"
+                        },
+                        {
+                            "mountPath": "/dev/shm",
+                            "name": "dshm"
                         }
                     ],
 
@@ -166,8 +170,15 @@
             "emptyDir": { "medium": "Memory" }
                     }, {
                         "name": "backrestrepo",
-            "emptyDir": { "medium": "Memory" }
-                    }, {
+                        "emptyDir": { "medium": "Memory" }
+                    },
+                    {
+                      "name": "dshm",
+                      "emptyDir": {
+                        "medium": "Memory"
+                      }
+                    },
+                    {
                         "name": "pgconf-volume",
             {{.ConfVolume}}
                     }


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

By default, the container runtime engine uses 64MiB of POSIX shared
memory, regardless of the resources that are given to the container.
Give this is inadequately low for larger PostgreSQL installs, its
necessary to expand the shared memory that the PostgreSQL container
has access to.

**What is the new behavior (if this is a feature change)?**

Using guidance from the [OpenShift documentation](https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html/developer_guide/dev-guide-shared-memory), this patch
mounts the shared memory directory to the PostgreSQL container
to expand the access to POSIX shared memory.

**Other information**:

Issue: #1358