### PR TITLE
Update the StorageOS Default PVC Size

### DIFF
--- a/conf/postgres-operator/pgo.yaml
+++ b/conf/postgres-operator/pgo.yaml
@@ -54,7 +54,7 @@ Storage:
     SupplementalGroups:  65534
   storageos:
     AccessMode:  ReadWriteOnce
-    Size:  300M
+    Size:  5Gi
     StorageType:  dynamic
     StorageClass:  fast
   primarysite:

--- a/docs/content/Installation/install-with-ansible/prerequisites.md
+++ b/docs/content/Installation/install-with-ansible/prerequisites.md
@@ -291,7 +291,7 @@ The following example defines a storageTo setup storage1 to use the storage clas
 ```ini
 storage5_name='storageos'
 storage5_access_mode='ReadWriteOnce'
-storage5_size='300M'
+storage5_size='5Gi'
 storage5_type='dynamic'
 storage5_class='fast'
 ```

--- a/installers/ansible/inventory
+++ b/installers/ansible/inventory
@@ -257,7 +257,7 @@ storage4_supplemental_groups=65534
 
 storage5_name='storageos'
 storage5_access_mode='ReadWriteOnce'
-storage5_size='300M'
+storage5_size='5Gi'
 storage5_type='dynamic'
 storage5_class='fast'
 

--- a/installers/method/kubectl/full_options
+++ b/installers/method/kubectl/full_options
@@ -197,7 +197,7 @@ value: "storageos"
 - name: STORAGE5_ACCESS_MODE
 value: "ReadWriteOnce"
 - name: STORAGE5_SIZE
-value: "300M"
+value: "5Gi"
 - name: STORAGE5_TYPE
 value: "dynamic"
 - name: STORAGE5_CLASS

--- a/installers/method/kubectl/postgres-operator.yml
+++ b/installers/method/kubectl/postgres-operator.yml
@@ -146,7 +146,7 @@ spec:
                   - name: STORAGE5_ACCESS_MODE
                     value: "ReadWriteOnce"
                   - name: STORAGE5_SIZE
-                    value: "300M"
+                    value: "5Gi"
                   - name: STORAGE5_TYPE
                     value: "dynamic"
                   - name: STORAGE5_CLASS


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently, the default PVC size for StorageOS is set to
'300M'. This value is not interpreted properly and results in
a default size to be used. Additionally, 300MB is to small to
support even most basic testing deployments of PostgreSQL.

**What is the new behavior (if this is a feature change)?**
The PVC values throughout have been updated to '5Gi', which is both
recognized properly by StorageOS and is a more reasonable value
for testing that can easily be updated to a larger value as needed.

**Other information**:
