### PR TITLE
Do not consider non-running Pods when searching for primaries

### DIFF
--- a/internal/operator/cluster/clusterlogic.go
+++ b/internal/operator/cluster/clusterlogic.go
@@ -33,8 +33,11 @@ import (
 	crv1 "github.com/crunchydata/postgres-operator/pkg/apis/crunchydata.com/v1"
 	"github.com/crunchydata/postgres-operator/pkg/events"
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -204,7 +207,7 @@ func addClusterCreateDeployments(clientset *kubernetes.Clientset, client *rest.R
 		config.DeploymentTemplate.Execute(os.Stdout, deploymentFields)
 	}
 
-	deployment := v1.Deployment{}
+	deployment := appsv1.Deployment{}
 	err = json.Unmarshal(primaryDoc.Bytes(), &deployment)
 	if err != nil {
 		log.Error("error unmarshalling primary json into Deployment " + err.Error())
@@ -404,7 +407,7 @@ func scaleReplicaCreateDeployment(clientset *kubernetes.Clientset, client *rest.
 		config.DeploymentTemplate.Execute(os.Stdout, replicaDeploymentFields)
 	}
 
-	replicaDeployment := v1.Deployment{}
+	replicaDeployment := appsv1.Deployment{}
 	err = json.Unmarshal(replicaDoc.Bytes(), &replicaDeployment)
 	if err != nil {
 		log.Error("error unmarshalling replica json into Deployment " + err.Error())
@@ -497,18 +500,29 @@ type ScaleClusterInfo struct {
 func ShutdownCluster(clientset *kubernetes.Clientset, restclient *rest.RESTClient,
 	cluster crv1.Pgcluster) error {
 
-	// first ensure the current primary deployment is properly recorded in the pg cluster.  This
-	// is needed to ensure the cluster can be
+	// first ensure the current primary deployment is properly recorded in the pg
+	// cluster. Only consider primaries that are running, as there could be
+	// evicted, etc. pods hanging around
 	selector := fmt.Sprintf("%s=%s,%s=%s", config.LABEL_PG_CLUSTER, cluster.Name,
 		config.LABEL_PGHA_ROLE, config.LABEL_PGHA_ROLE_PRIMARY)
-	pods, err := kubeapi.GetPods(clientset, selector, cluster.Namespace)
+
+	options := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("status.phase", string(v1.PodRunning)).String(),
+		LabelSelector: selector,
+	}
+
+	// only consider pods that are running
+	pods, err := clientset.CoreV1().Pods(cluster.Namespace).List(options)
+
 	if err != nil {
 		return err
 	}
+
 	if len(pods.Items) > 1 {
 		return fmt.Errorf("Cluster Operator: Invalid number of primary pods (%d) found when "+
 			"shutting down cluster %s", len(pods.Items), cluster.Name)
 	}
+
 	primaryPod := pods.Items[0]
 	if cluster.Annotations == nil {
 		cluster.Annotations = make(map[string]string)
@@ -594,7 +608,7 @@ func ScaleClusterDeployments(clientset *kubernetes.Clientset, cluster crv1.Pgclu
 	namespace := cluster.Namespace
 	// Get *all* remaining deployments for the cluster.  This includes the deployment for the
 	// primary, any replicas, the pgBackRest repo and any optional services (e.g. pgBouncer)
-	var deploymentList *v1.DeploymentList
+	var deploymentList *appsv1.DeploymentList
 	selector := fmt.Sprintf("%s=%s", config.LABEL_PG_CLUSTER, clusterName)
 	if deploymentList, err = kubeapi.GetDeployments(clientset, selector,
 		namespace); err != nil {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

There is a case where "Evicted" Pods may be lying around, and as
they still have old labels, it may confuse the Operator when it
is performing certain sanity checks.

**What is the new behavior (if this is a feature change)?**

This causes non-running Pods to be ignored as part of the
"multiple primary" checks.

**Other information**:

fixes #1623