### PR TITLE
Updates Installer Options and bugfix

### DIFF
--- a/docs/content/installation/configuration.md
+++ b/docs/content/installation/configuration.md
@@ -35,7 +35,7 @@ Operator.
 | `BADGER` | false | **Required** | Set to true enable pgBadger capabilities on all newly created clusters. This can be disabled by the client. |
 | `CCP_IMAGE_PREFIX` | crunchydata | **Required** | Configures the image prefix used when creating containers from Crunchy Container Suite. |
 | `CCP_IMAGE_PULL_SECRET` |  |  | Name of a Secret containing credentials for container image registries. |
-| `CCP_IMAGE_PULL_MANIFEST` |  |  | Provide a path to the Secret manifest to be installed in each namespace. (optional) |
+| `CCP_IMAGE_PULL_SECRET_MANIFEST` |  |  | Provide a path to the Secret manifest to be installed in each namespace. (optional) |
 | `CCP_IMAGE_TAG` |  | **Required** | Configures the image tag (version) used when creating containers from Crunchy Container Suite. |
 | `CREATE_RBAC` | true | **Required** | Set to true if the installer should create the RBAC resources required to run the PostgreSQL Operator. |
 | `CRUNCHY_DEBUG` | false |  | Set to configure Operator to use debugging mode. Note: this can cause sensitive data such as passwords to appear in Operator logs. |
@@ -61,6 +61,7 @@ Operator.
 | `GRAFANA_SUPPLEMENTAL_GROUPS` | 65534 |  | Set to configure any supplemental groups that should be added to security contexts for Grafana. |
 | `GRAFANA_VOLUME_SIZE` | 1G |  | Set to the size of persistent volume to create for Grafana. |
 | `METRICS` | false | **Required** | Set to true enable performance metrics on all newly created clusters. This can be disabled by the client. |
+| `METRICS_NAMESPACE` | `pgo` |  | Namespace in which the `metrics` deployments with be run. |
 | `NAMESPACE` |  |  | Set to a comma delimited string of all the namespaces Operator will manage. |
 | `NAMESPACE_MODE` | dynamic |  | When installing RBAC using 'create_rbac', the namespace mode determines what Cluster Roles are installed. Options: `dynamic`, `readonly`, and `disabled` |
 | `PGBADGERPORT` | 10000 | **Required** | Set to configure the default port used to connect to pgbadger. |
@@ -78,7 +79,7 @@ Operator.
 | `PGO_DISABLE_TLS` | false |  | Set to configure whether or not TLS should be enabled for the Crunchy PostgreSQL Operator apiserver. |
 | `PGO_IMAGE_PREFIX` | crunchydata | **Required** | Configures the image prefix used when creating containers for the Crunchy PostgreSQL Operator (apiserver, operator, scheduler..etc). |
 | `PGO_IMAGE_PULL_SECRET` |  |  | Name of a Secret containing credentials for container image registries. |
-| `PGO_IMAGE_PULL_MANIFEST` |  |  | Provide a path to the Secret manifest to be installed in each namespace. (optional) |
+| `PGO_IMAGE_PULL_SECRET_MANIFEST` |  |  | Provide a path to the Secret manifest to be installed in each namespace. (optional) |
 | `PGO_IMAGE_TAG` |  | **Required** | Configures the image tag used when creating containers for the Crunchy PostgreSQL Operator (apiserver, operator, scheduler..etc) |
 | `PGO_INSTALLATION_NAME` | devtest | **Required** | The name of the PGO installation. |
 | `PGO_NOAUTH_ROUTES` |  |  | Configures URL routes with mTLS and HTTP BasicAuth disabled. |
@@ -221,10 +222,10 @@ other storage classes in production deployments.
 | Name | Value |
 |------|-------|
 | STORAGE7_NAME | alternatesite |
-| STORAGE6_ACCESS_MODE | ReadWriteOnce |
+| STORAGE7_ACCESS_MODE | ReadWriteOnce |
 | STORAGE7_SIZE | 4G |
 | STORAGE7_TYPE | dynamic |
-| STORAGE6_CLASS | alternatesite |
+| STORAGE7_CLASS | alternatesite |
 
 #### GCE
 

--- a/installers/image/bin/pgo-deploy.sh
+++ b/installers/image/bin/pgo-deploy.sh
@@ -34,8 +34,11 @@ export SERVICE_TYPE=${SERVICE_TYPE:-ClusterIP}
 # Metrics Defaults
 export METRICS_NAMESPACE=${METRICS_NAMESPACE:-pgo}
 
-export KUBERNETES_IN_CLUSTER=${KUBERNETES_IN_CLUSTER:-true}
+# Installer Settings
+export ANSIBLE_CONFIG="/ansible/ansible.cfg"
 export DEPLOY_ACTION=${DEPLOY_ACTION:-install}
+export HOME="/tmp"
+export KUBERNETES_IN_CLUSTER=${KUBERNETES_IN_CLUSTER:-true}
 
 cat /inventory_template | envsubst > /tmp/inventory
 /usr/bin/env ansible-playbook -i /tmp/inventory --tags=$DEPLOY_ACTION /ansible/main.yml

--- a/installers/image/inventory_template
+++ b/installers/image/inventory_template
@@ -92,10 +92,6 @@ pgo_image_tag='$PGO_IMAGE_TAG'
 pgo_image_pull_secret='$PGO_IMAGE_PULL_SECRET'
 pgo_image_pull_secret_manifest='$PGO_IMAGE_PULL_SECRET_MANIFEST'
 
-# PGO Client Install
-pgo_client_install='$PGO_CLIENT_INSTALL'
-pgo_client_version='$PGO_CLIENT_VERSION'
-
 # PGO Apiserver TLS Settings
 pgo_tls_no_verify='$PGO_TLS_NO_VERIFY'
 pgo_disable_tls='$PGO_DISABLE_TLS'
@@ -148,10 +144,6 @@ pgbadgerport='$PGBADGERPORT'
 archive_mode='$ARCHIVE_MODE'
 archive_timeout=$ARCHIVE_TIMEOUT
 backrest_port='$BACKREST_PORT'
-
-# Log Defaults
-log_statement='$LOG_STATEMENT'
-log_min_duration_statement=$LOG_MIN_DURATION_STATEMENT
 
 # Autofail Settings
 disable_auto_failover='$DISABLE_AUTO_FAILOVER'
@@ -219,7 +211,7 @@ replica_storage='$REPLICA_STORAGE'
 wal_storage='$WAL_STORAGE'
 
 storage1_name='$STORAGE1_NAME'
-storage1_access_mode='$STORAGE_ACCESS_MODE'
+storage1_access_mode='$STORAGE1_ACCESS_MODE'
 storage1_size='$STORAGE1_SIZE'
 storage1_type='$STORAGE1_TYPE'
 
@@ -237,7 +229,7 @@ storage3_supplemental_groups=$STORAGE3_SUPPLEMENTAL_GROUPS
 storage4_name='$STORAGE4_NAME'
 storage4_access_mode='$STORAGE4_ACCESS_MODE'
 storage4_size='$STORAGE4_SIZE'
-storage4_match_labels='$STORAGE4_MATCH_LABEL'
+storage4_match_labels='$STORAGE4_MATCH_LABELS'
 storage4_type='$STORAGE4_TYPE'
 storage4_supplemental_groups=$STORAGE4_SUPPLEMENTAL_GROUPS
 
@@ -260,7 +252,7 @@ storage7_type='$STORAGE7_TYPE'
 storage7_class='$STORAGE7_CLASS'
 
 storage8_name='$STORAGE8_NAME'
-storage8_access_mode='$STORAGE8_ACCESS'
+storage8_access_mode='$STORAGE8_ACCESS_MODE'
 storage8_size='$STORAGE8_SIZE'
 storage8_type='$STORAGE8_TYPE'
 storage8_class='$STORAGE8_CLASS'

--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -37,8 +37,6 @@ spec:
               image: registry.developers.crunchydata.com/crunchydata/pgo-deployer:centos7-4.3.0
               imagePullPolicy: IfNotPresent
               env:
-                  - name: ANSIBLE_CONFIG
-                    value: "/ansible/ansible.cfg"
                   - name: ARCHIVE_MODE
                     value: "true"
                   - name: ARCHIVE_TIMEOUT
@@ -75,8 +73,6 @@ spec:
                     value: "false"
                   - name: EXPORTERPORT
                     value: "9187"
-                  - name: HOME
-                    value: "/tmp"
                   - name: METRICS
                     value: "false"
                   - name: NAMESPACE
@@ -145,6 +141,8 @@ spec:
                     value: "nfsstoragered"
                   - name: STORAGE4_ACCESS_MODE
                     value: "ReadWriteMany"
+                  - name: STORAGE4_SIZE
+                    value: "1G"
                   - name: STORAGE4_MATCH_LABEL
                     value: "crunchyzone=red"
                   - name: STORAGE4_TYPE


### PR DESCRIPTION
Values that were included in the postgres-operator.yml file but not operator
configuration options (HOME and ANSIBLE_CFG) are now set in the deploy script.
These settings should not need to be updated by a user.

This change updates values in the pgo-deployer files that were incorrect. This
includes docs, the postgres-operator.yml deployment file, and the
inventory_template.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
[ch8124]