### PR TITLE
Prevent ansible install from failing if resources exist

### DIFF
--- a/deploy/cluster-role-bindings.yaml
+++ b/deploy/cluster-role-bindings.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pgo-cluster-role
+  namespace: "$PGO_OPERATOR_NAMESPACE"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -10,4 +11,4 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: system:serviceaccount:$PGO_OPERATOR_NAMESPACE:postgres-operator
+  name: system:serviceaccount:"$PGO_OPERATOR_NAMESPACE":postgres-operator

--- a/deploy/cluster-role-bindings.yaml
+++ b/deploy/cluster-role-bindings.yaml
@@ -3,12 +3,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pgo-cluster-role
-  namespace: "$PGO_OPERATOR_NAMESPACE"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: pgo-cluster-role
 subjects:
 - apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: system:serviceaccount:"$PGO_OPERATOR_NAMESPACE":postgres-operator
+  kind: ServiceAccount
+  name: postgres-operator
+  namespace: "$PGO_OPERATOR_NAMESPACE"

--- a/deploy/install-rbac.sh
+++ b/deploy/install-rbac.sh
@@ -33,7 +33,7 @@ fi
 $DIR/install-bootstrap-creds.sh
 
 # create the Operator service accounts
-cat $DIR/service-accounts.yaml | envsubst | $PGO_CMD create -f -
+envsubst < $DIR/service-accounts.yaml | $PGO_CMD create -f -
 
 if [ -r "$PGO_IMAGE_PULL_SECRET_MANIFEST" ]; then
 	$PGO_CMD -n $PGO_OPERATOR_NAMESPACE create -f "$PGO_IMAGE_PULL_SECRET_MANIFEST"
@@ -71,23 +71,23 @@ fi
 # namespace in which it is deployed.
 if [[ "${PGO_NAMESPACE_MODE:-dynamic}" == "dynamic" ]]; then
 	# create the full cluster roles for the Operator
-	cat $DIR/cluster-roles.yaml | envsubst | $PGO_CMD create -f -
+	envsubst < $DIR/cluster-roles.yaml | $PGO_CMD create -f -
 	# create the cluster role binding for the Operator Service Account
-	cat $DIR/cluster-role-bindings.yaml | envsubst | $PGO_CMD create -f -
+	envsubst < $DIR/cluster-role-bindings.yaml | $PGO_CMD create -f -
 	echo "Cluster roles installed to enable dynamic namespace capabilities"
 elif [[ "${PGO_NAMESPACE_MODE}" == "readonly" ]]; then
 	# create the read-only cluster roles for the Operator
-	cat $DIR/cluster-roles-readonly.yaml | envsubst | $PGO_CMD create -f -
+	envsubst < $DIR/cluster-roles-readonly.yaml | $PGO_CMD create -f -
 	# create the cluster role binding for the Operator Service Account
-	cat $DIR/cluster-role-bindings.yaml | envsubst | $PGO_CMD create -f -
+	envsubst < $DIR/cluster-role-bindings.yaml | $PGO_CMD create -f -
 	echo "Cluster roles installed to enable read-only namespace capabilities"
 elif [[ "${PGO_NAMESPACE_MODE}" == "disabled" ]]; then
 	echo "Cluster roles not installed, namespace capabilites will be disabled"
 fi
 
 # Create the roles the Operator requires within it's own namespace
-cat $DIR/roles.yaml | envsubst | $PGO_CMD create -f -
-cat $DIR/role-bindings.yaml | envsubst | $PGO_CMD create -f -
+envsubst < $DIR/roles.yaml | $PGO_CMD create -f -
+envsubst < $DIR/role-bindings.yaml | $PGO_CMD create -f -
 
 # create the keys used for pgo API
 source $DIR/gen-api-keys.sh

--- a/deploy/install-rbac.sh
+++ b/deploy/install-rbac.sh
@@ -33,7 +33,7 @@ fi
 $DIR/install-bootstrap-creds.sh
 
 # create the Operator service accounts
-expenv -f $DIR/service-accounts.yaml | $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create -f -
+cat $DIR/service-accounts.yaml | envsubst | $PGO_CMD create -f -
 
 if [ -r "$PGO_IMAGE_PULL_SECRET_MANIFEST" ]; then
 	$PGO_CMD -n $PGO_OPERATOR_NAMESPACE create -f "$PGO_IMAGE_PULL_SECRET_MANIFEST"
@@ -71,23 +71,23 @@ fi
 # namespace in which it is deployed.
 if [[ "${PGO_NAMESPACE_MODE:-dynamic}" == "dynamic" ]]; then
 	# create the full cluster roles for the Operator
-	expenv -f $DIR/cluster-roles.yaml | $PGO_CMD create -f -
+	cat $DIR/cluster-roles.yaml | envsubst | $PGO_CMD create -f -
 	# create the cluster role binding for the Operator Service Account
-	expenv -f $DIR/cluster-role-bindings.yaml | $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create -f -
+	cat $DIR/cluster-role-bindings.yaml | envsubst | $PGO_CMD create -f -
 	echo "Cluster roles installed to enable dynamic namespace capabilities"
 elif [[ "${PGO_NAMESPACE_MODE}" == "readonly" ]]; then
 	# create the read-only cluster roles for the Operator
-	expenv -f $DIR/cluster-roles-readonly.yaml | $PGO_CMD create -f -
+	cat $DIR/cluster-roles-readonly.yaml | envsubst | $PGO_CMD create -f -
 	# create the cluster role binding for the Operator Service Account
-	expenv -f $DIR/cluster-role-bindings.yaml | $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create -f -
+	cat $DIR/cluster-role-bindings.yaml | envsubst | $PGO_CMD create -f -
 	echo "Cluster roles installed to enable read-only namespace capabilities"
 elif [[ "${PGO_NAMESPACE_MODE}" == "disabled" ]]; then
 	echo "Cluster roles not installed, namespace capabilites will be disabled"
 fi
 
 # Create the roles the Operator requires within it's own namespace
-expenv -f $DIR/roles.yaml | $PGO_CMD -n $PGO_OPERATOR_NAMESPACE create -f -
-expenv -f $DIR/role-bindings.yaml | $PGO_CMD -n $PGO_OPERATOR_NAMESPACE create -f -
+cat $DIR/roles.yaml | envsubst | $PGO_CMD create -f -
+cat $DIR/role-bindings.yaml | envsubst | $PGO_CMD create -f -
 
 # create the keys used for pgo API
 source $DIR/gen-api-keys.sh

--- a/deploy/role-bindings.yaml
+++ b/deploy/role-bindings.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pgo-role
+  namespace: "$PGO_OPERATOR_NAMESPACE"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +11,4 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: system:serviceaccount:$PGO_OPERATOR_NAMESPACE:postgres-operator
+  name: system:serviceaccount:"$PGO_OPERATOR_NAMESPACE":postgres-operator

--- a/deploy/role-bindings.yaml
+++ b/deploy/role-bindings.yaml
@@ -10,5 +10,6 @@ roleRef:
   name: pgo-role
 subjects:
 - apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: system:serviceaccount:"$PGO_OPERATOR_NAMESPACE":postgres-operator
+  kind: ServiceAccount
+  name: postgres-operator
+  namespace: "$PGO_OPERATOR_NAMESPACE"

--- a/deploy/roles.yaml
+++ b/deploy/roles.yaml
@@ -3,7 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-role
-  namespace: $PGO_OPERATOR_NAMESPACE
+  namespace: "$PGO_OPERATOR_NAMESPACE"
 rules:
   - apiGroups:
       - ''

--- a/installers/ansible/roles/pgo-operator/tasks/crds.yml
+++ b/installers/ansible/roles/pgo-operator/tasks/crds.yml
@@ -1,64 +1,60 @@
 ---
-- name: Check if PGCluster CRD Is Installed
-  shell: "{{ kubectl_or_oc }} get crd pgclusters.crunchydata.com"
-  register: crds_result
-  ignore_errors: yes
-  no_log: true
+- name: PGCluster CRD
   tags:
     - install
+  block:
+  - name: Check if PGCluster CRD Is Installed
+    shell: "{{ kubectl_or_oc }} get crd pgclusters.crunchydata.com"
+    register: crds_result
+    failed_when: false
 
-- name: Create PGClusters CRD
-  command: "{{ kubectl_or_oc }} create -f {{ role_path }}/files/crds/pgclusters-crd.yaml -n {{ pgo_operator_namespace }}"
-  when: crds_result.rc == 1
-  ignore_errors: no
-  no_log: false
-  tags:
-    - install
+  - name: Create PGClusters CRD
+    command: "{{ kubectl_or_oc }} create -f {{ role_path }}/files/crds/pgclusters-crd.yaml"
+    when: crds_result.rc == 1
+    ignore_errors: no
+    no_log: false
 
-- name: Check if PGPolicies CRD Is Installed
-  shell: "{{ kubectl_or_oc }} get crd pgpolicies.crunchydata.com"
-  register: crds_result
-  ignore_errors: yes
-  no_log: true
+- name: PGPolicies CRD
   tags:
     - install
+  block:
+  - name: Check if PGPolicies CRD Is Installed
+    shell: "{{ kubectl_or_oc }} get crd pgpolicies.crunchydata.com"
+    register: crds_result
+    failed_when: false
 
-- name: Create PGPolicies CRD
-  command: "{{ kubectl_or_oc }} create -f {{ role_path }}/files/crds/pgpolicies-crd.yaml -n {{ pgo_operator_namespace }}"
-  when: crds_result.rc == 1
-  ignore_errors: no
-  no_log: false
-  tags:
-    - install
+  - name: Create PGPolicies CRD
+    command: "{{ kubectl_or_oc }} create -f {{ role_path }}/files/crds/pgpolicies-crd.yaml"
+    when: crds_result.rc == 1
+    ignore_errors: no
+    no_log: false
 
-- name: Check if PGReplicas CRD Is Installed
-  shell: "{{ kubectl_or_oc }} get crd pgreplicas.crunchydata.com"
-  register: crds_result
-  ignore_errors: yes
-  no_log: true
+- name: PGReplicas CRD
   tags:
     - install
+  block:
+  - name: Check if PGReplicas CRD Is Installed
+    shell: "{{ kubectl_or_oc }} get crd pgreplicas.crunchydata.com"
+    register: crds_result
+    failed_when: false
 
-- name: Create PGReplicas CRD
-  command: "{{ kubectl_or_oc }} create -f {{ role_path }}/files/crds/pgreplicas-crd.yaml -n {{ pgo_operator_namespace }}"
-  when: crds_result.rc == 1
-  ignore_errors: no
-  no_log: false
-  tags:
-    - install
+  - name: Create PGReplicas CRD
+    command: "{{ kubectl_or_oc }} create -f {{ role_path }}/files/crds/pgreplicas-crd.yaml"
+    when: crds_result.rc == 1
+    ignore_errors: no
+    no_log: false
 
-- name: Check if PGTasks CRD Is Installed
-  shell: "{{ kubectl_or_oc }} get crd pgtasks.crunchydata.com"
-  register: crds_result
-  ignore_errors: yes
-  no_log: true
+- name: PGTasks CRD
   tags:
     - install
+  block:
+  - name: Check if PGTasks CRD Is Installed
+    shell: "{{ kubectl_or_oc }} get crd pgtasks.crunchydata.com"
+    register: crds_result
+    failed_when: false
 
-- name: Create PGTasks CRD
-  command: "{{ kubectl_or_oc }} create -f {{ role_path }}/files/crds/pgtasks-crd.yaml -n {{ pgo_operator_namespace }}"
-  when: crds_result.rc == 1
-  ignore_errors: no
-  no_log: false
-  tags:
-    - install
+  - name: Create PGTasks CRD
+    command: "{{ kubectl_or_oc }} create -f {{ role_path }}/files/crds/pgtasks-crd.yaml"
+    when: crds_result.rc == 1
+    ignore_errors: no
+    no_log: false

--- a/installers/ansible/roles/pgo-operator/tasks/main.yml
+++ b/installers/ansible/roles/pgo-operator/tasks/main.yml
@@ -292,38 +292,30 @@
     - name: Deploy PGO
       command: |
         {{ kubectl_or_oc }} create --filename='{{ output_dir }}/deployment.json' -n {{ pgo_operator_namespace }}
+    - name: PGO Client
       tags:
         - install
         - update
+      when: pgo_client_install == "true" and kubernetes_in_cluster == "false"
+      block:
+        - name: Download PGO Linux Client
+          become: yes
+          become_method: sudo
+          get_url:
+            url: "{{ pgo_client_url }}/pgo"
+            dest: "/usr/local/bin/pgo"
+            mode: 0755
+            force: yes
+          when: uname_result.stdout == "Linux"
 
-    - name: Download PGO Linux Client
-      become: yes
-      become_method: sudo
-      get_url:
-        url: "{{ pgo_client_url }}/pgo"
-        dest: "/usr/local/bin/pgo"
-        mode: 0755
-        force: yes
-      when: uname_result.stdout == "Linux" and
-            pgo_client_install == "true" and
-            kubernetes_in_cluster == "false"
-      tags:
-        - install
-        - update
-
-    - name: Download PGO MacOS Client
-      become: yes
-      become_method: sudo
-      get_url:
-        url: "{{ pgo_client_url }}/pgo-mac"
-        dest: "/usr/local/bin/pgo"
-        mode: 0755
-      when: uname_result.stdout == "Darwin" and
-            pgo_client_install == "true" and
-            kubernetes_in_cluster == "false"
-      tags:
-        - install
-        - update
+        - name: Download PGO MacOS Client
+          become: yes
+          become_method: sudo
+          get_url:
+            url: "{{ pgo_client_url }}/pgo-mac"
+            dest: "/usr/local/bin/pgo"
+            mode: 0755
+          when: uname_result.stdout == "Darwin"
 
     - name: Wait for PGO to finish deploying
       command: "{{ kubectl_or_oc }} rollout status deployment/postgres-operator -n {{ pgo_operator_namespace }}"

--- a/installers/ansible/roles/pgo-operator/tasks/main.yml
+++ b/installers/ansible/roles/pgo-operator/tasks/main.yml
@@ -171,9 +171,6 @@
 
       - name: Create Cluster RBAC (namespace_mode 'readonly')
         command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/cluster-rbac-readonly.yaml"
-        tags:
-          - install
-          - update
         when: cluster_rbac_readonly_result.rc == 1
 
     - name: Cluster Roles Disabled (namespace_mode 'disabled')
@@ -211,7 +208,6 @@
       tags:
         - install
         - update
-        - test
       when: create_rbac|bool and pgo_cluster_admin|bool
       block:
         - name: Check cluster-admin Cluster Role Binding for PGO Service Account
@@ -223,7 +219,7 @@
           command: |
             {{ kubectl_or_oc }} create clusterrolebinding pgo-cluster-admin \
               --clusterrole cluster-admin \
-              --user system:serviceaccount:{{ pgo_operator_namespace }}:postgres-operator
+              --serviceaccount "{{ pgo_operator_namespace }}:postgres-operator"
           when: pgo_cluster_admin_result.rc == 1
 
 

--- a/installers/ansible/roles/pgo-operator/tasks/main.yml
+++ b/installers/ansible/roles/pgo-operator/tasks/main.yml
@@ -65,96 +65,116 @@
       tags:
         - install
 
-    - name: Template PGO Admin Credentials
-      template:
-        src: pgouser-admin.yaml.j2
-        dest: "{{ output_dir }}/pgouser-admin.yaml"
-        mode: '0600'
+    - name: PGO Admin Credentials
       tags:
         - install
         - update
+      block:
+        - name: Template PGO Admin Credentials
+          template:
+            src: pgouser-admin.yaml.j2
+            dest: "{{ output_dir }}/pgouser-admin.yaml"
+            mode: '0600'
 
-    - name: Create PGO Admin Credentials
-      command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/pgouser-admin.yaml"
-      tags:
-        - install
-        - update
+        - name: Check PGO Admin Credentials
+          shell: "{{ kubectl_or_oc }} get -f {{ output_dir }}/pgouser-admin.yaml"
+          register: pgoadmin_cerds_result
+          failed_when: false
 
-    - name: Template PGO Admin Role & Permissions
-      template:
-        src: pgorole-pgoadmin.yaml.j2
-        dest: "{{ output_dir }}/pgorole-pgoadmin.yaml"
-        mode: '0600'
-      tags:
-        - install
-        - update
+        - name: Create PGO Admin Credentials
+          command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/pgouser-admin.yaml"
+          when: pgoadmin_cerds_result.rc == 1
 
-    - name: Create PGO Admin Role & Permissions
-      command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/pgorole-pgoadmin.yaml"
+    - name: PGO Admin Role & Permissions
       tags:
         - install
         - update
+      block:
+      - name: Template PGO Admin Role & Permissions
+        template:
+          src: pgorole-pgoadmin.yaml.j2
+          dest: "{{ output_dir }}/pgorole-pgoadmin.yaml"
+          mode: '0600'
 
-    - name: Template PGO Service Account
-      template:
-        src: pgo-service-account.yaml.j2
-        dest: "{{ output_dir }}/pgo-service-account.yaml"
-        mode: '0600'
-      tags:
-        - install
-        - update
+      - name: Check PGO Admin Role & Permissions
+        shell: "{{ kubectl_or_oc }} get -f {{ output_dir }}/pgorole-pgoadmin.yaml"
+        register: pgorole_pgoadmin_result
+        failed_when: false
+
+      - name: Create PGO Admin Role & Permissions
+        command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/pgorole-pgoadmin.yaml"
+        when: pgorole_pgoadmin_result.rc == 1
+
+    - name: PGO Service Account
       when: 
         - create_rbac|bool
-
-    - name: Create PGO Service Account
-      command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/pgo-service-account.yaml"
       tags:
         - install
         - update
-      when: 
-        - create_rbac|bool
+      block:
+      - name: Template PGO Service Account
+        template:
+          src: pgo-service-account.yaml.j2
+          dest: "{{ output_dir }}/pgo-service-account.yaml"
+          mode: '0600'
 
-    - name: Template Cluster RBAC (namespace_mode 'dynamic')
-      template:
-        src: cluster-rbac.yaml.j2
-        dest: "{{ output_dir }}/cluster-rbac.yaml"
-        mode: '0600'
-      tags:
-        - install
-        - update
-      when: 
-        - create_rbac|bool
-        - namespace_mode == "dynamic"
+      - name: Check PGO Service Account
+        shell: "{{ kubectl_or_oc }} get -f {{ output_dir }}/pgo-service-account.yaml"
+        register: pgo_service_account_result
+        failed_when: false
 
-    - name: Create Cluster RBAC (namespace_mode 'dynamic')
-      command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/cluster-rbac.yaml"
-      tags:
-        - install
-        - update
+      - name: Create PGO Service Account
+        command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/pgo-service-account.yaml"
+        when: pgo_service_account_result.rc == 1
+
+    - name: Cluster RBAC (namespace_mode 'dynamic')
       when: 
         - create_rbac|bool
         - namespace_mode == "dynamic"
-
-    - name: Template Cluster RBAC (namespace_mode 'readonly')
-      template:
-        src: cluster-rbac-readonly.yaml.j2
-        dest: "{{ output_dir }}/cluster-rbac-readonly.yaml"
-        mode: '0600'
       tags:
         - install
         - update
+      block:
+      - name: Template Cluster RBAC (namespace_mode 'dynamic')
+        template:
+          src: cluster-rbac.yaml.j2
+          dest: "{{ output_dir }}/cluster-rbac.yaml"
+          mode: '0600'
+
+      - name: Check Cluster RBAC (namespace_mode 'dynamic')
+        shell: "{{ kubectl_or_oc }} get -f {{ output_dir }}/cluster-rbac.yaml"
+        register: cluster_rbac_result
+        failed_when: false
+
+      - name: Create Cluster RBAC (namespace_mode 'dynamic')
+        command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/cluster-rbac.yaml"
+        when: cluster_rbac_result.rc == 1
+
+    - name: Cluster RBAC (namespace_mode 'readonly')
       when: 
         - create_rbac|bool
         - namespace_mode == "readonly"
-
-    - name: Create Cluster RBAC (namespace_mode 'readonly')
-      command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/cluster-rbac-readonly.yaml"
       tags:
         - install
         - update
-      when: 
-        - create_rbac|bool
-        - namespace_mode == "readonly"
+      block:
+      - name: Template Cluster RBAC (namespace_mode 'readonly')
+        template:
+          src: cluster-rbac-readonly.yaml.j2
+          dest: "{{ output_dir }}/cluster-rbac-readonly.yaml"
+          mode: '0600'
+
+      - name: Check Cluster RBAC (namespace_mode 'readonly')
+        shell: "{{ kubectl_or_oc }} get -f {{ output_dir }}/cluster-rbac-readonly.yaml"
+        register: cluster_rbac_readonly_result
+        failed_when: false
+
+      - name: Create Cluster RBAC (namespace_mode 'readonly')
+        command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/cluster-rbac-readonly.yaml"
+        tags:
+          - install
+          - update
+        when: cluster_rbac_readonly_result.rc == 1
 
     - name: Cluster Roles Disabled (namespace_mode 'disabled')
       debug:
@@ -187,32 +207,46 @@
         - create_rbac | bool
         - pgo_image_pull_secret_manifest != ''
 
-    - name: Create cluster-admin Cluster Role Binding for PGO Service Account
-      command: |
-        {{ kubectl_or_oc }} create clusterrolebinding pgo-cluster-admin \
-          --clusterrole cluster-admin \
-          --user system:serviceaccount:{{ pgo_operator_namespace }}:postgres-operator
+    - name: ClusterRolebinding for PGO Service Account
+      tags:
+        - install
+        - update
+        - test
       when: create_rbac|bool and pgo_cluster_admin|bool
-      tags:
-        - install
-        - update
+      block:
+        - name: Check cluster-admin Cluster Role Binding for PGO Service Account
+          shell: "{{ kubectl_or_oc }} get clusterrolebinding pgo-cluster-admin"
+          register: pgo_cluster_admin_result
+          failed_when: false
 
-    - name: Template PGO RBAC
-      template:
-        src: pgo-role-rbac.yaml.j2
-        dest: "{{ output_dir }}/pgo-role-rbac.yaml"
-        mode: '0600'
+        - name: Create cluster-admin Cluster Role Binding for PGO Service Account
+          command: |
+            {{ kubectl_or_oc }} create clusterrolebinding pgo-cluster-admin \
+              --clusterrole cluster-admin \
+              --user system:serviceaccount:{{ pgo_operator_namespace }}:postgres-operator
+          when: pgo_cluster_admin_result.rc == 1
+
+
+    - name: PGO RBAC
       tags:
         - install
         - update
       when: create_rbac|bool
+      block:
+      - name: Template PGO RBAC
+        template:
+          src: pgo-role-rbac.yaml.j2
+          dest: "{{ output_dir }}/pgo-role-rbac.yaml"
+          mode: '0600'
 
-    - name: Create PGO RBAC
-      command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/pgo-role-rbac.yaml"
-      tags:
-        - install
-        - update
-      when: create_rbac|bool
+      - name: Check PGO RBAC
+        shell: "{{ kubectl_or_oc }} get -f {{ output_dir }}/pgo-role-rbac.yaml"
+        register: pgo_role_rbac_result
+        failed_when: false
+
+      - name: Create PGO RBAC
+        command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/pgo-role-rbac.yaml"
+        when: pgo_role_rbac_result.rc == 1
 
     - name: Template Local PGO User
       template:
@@ -223,106 +257,139 @@
         - install
         - update
 
-    - name: Template PGO Configuration
-      template:
-        src: pgo.yaml.j2
-        dest: "{{ output_dir }}/pgo.yaml"
-        mode: '0600'
+    - name: PGO BackRest Repo Secret
       tags:
         - install
         - update
-
-    - name: Template PGO Service Configuration
-      template:
-        src: service.json.j2
-        dest: "{{ output_dir }}/service.json"
-        mode: '0600'
-      tags:
-        - install
-        - update
-
-    - name: Create PGO BackRest Repo Secret
-      command: |
-        {{ kubectl_or_oc }} create secret generic pgo-backrest-repo-config \
-          --from-file=config='{{ role_path }}/files/pgo-backrest-repo/config' \
-          --from-file=sshd_config='{{ role_path }}/files/pgo-backrest-repo/sshd_config' \
-          --from-file=aws-s3-ca.crt='{{ role_path }}/files/pgo-backrest-repo/aws-s3-ca.crt' \
-          --from-literal=aws-s3-key='{{ backrest_aws_s3_key }}' \
-          --from-literal=aws-s3-key-secret='{{ backrest_aws_s3_secret }}' \
-          -n {{ pgo_operator_namespace }}
-      tags:
-        - install
-        - update
-
-    - name: Create PGO API Secret
-      command: |
-        {{ kubectl_or_oc }} create secret tls pgo.tls \
-          --cert='{{ output_dir }}/server.crt' \
-          --key='{{ output_dir }}/server.pem' \
-          -n {{ pgo_operator_namespace }}
-      tags:
-        - install
-
-    - name: Create PGO ConfigMap
-      command: |
-        {{ kubectl_or_oc }} create configmap pgo-config \
-          --from-file=pgo.yaml='{{ output_dir }}/pgo.yaml' \
-          --from-file='{{ role_path }}/files/pgo-configs' \
-          -n {{ pgo_operator_namespace }}
-      tags:
-        - install
-        - update
-
-    - name: Create PGO Service
-      command: |
-        {{ kubectl_or_oc }} create --filename='{{ output_dir }}/service.json' -n {{ pgo_operator_namespace }}
-      tags:
-        - install
-        - update
-
-    - name: Template PGO Deployment
-      template:
-        src: deployment.json.j2
-        dest: "{{ output_dir }}/deployment.json"
-        mode: '0600'
-      tags:
-        - install
-        - update
-
-    - name: Deploy PGO
-      command: |
-        {{ kubectl_or_oc }} create --filename='{{ output_dir }}/deployment.json' -n {{ pgo_operator_namespace }}
-    - name: PGO Client
-      tags:
-        - install
-        - update
-      when: pgo_client_install == "true" and kubernetes_in_cluster == "false"
       block:
-        - name: Download PGO Linux Client
-          become: yes
-          become_method: sudo
-          get_url:
-            url: "{{ pgo_client_url }}/pgo"
-            dest: "/usr/local/bin/pgo"
-            mode: 0755
-            force: yes
-          when: uname_result.stdout == "Linux"
+        - name: Check PGO BackRest Repo Secret
+          shell: "{{ kubectl_or_oc }} get secret pgo-backrest-repo-config -n {{ pgo_operator_namespace }}"
+          register: pgo_backrest_repo_config_result
+          failed_when: false
 
-        - name: Download PGO MacOS Client
-          become: yes
-          become_method: sudo
-          get_url:
-            url: "{{ pgo_client_url }}/pgo-mac"
-            dest: "/usr/local/bin/pgo"
-            mode: 0755
-          when: uname_result.stdout == "Darwin"
+        - name: Create PGO BackRest Repo Secret
+          command: |
+            {{ kubectl_or_oc }} create secret generic pgo-backrest-repo-config \
+              --from-file=config='{{ role_path }}/files/pgo-backrest-repo/config' \
+              --from-file=sshd_config='{{ role_path }}/files/pgo-backrest-repo/sshd_config' \
+              --from-file=aws-s3-ca.crt='{{ role_path }}/files/pgo-backrest-repo/aws-s3-ca.crt' \
+              --from-literal=aws-s3-key='{{ backrest_aws_s3_key }}' \
+              --from-literal=aws-s3-key-secret='{{ backrest_aws_s3_secret }}' \
+              -n {{ pgo_operator_namespace }}
+          when: pgo_backrest_repo_config_result.rc == 1
 
-    - name: Wait for PGO to finish deploying
-      command: "{{ kubectl_or_oc }} rollout status deployment/postgres-operator -n {{ pgo_operator_namespace }}"
-      async: 600
+    - name: PGO API Secret
       tags:
         - install
         - update
+      block:
+        - name: Check PGO API Secret
+          shell: "{{ kubectl_or_oc }} get secret pgo.tls -n {{ pgo_operator_namespace }}"
+          register: pgo_tls_result
+          failed_when: false
+
+        - name: Create PGO API Secret
+          command: |
+            {{ kubectl_or_oc }} create secret tls pgo.tls \
+              --cert='{{ output_dir }}/server.crt' \
+              --key='{{ output_dir }}/server.pem' \
+              -n {{ pgo_operator_namespace }}
+          when: pgo_tls_result.rc == 1
+
+    - name: PGO ConfigMap
+      tags:
+        - install
+        - update
+      block:
+        - name: Template PGO Configuration
+          template:
+            src: pgo.yaml.j2
+            dest: "{{ output_dir }}/pgo.yaml"
+            mode: '0600'
+
+        - name: Check PGO ConfigMap
+          shell: "{{ kubectl_or_oc }} get configmap pgo-config -n {{ pgo_operator_namespace }}"
+          register: pgo_config_result
+          failed_when: false
+          
+        - name: Create PGO ConfigMap
+          command: |
+            {{ kubectl_or_oc }} create configmap pgo-config \
+              --from-file=pgo.yaml='{{ output_dir }}/pgo.yaml' \
+              --from-file='{{ role_path }}/files/pgo-configs' \
+              -n {{ pgo_operator_namespace }}
+          when: pgo_config_result.rc == 1
+
+    - name: PGO Service
+      tags:
+        - install
+        - update
+      block:
+        - name: Template PGO Service Configuration
+          template:
+            src: service.json.j2
+            dest: "{{ output_dir }}/service.json"
+            mode: '0600'
+
+        - name: Check PGO Service Configuration
+          shell: "{{ kubectl_or_oc }} get -f {{ output_dir }}/service.json -n {{ pgo_operator_namespace }}"
+          register: service_result
+          failed_when: false
+
+        - name: Create PGO Service
+          command: |
+            {{ kubectl_or_oc }} create --filename='{{ output_dir }}/service.json' -n {{ pgo_operator_namespace }}
+          when: service_result.rc == 1
+
+    - name: PGO Deployment
+      tags:
+        - install
+        - update
+      block:
+        - name: Template PGO Deployment
+          template:
+            src: deployment.json.j2
+            dest: "{{ output_dir }}/deployment.json"
+            mode: '0600'
+
+        - name: Check PGO Deployment
+          shell: "{{ kubectl_or_oc }} get -f {{ output_dir }}/deployment.json -n {{ pgo_operator_namespace }}"
+          register: deployment_json_result
+          failed_when: false
+
+        - name: Deploy PGO
+          command: |
+            {{ kubectl_or_oc }} create --filename='{{ output_dir }}/deployment.json' -n {{ pgo_operator_namespace }}
+          when: deployment_json_result.rc == 1
+
+        - name: Wait for PGO to finish deploying
+          command: "{{ kubectl_or_oc }} rollout status deployment/postgres-operator -n {{ pgo_operator_namespace }}"
+          async: 600
+
+- name: PGO Client
+  tags:
+    - install
+    - update
+  when: pgo_client_install == "true" and kubernetes_in_cluster == "false"
+  block:
+    - name: Download PGO Linux Client
+      become: yes
+      become_method: sudo
+      get_url:
+        url: "{{ pgo_client_url }}/pgo"
+        dest: "/usr/local/bin/pgo"
+        mode: 0755
+        force: yes
+      when: uname_result.stdout == "Linux"
+
+    - name: Download PGO MacOS Client
+      become: yes
+      become_method: sudo
+      get_url:
+        url: "{{ pgo_client_url }}/pgo-mac"
+        dest: "/usr/local/bin/pgo"
+        mode: 0755
+      when: uname_result.stdout == "Darwin"
 
 - name: Deploy PGO-Client Container
   tags:
@@ -335,13 +402,13 @@
         src: pgo-client.json.j2
         dest: "{{ output_dir }}/pgo-client.json"
         mode: '0600'
-      tags:
-        - install
-        - update
 
+    - name: Check PGO-Client Deployment
+      shell: "{{ kubectl_or_oc }} get -f {{ output_dir }}/pgo-client.json"
+      register: pgo_client_json_result
+      failed_when: false
+      
     - name: Create PGO-Client deployment
       command: |
-        {{ kubectl_or_oc }} create --filename='{{ output_dir }}/pgo-client.json' -n {{ pgo_operator_namespace }}
-      tags:
-        - install
-        - update
+        {{ kubectl_or_oc }} create --filename='{{ output_dir }}/pgo-client.json'
+      when: pgo_client_json_result.rc == 1

--- a/installers/ansible/roles/pgo-operator/tasks/main.yml
+++ b/installers/ansible/roles/pgo-operator/tasks/main.yml
@@ -208,7 +208,7 @@
       when: create_rbac|bool
 
     - name: Create PGO RBAC
-      command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/pgo-role-rbac.yaml  -n {{ pgo_operator_namespace }}"
+      command: "{{ kubectl_or_oc }} create -f {{ output_dir }}/pgo-role-rbac.yaml"
       tags:
         - install
         - update

--- a/installers/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
@@ -52,5 +52,6 @@ roleRef:
   name: pgo-cluster-role
 subjects:
 - apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: system:serviceaccount:{{ pgo_operator_namespace }}:postgres-operator
+  kind: ServiceAccount
+  name: postgres-operator
+  namespace: {{ pgo_operator_namespace }}

--- a/installers/ansible/roles/pgo-operator/templates/pgo-client.json.j2
+++ b/installers/ansible/roles/pgo-operator/templates/pgo-client.json.j2
@@ -3,6 +3,7 @@
     "kind": "Deployment",
     "metadata": {
         "name": "pgo-client",
+        "namespace": "{{ pgo_operator_namespace }}",
         "labels": {
             "vendor": "crunchydata"
         }

--- a/installers/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
@@ -21,6 +21,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pgo-role
+  namespace: {{ pgo_operator_namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/installers/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
@@ -28,5 +28,6 @@ roleRef:
   name: pgo-role
 subjects:
 - apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: system:serviceaccount:{{ pgo_operator_namespace }}:postgres-operator
+  kind: ServiceAccount
+  name: postgres-operator
+  namespace: {{ pgo_operator_namespace }}


### PR DESCRIPTION
The ansible install will fail if you run it and the resources that it tries to create already exist. This update adds checks so that if the resources exist, the installer will not attempt to create it. 

In bash some of the resource creation commands were defining the namespace in a yaml file and by using a command line flag. This change removes the flag and updates the environment variable substitution to use envsubst instead of expenv.

**Checklist:**
 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable? tested ansible, bash, and deployer installs. ran e2e on deployer


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
[ch8125]
Fixes #1298