### PR TITLE
Fixes typo in postgres-operator.yml

### DIFF
--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -285,7 +285,7 @@ spec:
                     value: "alternatesite"
                   - name: STORAGE8_NAME
                     value: "gce"
-                  - name: STORAGE8_ACCESS
+                  - name: STORAGE8_ACCESS_MODE
                     value: "ReadWriteOnce"
                   - name: STORAGE8_SIZE
                     value: "300M"


### PR DESCRIPTION
This typo caused the accessmode for gce storage to not be set.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable? 

Tested in gke using the gce storage type


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Clusters cannot be created because of pvc creation issue.


**What is the new behavior (if this is a feature change)?**
Clusters are created with the correct accessmode for gce


**Other information**:
