### PR TITLE
pgo client setup script

### DIFF
--- a/docs/content/Installation/postgres-operator-installer/kubectl-install.md
+++ b/docs/content/Installation/postgres-operator-installer/kubectl-install.md
@@ -95,17 +95,7 @@ variable in the `deploy.yml` file. This variable can be set to `install`,
 `update`, and `uninstall`. Each time a job is run you will need to cleanup the
 job using the command below.
 
-### Cleanup
-
-The job resources can be cleaned up by running a delete on the `deploy.yml`
-file. The resources can also be delete manually through the kubectl
-client.
-
-```
-kubectl delete -f deploy.yml
-```
-
-#### pgo Client Binary
+### pgo Client Binary
 
 Running the pgo client locally when using the pgo-installer image requires
 access to the certs stored in the `pgo.tls` Kubernetes secret. The `client.crt`
@@ -130,3 +120,13 @@ This will allow the the `pgo` client to have access to your postgres-operator
 instance. Full install instructions for installing the pgo client can be found
 in the [Install `pgo` client]({{< relref "/installation/install-pgo-client" >}})
 section of the docs.
+
+### Cleanup
+
+The job resources can be cleaned up by running a delete on the `deploy.yml`
+file. The resources can also be delete manually through the kubectl
+client.
+
+```
+kubectl delete -f deploy.yml
+```

--- a/docs/content/Installation/postgres-operator-installer/kubectl-install.md
+++ b/docs/content/Installation/postgres-operator-installer/kubectl-install.md
@@ -104,3 +104,29 @@ client.
 ```
 kubectl delete -f deploy.yml
 ```
+
+#### pgo Client Binary
+
+Running the pgo client locally when using the pgo-installer image requires
+access to the certs stored in the `pgo.tls` Kubernetes secret. The `client.crt`
+and `client.key` need to be pulled from this secret and stored locally in a
+location that is accessable to the `pgo` client. You will also need to setup a
+`pgouser` file that contains the admin username and password that was set in your
+inventory file. This username and password will be pulled from the
+`pgouser-admin` secret. The the `client-setup.sh` script will setup these
+resources in the `~/.pgo/$PGO_OPERATOR_NAMESPACE` directory. Please set the
+following environment variables after the pgo-installer job has completed:
+
+```
+cat <<EOF >> ~/.bashrc
+export PGOUSER="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/pgouser"
+export PGO_CA_CERT="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/client.crt"
+export PGO_CLIENT_CERT="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/client.crt"
+export PGO_CLIENT_KEY="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/client.key"
+EOF
+```
+
+This will allow the the `pgo` client to have access to your postgres-operator
+instance. Full install instructions for installing the pgo client can be found
+in the [Install `pgo` client]({{< relref "/installation/install-pgo-client" >}})
+section of the docs.

--- a/installers/image/bin/pgo-deploy.sh
+++ b/installers/image/bin/pgo-deploy.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+#  Copyright 2020 Crunchy Data Solutions, Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Operator Defaults
 export BACKREST_PORT=${BACKREST_PORT:-2022}
 export CRUNCHY_DEBUG=${CRUNCHY_DEBUG:-false}
 export DELETE_METRICS_NAMESPACE=${DELETE_METRICS_NAMESPACE:-false}

--- a/installers/method/kubectl/client-setup.sh
+++ b/installers/method/kubectl/client-setup.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+#  Copyright 2020 Crunchy Data Solutions, Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 # This script should be run after the operator has been deployed
 export PGO_OPERATOR_NAMESPACE=${PGO_OPERATOR_NAMESPACE:-pgo}
 

--- a/installers/method/kubectl/client-setup.sh
+++ b/installers/method/kubectl/client-setup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# This script should be run after the operator has been deployed
+export PGO_OPERATOR_NAMESPACE=${PGO_OPERATOR_NAMESPACE:-pgo}
+
+# Check that the pgouser-admin secret exists
+if [ -z "$(kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgouser-admin)" ]
+then
+    echo "pgouser-admin Secret not found in namespace: $PGO_OPERATOR_NAMESPACE"
+    echo "Please ensure that the PostgreSQL Operator has been installed."
+    echo "Exiting..."
+    exit 1
+fi
+
+# Check that the pgo.tls secret exists
+if [ -z "$(kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgo.tls)" ]
+then
+    echo "pgo.tls Secret not found in namespace: $PGO_OPERATOR_NAMESPACE"
+    echo "Please ensure that the PostgreSQL Operator has been installed."
+    echo "Exiting..."
+    exit 1
+fi
+
+
+# Creates the output directory for files
+OUTPUT_DIR=$HOME/.pgo/$PGO_OPERATOR_NAMESPACE
+mkdir -p $OUTPUT_DIR
+
+# Use the pgouser-admin secret to generate pgouser file
+kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgouser-admin -o 'jsonpath={.data.username}' | base64 --decode >> $OUTPUT_DIR/pgouser
+printf ":" >> $OUTPUT_DIR/pgouser
+kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgouser-admin -o 'jsonpath={.data.password}' | base64 --decode >> $OUTPUT_DIR/pgouser
+
+# Use the pgo.tls secret to generate the client cert files
+kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgo.tls -o 'jsonpath={.data.tls\.crt}' | base64 --decode >> $OUTPUT_DIR/client.crt
+kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgo.tls -o 'jsonpath={.data.tls\.key}' | base64 --decode >> $OUTPUT_DIR/client.key
+
+
+echo "pgo client files have been generated, please add the following to your bashrc"
+echo "export PGOUSER=$OUTPUT_DIR/pgouser"
+echo "export PGO_CA_CERT=$OUTPUT_DIR/client.crt"
+echo "export PGO_CLIENT_CERT=$OUTPUT_DIR/client.crt"
+echo "export PGO_CLIENT_KEY=$OUTPUT_DIR/client.key"

--- a/installers/method/kubectl/deploy.yml
+++ b/installers/method/kubectl/deploy.yml
@@ -34,7 +34,7 @@ spec:
             containers:
             - name: pgo-deploy
               command: ["/pgo-deploy.sh"]
-              image:crunchydata/pgo-installer:centos7-4.3.0
+              image: crunchydata/pgo-installer:centos7-4.3.0
               imagePullPolicy: IfNotPresent
               env:
                   - name: ANSIBLE_CONFIG


### PR DESCRIPTION
This commit adds a script to pull files from kube secrets into local files. These files can then be used by the pgo client to access the apiserver.

Also fixes a bug where a space was missing in the yaml where the image is defined.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
[ch7839]