### PR TITLE
Create from Backup Documentation

### DIFF
--- a/docs/content/architecture/provisioning.md
+++ b/docs/content/architecture/provisioning.md
@@ -128,6 +128,53 @@ For more information on how this works and what configuration settings are
 editable, please visit the "[Custom PostgreSQL configuration]({{< relref "/advanced/custom-configuration.md" >}})"
 section of the documentation.
 
+## Provisioning Using a Backup from an Another PostgreSQL Cluster
+
+When provisioning a new PostgreSQL cluster, it is possible to bootstrap the cluster using an
+existing backup from either another PostgreSQL cluster that is currently running, or from a
+PostgreSQL cluster that no longer exists (specifically a cluster that was deleted using the
+ `keep-backups` option, as discussed in section [Deprovisioning](#deprovisioning) below).  This
+is specifically accomplished by performing a `pgbackrest restore`  during cluster initialization
+in order to populate the initial `PGDATA` directory for the new cluster using the contents of a
+backup from another cluster.
+
+To leverage this capability, the name of the cluster containing the backup that should be utilzed
+when restoring simply needs to be specified using the `restore-from`  option when creating a new
+cluster:
+
+```shell
+pgo create cluster mycluster2 --restore-from=mycluster1
+```
+
+By default, pgBackRest will restore the latest backup available in the repository, and will replay
+all available WAL archives.  However, additional pgBackRest options can be specified using the 
+`restore-opts` option, which allows the restore command to be further tailored and customized.  For
+instance, the following demonstrates how a point-in-time restore can be utilized when creating a
+new cluster:
+
+```shell
+pgo create cluster mycluster2 \
+  --restore-from=mycluster1 \
+  --restore-opts="--type=time --target='2020-07-02 20:19:36.13557+00'"
+```
+
+Additionally, if bootstrapping from a cluster the utilizes AWS S3 storage with pgBackRest (or a
+cluster that utilized AWS S3 storage in the case of a former cluster), you can also also specify
+`s3` as the repository type in order to restore from a backup stored in an S3 storage bucket:
+
+```shell
+pgo create cluster mycluster2 \
+  --restore-from=mycluster1 \
+  --restore-opts="--repo-type=s3"
+```
+
+When restoring from a cluster that is currently running, the new cluster will simply connect to
+the existing pgBackRest repository host for that cluster in order to perform the pgBackRest
+restore.  If restoring from a former cluster that has since been deleted, a new pgBackRest
+repository host will be deployed for the sole purpose of bootstrapping the new cluster, and will
+then be destroyed once the restore is complete.  Also, please note that it is only possible for
+one cluster to bootstrap from another cluster (whether running or not) at any given time.
+
 ## Deprovisioning
 
 There may become a point where you need to completely deprovision, or delete, a

--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -348,6 +348,30 @@ pgo create cluster hactsluster \
     --tablespace=name=ts2:storageconfig=gce:pvcsize=20Gi
 ```
 
+#### Create a PostgreSQL Cluster Using a Backup from Another PostgreSQL Cluster
+
+It is also possible to create a new PostgreSQL Cluster using a backup from another
+PostgreSQL cluster.  To do so, simply specify the cluster containing the backup
+that you would like to utilize using the `restore-from` option:
+
+
+```shell
+pgo create cluster hacluster2 --restore-from=hacluster1
+```
+
+When using this approach, a `pgbackrest restore` will be performed using the pgBackRest
+repository for the `restore-from` cluster specified in order to populate the initial 
+`PGDATA` directory for the new PostgreSQL cluster.  By default, pgBackRest will restore
+to the latest backup available and replay all WAL.  However, a `restore-opts` option
+is also available that allows the `restore` command to be further customized, e.g. to
+perform a point-in-time restore and/or restore from an S3 storage bucket:
+
+```shell
+pgo create cluster hacluster2 \
+  --restore-from=hacluster1 \
+  --restore-opts="--repo-type=s3 --type=time --target='2020-07-02 20:19:36.13557+00'"
+```
+
 #### Tracking a Newly Provisioned Cluster
 
 A new PostgreSQL cluster can take a few moments to provision. You may have


### PR DESCRIPTION
This commit adds documentation that describes how a new cluster can now be created using a backup from another cluster (as implemented in #1679).  This includes a brief overview of this feature in the `Common Tasks` section of the PostgreSQL Operator documentation, along with further information inside of the `Provisioning` section.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Documentation does not exist for creating a cluster from an existing backup.

**What is the new behavior (if this is a feature change)?**

Documentation now exists for creating a cluster from an existing backup.

**Other information**:

N/A