### PR TITLE
Update RBAC Reconcile Order & Fix RBAC "does not exist" Logs (4.3 backpatch)

### DIFF
--- a/ns/nslogic.go
+++ b/ns/nslogic.go
@@ -337,7 +337,7 @@ func reconcileRoles(clientset *kubernetes.Clientset, targetNamespace string) err
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				log.Debugf("Role %s in namespace %s does not exist and will be created",
-					currRole.Name, targetNamespace)
+					role, targetNamespace)
 				createRole = true
 			} else {
 				errs = append(errs, err.Error())
@@ -408,7 +408,7 @@ func reconcileRoleBindings(clientset *kubernetes.Clientset, pgoNamespace,
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				log.Debugf("RoleBinding %s in namespace %s does not exist and will be created",
-					currRoleBinding.Name, targetNamespace)
+					roleBinding, targetNamespace)
 				createRoleBinding = true
 			} else {
 				errs = append(errs, err.Error())
@@ -489,7 +489,7 @@ func reconcileServiceAccounts(clientset *kubernetes.Clientset, targetNamespace s
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				log.Debugf("ServiceAccount %s in namespace %s does not exist and will be created",
-					currServiceAccount.Name, targetNamespace)
+					serviceAccount, targetNamespace)
 				createServiceAccount = true
 			} else {
 				errs = append(errs, err.Error())

--- a/ns/nslogic.go
+++ b/ns/nslogic.go
@@ -280,6 +280,13 @@ func ReconcileTargetRBAC(clientset *kubernetes.Clientset, pgoNamespace,
 		errs = append(errs, err.Error())
 	}
 
+	if err := reconcileRoles(clientset, targetNamespace); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := reconcileRoleBindings(clientset, pgoNamespace, targetNamespace); err != nil {
+		errs = append(errs, err.Error())
+	}
+
 	// If a SA was created or updated, or if it doesnt exist, ensure the image pull secrets
 	// are up to date
 	for _, reference := range operator.ImagePullSecrets {
@@ -302,13 +309,6 @@ func ReconcileTargetRBAC(clientset *kubernetes.Clientset, pgoNamespace,
 				errs = append(errs, err.Error())
 			}
 		}
-	}
-
-	if err := reconcileRoles(clientset, targetNamespace); err != nil {
-		errs = append(errs, err.Error())
-	}
-	if err := reconcileRoleBindings(clientset, pgoNamespace, targetNamespace); err != nil {
-		errs = append(errs, err.Error())
 	}
 
 	if len(errs) > 0 {


### PR DESCRIPTION
This is a 4.3 backpatch for https://github.com/CrunchyData/postgres-operator/pull/1548.