### PR TITLE
Fix Target Namespace Default in Bash for Dynamic RBAC

### DIFF
--- a/deploy/setupnamespaces.sh
+++ b/deploy/setupnamespaces.sh
@@ -45,7 +45,7 @@ IFS=', ' read -r -a array <<< "$NAMESPACE"
 if [ ${#array[@]} -eq 0 ]
 then
     echo "NAMESPACE is empty, updating Operator namespace ${PGO_OPERATOR_NAMESPACE}"
-    $PGOROOT/deploy/add-targeted-namespace.sh ${PGO_OPERATOR_NAMESPACE} > /dev/null
+    array=("${PGO_OPERATOR_NAMESPACE}")
 fi
 
 if [[ "${PGO_NAMESPACE_MODE:-dynamic}" != "dynamic" ]]


### PR DESCRIPTION
When using "dynamic rbac" without any namespace specified for the `NAMESPACE` env var (i.e. for a Bash install), the `add-targeted-namespace-dynamic-rbac.sh` script is now run in the Operator namespace instead of `add-targeted-namespace.sh`.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- `add-targeted-namespace.sh` is always run when no namespaces are specified via the `NAMESPACE` env var for a bash install

**What is the new behavior (if this is a feature change)?**

- If `PGO_DYNAMIC_RBAC=true`, `add-targeted-namespace-dynamic-rbac.sh` is run when no namespaces are specified via the `NAMESPACE` env var for a bash install

**Other information**:

N/A