### PR TITLE
Reference v4.3.0 instead of master for PostgreSQL installer file

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Based on your storage settings in your Kubernetes environment, you may be able t
 
 ```shell
 kubectl create namespace pgo
-kubectl apply -f https://raw.githubusercontent.com/CrunchyData/postgres-operator/master/installers/kubectl/postgres-operator.yml
+kubectl apply -f https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.3.0/installers/kubectl/postgres-operator.yml
 ```
 
 Otherwise, we highly recommend following the instructions from our [Quickstart](https://access.crunchydata.com/documentation/postgres-operator/latest/quickstart/).

--- a/docs/content/installation/configuration.md
+++ b/docs/content/installation/configuration.md
@@ -13,7 +13,7 @@ options.
 
 This section lists the options that you can configure to deploy the PostgreSQL
 Operator in your environment. The following list of environmental variables can
-be used in the [`postgres-operator.yml`](https://github.com/CrunchyData/postgres-operator/blob/master/installers/kubectl/postgres-operator.yml)
+be used in the [`postgres-operator.yml`](https://github.com/CrunchyData/postgres-operator/blob/v4.3.0/installers/kubectl/postgres-operator.yml)
 manifest.
 
 ## General Configuration

--- a/docs/content/installation/postgres-operator.md
+++ b/docs/content/installation/postgres-operator.md
@@ -15,7 +15,7 @@ repository:
 
 ```
 kubectl create namespace pgo
-kubectl apply -f https://raw.githubusercontent.com/CrunchyData/postgres-operator/master/installers/kubectl/postgres-operator.yml
+kubectl apply -f https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.3.0/installers/kubectl/postgres-operator.yml
 ```
 
 However, we still advise that you read onward to see how to properly configure
@@ -35,8 +35,8 @@ After configuring the Job template, the installer can be run using
 and takes care of setting up all of the objects required to run the PostgreSQL
 Operator.
 
-The installation manifest, called [`postgres-operator.yaml`](https://github.com/CrunchyData/postgres-operator/blob/master/installers/kubectl/postgres-operator.yml), is available in the [`installers/kubectl/postgres-operator.yml`](https://github.com/CrunchyData/postgres-operator/blob/master/installers/kubectl/postgres-operator.yml)
-path in the PostgreSQL Operator repository
+The installation manifest, called [`postgres-operator.yaml`](https://github.com/CrunchyData/postgres-operator/blob/v4.3.0/installers/kubectl/postgres-operator.yml), is available in the [`installers/kubectl/postgres-operator.yml`](https://github.com/CrunchyData/postgres-operator/blob/v4.3.0/installers/kubectl/postgres-operator.yml)
+path in the PostgreSQL Operator repository.
 
 
 ## Requirements
@@ -111,7 +111,7 @@ PostgreSQL Operator cannot create the RBAC itself.
 ## Configuration - `postgres-operator.yml`
 
 The `postgres-operator.yml` file contains all of the configuration parameters
-for deploying the PostgreSQL Operator. The [example file](https://github.com/CrunchyData/postgres-operator/blob/master/installers/kubectl/postgres-operator.yml)
+for deploying the PostgreSQL Operator. The [example file](https://github.com/CrunchyData/postgres-operator/blob/v4.3.0/installers/kubectl/postgres-operator.yml)
 contains defaults that should work in most Kubernetes environments, but it may
 require some customization.
 

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -27,7 +27,7 @@ If your environment is set up to use hostpath storage (found in things like [min
 
 ```
 kubectl create namespace pgo
-kubectl apply -f https://raw.githubusercontent.com/CrunchyData/postgres-operator/master/installers/kubectl/postgres-operator.yml
+kubectl apply -f https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.3.0/installers/kubectl/postgres-operator.yml
 ```
 
 If not, please read onward: you can still get up and running fairly quickly with just a little bit of configuration.
@@ -39,7 +39,7 @@ If not, please read onward: you can still get up and running fairly quickly with
 You will need to download the PostgreSQL Operator Installer manifest to your environment, which you can do with the following command:
 
 ```
-curl https://raw.githubusercontent.com/CrunchyData/postgres-operator/master/installers/kubectl/postgres-operator.yml > postgres-operator.yml
+curl https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.3.0/installers/kubectl/postgres-operator.yml > postgres-operator.yml
 ```
 
 If you wish to download a specific version of the installer, you can substitute `master` with the version of the tag, i.e.


### PR DESCRIPTION
Changes in "master" could affect people trying to install the
PostgreSQL Operator from defaults and can lead to odd errors. By
referencing an existing tag, the propensity to err decreases.

Issue: [ch8180]
Fixes #1496
Fixes #1507