### PR TITLE
Installer client-setup script: download pgo client binary

### DIFF
--- a/docs/content/installation/postgres-operator.md
+++ b/docs/content/installation/postgres-operator.md
@@ -182,15 +182,19 @@ chmod +x client-setup.sh
 ```
 
 {{% notice tip %}}
-Running this script can cause existing `pgouser`, `client.crt`, and `client.key`
-files to be overwritten.
+Running this script can cause existing `pgo` client binary, `pgouser`,
+`client.crt`, and `client.key` files to be overwritten.
 {{% /notice %}}
 
 The `client-setup.sh` script performs the following tasks:
 
 - Sets `$PGO_OPERATOR_NAMESPACE` to `pgo` if it is unset. This is the default
-namespace that the PostgreSQL Operator is deployed to
+namespace that the PostgreSQßL Operator is deployed to
+- Checks for valid Operating Systems and determines which `pgo` binary to
+download
 - Creates a directory in `$HOME/.pgo/$PGO_OPERATOR_NAMESPACE` (e.g. `/home/hippo/.pgo/pgo`)
+- Downloads the `pgo` binary, saves it to in `$HOME/.pgo/$PGO_OPERATOR_NAMESPACE`,
+and sets it to be executable
 - Pulls the TLS keypair from the PostgreSQL Operator `pgo.tls` Secret so that
 the `pgo` client can communicate with the PostgreSQL Operator. These are saved
 as `client.crt` and `client.key` in the `$HOME/.pgo/$PGO_OPERATOR_NAMESPACE`
@@ -214,12 +218,19 @@ environmental variables to your environment:
 
 ```shell
 cat <<EOF >> ~/.bashrc
+export PATH="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/pgo:$PATH"
 export PGOUSER="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/pgouser"
 export PGO_CA_CERT="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/client.crt"
 export PGO_CLIENT_CERT="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/client.crt"
 export PGO_CLIENT_KEY="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/client.key"
 EOF
 ```
+
+{{% notice tip %}}
+If you are using MacOS the `pgo-mac` binary will need to be renamed to `pgo`.
+Alternatively, you can update your path to include `pgo-mac`.
+`export PATH="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/pgo-mac:$PATH"`
+{{% /notice %}}
 
 By default, the `client-setup.sh` script targets the user that is stored in the
 `pgouser-admin` secret in the `pgo` (`$PGO_OPERATOR_NAMESPACE`) Namespace. If

--- a/installers/kubectl/client-setup.sh
+++ b/installers/kubectl/client-setup.sh
@@ -14,6 +14,35 @@
 # This script should be run after the operator has been deployed
 export PGO_OPERATOR_NAMESPACE="${PGO_OPERATOR_NAMESPACE:-pgo}"
 PGO_USER_ADMIN="${PGO_USER_ADMIN:-pgouser-admin}"
+PGO_CLIENT_VERSION="${PGO_CLIENT_VERSION:-v4.3.0}"
+PGO_CLIENT_URL="https://github.com/CrunchyData/postgres-operator/releases/download/${PGO_CLIENT_VERSION}"
+
+# Checks operating system and determines which binary to download
+UNAME_RESULT=$(uname)
+if [[ "${UNAME_RESULT}" == "Linux" ]]
+then
+    BIN_NAME="pgo"
+elif [[ "${UNAME_RESULT}" == "Darwin" ]]
+then
+    BIN_NAME="pgo-mac"
+else
+    echo "${UNAME_RESULT} is not supported, valid operating systems are: Linux, Darwin"
+    echo "Exiting..."
+    exit 1
+fi
+
+# Creates the output directory for files
+OUTPUT_DIR="${HOME}/.pgo/${PGO_OPERATOR_NAMESPACE}"
+mkdir -p "${OUTPUT_DIR}"
+# lock down the directory to just this user
+chmod a-rwx,u+rwx "${OUTPUT_DIR}"
+
+echo "Operating System found is ${UNAME_RESULT}. Downloading ${BIN_NAME} client binary..."
+
+FULL_PATH="${PGO_CLIENT_URL}/${BIN_NAME}"
+curl -L "${FULL_PATH}" -o "${OUTPUT_DIR}/${BIN_NAME}"
+chmod +x "${OUTPUT_DIR}/${BIN_NAME}"
+
 
 # Check that the pgouser-admin secret exists
 if [ -z "$(kubectl get secret -n ${PGO_OPERATOR_NAMESPACE} ${PGO_USER_ADMIN})" ]
@@ -33,13 +62,6 @@ then
     exit 1
 fi
 
-
-# Creates the output directory for files
-OUTPUT_DIR="${HOME}/.pgo/${PGO_OPERATOR_NAMESPACE}"
-mkdir -p "${OUTPUT_DIR}"
-# lock down the directory to just this user
-chmod a-rwx,u+rwx "${OUTPUT_DIR}"
-
 # Use the pgouser-admin secret to generate pgouser file
 kubectl get secret -n "${PGO_OPERATOR_NAMESPACE}" "${PGO_USER_ADMIN}" -o 'go-template={{.data.username | base64decode }}:{{.data.password | base64decode}}' > $OUTPUT_DIR/pgouser
 # ensure this file is locked down to the specific user running this
@@ -54,6 +76,7 @@ chmod a-rwx,u+rw "${OUTPUT_DIR}/client.crt" "${OUTPUT_DIR}/client.key"
 
 
 echo "pgo client files have been generated, please add the following to your bashrc"
+echo "export PATH=${OUTPUT_DIR}/${BIN_NAME}:\$PATH"
 echo "export PGOUSER=${OUTPUT_DIR}/pgouser"
 echo "export PGO_CA_CERT=${OUTPUT_DIR}/client.crt"
 echo "export PGO_CLIENT_CERT=${OUTPUT_DIR}/client.crt"


### PR DESCRIPTION
This update will download the `pgo` (Linux) or `pgo-mac` (Darwin) binary from
github based on the operating system. The binary will be downloaded to
`~/.pgo/<operator-namespace>` and should be added to the users `PATH`.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
