### PR TITLE
Feature add security context

### DIFF
--- a/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -25,7 +25,7 @@
             "spec": {
                 "securityContext" : {
                   "runAsUser": "1001"
-                }
+                },
                    
                 "serviceAccountName": "postgres-operator",
                 "containers": [

--- a/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -23,6 +23,10 @@
                 }
             },
             "spec": {
+                "securityContext" : {
+                  "runAsUser": "1001"
+                }
+                   
                 "serviceAccountName": "postgres-operator",
                 "containers": [
                     {


### PR DESCRIPTION
Add a securityContext to pgo-operator deployment. It's necessary if you run operator on a K8S cluster with PodSecuritPolicy set with RunAsNonRoot activate

 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
not necessary
 - [X] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)




**Other information**:
