### PR TITLE
Update User Permitted in Namespace Logic

### DIFF
--- a/apiserver/namespaceservice/namespaceimpl.go
+++ b/apiserver/namespaceservice/namespaceimpl.go
@@ -72,7 +72,7 @@ func ShowNamespace(clientset *kubernetes.Clientset, username string, request *ms
 		if err != nil {
 			resp.Status.Code = msgs.Error
 			resp.Status.Msg = fmt.Sprintf("Error when determining whether user [%s] is allowed "+
-				"access to namespace [%s]: %w", username, nsList[i], err)
+				"access to namespace [%s]: %s", username, nsList[i], err.Error())
 			return resp
 		}
 		r := msgs.NamespaceResult{


### PR DESCRIPTION
With this change the "user permitted in namespace" logic now properly indicates what namespaces a user is allowed to access and which they can't (i.e. because the install doesn't have access to that namespace, or the user themselves does not have permissions to access that namespace). Therefore, commands like `pgo show namespace` now return the proper results.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- The logic to determine whether or not a user can access a namespace is invalid

**What is the new behavior (if this is a feature change)?**

- The logic to determine whether or not a user can access a namespace now returns the proper results

**Other information**:

N/A