### PR TITLE
Fix S3-Only Cluster Cloning (4.2 backpatch)

### DIFF
--- a/operator/cluster/clone.go
+++ b/operator/cluster/clone.go
@@ -324,8 +324,11 @@ func cloneStep2(clientset *kubernetes.Clientset, client *rest.RESTClient, namesp
 			},
 		},
 		Spec: crv1.PgclusterSpec{
-			Port:           sourcePgcluster.Spec.Port,
-			PrimaryStorage: sourcePgcluster.Spec.PrimaryStorage,
+			BackrestS3Bucket:   sourcePgcluster.Spec.BackrestS3Bucket,
+			BackrestS3Endpoint: sourcePgcluster.Spec.BackrestS3Endpoint,
+			BackrestS3Region:   sourcePgcluster.Spec.BackrestS3Region,
+			Port:               sourcePgcluster.Spec.Port,
+			PrimaryStorage:     sourcePgcluster.Spec.PrimaryStorage,
 			UserLabels: map[string]string{
 				config.LABEL_BACKREST_STORAGE_TYPE: sourcePgcluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE],
 			},


### PR DESCRIPTION
**NOTE:** This is the 4.2 backpatch for PR https://github.com/CrunchyData/postgres-operator/pull/1514

All AWS S3 environment variables are now properly set on both the `pgBackRest` repo Pod and the `pgBackRest` restore Job when cloning a PGluster.  This ensures the restore is able to complete successfully during the second step of the clone workflow when cloning a cluster that utilizes `s3` storage only with `pgBackRest`.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Cloning a PostgreSQL cluster that utilizes storage type `s3` only fails during the restore step due to unset S3 environment variables.

**What is the new behavior (if this is a feature change)?**

All S3 environment variables are now properly set when cloning a cluster that utilizes storage type `s3` only, ensuring the entire clone process (including the restore step) is able to complete successfully.

**Other information**:

N/A