### PR TITLE
Pin Ansible version to 2.9.0+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GOPATH ?= $(HOME)/odev/go
 GOBIN ?= $(GOPATH)/bin
 
 # Default values if not already set
+ANSIBLE_VERSION ?= 2.9.*
 PGOROOT ?= $(GOPATH)/src/github.com/crunchydata/postgres-operator
 PGO_BASEOS ?= centos7
 PGO_CMD ?= kubectl
@@ -130,6 +131,7 @@ $(PGOROOT)/$(DFSET)/Dockerfile.%.$(DFSET):
 		--build-arg PREFIX=$(PGO_IMAGE_PREFIX) \
 		--build-arg PGVERSION=$(PGO_PG_VERSION) \
 		--build-arg BACKREST_VERSION=$(PGO_BACKREST_VERSION) \
+		--build-arg ANSIBLE_VERSION=$(ANSIBLE_VERSION) \
 		$(PGOROOT)
 
 %-img-buildah: %-img-build

--- a/centos7/Dockerfile.pgo-deployer.centos7
+++ b/centos7/Dockerfile.pgo-deployer.centos7
@@ -1,5 +1,6 @@
 ARG PREFIX
 ARG BASEVER
+ARG ANSIBLE_VERSION
 FROM ${PREFIX}/pgo-base:centos7-${BASEVER}
 
 LABEL name="pgo-deployer" \
@@ -12,7 +13,7 @@ RUN yum -y install epel-release \
  && yum -y install \
     --setopt=skip_missing_names_on_install=False \
     kubectl \
-    ansible \ 
+    ansible-${ANSIBLE_VERSION} \
     which \
     gettext
 
@@ -20,6 +21,9 @@ COPY installers/ansible /ansible
 COPY installers/image/bin/pgo-deploy.sh /pgo-deploy.sh
 COPY installers/image/inventory_template /inventory_template
 COPY bin/uid_daemon.sh /uid_daemon.sh
+
+ENV ANSIBLE_CONFIG="/ansible/ansible.cfg"
+ENV HOME="/tmp"
 
 RUN chmod g=u /etc/passwd
 RUN chmod g=u /uid_daemon.sh

--- a/docs/content/installation/other/ansible/prerequisites.md
+++ b/docs/content/installation/other/ansible/prerequisites.md
@@ -10,7 +10,7 @@ weight: 10
 The following is required prior to installing Crunchy PostgreSQL Operator using Ansible:
 
 * [postgres-operator playbooks](https://github.com/CrunchyData/postgres-operator/) source code for the target version
-* Ansible 2.8.0+
+* Ansible 2.9.0+
 
 ## Kubernetes Installs
 

--- a/installers/gcp-marketplace/Dockerfile
+++ b/installers/gcp-marketplace/Dockerfile
@@ -13,11 +13,11 @@ RUN install -D /bin/create_manifests.sh /opt/postgres-operator/cloud-marketplace
 RUN if [ -f /etc/os-release ] && [ debian = "$(. /etc/os-release; echo $ID)" ] && [ 10 -ge "$(. /etc/os-release; echo $VERSION_ID)" ]; then \
       apt-get update && apt-get install -y --no-install-recommends gnupg && rm -rf /var/lib/apt/lists/* && \
       wget -qO- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x93C4A3FD7BB9C367' | apt-key add && \
-      echo > /etc/apt/sources.list.d/ansible.list deb http://ppa.launchpad.net/ansible/ansible-2.8/ubuntu trusty main ; \
+      echo > /etc/apt/sources.list.d/ansible.list deb http://ppa.launchpad.net/ansible/ansible-2.9/ubuntu trusty main ; \
     fi
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ansible=2.8.* openssh-client \
+ && apt-get install -y --no-install-recommends ansible=2.9.* openssh-client \
  && rm -rf /var/lib/apt/lists/*
 
 COPY installers/ansible/* \

--- a/installers/gcp-marketplace/Dockerfile
+++ b/installers/gcp-marketplace/Dockerfile
@@ -9,7 +9,7 @@ FROM gcr.io/cloud-marketplace-tools/k8s/deployer_envsubst:${MARKETPLACE_VERSION}
 
 RUN install -D /bin/create_manifests.sh /opt/postgres-operator/cloud-marketplace-tools/bin/create_manifests.sh
 
-# https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#latest-releases-via-apt-debian
+# https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible-on-debian
 RUN if [ -f /etc/os-release ] && [ debian = "$(. /etc/os-release; echo $ID)" ] && [ 10 -ge "$(. /etc/os-release; echo $VERSION_ID)" ]; then \
       apt-get update && apt-get install -y --no-install-recommends gnupg && rm -rf /var/lib/apt/lists/* && \
       wget -qO- 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x93C4A3FD7BB9C367' | apt-key add && \

--- a/installers/image/bin/pgo-deploy.sh
+++ b/installers/image/bin/pgo-deploy.sh
@@ -35,9 +35,7 @@ export SERVICE_TYPE=${SERVICE_TYPE:-ClusterIP}
 export METRICS_NAMESPACE=${METRICS_NAMESPACE:-pgo}
 
 # Installer Settings
-export ANSIBLE_CONFIG="/ansible/ansible.cfg"
 export DEPLOY_ACTION=${DEPLOY_ACTION:-install}
-export HOME="/tmp"
 export KUBERNETES_IN_CLUSTER=${KUBERNETES_IN_CLUSTER:-true}
 
 cat /inventory_template | envsubst > /tmp/inventory

--- a/rhel7/Dockerfile.pgo-deployer.rhel7
+++ b/rhel7/Dockerfile.pgo-deployer.rhel7
@@ -1,6 +1,7 @@
 ARG BASEOS
 ARG BASEVER
 ARG PREFIX
+ARG ANSIBLE_VERSION
 FROM ${PREFIX}/pgo-base:${BASEOS}-${BASEVER}
 
 LABEL name="pgo-deployer" \
@@ -12,7 +13,7 @@ RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-late
     --setopt=skip_missing_names_on_install=False \
     --enablerepo='rhel-7-server-ose-4.4-rpms' \
     openshift-clients \
-    ansible \
+    ansible-${ANSIBLE_VERSION} \
     which \
     gettext
 
@@ -20,6 +21,9 @@ COPY installers/ansible /ansible
 COPY installers/image/bin/pgo-deploy.sh /pgo-deploy.sh
 COPY installers/image/inventory_template /inventory_template
 COPY bin/uid_daemon.sh /uid_daemon.sh
+
+ENV ANSIBLE_CONFIG="/ansible/ansible.cfg"
+ENV HOME="/tmp"
 
 RUN chmod g=u /etc/passwd
 RUN chmod g=u /uid_daemon.sh


### PR DESCRIPTION
This update standardizes the Ansible version across the different deployer
images and the documentation. The docs have been updated so that Ansible 2.9.0+
is a prerequisites for the Ansible installer (documented under other install
methods). The gcp-marketplace deployer image has been updated from Ansible 2.8.*
to 2.9.* and the pgo-deployer image has been pinned to 2.9.*.

The image specific environment variables are moved to the Dockerfile. The HOME
and ANSIBLE_CONFIG variables are currently set in the pgo-deploy script. This
causes issues when trying to use ansible without running the script or manually
setting these variables.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable? Built and tested 


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
