### PR TITLE
Remove "Operator Start Time" from "pgo status"

### DIFF
--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -171,7 +171,6 @@ pgo status
 which yields output similar to:
 
 ```
-Operator Start:          2019-12-26 17:53:45 +0000 UTC
 Databases:               8
 Claims:                  8
 Total Volume Size:       8Gi       

--- a/pgo/cmd/status.go
+++ b/pgo/cmd/status.go
@@ -18,12 +18,13 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/crunchydata/postgres-operator/pgo/api"
 	"github.com/crunchydata/postgres-operator/pgo/util"
 	msgs "github.com/crunchydata/postgres-operator/pkg/apiservermsgs"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var Summary bool
@@ -72,7 +73,6 @@ func showStatus(args []string, ns string) {
 func printSummary(status *msgs.StatusDetail) {
 
 	WID := 25
-	fmt.Printf("%s%s\n", util.Rpad("Operator Start:", " ", WID), status.OperatorStartTime)
 	fmt.Printf("%s%d\n", util.Rpad("Databases:", " ", WID), status.NumDatabases)
 	fmt.Printf("%s%d\n", util.Rpad("Claims:", " ", WID), status.NumClaims)
 	fmt.Printf("%s%s\n", util.Rpad("Total Volume Size:", " ", WID), util.Rpad(status.VolumeCap, " ", 10))

--- a/pkg/apiservermsgs/statusmsgs.go
+++ b/pkg/apiservermsgs/statusmsgs.go
@@ -35,14 +35,13 @@ type KeyValue struct {
 // by means of a volume mounted json blob it generates
 // swagger:model
 type StatusDetail struct {
-	OperatorStartTime string
-	NumDatabases      int
-	NumClaims         int
-	VolumeCap         string
-	DbTags            map[string]int
-	NotReady          []string
-	Nodes             []NodeInfo
-	Labels            []KeyValue
+	NumDatabases int
+	NumClaims    int
+	VolumeCap    string
+	DbTags       map[string]int
+	NotReady     []string
+	Nodes        []NodeInfo
+	Labels       []KeyValue
 }
 
 // ShowClusterResponse ...

--- a/testing/pgo_cli/operator_test.go
+++ b/testing/pgo_cli/operator_test.go
@@ -38,7 +38,7 @@ func TestOperatorCommands(t *testing.T) {
 			t.Run("shows something", func(t *testing.T) {
 				output, err := pgo("status", "-n", namespace()).Exec(t)
 				require.NoError(t, err)
-				require.Contains(t, output, "Operator Start")
+				require.Contains(t, output, "Total Volume Size")
 			})
 		})
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

No information is being returned about the Operator "start time" in `pgo status`

**What is the new behavior (if this is a feature change)?**

Upon inspection, this was not necessarily returning the start time even prior to the feature not working, and this information is available from standard Kubernetes commands, and likely more accurate.

**Other information**:

fixes #1605