### PR TITLE
Fix for GCP deployer for installer source files

### DIFF
--- a/installers/gcp-marketplace/Dockerfile
+++ b/installers/gcp-marketplace/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends ansible=2.8.* openssh-client \
  && rm -rf /var/lib/apt/lists/*
 
-COPY ansible/* \
+COPY installers/ansible/* \
      /opt/postgres-operator/ansible/
 COPY installers/favicon.png \
      installers/gcp-marketplace/install-job.yaml \


### PR DESCRIPTION
This was referencing a directory that has since moved.