### PR TITLE
Update Label & Selector for 'pgo show cluster'

### DIFF
--- a/conf/postgres-operator/cluster-bootstrap-job.json
+++ b/conf/postgres-operator/cluster-bootstrap-job.json
@@ -5,7 +5,6 @@
         "name": "{{.Name}}-bootstrap",
         "labels": {
             "vendor": "crunchydata",
-            "pgo-pg-database": "true",
             "pgo-backrest-job": "true",
             "pgha-bootstrap": "{{.Name}}",
             {{.DeploymentLabels}}
@@ -17,7 +16,7 @@
                 "labels": {
                     "name": "{{.Name}}",
                     "vendor": "crunchydata",
-                    "pgo-pg-database": "true",
+                    "pgha-bootstrap": "{{.Name}}",
                     {{.PodLabels}}
                 }
             },

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
@@ -5,7 +5,6 @@
         "name": "{{.Name}}-bootstrap",
         "labels": {
             "vendor": "crunchydata",
-            "pgo-pg-database": "true",
             "pgo-backrest-job": "true",
             "pgha-bootstrap": "{{.Name}}",
             {{.DeploymentLabels}}
@@ -17,7 +16,7 @@
                 "labels": {
                     "name": "{{.Name}}",
                     "vendor": "crunchydata",
-                    "pgo-pg-database": "true",
+                    "pgha-bootstrap": "{{.Name}}",
                     {{.PodLabels}}
                 }
             },

--- a/internal/apiserver/clusterservice/clusterimpl.go
+++ b/internal/apiserver/clusterservice/clusterimpl.go
@@ -229,7 +229,7 @@ func GetPods(clientset kubernetes.Interface, cluster *crv1.Pgcluster) ([]msgs.Sh
 	output := []msgs.ShowClusterPod{}
 
 	//get pods, but exclude backup pods and backrest repo
-	selector := config.LABEL_BACKREST_JOB + "!=true," + config.LABEL_BACKREST_RESTORE + "!=true," + config.LABEL_PGO_BACKREST_REPO + "!=true," + config.LABEL_PG_CLUSTER + "=" + cluster.Spec.Name
+	selector := fmt.Sprintf("%s=%s,%s", config.LABEL_PG_CLUSTER, cluster.GetName(), config.LABEL_PG_DATABASE)
 	log.Debugf("selector for GetPods is %s", selector)
 
 	pods, err := clientset.CoreV1().Pods(cluster.Namespace).List(metav1.ListOptions{LabelSelector: selector})


### PR DESCRIPTION
This commit updates the label selector utilized to identify the PostgreSQL Pods within a cluster when running the `pgo show cluster` command.  Specifically, the `pgo-pg-database` and `pg-cluster` labels are now utilized to ensure only database
Pods (i.e. PostgreSQL primary and replica Pods) are displayed when running this command.  Additionally, the `pgo-pg-database` label has been removed from the cluster bootstrap Job template to prevent bootstrap Pods from appearing in the output of the `pgo show cluster` command (the bootstrap Job can be uniquely identified as needed using the `pgha-bootstrap` label).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `pgo show cluster` command displays repo sync and bootstrap Pods when a cluster is created using either `pgo clone` or `pgo create cluster --restore-from`.

[ch8642]
[ch8544]

**What is the new behavior (if this is a feature change)?**

The `pgo show cluster` command now only displays PostgreSQL database pods (i.e. primary and replica Pods) when created using either `pgo clone` or `pgo create cluster --restore-from`.

**Other information**:

N/A