### PR TITLE
Validate Limit >= Request in some API calls

### DIFF
--- a/apiserver/common_test.go
+++ b/apiserver/common_test.go
@@ -1,0 +1,101 @@
+package apiserver
+
+/*
+Copyright 2018 - 2020 Crunchy Data Solutions, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestValidateResourceRequestLimit(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		resources := []struct{ request, limit, defaultRequest string }{
+			{"", "", "0"},
+			{"256Mi", "256Mi", "128Mi"},
+			{"", "256Mi", "128Mi"},
+			{"", "256Mi", "0"},
+			{"256Mi", "", "128Mi"},
+			{"64Mi", "", "128Mi"},
+			{"256Mi", "", "0"},
+			{"", "", "128Mi"},
+		}
+
+		for _, r := range resources {
+			defaultQuantity := resource.MustParse(r.defaultRequest)
+
+			if err := ValidateResourceRequestLimit(r.request, r.limit, defaultQuantity); err != nil {
+				t.Fatal(err)
+				return
+			}
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		resources := []struct{ request, limit, defaultRequest string }{
+			{"broken", "3000 Gigabytes", "128Mi"},
+			{"256Mi", "3000 Gigabytes", "128Mi"},
+			{"broken", "256Mi", "128Mi"},
+			{"256Mi", "128Mi", "512Mi"},
+			{"", "128Mi", "512Mi"},
+		}
+
+		for _, r := range resources {
+			defaultQuantity := resource.MustParse(r.defaultRequest)
+
+			if err := ValidateResourceRequestLimit(r.request, r.limit, defaultQuantity); err == nil {
+				t.Fatalf("expected error with values %v", r)
+				return
+			}
+		}
+	})
+}
+
+func TestValidateQuantity(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		quantities := []string{
+			"",
+			"100Mi",
+			"100M",
+			"250Gi",
+			"25G",
+			"0.1",
+			"1.2",
+			"150m",
+		}
+
+		for _, quantity := range quantities {
+			if err := ValidateQuantity(quantity); err != nil {
+				t.Fatal(err)
+				return
+			}
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		quantities := []string{
+			"broken",
+			"3000 Gigabytes",
+		}
+
+		for _, quantity := range quantities {
+			if err := ValidateQuantity(quantity); err == nil {
+				t.Fatalf("expected error with value %q", quantity)
+				return
+			}
+		}
+	})
+}

--- a/apiserver/pgbouncerservice/pgbouncerimpl.go
+++ b/apiserver/pgbouncerservice/pgbouncerimpl.go
@@ -45,31 +45,16 @@ func CreatePgbouncer(request *msgs.CreatePgbouncerRequest, ns, pgouser string) m
 	resp.Results = make([]string, 0)
 
 	// validate the CPU/Memory request parameters, if they are passed in
-	if err := apiserver.ValidateQuantity(request.CPULimit); err != nil {
+	if err := apiserver.ValidateResourceRequestLimit(request.CPURequest, request.CPULimit, resource.Quantity{}); err != nil {
 		resp.Status.Code = msgs.Error
-		resp.Status.Msg = fmt.Sprintf(apiserver.ErrMessageCPUValue,
-			request.CPULimit, err.Error())
+		resp.Status.Msg = err.Error()
 		return resp
 	}
 
-	if err := apiserver.ValidateQuantity(request.CPURequest); err != nil {
+	if err := apiserver.ValidateResourceRequestLimit(request.MemoryRequest, request.MemoryLimit,
+		apiserver.Pgo.Cluster.DefaultPgBouncerResourceMemory); err != nil {
 		resp.Status.Code = msgs.Error
-		resp.Status.Msg = fmt.Sprintf(apiserver.ErrMessageCPUValue,
-			request.CPURequest, err.Error())
-		return resp
-	}
-
-	if err := apiserver.ValidateQuantity(request.MemoryLimit); err != nil {
-		resp.Status.Code = msgs.Error
-		resp.Status.Msg = fmt.Sprintf(apiserver.ErrMessageMemoryValue,
-			request.MemoryLimit, err.Error())
-		return resp
-	}
-
-	if err := apiserver.ValidateQuantity(request.MemoryRequest); err != nil {
-		resp.Status.Code = msgs.Error
-		resp.Status.Msg = fmt.Sprintf(apiserver.ErrMessageMemoryValue,
-			request.MemoryRequest, err.Error())
+		resp.Status.Msg = err.Error()
 		return resp
 	}
 
@@ -306,32 +291,18 @@ func UpdatePgBouncer(request *msgs.UpdatePgBouncerRequest, namespace, pgouser st
 	}
 
 	// validate the CPU/Memory parameters, if they are passed in
-	// validate the CPU/Memory request parameters, if they are passed in
-	if err := apiserver.ValidateQuantity(request.CPULimit); err != nil {
+	zeroQuantity := resource.Quantity{}
+
+	if err := apiserver.ValidateResourceRequestLimit(request.CPURequest, request.CPULimit, zeroQuantity); err != nil {
 		response.Status.Code = msgs.Error
-		response.Status.Msg = fmt.Sprintf(apiserver.ErrMessageCPUValue,
-			request.CPULimit, err.Error())
+		response.Status.Msg = err.Error()
 		return response
 	}
 
-	if err := apiserver.ValidateQuantity(request.CPURequest); err != nil {
+	// Don't check the default value as pgBouncer is already deployed
+	if err := apiserver.ValidateResourceRequestLimit(request.MemoryRequest, request.MemoryLimit, zeroQuantity); err != nil {
 		response.Status.Code = msgs.Error
-		response.Status.Msg = fmt.Sprintf(apiserver.ErrMessageCPUValue,
-			request.CPURequest, err.Error())
-		return response
-	}
-
-	if err := apiserver.ValidateQuantity(request.MemoryLimit); err != nil {
-		response.Status.Code = msgs.Error
-		response.Status.Msg = fmt.Sprintf(apiserver.ErrMessageMemoryValue,
-			request.MemoryLimit, err.Error())
-		return response
-	}
-
-	if err := apiserver.ValidateQuantity(request.MemoryRequest); err != nil {
-		response.Status.Code = msgs.Error
-		response.Status.Msg = fmt.Sprintf(apiserver.ErrMessageMemoryValue,
-			request.MemoryRequest, err.Error())
+		response.Status.Msg = err.Error()
 		return response
 	}
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

There are no validations to check that the limit >= request.

**What is the new behavior (if this is a feature change)?**

This can be particularly noticeable on a create where one can request
a limit that is less than the server defaults. This provides some
sanity checking.

There are limitations on update: attempting to see if the
request/limit combos are accurate is a bit tedious. The main goal
is to provide a few sanity checks before applying the request/limits
to Deployments.