### PR TITLE
Remove empty "resources" blocks in various deployment templates

### DIFF
--- a/conf/postgres-operator/cluster-deployment.json
+++ b/conf/postgres-operator/cluster-deployment.json
@@ -185,7 +185,6 @@
                         "containerPort": 8009,
                         "protocol": "TCP"
                     }],
-                    "resources": {},
                     "imagePullPolicy": "IfNotPresent"
                 }{{if .EnableCrunchyadm}},
                 {

--- a/deploy/deployment.json
+++ b/deploy/deployment.json
@@ -204,7 +204,6 @@
                             }
                         ],
                         "volumeMounts": [],
-                        "resources": {},
                         "imagePullPolicy": "IfNotPresent"
                     },
                     {
@@ -225,7 +224,6 @@
                             }
                         ],
                         "volumeMounts": [],
-                        "resources": {},
                         "imagePullPolicy": "IfNotPresent"
                     }
                 ],

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -185,7 +185,6 @@
                         "containerPort": 8009,
                         "protocol": "TCP"
                     }],
-                    "resources": {},
                     "imagePullPolicy": "IfNotPresent"
                 }{{if .EnableCrunchyadm}},
                 {

--- a/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -210,7 +210,6 @@
                             }
                         ],
                         "volumeMounts": [],
-                        "resources": {},
                         "imagePullPolicy": "IfNotPresent"
                     }, {
                         "name": "event",
@@ -232,7 +231,6 @@
                             }
                         ],
                         "volumeMounts": [],
-                        "resources": {},
                         "imagePullPolicy": "IfNotPresent"
                     }
                 ],


### PR DESCRIPTION
These seem mostly, if not totally, harmless, but given there are
potentially overriding resources that occur in some of these templates,
it's better that these don't exist.

Issue: #1592