### PR TITLE
Specify a value for a S3 CA during cluster creation

### DIFF
--- a/apiservermsgs/clustermsgs.go
+++ b/apiservermsgs/clustermsgs.go
@@ -119,6 +119,9 @@ type CreateClusterRequest struct {
 	// the value of BackrestPVCSize can override the PVC size set in this
 	// storage config
 	BackrestStorageConfig string
+	// BackrestS3CASecretName specifies the name of a secret to use for the
+	// pgBackRest S3 CA instead of the default
+	BackrestS3CASecretName string
 }
 
 // CreateClusterDetail provides details about the PostgreSQL cluster that is

--- a/docs/content/pgo-client/reference/pgo_create_cluster.md
+++ b/docs/content/pgo-client/reference/pgo_create_cluster.md
@@ -37,6 +37,7 @@ pgo create cluster [flags]
       --pgbackrest-repo-path string           The pgBackRest repository path that should be utilized instead of the default. Required for standby
                                               clusters to define the location of an existing pgBackRest repository.
       --pgbackrest-s3-bucket string           The AWS S3 bucket that should be utilized for the cluster when the "s3" storage type is enabled for pgBackRest.
+      --pgbackrest-s3-ca-secret string        If used, specifies a Kubernetes secret that uses a different CA certificate for S3 or a S3-like storage interface. Must contain a key with the value "aws-s3-ca.crt"
       --pgbackrest-s3-endpoint string         The AWS S3 endpoint that should be utilized for the cluster when the "s3" storage type is enabled for pgBackRest.
       --pgbackrest-s3-key string              The AWS S3 key that should be utilized for the cluster when the "s3" storage type is enabled for pgBackRest.
       --pgbackrest-s3-key-secret string       The AWS S3 key secret that should be utilized for the cluster when the "s3" storage type is enabled for pgBackRest.
@@ -62,13 +63,13 @@ pgo create cluster [flags]
       --storage-config string                 The name of a Storage config in pgo.yaml to use for the cluster storage.
       --sync-replication                      Enables synchronous replication for the cluster.
       --tablespace strings                    Create a PostgreSQL tablespace on the cluster, e.g. "name=ts1:storageconfig=nfsstorage". The format is a key/value map that is delimited by "=" and separated by ":". The following parameters are available:
-                                              
+
                                               - name (required): the name of the PostgreSQL tablespace
                                               - storageconfig (required): the storage configuration to use, as specified in the list available in the "pgo-config" ConfigMap (aka "pgo.yaml")
                                               - pvcsize: the size of the PVC capacity, which overrides the value set in the specified storageconfig. Follows the Kubernetes quantity format.
-                                              
+
                                               For example, to create a tablespace with the NFS storage configuration with a PVC of size 10GiB:
-                                              
+
                                               --tablespace=name=ts1:storageconfig=nfsstorage:pvcsize=10Gi
       --tls-only                              If true, forces all PostgreSQL connections to be over TLS. Must also set "server-tls-secret" and "server-ca-secret"
   -u, --username string                       The username to use for creating the PostgreSQL user with standard permissions. Defaults to the value in the PostgreSQL Operator configuration.

--- a/operator/cluster/clone.go
+++ b/operator/cluster/clone.go
@@ -301,6 +301,7 @@ func cloneStep2(clientset *kubernetes.Clientset, client *rest.RESTClient, namesp
 	// do it
 	if err := util.CreateBackrestRepoSecrets(clientset,
 		util.BackrestRepoConfig{
+			BackrestS3CA:        s3Creds.AWSS3CA,
 			BackrestS3Key:       s3Creds.AWSS3Key,
 			BackrestS3KeySecret: s3Creds.AWSS3KeySecret,
 			ClusterName:         targetClusterName,

--- a/pgo/cmd/cluster.go
+++ b/pgo/cmd/cluster.go
@@ -262,6 +262,7 @@ func createCluster(args []string, ns string, createClusterCmd *cobra.Command) {
 	r.PodAntiAffinity = PodAntiAffinity
 	r.PodAntiAffinityPgBackRest = PodAntiAffinityPgBackRest
 	r.PodAntiAffinityPgBouncer = PodAntiAffinityPgBouncer
+	r.BackrestS3CASecretName = BackrestS3CASecretName
 	r.BackrestS3Key = BackrestS3Key
 	r.BackrestS3KeySecret = BackrestS3KeySecret
 	r.BackrestS3Bucket = BackrestS3Bucket

--- a/pgo/cmd/create.go
+++ b/pgo/cmd/create.go
@@ -63,6 +63,10 @@ var BackrestS3Region string
 var PVCSize string
 var BackrestPVCSize string
 
+// BackrestS3CASecretName, if provided, is the name of a secret to use that
+// contains a CA certificate to use for the pgBackRest repo
+var BackrestS3CASecretName string
+
 // BackrestRepoPath allows the pgBackRest repo path to be defined instead of using the default
 var BackrestRepoPath string
 
@@ -281,6 +285,9 @@ func init() {
 	createClusterCmd.Flags().StringVarP(&BackrestS3Bucket, "pgbackrest-s3-bucket", "", "",
 		"The AWS S3 bucket that should be utilized for the cluster when the \"s3\" "+
 			"storage type is enabled for pgBackRest.")
+	createClusterCmd.Flags().StringVar(&BackrestS3CASecretName, "pgbackrest-s3-ca-secret", "",
+		"If used, specifies a Kubernetes secret that uses a different CA certificate for "+
+			"S3 or a S3-like storage interface. Must contain a key with the value \"aws-s3-ca.crt\"")
 	createClusterCmd.Flags().StringVarP(&BackrestS3Endpoint, "pgbackrest-s3-endpoint", "", "",
 		"The AWS S3 endpoint that should be utilized for the cluster when the \"s3\" "+
 			"storage type is enabled for pgBackRest.")


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The PostgreSQL Operator by default ships with the trusted CA for AWS
S3 for ease of integration, though people may use other S3 compatible
interfaces. While one can relatively easily update the primary
"pgo-backrest-repo-config" Secret and set the value of "aws-s3-ca.crt"
to the value of the CA that they wish to use, there may be cases where
one must specify this value on a per-cluster basis.

**What is the new behavior (if this is a feature change)?**

This introduces the "--pgbackrest-s3-ca-secret" flag on the
"pgo create cluster" command. One must first create a Kubernetes Secret
and put the value of the CA in a key called "aws-s3-ca.crt". The name
of this Secret should be passed as the value to "--pgbackrest-s3-ca-secret",
and the PostgreSQL Operator will use this value as the CA that pgBackRest
will use for pushing to a S3 interface.

Any clones of this cluster will also use this CA for their pgBackRest
S3 interactions.

**Other information**:

Issue: [ch6918]
Issue: #1228
Issue: #1337