### PR TITLE
Installer cleanups

### DIFF
--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -106,13 +106,13 @@ spec:
                   - name: SCHEDULER_TIMEOUT
                     value: "3600"
                   - name: BACKREST_STORAGE
-                    value: "storageos"
+                    value: "hostpathstorage"
                   - name: BACKUP_STORAGE
-                    value: "storageos"
+                    value: "hostpathstorage"
                   - name: PRIMARY_STORAGE
-                    value: "storageos"
+                    value: "hostpathstorage"
                   - name: REPLICA_STORAGE
-                    value: "storageos"
+                    value: "hostpathstorage"
                   - name: STORAGE1_NAME
                     value: "hostpathstorage"
                   - name: STORAGE1_ACCESS_MODE


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the new behavior (if this is a feature change)?**

Client Installer:

- Better quoting around the environmental variables
- Allow for adjustment of the "pgouser-admin" user for grabbing
credentials
- Ensure the credentials are safely stored in the home directory
with tighter permissions

Default installer to `hostpathstorage`

This is used by many of the test enviroments (minikube, CRC) and
so this will make it easier for people to get the PostgreSQL Operator
up and running. Production installations typically tweak these
settings.