### PR TITLE
Use numeric UID in container images

### DIFF
--- a/centos7/Dockerfile.pgo-apiserver.centos7
+++ b/centos7/Dockerfile.pgo-apiserver.centos7
@@ -16,6 +16,6 @@ RUN yum -y install postgresql${PGVERSION} hostname && yum -y clean all
 ADD bin/apiserver /usr/local/bin
 ADD conf/postgres-operator /default-pgo-config
 
-USER daemon
+USER 2
 
 ENTRYPOINT ["/usr/local/bin/apiserver"]

--- a/centos7/Dockerfile.pgo-client.centos7
+++ b/centos7/Dockerfile.pgo-client.centos7
@@ -20,6 +20,6 @@ ENV PGO_CLIENT_KEY=${PGO_CLIENT_KEY}
 
 RUN chmod +x /usr/local/bin/pgo
 
-USER daemon
+USER 2
 
 CMD tail -f /dev/null

--- a/centos7/Dockerfile.pgo-event.centos7
+++ b/centos7/Dockerfile.pgo-event.centos7
@@ -11,6 +11,6 @@ LABEL name="pgo-event" \
 
 ADD bin/pgo-event /usr/local/bin
 
-USER daemon
+USER 2
 
 ENTRYPOINT ["/usr/local/bin/pgo-event.sh"]

--- a/centos7/Dockerfile.postgres-operator.centos7
+++ b/centos7/Dockerfile.postgres-operator.centos7
@@ -14,6 +14,6 @@ RUN yum -y install hostname postgresql${PGVERSION}  && yum -y clean all
 ADD bin/postgres-operator /usr/local/bin
 ADD conf/postgres-operator /default-pgo-config
 
-USER daemon
+USER 2
 
 ENTRYPOINT ["postgres-operator"]

--- a/rhel7/Dockerfile.pgo-apiserver.rhel7
+++ b/rhel7/Dockerfile.pgo-apiserver.rhel7
@@ -18,6 +18,6 @@ RUN yum -y install \
 ADD bin/apiserver /usr/local/bin
 ADD conf/postgres-operator /default-pgo-config
 
-USER daemon
+USER 2
 
 ENTRYPOINT ["/usr/local/bin/apiserver"]

--- a/rhel7/Dockerfile.pgo-client.rhel7
+++ b/rhel7/Dockerfile.pgo-client.rhel7
@@ -20,6 +20,6 @@ ENV PGO_CLIENT_KEY=${PGO_CLIENT_KEY}
 
 RUN chmod +x /usr/local/bin/pgo
 
-USER daemon
+USER 2
 
 CMD tail -f /dev/null

--- a/rhel7/Dockerfile.pgo-event.rhel7
+++ b/rhel7/Dockerfile.pgo-event.rhel7
@@ -11,6 +11,6 @@ LABEL name="pgo-event" \
 
 ADD bin/pgo-event /usr/local/bin
 
-USER daemon
+USER 2
 
 ENTRYPOINT ["/usr/local/bin/pgo-event.sh"]

--- a/rhel7/Dockerfile.postgres-operator.rhel7
+++ b/rhel7/Dockerfile.postgres-operator.rhel7
@@ -17,6 +17,6 @@ RUN yum -y install \
 ADD bin/postgres-operator /usr/local/bin
 ADD conf/postgres-operator /default-pgo-config
 
-USER daemon
+USER 2
 
 ENTRYPOINT ["postgres-operator"]


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Issue: CrunchyData/postgres-operator#1559

When using a PodSecurityPolicy with runAsUser=MustRunAsNonRoot, the operator pod does not run:

```
Error: container has runAsNonRoot and image has non-numeric user (daemon), cannot verify user is non-root
```

**Other information**:

All the images in this project now use numeric UIDs.