### PR TITLE
Clone a PostgreSQL cluster that is TLS only

### DIFF
--- a/internal/operator/cluster/clone.go
+++ b/internal/operator/cluster/clone.go
@@ -824,7 +824,19 @@ func createCluster(clientset kubernetes.Interface, client *rest.RESTClient, task
 				config.LABEL_BACKREST_STORAGE_TYPE: sourcePgcluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE],
 			},
 			TablespaceMounts: sourcePgcluster.Spec.TablespaceMounts,
-			WALStorage:       sourcePgcluster.Spec.WALStorage,
+			// Copy the TLS attributes. This does take the attributes 1-1, which means
+			// the cloned cluster uses a copy of the source cluster server TLS
+			// keypair. This is tough to make assumptions about, as we're unsure how
+			// clients may be connecting to the PostgreSQL cluster. Likely a better
+			// path forward is to do a restore and set different TLS and, if needed,
+			// CA settings.
+			TLS: crv1.TLSSpec{
+				CASecret:             sourcePgcluster.Spec.TLS.CASecret,
+				ReplicationTLSSecret: sourcePgcluster.Spec.TLS.ReplicationTLSSecret,
+				TLSSecret:            sourcePgcluster.Spec.TLS.TLSSecret,
+			},
+			TLSOnly:    sourcePgcluster.Spec.TLSOnly,
+			WALStorage: sourcePgcluster.Spec.WALStorage,
 		},
 		Status: crv1.PgclusterStatus{
 			State:   crv1.PgclusterStateCreated,


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Clone was unaware of the TLS secrets whereas PostgreSQL believed it was TLS-enabled. The postgresql.conf file indicated that TLS was enabled, but there were no TLS secrets mounted to the Pod

**What is the new behavior (if this is a feature change)?**

This copies the information over the TLS + CA secret to reference in the new cluster.

**Other information**:

closes #1677