### PR TITLE
Remove "backoffLimit" from Jobs

### DIFF
--- a/conf/postgres-operator/backrest-job.json
+++ b/conf/postgres-operator/backrest-job.json
@@ -12,7 +12,6 @@
                 }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",
@@ -75,7 +74,7 @@
                         }
                     }]
                 }],
-                "restartPolicy": "OnFailure"
+                "restartPolicy": "Never"
             }
         }
     }

--- a/conf/postgres-operator/backrest-restore-job.json
+++ b/conf/postgres-operator/backrest-restore-job.json
@@ -12,7 +12,6 @@
                 }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",

--- a/conf/postgres-operator/pgdump-job.json
+++ b/conf/postgres-operator/pgdump-job.json
@@ -11,7 +11,6 @@
         }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",

--- a/conf/postgres-operator/pgo.load-template.json
+++ b/conf/postgres-operator/pgo.load-template.json
@@ -5,7 +5,6 @@
         "name": "{{.Name}}"
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.Name}}",

--- a/conf/postgres-operator/pgo.sqlrunner-template.json
+++ b/conf/postgres-operator/pgo.sqlrunner-template.json
@@ -10,7 +10,6 @@
         }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",

--- a/conf/postgres-operator/rmdata-job.json
+++ b/conf/postgres-operator/rmdata-job.json
@@ -10,7 +10,6 @@
         }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
@@ -12,7 +12,6 @@
                 }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",
@@ -75,7 +74,7 @@
                         }
                     }]
                 }],
-                "restartPolicy": "OnFailure"
+                "restartPolicy": "Never"
             }
         }
     }

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-restore-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-restore-job.json
@@ -12,7 +12,6 @@
                 }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgdump-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgdump-job.json
@@ -11,7 +11,6 @@
         }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.load-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.load-template.json
@@ -5,7 +5,6 @@
         "name": "{{.Name}}"
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.Name}}",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
@@ -10,7 +10,6 @@
         }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/rmdata-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/rmdata-job.json
@@ -10,7 +10,6 @@
         }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "{{.JobName}}",

--- a/installers/gcp-marketplace/install-job.yaml
+++ b/installers/gcp-marketplace/install-job.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: '${OPERATOR_NAME}'
 spec:
-  backoffLimit: 0
   template:
     spec:
       serviceAccountName: '${INSTALLER_SERVICE_ACCOUNT}'

--- a/installers/method/ansible-playbook/roles/pgo-installer/templates/pgo-installer-job.json.j2
+++ b/installers/method/ansible-playbook/roles/pgo-installer/templates/pgo-installer-job.json.j2
@@ -9,7 +9,6 @@
         }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "pgo-installer",
@@ -56,4 +55,3 @@
         }
     }
 }
-

--- a/installers/method/ansible-playbook/roles/pgo-installer/templates/pgo-uninstaller-job.json.j2
+++ b/installers/method/ansible-playbook/roles/pgo-installer/templates/pgo-uninstaller-job.json.j2
@@ -9,7 +9,6 @@
         }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "pgo-uninstaller",
@@ -56,4 +55,3 @@
         }
     }
 }
-

--- a/installers/method/ansible-playbook/roles/pgo-installer/templates/pgo-update-job.json.j2
+++ b/installers/method/ansible-playbook/roles/pgo-installer/templates/pgo-update-job.json.j2
@@ -9,7 +9,6 @@
         }
     },
     "spec": {
-        "backoffLimit": 0,
         "template": {
             "metadata": {
                 "name": "pgo-update",
@@ -56,4 +55,3 @@
         }
     }
 }
-

--- a/operator/cluster/clone.go
+++ b/operator/cluster/clone.go
@@ -506,8 +506,6 @@ func createPgBackRestRepoSyncJob(clientset *kubernetes.Clientset, namespace stri
 			podSecurityContext.SupplementalGroups = []int64{int64(supplementalGroup)}
 		}
 	}
-	// set the backoff limit to be 0 to match our other jobs
-	backoffLimit := int32(0)
 	// set up the job template to synchronize the pgBackRest repo
 	job := batch_v1.Job{
 		ObjectMeta: meta_v1.ObjectMeta{
@@ -530,7 +528,6 @@ func createPgBackRestRepoSyncJob(clientset *kubernetes.Clientset, namespace stri
 			},
 		},
 		Spec: batch_v1.JobSpec{
-			BackoffLimit: &backoffLimit,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: jobName,


### PR DESCRIPTION
This reverts to using the Kubernetes default (6), and has the added
bonus of moving the repo sync job to restarting "on failure" (which
is safe based on how we use rsync in the job.
