### PR TITLE
Adds verbs to clusterrole needed for uninstall

### DIFF
--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -30,6 +30,7 @@ rules:
     resources:
       - secrets
     verbs:
+      - list
       - get
       - create
       - delete
@@ -43,6 +44,7 @@ rules:
       - get
       - create
       - delete
+      - list
   - apiGroups:
       - ''
     resources:
@@ -52,6 +54,7 @@ rules:
       - create
       - delete
       - patch
+      - list
   - apiGroups:
       - apps
       - extensions
@@ -96,6 +99,7 @@ rules:
       - jobs
     verbs:
       - delete
+      - list
   - apiGroups:
       - crunchydata.com
     resources:
@@ -105,6 +109,7 @@ rules:
       - pgtasks
     verbs:
       - delete
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
In order to uninstall the PostgreSQL Operator the clusterrole needs to be able
to list the following resources: secrets, configmaps, services, pvcs,
serviceaccounts, jobs, pgclusters, pgreplicas, pgpolicies, and pgtasks

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The ansible uninstall uses a selector to delete the resources listed above. This requires that the clusterrole have permission to list those resources. Since the clusterrole does not have these permissions the resources are not deleted.


**What is the new behavior (if this is a feature change)?**
Now the pgo-deployer clusterrole will be able to list and delete the resources using a selector.


**Other information**:
[ch8386]