### PR TITLE
Report accurate PVC capacity for replicas in `pgo show cluster`

### DIFF
--- a/internal/apiserver/common.go
+++ b/internal/apiserver/common.go
@@ -24,7 +24,6 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/kubeapi"
 	crv1 "github.com/crunchydata/postgres-operator/pkg/apis/crunchydata.com/v1"
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -54,21 +53,6 @@ var (
 	ErrMethodNotAllowed = errors.New("This method has is not allowed in the current PostgreSQL " +
 		"Operator installation")
 )
-
-func GetPVCName(pod *v1.Pod) map[string]string {
-	pvcList := make(map[string]string)
-
-	for _, v := range pod.Spec.Volumes {
-		if v.Name == "backrestrepo" || v.Name == "pgdata" || v.Name == "pgwal-volume" {
-			if v.VolumeSource.PersistentVolumeClaim != nil {
-				pvcList[v.Name] = v.VolumeSource.PersistentVolumeClaim.ClaimName
-			}
-		}
-	}
-
-	return pvcList
-
-}
 
 func CreateRMDataTask(clusterName, replicaName, taskName string, deleteBackups, deleteData, isReplica, isBackup bool, ns, clusterPGHAScope string) error {
 	var err error

--- a/pgo/cmd/cluster.go
+++ b/pgo/cmd/cluster.go
@@ -171,8 +171,8 @@ func printCluster(detail *msgs.ShowClusterDetail) {
 
 		podStr := fmt.Sprintf("%spod : %s (%s) on %s (%s) %s", TreeBranch, pod.Name, string(pod.Phase), pod.NodeName, pod.ReadyStatus, podType)
 		fmt.Println(podStr)
-		for _, pvc := range pod.PVCName {
-			fmt.Println(TreeBranch + "pvc : " + pvc)
+		for _, pvc := range pod.PVC {
+			fmt.Println(fmt.Sprintf("%spvc: %s (%s)", TreeBranch+TreeBranch, pvc.Name, pvc.Capacity))
 		}
 	}
 
@@ -209,9 +209,6 @@ func printCluster(detail *msgs.ShowClusterDetail) {
 
 		fmt.Println(limitsStr)
 	}
-
-	storageStr := fmt.Sprintf("%sstorage : Primary=%s Replica=%s", TreeBranch, detail.Cluster.Spec.PrimaryStorage.Size, detail.Cluster.Spec.ReplicaStorage.Size)
-	fmt.Println(storageStr)
 
 	for _, d := range detail.Deployments {
 		fmt.Println(TreeBranch + "deployment : " + d.Name)

--- a/pkg/apiservermsgs/clustermsgs.go
+++ b/pkg/apiservermsgs/clustermsgs.go
@@ -231,11 +231,23 @@ type ShowClusterPod struct {
 	Name        string
 	Phase       string
 	NodeName    string
-	PVCName     map[string]string
+	PVC         []ShowClusterPodPVC
 	ReadyStatus string
 	Ready       bool
 	Primary     bool
 	Type        string
+}
+
+// ShowClusterPodPVC contains information about a PVC that is bound to a Pod
+//
+// swagger:model
+type ShowClusterPodPVC struct {
+	// Capacity is the total storage capacity available. This comes from a
+	// Kubernetes resource Quantity string
+	Capacity string
+
+	// Name is the name of the PVC
+	Name string
 }
 
 // ShowClusterDeployment


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The PVC capacity that was displayed as part of `pgo show cluster` was
pulling from the values set on the pgcluster CRD, which, for replicas,
may not be accurate if the PVC size was changed.

**What is the new behavior (if this is a feature change)?**

This adjusts the PVC capacity lookup formula to get that information
from the PVC object itself (similar to `pgo df`). Additionally, this
modifies the printed output to more clearly indicate which PVCs belong
to which Pods.

**Other information**:

Issue: [ch8509]