### PR TITLE
Cluster QoS Guarnatees with Collect / pgBadger sidecar

### DIFF
--- a/conf/postgres-operator/collect.json
+++ b/conf/postgres-operator/collect.json
@@ -31,6 +31,12 @@
             "value": "{{.ExporterPort}}"
         }
     ],
+    "resources": {
+      "limits": {
+        "cpu": "100m",
+        "memory": "24Mi"
+      }
+    },
     "volumeMounts": [
         {
             "mountPath": "/collect-pguser",

--- a/conf/postgres-operator/pgbadger.json
+++ b/conf/postgres-operator/pgbadger.json
@@ -20,6 +20,12 @@
                     "name": "PGBADGER_SERVICE_PORT",
                     "value": "{{.PGBadgerPort}}"
                 } ],
+                "resources": {
+                  "limits": {
+                    "cpu": "500m",
+                    "memory": "24Mi"
+                  }
+                },
                 "volumeMounts": [
                     {
                         "mountPath": "/pgdata",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/collect.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/collect.json
@@ -31,6 +31,12 @@
             "value": "{{.ExporterPort}}"
         }
     ],
+    "resources": {
+      "limits": {
+        "cpu": "100m",
+        "memory": "24Mi"
+      }
+    },
     "volumeMounts": [
         {
             "mountPath": "/collect-pguser",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbadger.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbadger.json
@@ -20,6 +20,12 @@
                     "name": "PGBADGER_SERVICE_PORT",
                     "value": "{{.PGBadgerPort}}"
                 } ],
+                "resources": {
+                  "limits": {
+                    "cpu": "500m",
+                    "memory": "24Mi"
+                  }
+                },
                 "volumeMounts": [
                     {
                         "mountPath": "/pgdata",


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

While it is possible to deploy a PostgreSQL cluster with a guaranteed
Pod QoS, adding in a metrics or pgbadger sidecar would cause the QoS to be changed
to burstable.

**What is the new behavior (if this is a feature change)?**

Presently, this changes the collect + pgbadger template files to have sane default limits for their respective sidecars. People can modify the existing templates if they wish to change the values.

Issue: [ch8253]
Fixes #1526 