### PR TITLE
Allow SQL to execute on instances running on nonstandard port

### DIFF
--- a/controller/pod/promotionhandler.go
+++ b/controller/pod/promotionhandler.go
@@ -35,7 +35,7 @@ import (
 
 var (
 	// isInRecoveryCommand is the command run to determine if postgres is in recovery
-	isInRecoveryCMD []string = []string{"psql", "-t", "-c", "'SELECT pg_is_in_recovery();'"}
+	isInRecoveryCMD []string = []string{"psql", "-t", "-c", "'SELECT pg_is_in_recovery();'", "-p"}
 
 	// leaderStatusCMD is the command run to get the Patroni status for the primary
 	leaderStatusCMD []string = []string{"curl", fmt.Sprintf("localhost:%s/master",
@@ -139,6 +139,9 @@ func waitForStandbyPromotion(restConfig *rest.Config, clientset *kubernetes.Clie
 				"standby mode", cluster.Name)
 		case <-tick:
 			if !recoveryDisabled {
+				cmd := isInRecoveryCMD
+				cmd = append(cmd, cluster.Spec.Port)
+
 				isInRecoveryStr, _, _ := kubeapi.ExecToPodThroughAPI(restConfig, clientset,
 					isInRecoveryCMD, newPod.Spec.Containers[0].Name, newPod.Name,
 					newPod.Namespace, nil)

--- a/util/cluster.go
+++ b/util/cluster.go
@@ -261,7 +261,7 @@ func GetS3CredsFromBackrestRepoSecret(clientset *kubernetes.Clientset, namespace
 // Note: it is recommended to pre-hash the password (e.g. md5, SCRAM) so that
 // way the plaintext password is not logged anywhere. This also avoids potential
 // SQL injections
-func SetPostgreSQLPassword(clientset *kubernetes.Clientset, restconfig *rest.Config, pod *v1.Pod, username, password, sqlCustom string) error {
+func SetPostgreSQLPassword(clientset *kubernetes.Clientset, restconfig *rest.Config, pod *v1.Pod, port, username, password, sqlCustom string) error {
 	log.Debugf("set PostgreSQL password for user [%s]", username)
 
 	// if custom SQL is not set, use the default SQL
@@ -275,7 +275,7 @@ func SetPostgreSQLPassword(clientset *kubernetes.Clientset, restconfig *rest.Con
 	// string...well, as long as the function caller does this
 	sql := strings.NewReader(fmt.Sprintf(sqlRaw,
 		SQLQuoteIdentifier(username), SQLQuoteLiteral(password)))
-	cmd := []string{"psql"}
+	cmd := []string{"psql", "-p", port}
 
 	// exec into the pod to run the query
 	_, stderr, err := kubeapi.ExecToPodThroughAPI(restconfig, clientset,

--- a/util/policy.go
+++ b/util/policy.go
@@ -41,7 +41,7 @@ import (
 const primaryClusterLabel = "master"
 
 // ExecPolicy execute a sql policy against a cluster
-func ExecPolicy(clientset *kubernetes.Clientset, restclient *rest.RESTClient, restconfig *rest.Config, namespace string, policyName string, serviceName string) error {
+func ExecPolicy(clientset *kubernetes.Clientset, restclient *rest.RESTClient, restconfig *rest.Config, namespace, policyName, serviceName, port string) error {
 	//fetch the policy sql
 	sql, err := GetPolicySQL(restclient, namespace, policyName)
 
@@ -87,6 +87,8 @@ func ExecPolicy(clientset *kubernetes.Clientset, restclient *rest.RESTClient, re
 	// this gets us closer to what we want to do
 	command := []string{
 		"psql",
+		"-p",
+		port,
 		"postgres",
 		"postgres",
 		"-f",


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the new behavior (if this is a feature change)?**

The commands executing within the Pod were making a UNIX socket
connectoin onto port 5432, but did not account for instances set up
with nonstandard ports. This fixes said quandary.

Issue: [ch7934]