### PR TITLE
Ensure client-setup.sh does not error on certain existing installs

### DIFF
--- a/installers/kubectl/client-setup.sh
+++ b/installers/kubectl/client-setup.sh
@@ -62,11 +62,16 @@ then
     exit 1
 fi
 
+# there is an "issue" from an older installer where some of the files in the
+# directory are set to "read-only" for the files. This makes it a bit
+# challenging to update. So we need to give these files write permissions
+# if the files don't exist, we can ignore
+chmod u+rw "${OUTPUT_DIR}/pgouser" "${OUTPUT_DIR}/client.crt" "${OUTPUT_DIR}/client.key" 2> /dev/null
+
 # Use the pgouser-admin secret to generate pgouser file
 kubectl get secret -n "${PGO_OPERATOR_NAMESPACE}" "${PGO_USER_ADMIN}" -o 'go-template={{.data.username | base64decode }}:{{.data.password | base64decode}}' > $OUTPUT_DIR/pgouser
 # ensure this file is locked down to the specific user running this
 chmod a-rwx,u+rw "${OUTPUT_DIR}/pgouser"
-
 
 # Use the pgo.tls secret to generate the client cert files
 kubectl get secret -n "${PGO_OPERATOR_NAMESPACE}" pgo.tls -o 'go-template={{ index .data "tls.crt" | base64decode }}' > $OUTPUT_DIR/client.crt


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

An earlier version of the PostgreSQL Operator installer would set
file ownership to 0400 on certain files, which would cause issues with
the current client-setup.sh when it would attempt to overwrite these
files.

**What is the new behavior (if this is a feature change)?**

As the files are owned by the user executing the client setup script,
a solution is to relax the permissions on the files in question to
0600 (which is what they should be in their final form) before
attempting to overwrite them.

**Other information**:

Issue: [ch8076]