### PR TITLE
Pgdump specific PostgreSQL database for pgcluster

### DIFF
--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -678,11 +678,18 @@ provide only a subset of a database, such as a table.
 
 #### Create a Logical Backup
 
-To create a logical backup of a full database, you can run the following
+To create a logical backup of the 'postgres' database, you can run the following
 command:
 
 ```shell
 pgo backup hacluster --backup-type=pgdump
+```
+
+To create a logical backup of a specific database, you can use the `--database` flag,
+as in the following command:
+
+```shell
+pgo backup hacluster --backup-type=pgdump --database=mydb
 ```
 
 You can pass in specific options to `--backup-opts`, which can accept most of
@@ -724,6 +731,14 @@ You can restore a logical backup using the following command:
 ```shell
 pgo restore hacluster --backup-type=pgdump --backup-pvc=hacluster-pgdump-pvc \
   --pitr-target="2019-01-15-00-03-25" -n pgouser1
+```
+
+To restore to a specific database, add the `--pgdump-database` flag to the
+command from above:
+
+```shell
+pgo restore hacluster --backup-type=pgdump --backup-pvc=hacluster-pgdump-pvc \
+  --pgdump-database=mydb --pitr-target="2019-01-15-00-03-25" -n pgouser1
 ```
 
 ## High-Availability: Scaling Up & Down

--- a/pgo/cmd/backup.go
+++ b/pgo/cmd/backup.go
@@ -26,6 +26,10 @@ import (
 
 var PVCName string
 
+// PGDumpDB is used to store the name of the pgDump database when
+// performing either a backup or restore
+var PGDumpDB string
+
 var backupCmd = &cobra.Command{
 	Use:   "backup",
 	Short: "Perform a Backup",
@@ -82,6 +86,7 @@ func init() {
 	backupCmd.Flags().StringVarP(&BackupOpts, "backup-opts", "", "", "The options to pass into pgbackrest.")
 	backupCmd.Flags().StringVarP(&Selector, "selector", "s", "", "The selector to use for cluster filtering.")
 	backupCmd.Flags().StringVarP(&PVCName, "pvc-name", "", "", "The PVC name to use for the backup instead of the default.")
+	backupCmd.Flags().StringVarP(&PGDumpDB, "database", "d", "postgres", "The name of the database pgdump will backup.")
 	backupCmd.Flags().StringVar(&backupType, "backup-type", "pgbackrest", "The backup type to perform. Default is pgbackrest. Valid backup types are pgbackrest and pgdump.")
 	backupCmd.Flags().StringVarP(&BackrestStorageType, "pgbackrest-storage-type", "", "", "The type of storage to use when scheduling pgBackRest backups. Either \"local\", \"s3\" or both, comma separated. (default \"local\")")
 

--- a/pgo/cmd/pgdump.go
+++ b/pgo/cmd/pgdump.go
@@ -18,10 +18,11 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/crunchydata/postgres-operator/pgo/api"
 	msgs "github.com/crunchydata/postgres-operator/pkg/apiservermsgs"
 	log "github.com/sirupsen/logrus"
-	"os"
 )
 
 // createpgDumpBackup
@@ -33,6 +34,7 @@ func createpgDumpBackup(args []string, ns string) {
 	request.Namespace = ns
 	request.Selector = Selector
 	request.PVCName = PVCName
+	request.PGDumpDB = PGDumpDB
 	request.StorageConfig = StorageConfig
 	request.BackupOpts = BackupOpts
 

--- a/pgo/cmd/restore.go
+++ b/pgo/cmd/restore.go
@@ -68,6 +68,7 @@ func init() {
 		"the restore job, and in the case of a pgBackRest restore, also the new (i.e. restored) primary deployment. If not set, any node is used.")
 	restoreCmd.Flags().BoolVar(&NoPrompt, "no-prompt", false, "No command line confirmation.")
 	restoreCmd.Flags().StringVarP(&BackupPVC, "backup-pvc", "", "", "The PVC containing the pgdump to restore from.")
+	restoreCmd.Flags().StringVarP(&PGDumpDB, "pgdump-database", "d", "postgres", "The name of the database pgdump will restore.")
 	restoreCmd.Flags().StringVarP(&BackupType, "backup-type", "", "", "The type of backup to restore from, default is pgbackrest. Valid types are pgbackrest or pgdump.")
 	restoreCmd.Flags().StringVarP(&BackrestStorageType, "pgbackrest-storage-type", "", "", "The type of storage to use for a pgBackRest restore. Either \"local\", \"s3\". (default \"local\")")
 }
@@ -88,6 +89,7 @@ func restore(args []string, ns string) {
 		request.RestoreOpts = BackupOpts
 		request.PITRTarget = PITRTarget
 		request.FromPVC = BackupPVC // use PVC specified on command line for pgrestore
+		request.PGDumpDB = PGDumpDB
 		request.NodeLabel = NodeLabel
 
 		response, err = api.RestoreDump(httpclient, &SessionCredentials, request)

--- a/pkg/apiservermsgs/pgdumpmsgs.go
+++ b/pkg/apiservermsgs/pgdumpmsgs.go
@@ -32,6 +32,7 @@ type CreatepgDumpBackupRequest struct {
 	Namespace     string
 	Args          []string
 	Selector      string
+	PGDumpDB      string
 	PVCName       string
 	StorageConfig string
 	BackupOpts    string
@@ -57,6 +58,7 @@ type PgRestoreRequest struct {
 	Namespace   string
 	FromCluster string
 	FromPVC     string
+	PGDumpDB    string
 	RestoreOpts string
 	PITRTarget  string
 	NodeLabel   string


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently, the PostgreSQL Operator hard codes the 'postgres' database
when doing pgdump backups and restores.


**What is the new behavior (if this is a feature change)?**
This update allows the user to specify a database using the 
new '--database' flag with 
'pgo backup mycluster --backup-type=pgdump --database=mydb'.
Similarly, a pgdump restore can be performed with
'pgo restore mycluster --backup-type=pgdump --backup-pvc=mycluster-pgdump-pvc --pgdump-database=mydb'

Examples of proper command usage have also been added to the
'Common pgo Client Tasks' section of the documentation.


**Other information**:
[ch8255]