### PR TITLE
Add Missing S3 Environment Variable to Ansible S3 Template

### DIFF
--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbackrest-s3-env-vars.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbackrest-s3-env-vars.json
@@ -11,6 +11,7 @@
   "value": "{{.PgbackrestS3Region}}"
 },
 {
+  "name": "PGBACKREST_REPO1_S3_KEY",
   "valueFrom": {
     "secretKeyRef": {
       "name": "{{.PgbackrestS3SecretName}}",


### PR DESCRIPTION
This commit adds the missing `PGBACKREST_REPO1_S3_KEY` env var to the `pgbackrest-s3-env-vars.json` template in the Ansible installer.  This aligns the `pgbackrest-s3-env-vars.json` template across both the Ansible and Bash installers.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `PGBACKREST_REPO1_S3_KEY` env var is missing from the `pgbackrest-s3-env-vars.json` template in the Ansible installer.

**What is the new behavior (if this is a feature change)?**

The `PGBACKREST_REPO1_S3_KEY` env var is included in the `pgbackrest-s3-env-vars.json` template in the Ansible installer.

**Other information**:

N/A