### PR TITLE
Default to promote during PITR

### DIFF
--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -668,6 +668,10 @@ pgo restore hacluster --pitr-target="2019-12-23 08:00:00.000000+00" \
   --backup-opts="--type=time"
 ```
 
+When the restore is complete, the cluster is immediately available for reads and
+writes. To inspect the data before allowing connections, add pgBackRest's
+`--target-action=pause` option to the `--backup-opts` parameter.
+
 The PostgreSQL Operator supports the full set of pgBackRest restore options,
 which can be passed into the `--backup-opts` parameter. For more information,
 please review the [pgBackRest restore options](https://pgbackrest.org/command.html#command-restore)

--- a/testing/pgo_cli/cluster_backup_test.go
+++ b/testing/pgo_cli/cluster_backup_test.go
@@ -236,8 +236,9 @@ func TestClusterBackup(t *testing.T) {
 					require.Empty(t, stderr)
 
 					output, err := pgo("restore", cluster(), "-n", namespace(),
-						"--backup-opts=--type=time --target-action=promote",
-						"--pitr-target="+recoveryObjective, "--no-prompt",
+						"--backup-opts=--type=time",
+						"--pitr-target="+recoveryObjective,
+						"--no-prompt",
 					).Exec(t)
 					require.NoError(t, err)
 					require.Contains(t, output, recoveryObjective)

--- a/testing/pgo_cli/cluster_clone_test.go
+++ b/testing/pgo_cli/cluster_clone_test.go
@@ -1,0 +1,75 @@
+package pgo_cli_test
+
+/*
+ Copyright 2020 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterClone(t *testing.T) {
+	t.Parallel()
+
+	requireStanzaExists := func(t *testing.T, namespace, cluster string, timeout time.Duration) {
+		t.Helper()
+
+		ready := func() bool {
+			output, err := pgo("show", "backup", cluster, "-n", namespace).Exec(t)
+			require.NoError(t, err)
+			return strings.Contains(output, "status: ok")
+		}
+
+		if !ready() {
+			requireWaitFor(t, ready, timeout, time.Second,
+				"timeout waiting for stanza of %q in %q", cluster, namespace)
+		}
+	}
+
+	withNamespace(t, func(namespace func() string) {
+		withCluster(t, namespace, func(cluster func() string) {
+			t.Run("clone", func(t *testing.T) {
+				t.Run("creates a copy of a cluster", func(t *testing.T) {
+					requireClusterReady(t, namespace(), cluster(), time.Minute)
+					requireStanzaExists(t, namespace(), cluster(), 2*time.Minute)
+
+					// data in the origin cluster followed by a WAL flush
+					_, stderr := clusterPSQL(t, namespace(), cluster(), `
+						CREATE TABLE original (data) AS VALUES ('one'), ('two');
+						DO $$ BEGIN IF current_setting('server_version_num')::int > 100000
+							THEN PERFORM pg_switch_wal();
+							ELSE PERFORM pg_switch_xlog();
+						END IF; END $$`)
+					require.Empty(t, stderr)
+
+					output, err := pgo("clone", cluster(), "rex", "-n", namespace()).Exec(t)
+					require.NoError(t, err)
+					require.NotEmpty(t, output)
+
+					defer teardownCluster(t, namespace(), "rex", time.Now())
+					requireClusterReady(t, namespace(), "rex", 4*time.Minute)
+
+					stdout, stderr := clusterPSQL(t, namespace(), cluster(), `TABLE original`)
+					require.Empty(t, stderr)
+					require.Contains(t, stdout, "(2 rows)",
+						"expected original data to be present in the clone")
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

When performing a PITR of PostgreSQL 12 without a `--target-action`, the new cluster will pause giving the user a chance to inspect data before choosing to promote.

**What is the new behavior (if this is a feature change)?**

When performing a PITR (of any PostgreSQL version) without a `--target-action`, the new cluster will promote.

**Other information**:

The first two commits in this series already landed in 4.2 via #1390.
The last commit should be back-patched to 4.2.