### PR TITLE
Updates docs

### DIFF
--- a/docs/content/installation/postgres-operator.md
+++ b/docs/content/installation/postgres-operator.md
@@ -224,7 +224,7 @@ environmental variables to your environment:
 
 ```shell
 cat <<EOF >> ~/.bashrc
-export PATH="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/pgo:$PATH"
+export PATH="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE:$PATH"
 export PGOUSER="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/pgouser"
 export PGO_CA_CERT="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/client.crt"
 export PGO_CLIENT_CERT="$HOME/.pgo/$PGO_OPERATOR_NAMESPACE/client.crt"

--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -874,9 +874,11 @@ section of the documentation.
 ## Clone a PostgreSQL Cluster
 
 You can create a copy of an existing PostgreSQL cluster in a new PostgreSQL
-cluster by using the [`pgo clone`](/pgo-client/reference/pgo_clone/) command. To
-create a new copy of a PostgreSQL cluster, you can execute the following
-command:
+cluster by using the [`pgo clone`](/pgo-client/reference/pgo_clone/) command.
+The command copies the pgBackRest repository from the existing cluster and
+creates a new, single instance primary as its own cluster. To
+create the new, single instance, copy of a PostgreSQL cluster, you can execute
+the following command:
 
 ```shell
 pgo clone hacluster newhacluster

--- a/installers/kubectl/client-setup.sh
+++ b/installers/kubectl/client-setup.sh
@@ -76,7 +76,7 @@ chmod a-rwx,u+rw "${OUTPUT_DIR}/client.crt" "${OUTPUT_DIR}/client.key"
 
 
 echo "pgo client files have been generated, please add the following to your bashrc"
-echo "export PATH=${OUTPUT_DIR}/${BIN_NAME}:\$PATH"
+echo "export PATH=${OUTPUT_DIR}:\$PATH"
 echo "export PGOUSER=${OUTPUT_DIR}/pgouser"
 echo "export PGO_CA_CERT=${OUTPUT_DIR}/client.crt"
 echo "export PGO_CLIENT_CERT=${OUTPUT_DIR}/client.crt"


### PR DESCRIPTION
Updates the docs for installer to have correct path when using
client-setup script

This commit updates the docs to provide more info about how a cloned
cluster will be created. The newly cloned cluster will be a single
primary instance.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
