### PR TITLE
Deployer Container Updates & Enhancements

### DIFF
--- a/bin/uid_daemon.sh
+++ b/bin/uid_daemon.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Copyright 2020 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if ! whoami &> /dev/null
+then
+    if [[ -w /etc/passwd ]]
+    then
+        sed  "/daemon:x:2:/d" /etc/passwd >> /tmp/uid.tmp
+        cp /tmp/uid.tmp /etc/passwd
+        rm -f /tmp/uid.tmp
+        echo "${USER_NAME:-daemon}:x:$(id -u):0:${USER_NAME:-daemon} user:${HOME}:/bin/bash" >> /etc/passwd
+    fi
+fi
+exec "$@"

--- a/bin/uid_daemon.sh
+++ b/bin/uid_daemon.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/bash
 
 # Copyright 2020 Crunchy Data Solutions, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/centos7/Dockerfile.pgo-deployer.centos7
+++ b/centos7/Dockerfile.pgo-deployer.centos7
@@ -16,8 +16,16 @@ RUN yum -y install epel-release \
     which \
     gettext
 
-USER daemon
-
 COPY installers/ansible /ansible
 COPY installers/image/bin/pgo-deploy.sh /pgo-deploy.sh
 COPY installers/image/inventory_template /inventory_template
+COPY bin/uid_daemon.sh /uid_daemon.sh
+
+RUN chmod g=u /etc/passwd
+RUN chmod g=u /uid_daemon.sh
+
+ENTRYPOINT ["/uid_daemon.sh"]
+
+USER daemon
+
+CMD ["/pgo-deploy.sh"]

--- a/centos7/Dockerfile.pgo-deployer.centos7
+++ b/centos7/Dockerfile.pgo-deployer.centos7
@@ -26,6 +26,6 @@ RUN chmod g=u /uid_daemon.sh
 
 ENTRYPOINT ["/uid_daemon.sh"]
 
-USER daemon
+USER 2
 
 CMD ["/pgo-deploy.sh"]

--- a/installers/kubectl/postgres-operator-ocp311.yml
+++ b/installers/kubectl/postgres-operator-ocp311.yml
@@ -1,0 +1,205 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: pgo-deployer-sa
+    namespace: pgo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: pgo-deployer-crb
+    namespace: pgo
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:serviceaccount:pgo:pgo-deployer-sa
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: pgo-deploy
+    namespace: pgo
+spec:
+    backoffLimit: 0
+    template:
+        metadata:
+            name: pgo-deploy
+        spec:
+            serviceAccountName: pgo-deployer-sa
+            restartPolicy: Never
+            containers:
+            - name: pgo-deploy
+              command: ["/pgo-deploy.sh"]
+              image: registry.developers.crunchydata.com/crunchydata/pgo-deployer:centos7-4.3.1
+              imagePullPolicy: IfNotPresent
+              env:
+                  - name: ARCHIVE_MODE
+                    value: "true"
+                  - name: ARCHIVE_TIMEOUT
+                    value: "60"
+                  - name: BACKREST
+                    value: "true"
+                  - name: BADGER
+                    value: "false"
+                  - name: CRUNCHY_DEBUG
+                    value: "false"
+                  - name: CREATE_RBAC
+                    value: "true"
+                  - name: CCP_IMAGE_PREFIX
+                    value: "registry.developers.crunchydata.com/crunchydata"
+                  - name: CCP_IMAGE_TAG
+                    value: "centos7-12.3-4.3.1"
+                  - name: DB_PASSWORD_LENGTH
+                    value: "24"
+                  - name: DB_PORT
+                    value: "5432"
+                  - name: DB_REPLICAS
+                    value: "0"
+                  - name: DB_USER
+                    value: "testuser"
+                  - name: DEFAULT_INSTANCE_MEMORY
+                    value: "128Mi"
+                  - name: DEFAULT_PGBACKREST_MEMORY
+                    value: ""
+                  - name: DEFAULT_PGBOUNCER_MEMORY
+                    value: ""
+                  - name: DEPLOY_ACTION
+                    value: "install"
+                  - name: DISABLE_AUTO_FAILOVER
+                    value: "false"
+                  - name: DISABLE_FSGROUP
+                    value: "true"
+                  - name: DYNAMIC_RBAC
+                    value: "false"
+                  - name: EXPORTERPORT
+                    value: "9187"
+                  - name: METRICS
+                    value: "false"
+                  - name: NAMESPACE
+                    value: "pgo"
+                  - name: NAMESPACE_MODE
+                    value: "readonly"
+                  - name: PGBADGERPORT
+                    value: "10000"
+                  - name: PGO_ADMIN_PASSWORD
+                    value: "password"
+                  - name: PGO_ADMIN_PERMS
+                    value: "*"
+                  - name: PGO_ADMIN_ROLE_NAME
+                    value: "pgoadmin"
+                  - name: PGO_ADMIN_USERNAME
+                    value: "admin"
+                  - name: PGO_CLIENT_VERSION
+                    value: "v4.3.1"
+                  - name: PGO_IMAGE_PREFIX
+                    value: "registry.developers.crunchydata.com/crunchydata"
+                  - name: PGO_IMAGE_TAG
+                    value: "centos7-4.3.1"
+                  - name: PGO_INSTALLATION_NAME
+                    value: "devtest"
+                  - name: PGO_OPERATOR_NAMESPACE
+                    value: "pgo"
+                  - name: SCHEDULER_TIMEOUT
+                    value: "3600"
+                  - name: BACKREST_STORAGE
+                    value: "hostpathstorage"
+                  - name: BACKUP_STORAGE
+                    value: "hostpathstorage"
+                  - name: PRIMARY_STORAGE
+                    value: "hostpathstorage"
+                  - name: REPLICA_STORAGE
+                    value: "hostpathstorage"
+                  - name: WAL_STORAGE
+                    value: ""
+                  - name: STORAGE1_NAME
+                    value: "hostpathstorage"
+                  - name: STORAGE1_ACCESS_MODE
+                    value: "ReadWriteMany"
+                  - name: STORAGE1_SIZE
+                    value: "1G"
+                  - name: STORAGE1_TYPE
+                    value: "create"
+                  - name: STORAGE2_NAME
+                    value: "replicastorage"
+                  - name: STORAGE2_ACCESS_MODE
+                    value: "ReadWriteMany"
+                  - name: STORAGE2_SIZE
+                    value: "700M"
+                  - name: STORAGE2_TYPE
+                    value: "create"
+                  - name: STORAGE3_NAME
+                    value: "nfsstorage"
+                  - name: STORAGE3_ACCESS_MODE
+                    value: "ReadWriteMany"
+                  - name: STORAGE3_SIZE
+                    value: "1G"
+                  - name: STORAGE3_TYPE
+                    value: "create"
+                  - name: STORAGE3_SUPPLEMENTAL_GROUPS
+                    value: "65534"
+                  - name: STORAGE4_NAME
+                    value: "nfsstoragered"
+                  - name: STORAGE4_ACCESS_MODE
+                    value: "ReadWriteMany"
+                  - name: STORAGE4_SIZE
+                    value: "1G"
+                  - name: STORAGE4_MATCH_LABEL
+                    value: "crunchyzone=red"
+                  - name: STORAGE4_TYPE
+                    value: "create"
+                  - name: STORAGE4_SUPPLEMENTAL_GROUPS
+                    value: "65534"
+                  - name: STORAGE5_NAME
+                    value: "storageos"
+                  - name: STORAGE5_ACCESS_MODE
+                    value: "ReadWriteOnce"
+                  - name: STORAGE5_SIZE
+                    value: "5Gi"
+                  - name: STORAGE5_TYPE
+                    value: "dynamic"
+                  - name: STORAGE5_CLASS
+                    value: "fast"
+                  - name: STORAGE6_NAME
+                    value: "primarysite"
+                  - name: STORAGE6_ACCESS_MODE
+                    value: "ReadWriteOnce"
+                  - name: STORAGE6_SIZE
+                    value: "4G"
+                  - name: STORAGE6_TYPE
+                    value: "dynamic"
+                  - name: STORAGE6_CLASS
+                    value: "primarysite"
+                  - name: STORAGE7_NAME
+                    value: "alternatesite"
+                  - name: STORAGE7_ACCESS_MODE
+                    value: "ReadWriteOnce"
+                  - name: STORAGE7_SIZE
+                    value: "4G"
+                  - name: STORAGE7_TYPE
+                    value: "dynamic"
+                  - name: STORAGE7_CLASS
+                    value: "alternatesite"
+                  - name: STORAGE8_NAME
+                    value: "gce"
+                  - name: STORAGE8_ACCESS
+                    value: "ReadWriteOnce"
+                  - name: STORAGE8_SIZE
+                    value: "300M"
+                  - name: STORAGE8_TYPE
+                    value: "dynamic"
+                  - name: STORAGE8_CLASS
+                    value: "standard"
+                  - name: STORAGE9_NAME
+                    value: "rook"
+                  - name: STORAGE9_ACCESS_MODE
+                    value: "ReadWriteOnce"
+                  - name: STORAGE9_SIZE
+                    value: "1Gi"
+                  - name: STORAGE9_TYPE
+                    value: "dynamic"
+                  - name: STORAGE9_CLASS
+                    value: "rook-ceph-block"

--- a/installers/kubectl/postgres-operator-ocp311.yml
+++ b/installers/kubectl/postgres-operator-ocp311.yml
@@ -14,9 +14,9 @@ roleRef:
     kind: ClusterRole
     name: cluster-admin
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: system:serviceaccount:pgo:pgo-deployer-sa
+- kind: ServiceAccount
+  name: pgo-deployer-sa
+  namespace: pgo
 ---
 apiVersion: batch/v1
 kind: Job

--- a/installers/kubectl/postgres-operator-ocp311.yml
+++ b/installers/kubectl/postgres-operator-ocp311.yml
@@ -33,7 +33,6 @@ spec:
             restartPolicy: Never
             containers:
             - name: pgo-deploy
-              command: ["/pgo-deploy.sh"]
               image: registry.developers.crunchydata.com/crunchydata/pgo-deployer:centos7-4.3.1
               imagePullPolicy: IfNotPresent
               env:

--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -134,7 +134,6 @@ spec:
             restartPolicy: Never
             containers:
             - name: pgo-deploy
-              command: ["/pgo-deploy.sh"]
               image: registry.developers.crunchydata.com/crunchydata/pgo-deployer:centos7-4.3.1
               imagePullPolicy: IfNotPresent
               env:

--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -38,9 +38,9 @@ rules:
     resources:
       - configmaps
       - services
-      - serviceaccounts
       - persistentvolumeclaims
     verbs:
+      - get
       - create
       - delete
   - apiGroups:
@@ -48,6 +48,7 @@ rules:
     resources:
       - serviceaccounts
     verbs:
+      - get
       - create
       - delete
       - patch
@@ -77,6 +78,7 @@ rules:
       - roles
       - rolebindings
     verbs:
+      - get
       - create
       - delete
       - bind

--- a/rhel7/Dockerfile.pgo-deployer.rhel7
+++ b/rhel7/Dockerfile.pgo-deployer.rhel7
@@ -16,8 +16,16 @@ RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-late
     which \
     gettext
 
-USER daemon
-
 COPY installers/ansible /ansible
 COPY installers/image/bin/pgo-deploy.sh /pgo-deploy.sh
 COPY installers/image/inventory_template /inventory_template
+COPY bin/uid_daemon.sh /uid_daemon.sh
+
+RUN chmod g=u /etc/passwd
+RUN chmod g=u /uid_daemon.sh
+
+ENTRYPOINT ["/uid_daemon.sh"]
+
+USER daemon
+
+CMD ["/pgo-deploy.sh"]

--- a/rhel7/Dockerfile.pgo-deployer.rhel7
+++ b/rhel7/Dockerfile.pgo-deployer.rhel7
@@ -10,8 +10,8 @@ LABEL name="pgo-deployer" \
 RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
  && yum -y install \
     --setopt=skip_missing_names_on_install=False \
-    --enablerepo='rhel-7-server-ose-3.11-rpms' \
-    atomic-openshift-clients \
+    --enablerepo='rhel-7-server-ose-4.4-rpms' \
+    openshift-clients \
     ansible \
     which \
     gettext

--- a/rhel7/Dockerfile.pgo-deployer.rhel7
+++ b/rhel7/Dockerfile.pgo-deployer.rhel7
@@ -26,6 +26,6 @@ RUN chmod g=u /uid_daemon.sh
 
 ENTRYPOINT ["/uid_daemon.sh"]
 
-USER daemon
+USER 2
 
 CMD ["/pgo-deploy.sh"]


### PR DESCRIPTION
The `pgo-deployer-cr` ClusterRole has now been assigned additional `get` privileges as required to determine whether or not certain resources already exist prior to attempting to create them.

The Dockerfile for the pgo-deployer container has also been updated to install the latest version of the OpenShift client (v4.4).  This includes enabling the  'rhel-7-server-ose-4.4-rpms' repo as needed to install the latest client.

Additionally, this commit creates a spec specifically for use by OpenShift 3.11 users when installing via the `kubectl` install method.  This spec binds the `pgo-deployer-sa` ServiceAccount to the `cluster-admin` role as needed to ensure the deployer can create any RBAC required by the Operator.  This specifically works around a defect in OCP 3.11 in which the Operator is unable to create roles it does not currently have (specifically due to a deficiency with the `escalate` verb for roles).

Being that this is an OpenShift specific deployment, a few defaults have been changed from the standard `postgresql-operator.yaml`. Specifically, `DISABLE_FSGROUPS` is set to `true` as required to run within the `restricted` SCC on OpenShift, and `NAMESPACE_MODE` has been set to `readonly` since `dynamic` is unable to work properly in OCP 3.11 due to the same known `escalate` issue.

And finally, the deployer container is now able to run as an arbitrary UID in an OpenShift environment.  This ensures that the deployer is able to run properly using the `restricted` SCC.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- The deployer SA is not assigned all required `get` privileges in `postgresql-operator.yml` as required to run the `install` tag back-to-back
- OpenShift clients `v3.11` are installed
- The `postgresql-operator.yml` spec can not be used with OpenShift due to a deficiency with the `escalate` verb for roles
- The deployer container is unable to run with an arbitrary UID

**What is the new behavior (if this is a feature change)?**

- The deployer SA is  assigned all required `get` privileges in `postgresql-operator.yml`, allowing the `install` tag to be run back-to-back
- OpenShift clients `v4.4` are installed
- A new `postgresql-operator-ocp311.yml` file has been created for OCP 3.11 users, which uses the `cluster-admin` role for deployment of the Operator in order to workaround the known issue with the `escalate` verb
-  The deployer container is able to run with an arbitrary UID

**Other information**:

N/A