### PR TITLE
Updates Client Setup Script: bugfix

### DIFF
--- a/docs/content/Installation/postgres-operator-installer/_index.md
+++ b/docs/content/Installation/postgres-operator-installer/_index.md
@@ -98,7 +98,7 @@ cleanup the job using the command from the **Cleanup** section.
 
 ### pgo Client Binary
 
-Running the pgo client locally when using the `pgo-deployer` image requires
+Running the `pgo` client locally when using the `pgo-deployer` image requires
 access to the certs stored in the `pgo.tls` Kubernetes secret. The `client.crt`
 and `client.key` need to be pulled from this secret and stored locally in a
 location that is accessable to the `pgo` client. You will also need to setup a
@@ -107,6 +107,12 @@ inventory file. This username and password will be pulled from the
 `pgouser-admin` secret. The the `client-setup.sh` script will setup these
 resources in the `~/.pgo/$PGO_OPERATOR_NAMESPACE` directory. Please set the
 following environment variables after the `pgo-deployer` job has completed:
+
+
+{{% notice tip %}}
+Running this script will cause existing `pgouser`, `client.crt`, and `client.key`
+files to be overwritten.
+{{% /notice %}}
 
 ```
 cat <<EOF >> ~/.bashrc

--- a/installers/method/kubectl/client-setup.sh
+++ b/installers/method/kubectl/client-setup.sh
@@ -38,13 +38,11 @@ OUTPUT_DIR=$HOME/.pgo/$PGO_OPERATOR_NAMESPACE
 mkdir -p $OUTPUT_DIR
 
 # Use the pgouser-admin secret to generate pgouser file
-kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgouser-admin -o 'jsonpath={.data.username}' | base64 --decode >> $OUTPUT_DIR/pgouser
-printf ":" >> $OUTPUT_DIR/pgouser
-kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgouser-admin -o 'jsonpath={.data.password}' | base64 --decode >> $OUTPUT_DIR/pgouser
+kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgouser-admin -o 'go-template={{.data.username | base64decode }}:{{.data.password | base64decode}}' > $OUTPUT_DIR/pgouser
 
 # Use the pgo.tls secret to generate the client cert files
-kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgo.tls -o 'jsonpath={.data.tls\.crt}' | base64 --decode >> $OUTPUT_DIR/client.crt
-kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgo.tls -o 'jsonpath={.data.tls\.key}' | base64 --decode >> $OUTPUT_DIR/client.key
+kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgo.tls -o 'go-template={{ index .data "tls.crt" | base64decode }}' > $OUTPUT_DIR/client.crt
+kubectl get secret -n $PGO_OPERATOR_NAMESPACE pgo.tls -o 'go-template={{ index .data "tls.key" | base64decode }}' > $OUTPUT_DIR/client.key
 
 
 echo "pgo client files have been generated, please add the following to your bashrc"


### PR DESCRIPTION
This update changes how the setup script generates the `pgouser`, `client.crt`,
and `client.key` files. Currently new data will be appended to any existing
data. Now the script will overwrite the old data in each file.

The script now relies on the `go-template` output feature of `kubectl`. This
simplifies the script by decoding the username and password and generating the
`pgouser` file in one line. The commands to pull the client key and cert are
also updated to use `go-template`

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
[ch7888]