### PR TITLE
Adds metrics support for helm and pgo-deployer

### DIFF
--- a/docs/content/installation/other/helm.md
+++ b/docs/content/installation/other/helm.md
@@ -64,7 +64,7 @@ file will be used to populate the configuation options in the ConfigMap.
 ### Configuration - `values.yaml`
 
 The `values.yaml` file contains all of the configuration parametes for deploying
-the PostgreSQL Operator. The [values.yaml file]() contains the defaults that
+the PostgreSQL Operator. The [values.yaml file](https://github.com/CrunchyData/postgres-operator/blob/v4.4.0-beta.1/installers/helm/values.yaml) contains the defaults that
 should work in most Kubernetes environments, but it may require some customization.
 
 For a detailed description of each configuration parameter, please read the

--- a/docs/content/installation/other/helm.md
+++ b/docs/content/installation/other/helm.md
@@ -64,7 +64,7 @@ file will be used to populate the configuation options in the ConfigMap.
 ### Configuration - `values.yaml`
 
 The `values.yaml` file contains all of the configuration parametes for deploying
-the PostgreSQL Operator. The [values.yaml file](https://github.com/CrunchyData/postgres-operator/blob/v4.4.0-beta.1/installers/helm/values.yaml) contains the defaults that
+the PostgreSQL Operator. The [values.yaml file](https://github.com/CrunchyData/postgres-operator/blob/master/installers/helm/postgres-operator/values.yaml) contains the defaults that
 should work in most Kubernetes environments, but it may require some customization.
 
 For a detailed description of each configuration parameter, please read the

--- a/docs/content/installation/postgres-operator.md
+++ b/docs/content/installation/postgres-operator.md
@@ -272,6 +272,52 @@ If successful, you should see output similar to this:
 pgo client version 4.4.0-beta.1
 pgo-apiserver version 4.4.0-beta.1
 ```
+## Installing Metrics Infrastructure
+
+The `pgo-deployer` image can be used to deploy Grafana and Prometheus alongside
+the PostgreSQL Operator. The settings outlined in the [Installing-metrics]({{< relref "/installation/other/ansible/installing-metrics" >}})
+seciton of the documentation can be defined in your `values.yaml` configmap.
+Once you have updated the relevant metrics options you can update the
+`DEPLOY_ACTION` of the job manifest. By updating the environment variable to
+include `install-metrics` the installer will use the metrics settings when
+deploying.
+
+### Installing
+
+The following can be used to install the PostgreSQL Operator and metrics
+infrastructure at the same time.
+
+```yaml
+env:
+  - name: DEPLOY_ACTION
+    value: install,install-metrics
+```
+
+### Uninstalling
+
+The following can be used to uninstall the PostgreSQL Operator and metrics 
+infrastructure at the same time.
+```yaml
+env:
+  - name: DEPLOY_ACTION
+    value: uninstall,uninstall-metrics
+```
+
+### Updating Previous Deployment
+
+If you have previously deployed the PostgreSQL Operator, you can install or
+uninstall the metrics infrastructure separately using these settings:
+
+```yaml
+# Install
+env:
+  - name: DEPLOY_ACTION
+    value: install-metrics
+# Uninstall
+env:
+  - name: DEPLOY_ACTION
+    value: uninstall-metrics
+```
 
 ## Post-Installation
 

--- a/installers/kubectl/postgres-operator-ocp311.yml
+++ b/installers/kubectl/postgres-operator-ocp311.yml
@@ -26,7 +26,7 @@ metadata:
 data:
   values.yaml: |+
     ---
-    archive_mode: "true"
+    archive_mode: true
     archive_timeout: "60"
     backrest_aws_s3_bucket: ""
     backrest_aws_s3_endpoint: ""
@@ -34,13 +34,13 @@ data:
     backrest_aws_s3_region: ""
     backrest_aws_s3_secret: ""
     backrest_port: "2022"
-    badger: "false"
+    badger: false
     ccp_image_prefix: "registry.developers.crunchydata.com/crunchydata"
     ccp_image_pull_secret: ""
     ccp_image_pull_secret_manifest: ""
     ccp_image_tag: "centos7-12.3-4.4.0-beta.1"
-    create_rbac: "true"
-    crunchy_debug: "false"
+    create_rbac: true
+    crunchy_debug: false
     db_name: ""
     db_password_age_days: "0"
     db_password_length: "24"
@@ -50,26 +50,26 @@ data:
     default_instance_memory: "128Mi"
     default_pgbackrest_memory: "48Mi"
     default_pgbouncer_memory: "24Mi"
-    delete_metrics_namespace: "false"
-    delete_operator_namespace: "false"
-    delete_watched_namespaces: "false"
-    disable_auto_failover: "false"
-    disable_fsgroup: "false"
-    reconcile_rbac: "true"
+    delete_metrics_namespace: false
+    delete_operator_namespace: false
+    delete_watched_namespaces: false
+    disable_auto_failover: false
+    disable_fsgroup: false
+    reconcile_rbac: true
     exporterport: "9187"
     grafana_admin_password: ""
     grafana_admin_username: "admin"
-    grafana_install: "false"
+    grafana_install: false
     grafana_storage_access_mode: "ReadWriteOnce"
     grafana_storage_class_name: "fast"
     grafana_supplemental_groups: "65534"
     grafana_volume_size: "1G"
-    metrics: "false"
+    metrics: false
     metrics_namespace: "pgo"
     namespace: "pgo"
     namespace_mode: "dynamic"
     pgbadgerport: "10000"
-    pgo_add_os_ca_store: "false"
+    pgo_add_os_ca_store: false
     pgo_admin_password: "examplepassword"
     pgo_admin_perms: "*"
     pgo_admin_role_name: "pgoadmin"
@@ -77,11 +77,11 @@ data:
     pgo_apiserver_port: "8443"
     pgo_apiserver_url: "https://postgres-operator"
     pgo_client_cert_secret: "pgo.tls"
-    pgo_client_container_install: "false"
+    pgo_client_container_install: false
     pgo_client_version: "4.4.0-beta.1"
-    pgo_cluster_admin: "false"
-    pgo_disable_eventing: "false"
-    pgo_disable_tls: "false"
+    pgo_cluster_admin: false
+    pgo_disable_eventing: false
+    pgo_disable_tls: false
     pgo_image_prefix: "registry.developers.crunchydata.com/crunchydata"
     pgo_image_pull_secret: ""
     pgo_image_pull_secret_manifest: ""
@@ -90,18 +90,18 @@ data:
     pgo_noauth_routes: ""
     pgo_operator_namespace: "pgo"
     pgo_tls_ca_store: ""
-    pgo_tls_no_verify: "false"
+    pgo_tls_no_verify: false
     pod_anti_affinity: "preferred"
     pod_anti_affinity_pgbackrest: ""
     pod_anti_affinity_pgbouncer: ""
-    prometheus_install: "false"
+    prometheus_install: false
     prometheus_storage_access_mode: "ReadWriteOnce"
     prometheus_storage_class_name: "fast"
     prometheus_supplemental_groups: "65534"
     prometheus_volume_size: "1G"
     scheduler_timeout: "3600"
     service_type: "ClusterIP"
-    sync_replication: "false"
+    sync_replication: false
     backrest_storage: "hostpathstorage"
     backup_storage: "hostpathstorage"
     primary_storage: "hostpathstorage"

--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -119,7 +119,7 @@ rules:
   data:
     values.yaml: |+
       ---
-      archive_mode: "true"
+      archive_mode: true
       archive_timeout: "60"
       backrest_aws_s3_bucket: ""
       backrest_aws_s3_endpoint: ""
@@ -127,13 +127,13 @@ rules:
       backrest_aws_s3_region: ""
       backrest_aws_s3_secret: ""
       backrest_port: "2022"
-      badger: "false"
+      badger: false
       ccp_image_prefix: "registry.developers.crunchydata.com/crunchydata"
       ccp_image_pull_secret: ""
       ccp_image_pull_secret_manifest: ""
       ccp_image_tag: "centos7-12.3-4.4.0-beta.1"
-      create_rbac: "true"
-      crunchy_debug: "false"
+      create_rbac: true
+      crunchy_debug: false
       db_name: ""
       db_password_age_days: "0"
       db_password_length: "24"
@@ -143,26 +143,26 @@ rules:
       default_instance_memory: "128Mi"
       default_pgbackrest_memory: "48Mi"
       default_pgbouncer_memory: "24Mi"
-      delete_metrics_namespace: "false"
-      delete_operator_namespace: "false"
-      delete_watched_namespaces: "false"
-      disable_auto_failover: "false"
-      disable_fsgroup: "false"
-      reconcile_rbac: "true"
+      delete_metrics_namespace: false
+      delete_operator_namespace: false
+      delete_watched_namespaces: false
+      disable_auto_failover: false
+      disable_fsgroup: false
+      reconcile_rbac: true
       exporterport: "9187"
       grafana_admin_password: ""
       grafana_admin_username: "admin"
-      grafana_install: "false"
+      grafana_install: false
       grafana_storage_access_mode: "ReadWriteOnce"
       grafana_storage_class_name: "fast"
       grafana_supplemental_groups: "65534"
       grafana_volume_size: "1G"
-      metrics: "false"
+      metrics: false
       metrics_namespace: "pgo"
       namespace: "pgo"
       namespace_mode: "dynamic"
       pgbadgerport: "10000"
-      pgo_add_os_ca_store: "false"
+      pgo_add_os_ca_store: false
       pgo_admin_password: "examplepassword"
       pgo_admin_perms: "*"
       pgo_admin_role_name: "pgoadmin"
@@ -170,11 +170,11 @@ rules:
       pgo_apiserver_port: "8443"
       pgo_apiserver_url: "https://postgres-operator"
       pgo_client_cert_secret: "pgo.tls"
-      pgo_client_container_install: "false"
+      pgo_client_container_install: false
       pgo_client_version: "4.4.0-beta.1"
-      pgo_cluster_admin: "false"
-      pgo_disable_eventing: "false"
-      pgo_disable_tls: "false"
+      pgo_cluster_admin: false
+      pgo_disable_eventing: false
+      pgo_disable_tls: false
       pgo_image_prefix: "registry.developers.crunchydata.com/crunchydata"
       pgo_image_pull_secret: ""
       pgo_image_pull_secret_manifest: ""
@@ -183,18 +183,18 @@ rules:
       pgo_noauth_routes: ""
       pgo_operator_namespace: "pgo"
       pgo_tls_ca_store: ""
-      pgo_tls_no_verify: "false"
+      pgo_tls_no_verify: false
       pod_anti_affinity: "preferred"
       pod_anti_affinity_pgbackrest: ""
       pod_anti_affinity_pgbouncer: ""
-      prometheus_install: "false"
+      prometheus_install: false
       prometheus_storage_access_mode: "ReadWriteOnce"
       prometheus_storage_class_name: "fast"
       prometheus_supplemental_groups: "65534"
       prometheus_volume_size: "1G"
       scheduler_timeout: "3600"
       service_type: "ClusterIP"
-      sync_replication: "false"
+      sync_replication: false
       backrest_storage: "hostpathstorage"
       backup_storage: "hostpathstorage"
       primary_storage: "hostpathstorage"


### PR DESCRIPTION
Metrics support was an undocumented feature of the pgo-deployer. This commit
adds documentation around how you can use the `kubectl` job manifest and
`pgo-deployer` to install and uninstall the metrics infrastructure.

The deployment options in the new yaml files are updated so that the boolean
values are treated as bool instead of string.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
