### PR TITLE
Remove cluster-admin Requirement From Deployer Container & Role Binding Cleanup

### DIFF
--- a/deploy/cluster-role-bindings.yaml
+++ b/deploy/cluster-role-bindings.yaml
@@ -8,7 +8,6 @@ roleRef:
   kind: ClusterRole
   name: pgo-cluster-role
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: postgres-operator
   namespace: "$PGO_OPERATOR_NAMESPACE"

--- a/deploy/role-bindings.yaml
+++ b/deploy/role-bindings.yaml
@@ -9,7 +9,6 @@ roleRef:
   kind: Role
   name: pgo-role
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: postgres-operator
   namespace: "$PGO_OPERATOR_NAMESPACE"

--- a/installers/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
@@ -51,7 +51,6 @@ roleRef:
   kind: ClusterRole
   name: pgo-cluster-role
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: postgres-operator
   namespace: {{ pgo_operator_namespace }}

--- a/installers/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
@@ -27,7 +27,6 @@ roleRef:
   kind: Role
   name: pgo-role
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: postgres-operator
   namespace: {{ pgo_operator_namespace }}

--- a/installers/image/inventory_template
+++ b/installers/image/inventory_template
@@ -304,3 +304,8 @@ prometheus_supplemental_groups=$PROMETHEUS_SUPPLEMENTAL_GROUPS
 delete_operator_namespace='$DELETE_OPERATOR_NAMESPACE'
 delete_watched_namespaces='$DELETE_WATCHED_NAMESPACES'
 delete_metrics_namespace='$DELETE_METRICS_NAMESPACE'
+
+# This is a dummy value for 'pgo_client_version' to prevent the pre-flight check for this variable
+# from failing.  This is harmless since the client will never be installed via the deployer
+# container, so this value will never actually be utilized during the installation.
+pgo_client_version=' '

--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -17,7 +17,14 @@ rules:
       - get
       - list
       - create
+      - patch
       - delete
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - list
   - apiGroups:
       - ''
     resources:
@@ -36,6 +43,14 @@ rules:
     verbs:
       - create
       - delete
+  - apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - delete
+      - patch
   - apiGroups:
       - apps
     resources:

--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -53,6 +53,7 @@ rules:
       - patch
   - apiGroups:
       - apps
+      - extensions
     resources:
       - deployments
     verbs:

--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -4,19 +4,102 @@ metadata:
     name: pgo-deployer-sa
     namespace: pgo
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pgo-deployer-cr
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - services
+      - serviceaccounts
+      - persistentvolumeclaims
+    verbs:
+      - create
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+      - roles
+      - rolebindings
+    verbs:
+      - create
+      - delete
+      - bind
+      - escalate
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - create
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - delete
+  - apiGroups:
+      - crunchydata.com
+    resources:
+      - pgclusters
+      - pgreplicas
+      - pgpolicies
+      - pgtasks
+    verbs:
+      - delete
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     name: pgo-deployer-crb
-    namespace: pgo
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: cluster-admin
+    name: pgo-deployer-cr
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: system:serviceaccount:pgo:pgo-deployer-sa
+- kind: ServiceAccount
+  name: pgo-deployer-sa
+  namespace: pgo
 ---
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
This commit creates a new `ClusterRole` specifically for use by the `pgo-deployer-sa` `ServiceAccount`.  With this new role all privileges required for the deployer container to successfully perform a PostgreSQL Operator installation are now explicitly defined in the `pgo deployer-cr` `ClusterRole` (which is located in the `postgres-operator.yaml` specification). This means the deployer container, and therefore installing via `kubectl`, no longer requires the use of `cluster-admin`.

Also, various `ClusterRoleBindings`/`RoleBindings` that were recently updated to use `kind: ServiceAccount` have been updated to remove the `apiGroup`, ensuring the bindings can be successfully created.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The deployer container `ServiceAccount` utilizes the `cluster-admin` `ClusterRole`.

[ch8182]

**What is the new behavior (if this is a feature change)?**

The deployer container `ServiceAccount` utilizes it's own `ClusterRole` containing only those privileges required to perform the install (there removing the need to use `cluster-admin`).

**Other information**:

Fixes #1492