### PR TITLE
Dynamic RBAC in Deployer Container & Update Priv for ServiceAccounts in Ansible Installer

### DIFF
--- a/installers/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
@@ -22,6 +22,7 @@ rules:
     verbs:
     - get
     - create
+    - update
     - delete
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/installers/image/inventory_template
+++ b/installers/image/inventory_template
@@ -34,6 +34,22 @@ create_rbac='$CREATE_RBAC'
 # ==================
 namespace_mode='$NAMESPACE_MODE'
 
+# Dynamic RBAC
+# ==================
+# Note: this setting is only applicable if 'namespace_mode' is set to
+# 'readonly' or 'disabled'.
+#
+# When creating target namespaces during installation, this setting
+# determines what RBAC is created within the target namespace.  If set to
+# 'true', the RBAC created in those namespaces will allow the PostgreSQL
+# Operator itself to create the ServiceAccounts, Roles and RoleBindings
+# it requires to create PG clusters.  If set to 'false' (the default), 
+# the installer will instead create the ServiceAccounts, Roles and
+# RoleBindings), and the PostgreSQL Operator will not be granted the
+# ability to create the RBAC it requires within those namespaces.
+# ==================
+dynamic_rbac='$DYNAMIC_RBAC'
+
 # ===================
 # PGO Client Container Settings
 # The following settings configure the deployment of a PGO Client Container

--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -172,6 +172,8 @@ spec:
                     value: "false"
                   - name: DISABLE_FSGROUP
                     value: "false"
+                  - name: DYNAMIC_RBAC
+                    value: "false"
                   - name: EXPORTERPORT
                     value: "9187"
                   - name: METRICS


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- `dynamic_rbac` RBAC is missing from `inventory_template` for the deployer container, and the associated `DYNAMIC_RBAC` is missing from the Job spec in `postgres-operator.yml`
- The `update` priv  for ServiceAccounts is missing from 'pgo-cluster-role' in the Ansible installer

**What is the new behavior (if this is a feature change)?**

- `dynamic_rbac` RBAC is inlcluded  in `inventory_template` for the deployer container, and the associated `DYNAMIC_RBAC` is included in the Job spec in `postgres-operator.yml`
- The `update` priv  for ServiceAccounts is included in 'pgo-cluster-role' in the Ansible installer.

**Other information**:

N/A