### PR TITLE
Change Restart Policy in Backrest Job Template to "Never"

### DIFF
--- a/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
+++ b/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
@@ -75,7 +75,7 @@
                         }
                     }]
                 }],
-                "restartPolicy": "OnFailure"
+                "restartPolicy": "Never"
             }
         }
     }

--- a/conf/postgres-operator/backrest-job.json
+++ b/conf/postgres-operator/backrest-job.json
@@ -75,7 +75,7 @@
                         }
                     }]
                 }],
-                "restartPolicy": "OnFailure"
+                "restartPolicy": "Never"
             }
         }
     }


### PR DESCRIPTION
The `restartPolicy` in the pgBackRest job template (`backrest-job.json`) has been updated in both the Bash and Ansible installers from `OnFailure` to `Never`.  This aligns the restart policy for pgBackRest jobs with all other jobs created by the Operator, while also ensuring the Job is properly run when using older versions of Kubernetes (e.g. OCP 3.11).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `restartPolicy` in the pgBackRest job template (`backrest-job.json`) is `OnFailure`.

**What is the new behavior (if this is a feature change)?**

The `restartPolicy` in the pgBackRest job template (`backrest-job.json`) is `Never`.

**Other information**:

N/A