### PR TITLE
Improved `client_setup.sh` script performance in case of failure

### DIFF
--- a/installers/kubectl/client-setup.sh
+++ b/installers/kubectl/client-setup.sh
@@ -39,7 +39,7 @@ install -d -m a-rwx,u+rwx "${OUTPUT_DIR}"
 
 echo "Operating System found is ${UNAME_RESULT}. Downloading ${BIN_NAME} client binary..."
 
-curl -Lo "${OUTPUT_DIR}/pgo" "${PGO_CLIENT_URL}/${BIN_NAME}"
+curl -C - -Lo "${OUTPUT_DIR}/pgo" "${PGO_CLIENT_URL}/${BIN_NAME}"
 chmod +x "${OUTPUT_DIR}/pgo"
 
 


### PR DESCRIPTION
Improved script performance in case of failure by skipping the download of the client binary  if already downloaded or alternatively resuming an interrupted download.

```txt
$ man curl

    ...

-C, --continue-at <offset>
      Continue/Resume a previous file transfer at the given offset. The given offset is the exact number of bytes that will be skipped, counting from the beginning of the source file before  it  is
      transferred to the destination.  If used with uploads, the FTP server command SIZE will not be used by curl.

      Use "-C -" to tell curl to automatically find out where/how to resume the transfer. It then uses the given output/input files to figure that out.

      If this option is used several times, the last one will be used.

      See also -r, --range.
```

 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)