### PR TITLE
Update the default storage type to use storageos

### DIFF
--- a/installers/method/kubectl/postgres-operator.yml
+++ b/installers/method/kubectl/postgres-operator.yml
@@ -98,13 +98,13 @@ spec:
                   - name: SCHEDULER_TIMEOUT
                     value: "3600"
                   - name: BACKREST_STORAGE
-                    value: "gce"
+                    value: "storageos"
                   - name: BACKUP_STORAGE
-                    value: "gce"
+                    value: "storageos"
                   - name: PRIMARY_STORAGE
-                    value: "gce"
+                    value: "storageos"
                   - name: REPLICA_STORAGE
-                    value: "gce"
+                    value: "storageos"
                   - name: STORAGE1_NAME
                     value: "hostpathstorage"
                   - name: STORAGE1_ACCESS_MODE


### PR DESCRIPTION
`storageos` was originally the default but was updated to `gce`, this corrects the change.
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
