### PR TITLE
remove specDescriptors[].value from CSV

### DIFF
--- a/installers/olm/postgresoperator.crd.descriptions.yaml
+++ b/installers/olm/postgresoperator.crd.descriptions.yaml
@@ -11,72 +11,61 @@
     - { kind: Service, version: v1 }
   specDescriptors:
     - path: ccpimage
-      value: "crunchy-postgres-ha"
       displayName: PostgreSQL Image
       description: The Crunchy PostgreSQL image to use. Possible values are "crunchy-postgres-ha" and "crunchy-postgres-gis-ha"
       x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:text'
     - path: ccpimagetag
-      value: "${CCP_IMAGE_TAG}"
       displayName: PostgreSQL Image Tag
       description: The tag of the PostgreSQL image to use. Example is "${CCP_IMAGE_TAG}"
       x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:text'
     - path: clustername
-      value: "hippo"
       displayName: PostgreSQL Cluster name
       description: The name that is assigned to this specific PostgreSQL cluster
       x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:text'
     - path: database
-      value: "hippo"
       displayName: Initial PostgreSQL database name
       description: The name of the initial database to be created inside of the PostgreSQL cluster, e.g. "hippo"
       x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:text'
     - path: exporterport
-      value: 9187
       displayName: PostgreSQL Monitor Port
       description: The port to use for the PostgreSQL metrics exporter used for cluster monitoring, e.g. "9187"
       x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:number'
     - path: name
-      value: "hippo"
       displayName: PostgreSQL CRD name
       description: The name of the CRD entry. Should match the PostgreSQL Cluster name
       x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:text'
     - path: pgbadgerport
-      value: 10000
       displayName: pgBadger Port
       description: The port to use for the pgBadger PostgreSQL query analysis service, e.g. "10000"
       x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:number'
     - path: port
-      value: 5432
       displayName: PostgreSQL Port
       description: The port to use for the PostgreSQL cluster, e.g. "5432"
       x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:number'
 
     - path: rootsecretname
-      value: "hippo-postgres-secret"
       displayName: PostgreSQL superuser credentials
       description: The name of the Secret that contains the PostgreSQL superuser credentials
       x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:text'
+        - 'urn:alm:descriptor:io.kubernetes:Secret'
     - path: primarysecretname
-      value: "hippo-primaryuser-secret"
       displayName: PostgreSQL support service credentials
       description: The name of the Secret that contains the credentials used for managing cluster instance authentication, e.g. connections for replicas
       x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:text'
+        - 'urn:alm:descriptor:io.kubernetes:Secret'
     - path: usersecretname
-      value: "hippo-testuser-secret"
       displayName: PostgreSQL user credentials
       description: The name of the Secret that contains the PostgreSQL user credentials for logging into the PostgreSQL cluster
       x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:text'
+        - 'urn:alm:descriptor:io.kubernetes:Secret'
 
     # `operator-sdk scorecard` expects this field to have a descriptor.
     - path: PrimaryStorage
@@ -85,7 +74,6 @@
       x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PrimaryStorage'
     - path: PrimaryStorage.name
-      value: "hippo"
       displayName: PostgreSQL Primary Storage Name
       description: Contains the name of the PostgreSQL cluster to associate with this storage. Should match the Cluster name
       x-descriptors:
@@ -98,7 +86,6 @@
         - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PrimaryStorage'
         - 'urn:alm:descriptor:io.kubernetes:StorageClass'
     - path: PrimaryStorage.accessmode
-      value: "ReadWriteOnce"
       displayName: PostgreSQL Primary StorageClass Access Mode
       description: The access mode for the storage class, e.g. "ReadWriteOnce"
       x-descriptors:
@@ -106,7 +93,6 @@
         - 'urn:alm:descriptor:com.tectonic.ui:select:ReadWriteOnce'
         - 'urn:alm:descriptor:com.tectonic.ui:select:ReadWriteMany'
     - path: PrimaryStorage.size
-      value: "1G"
       displayName: PostgreSQL Primary Data PVC Size
       description: The size of the PVC that will store the data for the primary PostgreSQL instance, e.g. "1G"
       x-descriptors:
@@ -114,14 +100,12 @@
         - 'urn:alm:descriptor:com.tectonic.ui:text'
 
     - path: status
-      value: ""
       displayName: Deprecated
       description: Deprecated
       x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:text'
         - 'urn:alm:descriptor:com.tectonic.ui:advanced'
     - path: userlabels
-      value: "{}"
       displayName: User defined labels
       description: A set of labels that help the PostgreSQL Operator manage a PostgreSQL cluster
       x-descriptors:


### PR DESCRIPTION
The value field was used to render default values in the OLM UI
but this was not their intent and it prevents installation in 4.3+
openshift clusters. Using alm-examples to imply default hints to
the UI is the best path until CRD/v1 is used and defaulting can
be integrated at the CRD level.

Additionally, adjust x-descriptors for a few items to add a richer "secrets" UI experience instead of a textbox. [Reference](https://github.com/openshift/console/blob/master/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md#3-k8sresourceprefix).

Fixes #1260

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
**Added in commit messages following the pattern of existing commits**
 - [ ] Have you updated or added documentation for the change, as applicable?
**N/A** 
 - [X] Have you tested your changes on all related environments with successful results, as applicable? 
**Openshift 4.3 + backported this change against pgo branch REL_4_2**



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Currently the CSV generation scripts include `specDescriptors[].value` key which was being used to set a default value when OLM renders the "edit form" UI, but this is not the intended use of that key. 

A minor change is also included here, and it simply changing the x-descriptor type from `text` to `Secret` which gives end-users a drop-down dialogue box to select an existing secret name instead of having to type a string into the "edit form".

**What is the new behavior (if this is a feature change)?**

For the most part, these values were implied in the `alm-examples` for the CSV, and as such they were able to be removed without issue. 

In some cases, the difference between what was in the `specDescriptors[].value` for a given spec item and the value for the same key in `alm-examples` was purely in name. So for example, `clustername` was set to `hippo` in the specDescriptor but was `example` in the `alm-example`. I figured it wouldn't matter which name we took as long as it was consistent, so I left the `alm-examples` values in place.

No issues on my end rendering the packages (Makefile target `package-openshift` and `package-redhat`) after these changes were made.

**Other information**:

**Fairly important here** -- I'm making this change to the **master** branch, but this ideally needs to make it as a backport to REL_4_2 and into 4.2.1 and 4.2.2 if at all possible. I believe there are some changes released into later versions of Openshift 4.3 recently (read: released earlier than expected - which was previously Openshift 4.4 as documented in the referenced issue #1260) that can cause issues installing the operator pod. The backport of these changes, re-rendering of the CSV, and re-submission of the bundles into the certified version of the operator should mitigate the problem.

In my testing I was able to cherry-pick the change back into REL_4_2 without issue. I haven't included it here as I figured it best to let you decide how to best backport.

I was not able to test against the master branch due to the lack of publicly available pgo 4.3 images in hub (from what I could see, happy to be corrected). In my testing, my scorecard test passed without issue with the exception of bundle validation in the OLM module of scorecard - but I think this is a red herring in the way I was testing locally. Interested to see if you find different results in testing.

My Scorecard Results (truncated for clarity), specifically for pgcluster CR:

```json
{
  "name": "Spec Block Exists",
  "description": "Custom Resource has a Spec Block",
  "state": "pass"
}
{
  "name": "Status Block Exists",
  "description": "Custom Resource has a Status Block",
  "state": "pass"
}
{
  "name": "Writing into CRs has an effect",
  "description": "A CR sends PUT/POST requests to the API server to modify resources in response to spec block changes",
  "state": "pass"
}
{
  "name": "Spec fields with descriptors",
  "description": "All spec fields have matching descriptors in the CSV",
  "state": "pass"
}
{
  "name": "Status fields with descriptors",
  "description": "All status fields have matching descriptors in the CSV",
  "state": "pass"
}
{
  "name": "Bundle Validation Test",
  "description": "Validates bundle contents",
  "state": "fail"
}
{
  "name": "Provided APIs have validation",
  "description": "All CRDs have an OpenAPI validation subsection",
  "state": "pass"
}
{
  "name": "Owned CRDs have resources listed",
  "description": "All Owned CRDs contain a resources subsection",
  "state": "pass"
}
```

My Courier Results against REL_4_2:

```
$ tree ; operator-courier verify --ui_validate_io .; echo $?
.
├── 4.2.2
│   ├── pgbackups.crunchydata.com.crd.yaml
│   ├── pgclusters.crunchydata.com.crd.yaml
│   ├── pgpolicies.crunchydata.com.crd.yaml
│   ├── pgreplicas.crunchydata.com.crd.yaml
│   ├── pgtasks.crunchydata.com.crd.yaml
│   └── postgresoperator.v4.2.2.clusterserviceversion.yaml
└── postgresql.package.yaml

1 directory, 7 files
0
```

Any issues, let me know - happy to help resolve ASAP.

