### PR TITLE
Update pgBackRest Supported Flags

### DIFF
--- a/apiserver/backupoptions/pgbackrestoptions.go
+++ b/apiserver/backupoptions/pgbackrestoptions.go
@@ -20,14 +20,45 @@ import (
 	"strings"
 )
 
-var pgBackRestOptsBlacklist = []string{"--archive-check", "--no-archive-check", "--online", "--no-online", "--link-all",
-	"--link-map", "--tablespace-map", "--tablespace-map-all", "--cmd-ssh", "--config", "--config-include-path",
-	"--config-path", "--lock-path", "--neutral-umask", "--no-neutral-umask", "--stanza", "--log-timestamp",
-	"--repo-cipher-type", "--repo-host", "--repo-host-cmd", "--repo-host-config", "--repo-host-config-include-path",
-	"--repo-host-config-path", "--repo-host-port", "--repo-host-user", "--repo-path", "--repo-s3-bucket",
-	"--repo-s3-ca-file", "--repo-s3-ca-path", "--repo-s3-endpoint", "--repo-s3-host", "--repo-s3-region",
-	"--repo-s3-verify-ssl", "--repo-type", "--pg-host", "--pg-host-cmd", "--pg-host-config",
-	"--pg-host-config-include-path", "--pg-host-config-path", "--pg-host-port", "--pg-host-user", "--pg-path", "--pg-port"}
+var pgBackRestOptsDenyList = []string{
+	"--cmd-ssh",
+	"--config",
+	"--config-include-path",
+	"--config-path",
+	"--link-all",
+	"--link-map",
+	"--lock-path",
+	"--log-timestamp",
+	"--neutral-umask",
+	"--no-neutral-umask",
+	"--no-online",
+	"--online",
+	"--pg-host",
+	"--pg-host-cmd",
+	"--pg-host-config",
+	"--pg-host-config-include-path",
+	"--pg-host-config-path",
+	"--pg-host-port",
+	"--pg-host-user",
+	"--pg-path",
+	"--pg-port",
+	"--repo-host",
+	"--repo-host-cmd",
+	"--repo-host-config",
+	"--repo-host-config-include-path",
+	"--repo-host-config-path",
+	"--repo-host-port",
+	"--repo-host-user",
+	"--repo-path",
+	"--repo-s3-bucket",
+	"--repo-s3-endpoint",
+	"--repo-s3-host",
+	"--repo-s3-region",
+	"--repo-type",
+	"--stanza",
+	"--tablespace-map",
+	"--tablespace-map-all",
+}
 
 type pgBackRestBackupOptions struct {
 	ArchiveCopy              bool   `flag:"archive-copy"`
@@ -225,10 +256,10 @@ func isValidBackrestLogLevel(logLevel string) bool {
 	return isValidValue(logLevels, logLevel)
 }
 
-func (backRestBackupOpts pgBackRestBackupOptions) getBlacklistFlags() ([]string, []string) {
-	return pgBackRestOptsBlacklist, nil
+func (backRestBackupOpts pgBackRestBackupOptions) getDenyListFlags() ([]string, []string) {
+	return pgBackRestOptsDenyList, nil
 }
 
-func (backRestRestoreOpts pgBackRestRestoreOptions) getBlacklistFlags() ([]string, []string) {
-	return pgBackRestOptsBlacklist, nil
+func (backRestRestoreOpts pgBackRestRestoreOptions) getDenyListFlags() ([]string, []string) {
+	return pgBackRestOptsDenyList, nil
 }

--- a/apiserver/backupoptions/pgdumpoptions.go
+++ b/apiserver/backupoptions/pgdumpoptions.go
@@ -20,10 +20,28 @@ import (
 	"strings"
 )
 
-var pgDumpRestoreOptsBlacklist = []string{"--binary-upgrade", "--no-reconnect", "--dbname", "--host", "--port",
-	"--username", "--no-password", "--password", "--version"}
+var pgDumpRestoreOptsDenyList = []string{
+	"--binary-upgrade",
+	"--dbname",
+	"--host",
+	"--no-password",
+	"--no-reconnect",
+	"--password",
+	"--port",
+	"--username",
+	"--version",
+}
 
-var pgDumpRestoreOptsBlacklistShort = []string{"-R", "-d", "-h", "-p", "-U", "-w", "-W", "-V"}
+var pgDumpRestoreOptsDenyListShort = []string{
+	"-R",
+	"-d",
+	"-h",
+	"-p",
+	"-U",
+	"-w",
+	"-W",
+	"-V",
+}
 
 type pgDumpOptions struct {
 	DataOnly                   bool     `flag:"data-only" flag-short:"a"`
@@ -265,14 +283,14 @@ func (restoreOpts pgRestoreOptions) validate(setFlagFieldNames []string) error {
 	return nil
 }
 
-func (dumpOpts pgDumpOptions) getBlacklistFlags() ([]string, []string) {
-	return pgDumpRestoreOptsBlacklist, pgDumpRestoreOptsBlacklistShort
+func (dumpOpts pgDumpOptions) getDenyListFlags() ([]string, []string) {
+	return pgDumpRestoreOptsDenyList, pgDumpRestoreOptsDenyListShort
 }
 
-func (dumpAllOpts pgDumpAllOptions) getBlacklistFlags() ([]string, []string) {
-	return pgDumpRestoreOptsBlacklist, pgDumpRestoreOptsBlacklistShort
+func (dumpAllOpts pgDumpAllOptions) getDenyListFlags() ([]string, []string) {
+	return pgDumpRestoreOptsDenyList, pgDumpRestoreOptsDenyListShort
 }
 
-func (restoreOpts pgRestoreOptions) getBlacklistFlags() ([]string, []string) {
-	return pgDumpRestoreOptsBlacklist, pgDumpRestoreOptsBlacklistShort
+func (restoreOpts pgRestoreOptions) getDenyListFlags() ([]string, []string) {
+	return pgDumpRestoreOptsDenyList, pgDumpRestoreOptsDenyListShort
 }


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently the apiserver runs validation on the backrest backup/restore options that can be passed in when one of these jobs are created. The flags that can be passed are checked in two ways, if it is a flag that is known to the operator and if that flag is on the "blacklist". If the flag is unknown the backup will be denied and the apiserver will provide a response saying that which flag is unknown. If this unknown flag is on the "blacklist" then it is valid but not supported by PGO, a response will be given by the apiserver saying which flag is unsupported. Validation is also run on the known flags to ensure that their values are allowed and provide fast feedback to the user if they try to pass in an invalid value for a valid flag.


**What is the new behavior (if this is a feature change)?**
The overall goal of this ticket is to allow users to access more of the pgbackrest functions and new features without adding the overhead of having to add each new pgBackRest flag. This will be done by removing some of the validation login and allowing users to pass in a flag to pgBackRest even if it is "unknown" to PGO.

**Other information**:
[ch7665]