### PR TITLE
Remove references to "client.pem"

### DIFF
--- a/docs/content/installation/other/ansible/installing-operator.md
+++ b/docs/content/installation/other/ansible/installing-operator.md
@@ -87,7 +87,7 @@ cat <<EOF >> ~/.bashrc
 export PGOUSER="${HOME?}/.pgo/<PGO_NAMESPACE>/pgouser"
 export PGO_CA_CERT="${HOME?}/.pgo/<PGO_NAMESPACE>/client.crt"
 export PGO_CLIENT_CERT="${HOME?}/.pgo/<PGO_NAMESPACE>/client.crt"
-export PGO_CLIENT_KEY="${HOME?}/.pgo/<PGO_NAMESPACE>/client.pem"
+export PGO_CLIENT_KEY="${HOME?}/.pgo/<PGO_NAMESPACE>/client.key"
 export PGO_APISERVER_URL='https://127.0.0.1:8443'
 EOF
 ```

--- a/docs/content/installation/other/ansible/updating-operator.md
+++ b/docs/content/installation/other/ansible/updating-operator.md
@@ -91,7 +91,7 @@ cat <<EOF >> ~/.bashrc
 export PGOUSER="${HOME?}/.pgo/<PGO_NAMESPACE>/pgouser"
 export PGO_CA_CERT="${HOME?}/.pgo/<PGO_NAMESPACE>/client.crt"
 export PGO_CLIENT_CERT="${HOME?}/.pgo/<PGO_NAMESPACE>/client.crt"
-export PGO_CLIENT_KEY="${HOME?}/.pgo/<PGO_NAMESPACE>/client.pem"
+export PGO_CLIENT_KEY="${HOME?}/.pgo/<PGO_NAMESPACE>/client.key"
 export PGO_APISERVER_URL='https://127.0.0.1:8443'
 EOF
 ```

--- a/docs/content/installation/pgo-client.md
+++ b/docs/content/installation/pgo-client.md
@@ -63,7 +63,7 @@ Next, copy the certificates to this new directory:
 
 ```bash
 cp /PATH/TO/client.crt ${HOME?}/.pgo/client.crt && chmod 600 ${HOME?}/.pgo/client.crt
-cp /PATH/TO/client.pem ${HOME?}/.pgo/client.pem && chmod 400 ${HOME?}/.pgo/client.pem
+cp /PATH/TO/client.key ${HOME?}/.pgo/client.key && chmod 400 ${HOME?}/.pgo/client.key
 ```
 
 Finally, set the following environment variables to point to the client TLS files:
@@ -72,7 +72,7 @@ Finally, set the following environment variables to point to the client TLS file
 cat <<EOF >> ${HOME?}/.bashrc
 export PGO_CA_CERT="${HOME?}/.pgo/client.crt"
 export PGO_CLIENT_CERT="${HOME?}/.pgo/client.crt"
-export PGO_CLIENT_KEY="${HOME?}/.pgo/client.pem"
+export PGO_CLIENT_KEY="${HOME?}/.pgo/client.key"
 EOF
 ```
 
@@ -220,7 +220,7 @@ Next, copy the certificates to this new directory:
 
 ```bash
 copy \PATH\TO\client.crt "%HOMEPATH%\pgo"
-copy \PATH\TO\client.pem "%HOMEPATH%\pgo"
+copy \PATH\TO\client.key "%HOMEPATH%\pgo"
 ```
 
 Finally, set the following environment variables to point to the client TLS files:
@@ -228,7 +228,7 @@ Finally, set the following environment variables to point to the client TLS file
 ```bash
 setx PGO_CA_CERT "%HOMEPATH%\pgo\client.crt"
 setx PGO_CLIENT_CERT "%HOMEPATH%\pgo\client.crt"
-setx PGO_CLIENT_KEY "%HOMEPATH%\pgo\client.pem"
+setx PGO_CLIENT_KEY "%HOMEPATH%\pgo\client.key"
 ```
 
 #### Configuring `pgouser`

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -102,7 +102,7 @@ This will download the `pgo` client and provide instructions for how to easily u
 export PGOUSER="${HOME?}/.pgo/pgo/pgouser"
 export PGO_CA_CERT="${HOME?}/.pgo/pgo/client.crt"
 export PGO_CLIENT_CERT="${HOME?}/.pgo/pgo/client.crt"
-export PGO_CLIENT_KEY="${HOME?}/.pgo/pgo/client.pem"
+export PGO_CLIENT_KEY="${HOME?}/.pgo/pgo/client.key"
 export PGO_APISERVER_URL='https://127.0.0.1:8443'
 export PGO_NAMESPACE=pgo
 ```
@@ -114,7 +114,7 @@ cat <<EOF >> ~/.bashrc
 export PGOUSER="${HOME?}/.pgo/pgo/pgouser"
 export PGO_CA_CERT="${HOME?}/.pgo/pgo/client.crt"
 export PGO_CLIENT_CERT="${HOME?}/.pgo/pgo/client.crt"
-export PGO_CLIENT_KEY="${HOME?}/.pgo/pgo/client.pem"
+export PGO_CLIENT_KEY="${HOME?}/.pgo/pgo/client.key"
 export PGO_APISERVER_URL='https://127.0.0.1:8443'
 export PGO_NAMESPACE=pgo
 EOF

--- a/installers/ansible/roles/pgo-operator/tasks/certs.yml
+++ b/installers/ansible/roles/pgo-operator/tasks/certs.yml
@@ -7,9 +7,9 @@
     - install
 
 - name: Generate RSA Key
-  command: openssl genrsa -out "{{ output_dir }}/server.pem" 2048
+  command: openssl genrsa -out "{{ output_dir }}/server.key" 2048
   args:
-    creates: "{{ output_dir }}/server.pem"
+    creates: "{{ output_dir }}/server.key"
   tags:
     - install
 
@@ -17,7 +17,7 @@
   command: openssl req \
     -new \
     -subj '/C=US/ST=SC/L=Charleston/O=CrunchyData/CN=pg-operator' \
-    -key "{{ output_dir }}/server.pem" \
+    -key "{{ output_dir }}/server.key" \
     -out "{{ output_dir }}/server.csr"
   args:
     creates: "{{ output_dir }}/server.csr"
@@ -28,7 +28,7 @@
   command: openssl req \
     -x509 \
     -days 1825 \
-    -key "{{ output_dir }}/server.pem" \
+    -key "{{ output_dir }}/server.key" \
     -in "{{ output_dir }}/server.csr" \
     -out "{{ output_dir }}/server.crt"
   args:
@@ -49,6 +49,6 @@
     - install
 
 - name: Copy keys to {{ pgo_keys_dir }}
-  command: "cp {{ output_dir }}/server.pem {{ pgo_keys_dir }}/client.pem"
+  command: "cp {{ output_dir }}/server.key {{ pgo_keys_dir }}/client.key"
   tags:
     - install

--- a/installers/ansible/roles/pgo-operator/tasks/main.yml
+++ b/installers/ansible/roles/pgo-operator/tasks/main.yml
@@ -288,7 +288,7 @@
           command: |
             {{ kubectl_or_oc }} create secret tls pgo.tls \
               --cert='{{ output_dir }}/server.crt' \
-              --key='{{ output_dir }}/server.pem' \
+              --key='{{ output_dir }}/server.key' \
               -n {{ pgo_operator_namespace }}
           when: pgo_tls_result.rc == 1
 

--- a/installers/ansible/roles/pgo-operator/templates/pgo-client.json.j2
+++ b/installers/ansible/roles/pgo-operator/templates/pgo-client.json.j2
@@ -69,7 +69,7 @@
                             },
                             {
                                 "name": "PGO_CLIENT_KEY",
-                                "value": "pgo-tls/client.pem"
+                                "value": "pgo-tls/client.key"
                             }
                         ],
                         "volumeMounts": [
@@ -92,7 +92,7 @@
                                 },
                                 {
                                     "key": "tls.key",
-                                    "path": "client.pem"
+                                    "path": "client.key"
                                 }
                             ]
                         }

--- a/testing/pgo_cli/suite_test.go
+++ b/testing/pgo_cli/suite_test.go
@@ -77,7 +77,7 @@ func TestMain(m *testing.M) {
 				TestContext.DefaultEnvironment = append(TestContext.DefaultEnvironment,
 					"PGO_CA_CERT="+filepath.Join(home, ".pgo", ns, "output", "server.crt"),
 					"PGO_CLIENT_CERT="+filepath.Join(home, ".pgo", ns, "output", "server.crt"),
-					"PGO_CLIENT_KEY="+filepath.Join(home, ".pgo", ns, "output", "server.pem"),
+					"PGO_CLIENT_KEY="+filepath.Join(home, ".pgo", ns, "output", "server.key"),
 				)
 			}
 		}


### PR DESCRIPTION
This has been standardized around "client.key" except in a few
places.

Issue: [ch8588]
closes #1651 