### PR TITLE
Have the installers default to v4.3.0-beta.3

### DIFF
--- a/docs/content/installation/other/ansible/_index.md
+++ b/docs/content/installation/other/ansible/_index.md
@@ -8,14 +8,14 @@ weight: 100
 # Crunchy Data PostgreSQL Operator Playbooks
 
 The Crunchy Data PostgreSQL Operator Playbooks contain [Ansible](https://www.ansible.com/)
-roles for installing and managing the [Crunchy Data PostgreSQL Operator](https://access.crunchydata.com/documentation/postgres-operator/4.3.0/installation/install-with-ansible/).  
+roles for installing and managing the [Crunchy Data PostgreSQL Operator]({{< relref "/installation/install-with-ansible/_index.html" >}}).  
 
 ## Features
 
 The playbooks provided allow users to:
 
 * install PostgreSQL Operator on Kubernetes and OpenShift
-* install PostgreSQL Operator from a Linux, Mac or Windows(Ubuntu subsystem)host
+* install PostgreSQL Operator from a Linux, Mac or Windows (Ubuntu subsystem) host
 * generate TLS certificates required by the PostgreSQL Operator
 * configure PostgreSQL Operator settings from a single inventory file
 * support a variety of deployment models
@@ -24,5 +24,4 @@ The playbooks provided allow users to:
 
 * [Ansible](https://www.ansible.com/)
 * [Crunchy Data](https://www.crunchydata.com/)
-* [Crunchy Data PostgreSQL Operator Documentation](https://crunchydata.github.io/postgres-operator/stable/)
 * [Crunchy Data PostgreSQL Operator Project](https://github.com/CrunchyData/postgres-operator)

--- a/docs/content/installation/other/bash.md
+++ b/docs/content/installation/other/bash.md
@@ -31,7 +31,7 @@ The Operator follows a golang project structure, you can create a structure as f
     cd $HOME/odev/src/github.com/crunchydata
     git clone https://github.com/CrunchyData/postgres-operator.git
     cd postgres-operator
-	git checkout v4.3.0
+	git checkout v4.3.0-beta.3
 
 
 This creates a directory structure under your HOME directory name *odev* and clones the current Operator version to that structure.  

--- a/installers/ansible/inventory
+++ b/installers/ansible/inventory
@@ -93,7 +93,7 @@ namespace='pgouser1,pgouser2'
 # CentOS7 images can be found in dockerhub: https://hub.docker.com/u/crunchydata
 # RHEL7 images are available to Crunchy customers: https://access.crunchydata.com/login/
 ccp_image_prefix='registry.developers.crunchydata.com/crunchydata'
-ccp_image_tag='centos7-12.2-4.3.0'
+ccp_image_tag='centos7-12.2-4.3.0-beta.3'
 
 # Name of a Secret containing credentials for container image registries.
 # Provide a path to the Secret manifest to be installed in each namespace. (optional)
@@ -102,7 +102,7 @@ ccp_image_pull_secret_manifest=''
 
 # Crunchy PostgreSQL Operator images to use.  The tags centos7 and rhel7 are acceptable.
 pgo_image_prefix='registry.developers.crunchydata.com/crunchydata'
-pgo_image_tag='centos7-4.3.0'
+pgo_image_tag='centos7-4.3.0-beta.3'
 
 # Name of a Secret containing credentials for container image registries.
 # Provide a path to the Secret manifest to be installed in each namespace. (optional)
@@ -111,7 +111,7 @@ pgo_image_tag='centos7-4.3.0'
 
 # PGO Client Install
 pgo_client_install='true'
-pgo_client_version='v4.3.0'
+pgo_client_version='v4.3.0-beta.3'
 
 # PGO Apiserver TLS Settings
 #pgo_tls_no_verify='false'

--- a/installers/gcp-marketplace/inventory.ini
+++ b/installers/gcp-marketplace/inventory.ini
@@ -16,11 +16,11 @@ pgo_operator_namespace='${OPERATOR_NAMESPACE}'
 namespace=''
 
 ccp_image_prefix='registry.developers.crunchydata.com/crunchydata'
-ccp_image_tag='centos7-12.2-4.3.0'
+ccp_image_tag='centos7-12.2-4.3.0-beta.3'
 ccp_image_pull_secret=''
 ccp_image_pull_secret_manifest=''
 pgo_image_prefix='registry.developers.crunchydata.com/crunchydata'
-pgo_image_tag='centos7-4.3.0'
+pgo_image_tag='centos7-4.3.0-beta.3'
 
 pgo_image='${OPERATOR_IMAGE}'
 pgo_event_image='${OPERATOR_IMAGE_EVENT}'
@@ -29,7 +29,7 @@ pgo_scheduler_image='${OPERATOR_IMAGE_SCHEDULER}'
 
 # PGO Client Install
 pgo_client_install='false'
-pgo_client_version='v4.3.0'
+pgo_client_version='v4.3.0-beta.3'
 
 backrest='true'
 badger='false'

--- a/installers/kubectl/client-setup.sh
+++ b/installers/kubectl/client-setup.sh
@@ -14,7 +14,7 @@
 # This script should be run after the operator has been deployed
 export PGO_OPERATOR_NAMESPACE="${PGO_OPERATOR_NAMESPACE:-pgo}"
 PGO_USER_ADMIN="${PGO_USER_ADMIN:-pgouser-admin}"
-PGO_CLIENT_VERSION="${PGO_CLIENT_VERSION:-v4.3.0}"
+PGO_CLIENT_VERSION="${PGO_CLIENT_VERSION:-v4.3.0-beta.3}"
 PGO_CLIENT_URL="https://github.com/CrunchyData/postgres-operator/releases/download/${PGO_CLIENT_VERSION}"
 
 # Checks operating system and determines which binary to download

--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -34,7 +34,7 @@ spec:
             containers:
             - name: pgo-deploy
               command: ["/pgo-deploy.sh"]
-              image: registry.developers.crunchydata.com/crunchydata/pgo-deployer:centos7-4.3.0
+              image: registry.developers.crunchydata.com/crunchydata/pgo-deployer:centos7-4.3.0-beta.3
               imagePullPolicy: IfNotPresent
               env:
                   - name: ANSIBLE_CONFIG
@@ -54,7 +54,7 @@ spec:
                   - name: CCP_IMAGE_PREFIX
                     value: "registry.developers.crunchydata.com/crunchydata"
                   - name: CCP_IMAGE_TAG
-                    value: "centos7-12.2-4.3.0"
+                    value: "centos7-12.2-4.3.0-beta.3"
                   - name: DB_PASSWORD_LENGTH
                     value: "24"
                   - name: DB_PORT
@@ -94,11 +94,11 @@ spec:
                   - name: PGO_ADMIN_USERNAME
                     value: "admin"
                   - name: PGO_CLIENT_VERSION
-                    value: "v4.3.0"
+                    value: "v4.3.0-beta.3"
                   - name: PGO_IMAGE_PREFIX
                     value: "registry.developers.crunchydata.com/crunchydata"
                   - name: PGO_IMAGE_TAG
-                    value: "centos7-4.3.0"
+                    value: "centos7-4.3.0-beta.3"
                   - name: PGO_INSTALLATION_NAME
                     value: "devtest"
                   - name: PGO_OPERATOR_NAMESPACE


### PR DESCRIPTION
This should make it easier to set up and test the installers, and
also allows me to test one thing in particular around the installers.