### PR TITLE
Avoid SQL delimiters in generated passwords

### DIFF
--- a/util/secrets.go
+++ b/util/secrets.go
@@ -41,8 +41,8 @@ const UserSecretFormat = "%s-%s" + crv1.UserSecretSuffix
 // (`man ascii`)
 const (
 	// passwordCharLower is the lowest ASCII character to use for generating a
-	// password, which is 33
-	passwordCharLower = 33
+	// password, which is 40
+	passwordCharLower = 40
 	// passwordCharUpper is the highest ASCII character to use for generating a
 	// password, which is 126
 	passwordCharUpper = 126
@@ -50,7 +50,7 @@ const (
 
 // passwordCharSelector is a "big int" that we need to select the random ASCII
 // character for the password. Since the random integer generator looks for
-// values from [0,X), we need to force this to be [33,126]
+// values from [0,X), we need to force this to be [40,126]
 var passwordCharSelector = big.NewInt(passwordCharUpper - passwordCharLower)
 
 // CreateSecret create the secret, user, and primary secrets


### PR DESCRIPTION
Dollar sign, apostrophe, and quotation mark are all below 40 (0x28).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
