### PR TITLE
Ensure metrics sidecar is deployed when enabled for cloned cluster

### DIFF
--- a/controller/job/backresthandler.go
+++ b/controller/job/backresthandler.go
@@ -123,6 +123,7 @@ func (c *Controller) handleCloneBackrestRestoreUpdate(job *apiv1.Job) error {
 		// create the cluster
 		cloneTask := util.CloneTask{
 			BackrestPVCSize:   job.ObjectMeta.Annotations[config.ANNOTATION_CLONE_BACKREST_PVC_SIZE],
+			EnableMetrics:     job.ObjectMeta.Annotations[config.ANNOTATION_CLONE_ENABLE_METRICS] == "true",
 			PGOUser:           job.ObjectMeta.Labels[config.LABEL_PGOUSER],
 			PVCSize:           job.ObjectMeta.Annotations[config.ANNOTATION_CLONE_PVC_SIZE],
 			SourceClusterName: sourceClusterName,

--- a/controller/job/reposynchandler.go
+++ b/controller/job/reposynchandler.go
@@ -69,6 +69,7 @@ func (c *Controller) handleRepoSyncUpdate(job *apiv1.Job) error {
 	// now, set up a new pgtask that will allow us to perform the restore
 	cloneTask := util.CloneTask{
 		BackrestPVCSize:   job.ObjectMeta.Annotations[config.ANNOTATION_CLONE_BACKREST_PVC_SIZE],
+		EnableMetrics:     job.ObjectMeta.Annotations[config.ANNOTATION_CLONE_ENABLE_METRICS] == "true",
 		PGOUser:           job.ObjectMeta.Labels[config.LABEL_PGOUSER],
 		PVCSize:           job.ObjectMeta.Annotations[config.ANNOTATION_CLONE_PVC_SIZE],
 		SourceClusterName: sourceClusterName,


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

A regression likely introduced with a rebase caused the metrics
sidecar to not be deployed alongside a cloned cluster when it was
requested.

**What is the new behavior (if this is a feature change)?**

This ensures the request to deploy a metrics sidecar is
not lost during the multi-step clone process.

**Other information**:

Issue: [ch7849]