### PR TITLE
Remove "expenv" as a dependency for the PostgreSQL Operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,11 +134,9 @@ linuxpgo: build-pgo-client
 
 macpgo:
 	cd pgo && env GOOS=darwin GOARCH=amd64 go build pgo.go && mv pgo $(GOBIN)/pgo-mac
-	env GOOS=darwin GOARCH=amd64 go build github.com/blang/expenv && mv expenv $(GOBIN)/expenv-mac
 
 winpgo:
 	cd pgo && env GOOS=windows GOARCH=386 go build pgo.go && mv pgo.exe $(GOBIN)/pgo.exe
-	env GOOS=windows GOARCH=386 go build github.com/blang/expenv && mv expenv.exe $(GOBIN)/expenv.exe
 
 
 #======= Image builds =======
@@ -213,9 +211,6 @@ release:  linuxpgo macpgo winpgo
 	cp $(GOBIN)/pgo $(RELTMPDIR)
 	cp $(GOBIN)/pgo-mac $(RELTMPDIR)
 	cp $(GOBIN)/pgo.exe $(RELTMPDIR)
-	cp $(GOBIN)/expenv $(RELTMPDIR)
-	cp $(GOBIN)/expenv-mac $(RELTMPDIR)
-	cp $(GOBIN)/expenv.exe $(RELTMPDIR)
 	cp $(PGOROOT)/examples/pgo-bash-completion $(RELTMPDIR)
 	tar czvf $(RELFILE) -C $(RELTMPDIR) .
 

--- a/bin/get-deps.sh
+++ b/bin/get-deps.sh
@@ -87,11 +87,3 @@ else
 	echo "=== Installing dep ==="
 	curl -S https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 fi
-
-if which expenv; then
-	echo "  Found expenv"
-else
-	echo "=== Installing expenv ==="
-	# TODO: expenv uses Go modules, could retrieve specific version
-	go get github.com/blang/expenv
-fi

--- a/deploy/upgrade-creds.sh
+++ b/deploy/upgrade-creds.sh
@@ -59,7 +59,7 @@ do
         $PGO_CMD delete secret pgorole-$PGO_ROLENAME -n $PGO_OPERATOR_NAMESPACE
     fi
 
-    expenv -f $DIR/pgorole.yaml | $PGO_CMD create -f -
+    cat $DIR/pgorole.yaml | envsubst | $PGO_CMD create -f -
 done < "$ROLE_INPUT"
 
 
@@ -80,5 +80,5 @@ do
     if [ $? -eq 0 ]; then
         $PGO_CMD delete secret pgouser-$PGO_USERNAME -n $PGO_OPERATOR_NAMESPACE
     fi
-    expenv -f $DIR/pgouser.yaml | $PGO_CMD create -f -
+    cat $DIR/pgouser.yaml | envsubst | $PGO_CMD create -f -
 done < "$USER_INPUT"

--- a/docs/content/installation/other/bash.md
+++ b/docs/content/installation/other/bash.md
@@ -43,13 +43,6 @@ Environment variables control aspects of the Operator installation.  You can cop
     cat $HOME/odev/src/github.com/crunchydata/postgres-operator/examples/envs.sh >> $HOME/.bashrc
     source $HOME/.bashrc
 
-For various scripts used by the Operator, the *expenv* utility is required, download this utility from the Github Releases page, and place it into your PATH (e.g. $HOME/odev/bin).
-{{% notice tip %}}There is also a Makefile target that includes is *expenv* and several other dependencies that are only needed if you plan on building from source:
-
-    make setup
-
-{{% /notice %}}
-
 ## Default Installation - Namespace Creation
 
 Creating Kubernetes namespaces is typically something that only a

--- a/examples/load/README.md
+++ b/examples/load/README.md
@@ -3,7 +3,7 @@
 Loading a sample file, sample.json, requires some setup
 at the volume level.
 
-### Making Data Loadable 
+### Making Data Loadable
 
 #### NFS
 
@@ -29,8 +29,8 @@ the sample load configuration.
 We test with storageos and it offers a RWO storage class
 that can be used for volume provisioning.
 
-To accomplish this, download the storageos CLI from their 
-github site and ensure you have the following environement 
+To accomplish this, download the storageos CLI from their
+github site and ensure you have the following environement
 variables added to ~/.bashrc as follows:
 
 	export PGO_NAMESPACE=pgouser1 (update to match your environment)
@@ -40,18 +40,13 @@ Then execute
 
 	source ~/.bashrc
 
-Also, if not already installed, fetch a Go module for expanding environment 
-variables with:
-
-	go get github.com/blang/expenv
-
 Now, to prepare a volume with sample load data, you do the following
 for storageos:
 
 Create the PVC that will create a blank storageos volume
 for us to use:
 
-    expenv -f csv-pvc-sc.yaml | kubectl create -f -
+    cat csv-pvc-sc.yaml | envsubst | kubectl create -f -
 
 Next, locate the storageos Kube IP address:
 
@@ -95,4 +90,3 @@ To conclude, you would load using a storage class using a command similar
 to this one:
 
     pgo load --load-config=sample-json-load-config-sc.yaml  --selector=name=mycluster -n pgouser1
-

--- a/pv/create-pv-nfs-label.sh
+++ b/pv/create-pv-nfs-label.sh
@@ -22,5 +22,5 @@ do
    	echo "creating PV crunchy-pv$i"
 	export COUNTER=$i
 	$PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE delete pv crunchy-pv$i
-	expenv -f $DIR/crunchy-pv-nfs-label.json | $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create -f -
+	cat $DIR/crunchy-pv-nfs-label.json | envsubst | $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create -f -
 done

--- a/pv/create-pv-nfs-legacy.sh
+++ b/pv/create-pv-nfs-legacy.sh
@@ -22,5 +22,5 @@ do
    	echo "creating PV crunchy-pv$i"
 	export COUNTER=$i
 	$PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE delete pv crunchy-pv$i
-	expenv -f $DIR/crunchy-pv-nfs.json | $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create -f -
+	cat $DIR/crunchy-pv-nfs.json | envsubst | $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create -f -
 done

--- a/pv/create-pv.sh
+++ b/pv/create-pv.sh
@@ -21,5 +21,5 @@ do
    	echo "creating PV crunchy-pv$i"
 	export COUNTER=$i
 	$PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE delete pv crunchy-pv$i
-	expenv -f $DIR/crunchy-pv.json | $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create -f -
+	cat $DIR/crunchy-pv.json | envsubst | $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create -f -
 done


### PR DESCRIPTION
Where appropriate, the `envsubst` command, which comes with our
base images and is fairly standard across *nix.

Issue: [ch8013]