### PR TITLE
Node Affinity Cleanups

### DIFF
--- a/apiserver/clusterservice/clusterimpl.go
+++ b/apiserver/clusterservice/clusterimpl.go
@@ -697,14 +697,6 @@ func CreateCluster(request *msgs.CreateClusterRequest, ns, pgouser string) msgs.
 		}
 	}
 
-	if apiserver.Pgo.Cluster.PrimaryNodeLabel != "" {
-		//already should be validate at apiserver startup
-		parts := strings.Split(apiserver.Pgo.Cluster.PrimaryNodeLabel, "=")
-		userLabelsMap[config.LABEL_NODE_LABEL_KEY] = parts[0]
-		userLabelsMap[config.LABEL_NODE_LABEL_VALUE] = parts[1]
-		log.Debug("primary node labels used from pgo.yaml")
-	}
-
 	// validate & parse nodeLabel if exists
 	if request.NodeLabel != "" {
 		if err = apiserver.ValidateNodeLabel(request.NodeLabel); err != nil {

--- a/apiserver/clusterservice/scaleimpl.go
+++ b/apiserver/clusterservice/scaleimpl.go
@@ -93,19 +93,9 @@ func ScaleCluster(name, replicaCount, storageConfig, nodeLabel,
 		spec.UserLabels[config.LABEL_SERVICE_TYPE] = serviceType
 	}
 
-	var parts []string
-
 	//set replica node lables to blank to start with, then check for overrides
 	spec.UserLabels[config.LABEL_NODE_LABEL_KEY] = ""
 	spec.UserLabels[config.LABEL_NODE_LABEL_VALUE] = ""
-
-	if apiserver.Pgo.Cluster.ReplicaNodeLabel != "" {
-		//should have been validated at apiserver startup
-		parts = strings.Split(apiserver.Pgo.Cluster.ReplicaNodeLabel, "=")
-		spec.UserLabels[config.LABEL_NODE_LABEL_KEY] = parts[0]
-		spec.UserLabels[config.LABEL_NODE_LABEL_VALUE] = parts[1]
-		log.Debug("using pgo.yaml ReplicaNodeLabel for replica creation")
-	}
 
 	// validate & parse nodeLabel if exists
 	if nodeLabel != "" {

--- a/conf/postgres-operator/pgo.yaml
+++ b/conf/postgres-operator/pgo.yaml
@@ -1,6 +1,4 @@
 Cluster:
-  PrimaryNodeLabel:
-  ReplicaNodeLabel:
   CCPImagePrefix:  crunchydata
   Metrics:  false
   Badger:  false

--- a/config/pgoconfig.go
+++ b/config/pgoconfig.go
@@ -186,8 +186,6 @@ const deploymentTemplatePath = "cluster-deployment.json"
 type ClusterStruct struct {
 	CCPImagePrefix                 string
 	CCPImageTag                    string
-	PrimaryNodeLabel               string
-	ReplicaNodeLabel               string
 	Policies                       string
 	Metrics                        bool
 	Badger                         bool
@@ -294,20 +292,6 @@ func (c *PgoConfig) Validate() error {
 	} else {
 		if _, err := strconv.Atoi(c.Cluster.Port); err != nil {
 			return errors.New(errPrefix + "Invalid Port: " + err.Error())
-		}
-	}
-
-	if c.Cluster.PrimaryNodeLabel != "" {
-		parts := strings.Split(c.Cluster.PrimaryNodeLabel, "=")
-		if len(parts) != 2 {
-			return errors.New(errPrefix + "Cluster.PrimaryNodeLabel does not follow key=value format")
-		}
-	}
-
-	if c.Cluster.ReplicaNodeLabel != "" {
-		parts := strings.Split(c.Cluster.ReplicaNodeLabel, "=")
-		if len(parts) != 2 {
-			return errors.New(errPrefix + "Cluster.ReplicaNodeLabel does not follow key=value format")
 		}
 	}
 

--- a/docs/content/Configuration/pgo-yaml-configuration.md
+++ b/docs/content/Configuration/pgo-yaml-configuration.md
@@ -15,8 +15,6 @@ The *pgo.yaml* file is broken into major sections as described below:
 | Setting |Definition  |
 |---|---|
 |BasicAuth        | If set to `"true"` will enable Basic Authentication. If set to `"false"`, will allow a valid Operator user to successfully authenticate regardless of the value of the password provided for Basic Authentication. Defaults to `"true".`
-|PrimaryNodeLabel        |newly created primary deployments will specify this node label if specified, unless you override it using the --node-label command line flag, if not set, no node label is specifed
-|ReplicaNodeLabel        |newly created replica deployments will specify this node label if specified, unless you override it using the --node-label command line flag, if not set, no node label is specifed
 |CCPImagePrefix        |newly created containers will be based on this image prefix (e.g. crunchydata), update this if you require a custom image prefix
 |CCPImageTag        |newly created containers will be based on this image version (e.g. centos7-12.2-4.3.0), unless you override it using the --ccp-image-tag command line flag
 |Port        | the PostgreSQL port to use for new containers (e.g. 5432)

--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -108,8 +108,6 @@ BasicAuth: ""
 Cluster:
   CCPImagePrefix: crunchydata
   CCPImageTag: centos7-12.2-4.3.0
-  PrimaryNodeLabel: ""
-  ReplicaNodeLabel: ""
   Policies: ""
   Metrics: false
   Badger: false

--- a/installers/ansible/roles/pgo-operator/templates/pgo.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/pgo.yaml.j2
@@ -1,6 +1,4 @@
 Cluster:
-  PrimaryNodeLabel:
-  ReplicaNodeLabel:
   CCPImagePrefix:  {{ ccp_image_prefix }}
   CCPImageTag:  {{ ccp_image_tag }}
   DisableAutofail:  {{ disable_auto_failover }}

--- a/operator/cluster/cluster.go
+++ b/operator/cluster/cluster.go
@@ -21,7 +21,6 @@ package cluster
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	crv1 "github.com/crunchydata/postgres-operator/apis/crunchydata.com/v1"
@@ -157,14 +156,6 @@ func AddClusterBase(clientset *kubernetes.Clientset, client *rest.RESTClient, cl
 			//the replica should not use the same node labels as the primary
 			spec.UserLabels[config.LABEL_NODE_LABEL_KEY] = ""
 			spec.UserLabels[config.LABEL_NODE_LABEL_VALUE] = ""
-
-			//check for replica node label in pgo.yaml
-			if operator.Pgo.Cluster.ReplicaNodeLabel != "" {
-				parts := strings.Split(operator.Pgo.Cluster.ReplicaNodeLabel, "=")
-				spec.UserLabels[config.LABEL_NODE_LABEL_KEY] = parts[0]
-				spec.UserLabels[config.LABEL_NODE_LABEL_VALUE] = parts[1]
-				log.Debug("using pgo.yaml ReplicaNodeLabel for replica creation")
-			}
 
 			labels := make(map[string]string)
 			labels[config.LABEL_PG_CLUSTER] = cl.Spec.Name

--- a/operator/cluster/clusterlogic.go
+++ b/operator/cluster/clusterlogic.go
@@ -323,7 +323,7 @@ func Scale(clientset *kubernetes.Clientset, client *rest.RESTClient, replica *cr
 		PrimarySecretName:  cluster.Spec.PrimarySecretName,
 		UserSecretName:     cluster.Spec.UserSecretName,
 		ContainerResources: operator.GetResourcesJSON(cluster.Spec.Resources),
-		NodeSelector:       operator.GetReplicaAffinity(cluster.Spec.UserLabels, replica.Spec.UserLabels),
+		NodeSelector:       operator.GetAffinity(replica.Spec.UserLabels["NodeLabelKey"], replica.Spec.UserLabels["NodeLabelValue"], "In"),
 		PodAntiAffinity:    operator.GetPodAntiAffinity(cluster, crv1.PodAntiAffinityDeploymentDefault, cluster.Spec.PodAntiAffinity.Default),
 		CollectAddon:       operator.GetCollectAddon(clientset, namespace, &cluster.Spec),
 		CollectVolume:      operator.GetCollectVolume(clientset, cluster, namespace),

--- a/operator/clusterutilities.go
+++ b/operator/clusterutilities.go
@@ -569,28 +569,6 @@ func GetAffinity(nodeLabelKey, nodeLabelValue string, affoperator string) string
 	return affinityDoc.String()
 }
 
-// GetReplicaAffinity ...
-// use NotIn as an operator when a node-label is not specified on the
-// replica, use the node labels from the primary in this case
-// use In as an operator when a node-label is specified on the replica
-// use the node labels from the replica in this case
-func GetReplicaAffinity(clusterLabels, replicaLabels map[string]string) string {
-	var operator, key, value string
-	log.Debug("GetReplicaAffinity ")
-	if replicaLabels[config.LABEL_NODE_LABEL_KEY] != "" {
-		//use the replica labels
-		operator = "In"
-		key = replicaLabels[config.LABEL_NODE_LABEL_KEY]
-		value = replicaLabels[config.LABEL_NODE_LABEL_VALUE]
-	} else {
-		//use the cluster labels
-		operator = "NotIn"
-		key = clusterLabels[config.LABEL_NODE_LABEL_KEY]
-		value = clusterLabels[config.LABEL_NODE_LABEL_VALUE]
-	}
-	return GetAffinity(key, value, operator)
-}
-
 // GetPodAntiAffinity returns the populated pod anti-affinity json that should be attached to
 // the various pods comprising the pg cluster
 func GetPodAntiAffinity(cluster *crv1.Pgcluster, deploymentType crv1.PodAntiAffinityDeployment, podAntiAffinityType crv1.PodAntiAffinityType) string {


### PR DESCRIPTION
- Removes the node affinity defaults, due to the changes of PostgreSQL cluster topology management since the beginning of Operator development
- Treat the node affinity rules of the PostgreSQL replicas the same as those of "primaries" given a replica can become a primary.