### PR TITLE
Manual Upgrade Procedure Documentation Note

### DIFF
--- a/docs/content/Upgrade/manual/_index.md
+++ b/docs/content/Upgrade/manual/_index.md
@@ -9,7 +9,9 @@ weight: 100
 
 In the event that the automated upgrade cannot be used, below are manual upgrade procedures for both PostgreSQL Operator 3.5 and 4.0 releases. These procedures will require action by the Operator administrator of your organization in order to upgrade to the current release of the Operator. Some upgrade steps are still automated within the Operator, but not all are possible with this upgrade method. As such, the pages below show the specific steps required to upgrade different versions of the PostgreSQL Operator depending on your current environment.
 
-In the event that you are performing a manual upgrade, it is recommended to upgrade to the latest PostgreSQL Operator available.
+NOTE: If you are upgrading from Crunchy PostgreSQL Operator version 4.1.0 or later, the [Automated Upgrade Procedure](/upgrade/automatedupgrade) is recommended. If you are upgrading PostgreSQL 12 clusters, you MUST use the [Automated Upgrade Procedure](/upgrade/automatedupgrade). 
+
+When performing a manual upgrade, it is recommended to upgrade to the latest PostgreSQL Operator available.
 
 [Manual Upgrade - PostgreSQL Operator 3.5]( {{< relref "upgrade/manual/upgrade35.md" >}})
 

--- a/docs/content/Upgrade/manual/upgrade4.md
+++ b/docs/content/Upgrade/manual/upgrade4.md
@@ -9,7 +9,7 @@ weight: 8
 
 Below are the procedures for upgrading to version 4.3.0 of the Crunchy PostgreSQL Operator using the Bash or Ansible installation methods. This version of the PostgreSQL Operator has several fundamental changes to the existing PGCluster structure and deployment model. Most notably for those upgrading from 4.1 and below, all PGClusters use the new Crunchy PostgreSQL HA container in place of the previous Crunchy PostgreSQL containers. The use of this new container is a breaking change from previous versions of the Operator did not use the HA containers.
 
-NOTE: If you are upgrading from Crunchy PostgreSQL Operator version 4.1.0 or later, the [Automated Upgrade Procedure](/upgrade/automatedupgrade) is recommended.
+NOTE: If you are upgrading from Crunchy PostgreSQL Operator version 4.1.0 or later, the [Automated Upgrade Procedure](/upgrade/automatedupgrade) is recommended. If you are upgrading PostgreSQL 12 clusters, you MUST use the [Automated Upgrade Procedure](/upgrade/automatedupgrade). 
 
 #### Crunchy PostgreSQL High Availability Containers
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**
A note is added in the manual upgrade index page and in the manual
upgrade page for Postgres Operator 4 upgrades noting that the
automated procedure must be used for Postgres 12 clusters, as well
as emphasizing it is recommended when available, starting with
Postgres Operator version 4.1.0.


**Other information**:
