### PR TITLE
Pass the container prefix when scheduling Pgbackrest jobs

### DIFF
--- a/operator/backrest/backup.go
+++ b/operator/backrest/backup.go
@@ -75,7 +75,7 @@ func Backrest(namespace string, clientset *kubernetes.Clientset, task *crv1.Pgta
 		Command:                       cmd,
 		CommandOpts:                   task.Spec.Parameters[config.LABEL_BACKREST_OPTS],
 		PITRTarget:                    "",
-		PGOImagePrefix:                task.Spec.Parameters[config.LABEL_IMAGE_PREFIX],
+		PGOImagePrefix:                util.GetValueOrDefault(task.Spec.Parameters[config.LABEL_IMAGE_PREFIX], operator.Pgo.Pgo.PGOImagePrefix),
 		PGOImageTag:                   operator.Pgo.Pgo.PGOImageTag,
 		PgbackrestStanza:              task.Spec.Parameters[config.LABEL_PGBACKREST_STANZA],
 		PgbackrestDBPath:              task.Spec.Parameters[config.LABEL_PGBACKREST_DB_PATH],

--- a/pgo-scheduler/scheduler/pgbackrest.go
+++ b/pgo-scheduler/scheduler/pgbackrest.go
@@ -151,6 +151,7 @@ func (b BackRestBackupJob) Run() {
 		backupOptions: fmt.Sprintf("--type=%s %s", b.backupType, b.options),
 		stanza:        b.stanza,
 		storageType:   b.storageType,
+		imagePrefix:   cluster.Spec.PGOImagePrefix,
 	}
 
 	err = kubeapi.Createpgtask(restClient, backrest.NewBackRestTask(), b.namespace)

--- a/pgo-scheduler/scheduler/tasks.go
+++ b/pgo-scheduler/scheduler/tasks.go
@@ -31,6 +31,7 @@ type pgBackRestTask struct {
 	backupOptions string
 	stanza        string
 	storageType   string
+	imagePrefix   string
 }
 
 func (p pgBackRestTask) NewBackRestTask() *crv1.Pgtask {
@@ -49,6 +50,7 @@ func (p pgBackRestTask) NewBackRestTask() *crv1.Pgtask {
 				config.LABEL_BACKREST_COMMAND:      crv1.PgtaskBackrestBackup,
 				config.LABEL_BACKREST_OPTS:         fmt.Sprintf("--stanza=%s %s", p.stanza, p.backupOptions),
 				config.LABEL_BACKREST_STORAGE_TYPE: p.storageType,
+				config.LABEL_IMAGE_PREFIX:          p.imagePrefix,
 			},
 		},
 	}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
There is a bug where the correct image prefix is
not properly taken from the pgcluster CRD when creating
a pgbackrest schedule. The bug results in an empty value that
is not properly checked when submitting the associated pgtask.

**What is the new behavior (if this is a feature change)?**
This update corrects the initial error, and adds an additional
check that the value is set before submitting the task.

**Other information**:
