### PR TITLE
Tie CPU Limits to CPU Requests

### DIFF
--- a/apis/crunchydata.com/v1/cluster.go
+++ b/apis/crunchydata.com/v1/cluster.go
@@ -58,9 +58,9 @@ type PgclusterSpec struct {
 	// container definition. You can set individual items such as "cpu" and
 	// "memory", e.g. "{ cpu: "0.5", memory: "2Gi" }"
 	//
-	// Presently we only set the "Request" portion of the Container resource
-	// definition, but if we do allow for the "Limit" portion to be set, we would
-	// keep it unified to get a "Guaranteed" QoS.
+	// For memory requests, we only set the "Request" portion of the Container
+	// resource definition, but if we do allow for the "Limit" portion to be set,
+	// we would keep it unified to get a "Guaranteed" QoS.
 	//
 	// We don't set the Limit you say? Yes: we want to avoid the OOM killer coming
 	// for the PostgreSQL process or any of their backends per lots of guidance
@@ -78,8 +78,13 @@ type PgclusterSpec struct {
 	// and have a failover event, vs. having an individual client backend killed
 	// and causing potential "bad things."
 	//
+	// For more info on PostgreSQL and Kubernetes memory management, see:
+	//
 	// https://www.postgresql.org/docs/current/kernel-resources.html#LINUX-MEMORY-OVERCOMMIT
 	// https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-limits-are-run
+	//
+	// Now, for CPU, we set both the Request and the Limit, based on how
+	// Kubernetes interacts with these parameters
 	Resources v1.ResourceList `json:"resources"`
 	// BackrestResources, if specified, contains the container request resources
 	// for the pgBackRest Deployment for this PostgreSQL cluster

--- a/conf/postgres-operator/container-resources.json
+++ b/conf/postgres-operator/container-resources.json
@@ -1,5 +1,10 @@
 {{ if or .RequestsMemory .RequestsCPU }}
 "resources": {
+  {{ if .RequestsCPU }}
+  "limits": {
+    "cpu": "{{.RequestsCPU}}"
+  },
+  {{ end }}
   "requests": {
     {{ if .RequestsCPU }}
     "cpu": "{{.RequestsCPU}}"{{ if .RequestsMemory }},{{ end }}

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/container-resources.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/container-resources.json
@@ -1,5 +1,9 @@
 {{ if or .RequestsMemory .RequestsCPU }}
 "resources": {
+  {{ if .RequestsCPU }}
+  "limits": {
+    "cpu": "{{.RequestsCPU}}"
+  },
   "requests": {
     {{ if .RequestsCPU }}
     "cpu": "{{.RequestsCPU}}"{{ if .RequestsMemory }},{{ end }}

--- a/operator/cluster/pgbouncer.go
+++ b/operator/cluster/pgbouncer.go
@@ -1087,6 +1087,9 @@ func updatePgBouncerResources(clientset *kubernetes.Clientset, restclient *rest.
 	// the pgBouncer container is the first one, the resources can be updated
 	// from it
 	deployment.Spec.Template.Spec.Containers[0].Resources.Requests = cluster.Spec.PgBouncerResources
+	deployment.Spec.Template.Spec.Containers[0].Resources.Limits = cluster.Spec.PgBouncerResources
+	// delete the memory limit
+	delete(deployment.Spec.Template.Spec.Containers[0].Resources.Limits, v1.ResourceMemory)
 
 	// and update the deployment
 	// update the deployment with the new values


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change

**What is the current behavior? (link to any open issues here)**

c9059ab8 and several commits after removed the ability to set container
resource limits on both memory and CPU for the PostgreSQL, pgBackRest,
and pgBouncer containers. While there are documented reasons as to why
we do not want to rely on Kubernetes treatment of the container memory
limit setting, the same concerns do not apply to CPU limits


**What is the new behavior (if this is a feature change)?**

As such, this patch reinstates the ability to set CPU limits, but ties
it to the specific resource request. As such, making a request for CPU
resources simultaneously sets the request and limit parameters for the
container within the Pod. The default behavior does not change: no
CPU resources are requested for any Deployments.

**Other information**:

Issue: [ch7919]