### PR TITLE
Codify Versions in Documentation

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -26,6 +26,7 @@ highlightClientSide = false # set true to use highlight.pack.js instead of the d
 menushortcutsnewtab = false # set true to open shortcuts links to a new tab/window
 enableGitInfo = true
 operatorVersion = "4.4.0-beta.2"
+postgresVersion = "12.3"
 
 [outputs]
 home = [ "HTML", "RSS", "JSON"]

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -27,6 +27,7 @@ menushortcutsnewtab = false # set true to open shortcuts links to a new tab/wind
 enableGitInfo = true
 operatorVersion = "4.4.0-beta.2"
 postgresVersion = "12.3"
+centosBase = "centos7"
 
 [outputs]
 home = [ "HTML", "RSS", "JSON"]

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -25,6 +25,7 @@ disableNavChevron = false # set true to hide next/prev chevron, default is false
 highlightClientSide = false # set true to use highlight.pack.js instead of the default hugo chroma highlighter
 menushortcutsnewtab = false # set true to open shortcuts links to a new tab/window
 enableGitInfo = true
+operatorVersion = "4.4.0-beta.2"
 
 [outputs]
 home = [ "HTML", "RSS", "JSON"]

--- a/docs/content/Configuration/compatibility.md
+++ b/docs/content/Configuration/compatibility.md
@@ -1,7 +1,6 @@
 
 ---
 title: "Compatibility Requirements"
-Latest Release: 4.3.0 {docdate}
 draft: false
 weight: 1
 ---

--- a/docs/content/Configuration/configuration.md
+++ b/docs/content/Configuration/configuration.md
@@ -1,7 +1,5 @@
-
 ---
 title: "Configuration Resources"
-Latest Release: 4.4.0-beta.2 {docdate}
 draft: false
 weight: 2
 ---

--- a/docs/content/Configuration/pgo-yaml-configuration.md
+++ b/docs/content/Configuration/pgo-yaml-configuration.md
@@ -16,7 +16,7 @@ The *pgo.yaml* file is broken into major sections as described below:
 |---|---|
 |BasicAuth        | If set to `"true"` will enable Basic Authentication. If set to `"false"`, will allow a valid Operator user to successfully authenticate regardless of the value of the password provided for Basic Authentication. Defaults to `"true".`
 |CCPImagePrefix        |newly created containers will be based on this image prefix (e.g. crunchydata), update this if you require a custom image prefix
-|CCPImageTag        |newly created containers will be based on this image version (e.g. centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}}), unless you override it using the --ccp-image-tag command line flag
+|CCPImageTag        |newly created containers will be based on this image version (e.g. {{< param centosBase >}}-{{< param postgresVersion >}}-{{< param operatorVersion >}}), unless you override it using the --ccp-image-tag command line flag
 |Port        | the PostgreSQL port to use for new containers (e.g. 5432)
 |PGBadgerPort | the port used to connect to pgbadger (e.g. 10000)
 |ExporterPort | the port used to connect to postgres exporter (e.g. 9187)

--- a/docs/content/Configuration/pgo-yaml-configuration.md
+++ b/docs/content/Configuration/pgo-yaml-configuration.md
@@ -1,7 +1,7 @@
 
 ---
 title: "PGO YAML"
-Latest Release: 4.4.0-beta.2 {docdate}
+
 draft: false
 weight: 3
 ---
@@ -16,7 +16,7 @@ The *pgo.yaml* file is broken into major sections as described below:
 |---|---|
 |BasicAuth        | If set to `"true"` will enable Basic Authentication. If set to `"false"`, will allow a valid Operator user to successfully authenticate regardless of the value of the password provided for Basic Authentication. Defaults to `"true".`
 |CCPImagePrefix        |newly created containers will be based on this image prefix (e.g. crunchydata), update this if you require a custom image prefix
-|CCPImageTag        |newly created containers will be based on this image version (e.g. centos7-12.3-4.4.0-beta.2), unless you override it using the --ccp-image-tag command line flag
+|CCPImageTag        |newly created containers will be based on this image version (e.g. centos7-12.3-{{< param operatorVersion >}}), unless you override it using the --ccp-image-tag command line flag
 |Port        | the PostgreSQL port to use for new containers (e.g. 5432)
 |PGBadgerPort | the port used to connect to pgbadger (e.g. 10000)
 |ExporterPort | the port used to connect to postgres exporter (e.g. 9187)

--- a/docs/content/Configuration/pgo-yaml-configuration.md
+++ b/docs/content/Configuration/pgo-yaml-configuration.md
@@ -16,7 +16,7 @@ The *pgo.yaml* file is broken into major sections as described below:
 |---|---|
 |BasicAuth        | If set to `"true"` will enable Basic Authentication. If set to `"false"`, will allow a valid Operator user to successfully authenticate regardless of the value of the password provided for Basic Authentication. Defaults to `"true".`
 |CCPImagePrefix        |newly created containers will be based on this image prefix (e.g. crunchydata), update this if you require a custom image prefix
-|CCPImageTag        |newly created containers will be based on this image version (e.g. centos7-12.3-{{< param operatorVersion >}}), unless you override it using the --ccp-image-tag command line flag
+|CCPImageTag        |newly created containers will be based on this image version (e.g. centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}}), unless you override it using the --ccp-image-tag command line flag
 |Port        | the PostgreSQL port to use for new containers (e.g. 5432)
 |PGBadgerPort | the port used to connect to pgbadger (e.g. 10000)
 |ExporterPort | the port used to connect to postgres exporter (e.g. 9187)

--- a/docs/content/Security/install-postgres-operator-rbac.md
+++ b/docs/content/Security/install-postgres-operator-rbac.md
@@ -7,9 +7,9 @@ weight: 7
 
 ## Installation of PostgreSQL Operator RBAC
 
-For a list of the RBAC required to install the PostgreSQL Operator, please view the [`postgres-operator.yml`](https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml) file:
+For a list of the RBAC required to install the PostgreSQL Operator, please view the [`postgres-operator.yml`](https://raw.githubusercontent.com/CrunchyData/postgres-operator/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml) file:
 
-[https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml](https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml)
+[https://raw.githubusercontent.com/CrunchyData/postgres-operator/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml](https://raw.githubusercontent.com/CrunchyData/postgres-operator/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml)
 
 The first step is to install the PostgreSQL Operator RBAC configuration.  This can be accomplished  by running:
 

--- a/docs/content/Upgrade/_index.md
+++ b/docs/content/Upgrade/_index.md
@@ -1,15 +1,13 @@
 ---
 title: "Upgrade"
-Latest Release: 4.4.0-beta.2 {docdate}
 draft: false
 weight: 80
 ---
 
 # Upgrading the Crunchy PostgreSQL Operator
 
-There are two methods for upgrading your existing deployment of the PostgreSQL Operator. 
+There are two methods for upgrading your existing deployment of the PostgreSQL Operator.
 
 If you are upgrading from PostgreSQL Operator 4.1.0 or later, you are encouraged to use the [Automated Upgrade Procedure](/upgrade/automatedupgrade). This method simplifies the upgrade process, as well as maintains your existing clusters in place prior to their upgrade.
 
 For versions before 4.1.0, please see the appropriate [manual procedure](/upgrade/manual).
-

--- a/docs/content/Upgrade/automatedupgrade.md
+++ b/docs/content/Upgrade/automatedupgrade.md
@@ -1,6 +1,5 @@
 ---
 title: "Automated PostgreSQL Operator Upgrade - Operator 4.1+"
-Latest Release: 4.4.0-beta.2 {docdate}
 draft: false
 weight: 80
 ---
@@ -10,7 +9,7 @@ weight: 80
 The automated upgrade to a new release of the PostgreSQL Operator comprises two main steps:
 
 * Upgrading the PostgreSQL Operator itself
-* Upgrading the existing PostgreSQL Clusters to the new release 
+* Upgrading the existing PostgreSQL Clusters to the new release
 
 The first step will result in an upgraded PostgreSQL Operator that is able to create and manage new clusters as expected, but will be unable to manage existing clusters until they have been upgraded. The second step upgrades the clusters to the current Operator version, allowing them to once again be fully managed by the Operator.
 
@@ -35,10 +34,10 @@ The automated upgrade procedure is designed to facilate the quickest and most ef
 8. Metrics - While the PostgreSQL Operator upgrade process will not delete an existing Metrics Stack, it does not currently support the upgrade of existing metrics infrastructure.
 
 ##### NOTE: As with any upgrade procedure, it is strongly recommended that a full logical backup is taken before any upgrade procedure is started. Please see the [Logical Backups](/pgo-client/common-tasks#logical-backups-pg_dump--pg_dumpall) section of the Common Tasks page for more information.
- 
+
 ### Automated Upgrade when using an Ansible installation of the PostgreSQL Operator
 
-For existing PostgreSQL Operator deployments that were installed using Ansible, the upgrade process is straightforward. 
+For existing PostgreSQL Operator deployments that were installed using Ansible, the upgrade process is straightforward.
 
 First, you will copy your existing inventory file as a backup for your existing settings. You will reference these settings, but you will need to use the updated version of the inventory file for the current version of PostgreSQL Operator.
 
@@ -71,18 +70,18 @@ export NOAUTH_ROUTES=""
 export EXCLUDE_OS_TRUST=false
 ```
 
-Then, for either 4.1.X or 4.2.X, 
+Then, for either 4.1.X or 4.2.X,
 
-Update the `PGO_VERSION` variable to `4.4.0-beta.2`
+Update the `PGO_VERSION` variable to `{{< param operatorVersion >}}`
 
-Finally, source this file with 
+Finally, source this file with
 ```
 source $HOME/.bashrc
 ```
 
 ##### PostgreSQL Operator Configuration File updates
 
-Next, you will and save a copy of your existing pgo.yaml file (`$PGOROOT/conf/postgres-operator/pgo.yaml`) as pgo_old.yaml or similar. 
+Next, you will and save a copy of your existing pgo.yaml file (`$PGOROOT/conf/postgres-operator/pgo.yaml`) as pgo_old.yaml or similar.
 
 Once this is saved, you will checkout the current release of the PostgreSQL Operator and update the pgo.yaml for the current version, making sure to make updates to the CCPImageTag and storage settings in line with the [Considerations](/upgrade/automatedupgrade#considerations) given above.
 
@@ -100,15 +99,15 @@ This script will undeploy the current PostgreSQL Operator, configure the desired
 After this script completes, it is strongly recommended that you create a test cluster to validate the Operator is functioning as expected before moving on to the individual cluster upgrades.
 
 ## PostgreSQL Operator Automated Cluster Upgrade
-    
+
 Previously, the existing cluster upgrade focused on updating a cluster's underlying container images. However, due to the various changes in the PostgreSQL Operator's operation between the various versions (including numerous updates to the relevant CRDs, integration of Patroni for HA and other significant changes), updates between PostgreSQL Operator releases required the manual deletion of the existing clusters while preserving the underlying PVC storage. After installing the new PostgreSQL Operator version, the clusters could be recreated manually with the name of the new cluster matching the existing PVC's name.
 
 The automated upgrade process provides a mechanism where, instead of being deleted, the existing PostgreSQL clusters will be left in place during the PostgreSQL Operator upgrade. While normal Operator functionality will be restricted on these existing clusters until they are upgraded to the currently installed PostgreSQL Operator version, the pods, services, etc will still be in place and accessible via other methods (e.g. kubectl, service IP, etc).
-    
+
 To upgrade a particular cluster, use
 ```    
 pgo upgrade mycluster
-``` 
+```
 This will follow a similar process to the documented manual process, where the pods, deployments, replicasets, pgtasks and jobs are deleted, the cluster's replicas are scaled down and replica PVCs deleted, but the primary PVC and backrest-repo PVC are left in place. Existing services for the primary, replica and backrest-shared-repo are also kept and will be updated to the requirements of the current version. Configmaps and secrets are kept except where deletion is required. For a cluster 'mycluster', the following configmaps will be deleted (if they exist) and recreated:
 ```    
 mycluster-leader

--- a/docs/content/Upgrade/manual/upgrade35.md
+++ b/docs/content/Upgrade/manual/upgrade35.md
@@ -49,7 +49,7 @@ For example, given the following output:
 ```
 $ pgo show cluster mycluster
 
-cluster : mycluster (crunchy-postgres:centos7-11.5-2.4.2)
+cluster : mycluster (crunchy-postgres:{{< param centosBase >}}-11.5-2.4.2)
 	pod : mycluster-7bbf54d785-pk5dq (Running) on kubernetes1 (1/1) (replica)
 	pvc : mycluster
 	pod : mycluster-ypvq-5b9b8d645-nvlb6 (Running) on kubernetes1 (1/1) (primary)

--- a/docs/content/Upgrade/manual/upgrade35.md
+++ b/docs/content/Upgrade/manual/upgrade35.md
@@ -1,21 +1,20 @@
 ---
 title: "Manual Upgrade - Operator 3.5"
-Latest Release: 4.4.0-beta.2 {docdate}
 draft: false
 weight: 8
 ---
 
-## Upgrading the Crunchy PostgreSQL Operator from Version 3.5 to 4.4.0-beta.2
+## Upgrading the Crunchy PostgreSQL Operator from Version 3.5 to {{< param operatorVersion >}}
 
-This section will outline the procedure to upgrade a given cluster created using PostgreSQL Operator 3.5.x to PostgreSQL Operator version 4.4.0-beta.2. This version of the PostgreSQL Operator has several fundamental changes to the existing PGCluster structure and deployment model. Most notably, all PGClusters use the new Crunchy PostgreSQL HA container in place of the previous Crunchy PostgreSQL containers. The use of this new container is a breaking change from previous versions of the Operator.
+This section will outline the procedure to upgrade a given cluster created using PostgreSQL Operator 3.5.x to PostgreSQL Operator version {{< param operatorVersion >}}. This version of the PostgreSQL Operator has several fundamental changes to the existing PGCluster structure and deployment model. Most notably, all PGClusters use the new Crunchy PostgreSQL HA container in place of the previous Crunchy PostgreSQL containers. The use of this new container is a breaking change from previous versions of the Operator.
 
 #### Crunchy PostgreSQL High Availability Containers
 
-Using the PostgreSQL Operator 4.4.0-beta.2 requires replacing your `crunchy-postgres` and `crunchy-postgres-gis` containers with the `crunchy-postgres-ha` and `crunchy-postgres-gis-ha` containers respectively. The underlying PostgreSQL installations in the container remain the same but are now optimized for Kubernetes environments to provide the new high-availability functionality.
+Using the PostgreSQL Operator {{< param operatorVersion >}} requires replacing your `crunchy-postgres` and `crunchy-postgres-gis` containers with the `crunchy-postgres-ha` and `crunchy-postgres-gis-ha` containers respectively. The underlying PostgreSQL installations in the container remain the same but are now optimized for Kubernetes environments to provide the new high-availability functionality.
 
 A major change to this container is that the PostgreSQL process is now managed by Patroni. This allows a PostgreSQL cluster that is deployed by the PostgreSQL Operator to manage its own uptime and availability, to elect a new leader in the event of a downtime scenario, and to automatically heal after a failover event.
 
-When creating your new clusters using version 4.4.0-beta.2 of the PostgreSQL Operator, the `pgo create cluster` command will automatically use the new `crunchy-postgres-ha` image if the image is unspecified. If you are creating a PostGIS enabled cluster, please be sure to use the updated image name, as with the command:
+When creating your new clusters using version {{< param operatorVersion >}} of the PostgreSQL Operator, the `pgo create cluster` command will automatically use the new `crunchy-postgres-ha` image if the image is unspecified. If you are creating a PostGIS enabled cluster, please be sure to use the updated image name, as with the command:
 
 ```
 pgo create cluster mygiscluster --ccp-image=crunchy-postgres-gis-ha
@@ -31,7 +30,7 @@ You will need the following items to complete the upgrade:
 
 ##### Step 1
 
-Create a new Linux user with the same permissions as the existing user used to install the Crunchy PostgreSQL Operator. This is necessary to avoid any issues with environment variable differences between 3.5 and 4.4.0-beta.2.
+Create a new Linux user with the same permissions as the existing user used to install the Crunchy PostgreSQL Operator. This is necessary to avoid any issues with environment variable differences between 3.5 and {{< param operatorVersion >}}.
 
 ##### Step 2
 
@@ -41,7 +40,7 @@ For the cluster(s) you wish to upgrade, record the cluster details provided by
 pgo show cluster <clustername>
 ```
 
-so that your new clusters can be recreated with the proper settings. 
+so that your new clusters can be recreated with the proper settings.
 
 Also, you will need to note the name of the primary PVC. If it does not exactly match the cluster name, you will need to recreate your cluster using the primary PVC name as the new cluster name.
 
@@ -80,7 +79,7 @@ For the cluster(s) you wish to upgrade, scale down any replicas, if necessary, t
 pgo delete cluster <clustername>
 ```
 
-If there are any remaining jobs for this deleted cluster, use 
+If there are any remaining jobs for this deleted cluster, use
 
 ```
 kubectl -n <namespace> delete job <jobname>
@@ -101,7 +100,7 @@ $COROOT/deploy/remove-crd.sh
 
 ##### Step 6
 
-Log in as your new Linux user and install the 4.4.0-beta.2 PostgreSQL Operator as described in the [Bash Installation Procedure]( {{< relref "installation/other/bash.md" >}}).
+Log in as your new Linux user and install the {{< param operatorVersion >}} PostgreSQL Operator as described in the [Bash Installation Procedure]( {{< relref "installation/other/bash.md" >}}).
 
 Be sure to add the existing namespace to the Operator's list of watched namespaces (see the [Namespace]( {{< relref "architecture/namespace.md" >}}) section of this document for more information) and make sure to avoid overwriting any existing data storage.
 
@@ -110,7 +109,7 @@ We strongly recommend that you create a test cluster before proceeding to the ne
 
 ##### Step 7
 
-Once the Operator is installed and functional, create a new 4.4.0-beta.2 cluster matching the cluster details recorded in Step 1. Be sure to use the primary PVC name (also noted in Step 1) and the same major PostgreSQL version as was used previously. This will allow the new clusters to utilize the existing PVCs.
+Once the Operator is installed and functional, create a new {{< param operatorVersion >}} cluster matching the cluster details recorded in Step 1. Be sure to use the primary PVC name (also noted in Step 1) and the same major PostgreSQL version as was used previously. This will allow the new clusters to utilize the existing PVCs.
 
 NOTE: If you have existing pgBackRest backups stored that you would like to have available in the upgraded cluster, you will need to follow the [PVC Renaming Procedure]( {{< relref "Upgrade/manual/upgrade35#pgbackrest-repo-pvc-renaming" >}}).
 
@@ -122,7 +121,7 @@ pgo create cluster <clustername> -n <namespace>
 
 ##### Step 8
 
-Manually update the old leftover Secrets to use the new label as defined in 4.4.0-beta.2:
+Manually update the old leftover Secrets to use the new label as defined in {{< param operatorVersion >}}:
 
 ```
 kubectl -n <namespace> label secret/<clustername>-postgres-secret pg-cluster=<clustername> -n <namespace>
@@ -169,7 +168,7 @@ To begin, save the output from
 kubectl -n <namespace> describe pvc mycluster-backrest-shared-repo
 ```
 
-for later use when recreating this PVC with the new name. In this output, note the "Volume" name, which is the name of the underlying PV. 
+for later use when recreating this PVC with the new name. In this output, note the "Volume" name, which is the name of the underlying PV.
 
 ##### Step 2
 
@@ -201,7 +200,7 @@ You will remove the "claimRef" section of the PV with
 kubectl -n <namespace> patch pv <PV name> --type=json -p='[{"op": "remove", "path": "/spec/claimRef"}]'
 ```
 
-which will make the PV "Available" so it may be reused by the new PVC. 
+which will make the PV "Available" so it may be reused by the new PVC.
 
 ##### Step 5
 
@@ -211,7 +210,7 @@ Now, create a file with contents similar to the following:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: mycluster-pgbr-repo 
+  name: mycluster-pgbr-repo
   namespace: demo
 spec:
   storageClassName: ""
@@ -239,4 +238,4 @@ To check that your PVC is "Bound", run
 ```
 kubectl -n <namespace> get pvc mycluster-pgbr-repo
 ```
-Congratulations, you have renamed your PVC! Once the PVC Status is "Bound", your cluster can be recreated. If you altered the Reclaim Policy on your PV in Step 1, you will want to reset it now. 
+Congratulations, you have renamed your PVC! Once the PVC Status is "Bound", your cluster can be recreated. If you altered the Reclaim Policy on your PV in Step 1, you will want to reset it now.

--- a/docs/content/Upgrade/manual/upgrade4.md
+++ b/docs/content/Upgrade/manual/upgrade4.md
@@ -1,23 +1,22 @@
 ---
 title: "Manual Upgrade - Operator 4"
-Latest Release: 4.4.0-beta.2 {docdate}
 draft: false
 weight: 8
 ---
 
 ## Manual PostgreSQL Operator 4 Upgrade Procedure
 
-Below are the procedures for upgrading to version 4.4.0-beta.2 of the Crunchy PostgreSQL Operator using the Bash or Ansible installation methods. This version of the PostgreSQL Operator has several fundamental changes to the existing PGCluster structure and deployment model. Most notably for those upgrading from 4.1 and below, all PGClusters use the new Crunchy PostgreSQL HA container in place of the previous Crunchy PostgreSQL containers. The use of this new container is a breaking change from previous versions of the Operator did not use the HA containers.
+Below are the procedures for upgrading to version {{< param operatorVersion >}} of the Crunchy PostgreSQL Operator using the Bash or Ansible installation methods. This version of the PostgreSQL Operator has several fundamental changes to the existing PGCluster structure and deployment model. Most notably for those upgrading from 4.1 and below, all PGClusters use the new Crunchy PostgreSQL HA container in place of the previous Crunchy PostgreSQL containers. The use of this new container is a breaking change from previous versions of the Operator did not use the HA containers.
 
-NOTE: If you are upgrading from Crunchy PostgreSQL Operator version 4.1.0 or later, the [Automated Upgrade Procedure](/upgrade/automatedupgrade) is recommended. If you are upgrading PostgreSQL 12 clusters, you MUST use the [Automated Upgrade Procedure](/upgrade/automatedupgrade). 
+NOTE: If you are upgrading from Crunchy PostgreSQL Operator version 4.1.0 or later, the [Automated Upgrade Procedure](/upgrade/automatedupgrade) is recommended. If you are upgrading PostgreSQL 12 clusters, you MUST use the [Automated Upgrade Procedure](/upgrade/automatedupgrade).
 
 #### Crunchy PostgreSQL High Availability Containers
 
-Using the PostgreSQL Operator 4.4.0-beta.2 requires replacing your `crunchy-postgres` and `crunchy-postgres-gis` containers with the `crunchy-postgres-ha` and `crunchy-postgres-gis-ha` containers respectively. The underlying PostgreSQL installations in the container remain the same but are now optimized for Kubernetes environments to provide the new high-availability functionality.
+Using the PostgreSQL Operator {{< param operatorVersion >}} requires replacing your `crunchy-postgres` and `crunchy-postgres-gis` containers with the `crunchy-postgres-ha` and `crunchy-postgres-gis-ha` containers respectively. The underlying PostgreSQL installations in the container remain the same but are now optimized for Kubernetes environments to provide the new high-availability functionality.
 
 A major change to this container is that the PostgreSQL process is now managed by Patroni. This allows a PostgreSQL cluster that is deployed by the PostgreSQL Operator to manage its own uptime and availability, to elect a new leader in the event of a downtime scenario, and to automatically heal after a failover event.
 
-When creating your new clusters using version 4.4.0-beta.2 of the PostgreSQL Operator, the `pgo create cluster` command will automatically use the new `crunchy-postgres-ha` image if the image is unspecified. If you are creating a PostGIS enabled cluster, please be sure to use the updated image name, as with the command:
+When creating your new clusters using version {{< param operatorVersion >}} of the PostgreSQL Operator, the `pgo create cluster` command will automatically use the new `crunchy-postgres-ha` image if the image is unspecified. If you are creating a PostGIS enabled cluster, please be sure to use the updated image name, as with the command:
 
 ```
 pgo create cluster mygiscluster --ccp-image=crunchy-postgres-gis-ha
@@ -35,7 +34,7 @@ Below are the procedures for upgrading the PostgreSQL Operator and PostgreSQL cl
 
 You will need the following items to complete the upgrade:
 
-* The latest 4.4.0-beta.2 code for the Postgres Operator available
+* The latest {{< param operatorVersion >}} code for the Postgres Operator available
 
 These instructions assume you are executing in a terminal window and that your user has admin privileges in your Kubernetes or Openshift environment.
 
@@ -102,7 +101,7 @@ and then, for all versions, delete the "backrest-repo-config" secret, if it exis
 kubectl delete secret <clustername>-backrest-repo-config
 ```
 
-If there are any remaining jobs for this deleted cluster, use 
+If there are any remaining jobs for this deleted cluster, use
 
 ```
 kubectl -n <namespace> delete job <jobname>
@@ -116,7 +115,7 @@ NOTE: Please note the name of each cluster, the namespace used, and be sure not 
 
 ##### Step 4
 
-Save a copy of your current inventory file with a new name (such as `inventory.backup)` and checkout the latest 4.4.0-beta.2 tag of the Postgres Operator.
+Save a copy of your current inventory file with a new name (such as `inventory.backup)` and checkout the latest {{< param operatorVersion >}} tag of the Postgres Operator.
 
 
 ##### Step 5
@@ -147,7 +146,7 @@ We strongly recommend that you create a test cluster before proceeding to the ne
 
 ##### Step 8
 
-Once the Operator is installed and functional, create a new 4.4.0-beta.2 cluster matching the cluster details recorded in Step 1. Be sure to use the primary PVC name (also noted in Step 1) and the same major PostgreSQL version as was used previously. This will allow the new clusters to utilize the existing PVCs. 
+Once the Operator is installed and functional, create a new {{< param operatorVersion >}} cluster matching the cluster details recorded in Step 1. Be sure to use the primary PVC name (also noted in Step 1) and the same major PostgreSQL version as was used previously. This will allow the new clusters to utilize the existing PVCs.
 
 NOTE: If you have existing pgBackRest backups stored that you would like to have available in the upgraded cluster, you will need to follow the [PVC Renaming Procedure]( {{< relref "Upgrade/manual/upgrade4#pgbackrest-repo-pvc-renaming" >}}).
 
@@ -181,7 +180,7 @@ Scale up to the required number of replicas, as needed.
 
 Congratulations! Your cluster is upgraded and ready to use!
 
-### Bash Installation Upgrade Procedure 
+### Bash Installation Upgrade Procedure
 
 Below are the procedures for upgrading the PostgreSQL Operator and PostgreSQL clusters using the Bash installation method.
 
@@ -284,7 +283,7 @@ $PGOROOT/deploy/cleanup-rbac.sh
 For versions 4.0, 4.1 and 4.2, update environment variables in the bashrc:
 
 ```
-export PGO_VERSION=4.4.0-beta.2
+export PGO_VERSION={{< param operatorVersion >}}
 ```
 
 NOTE: This will be the only update to the bashrc file for 4.2.
@@ -341,9 +340,9 @@ source ~/.bashrc
 
 ##### Step 8
 
-Ensure you have checked out the latest 4.4.0-beta.2 version of the source code and update the pgo.yaml file in `$PGOROOT/conf/postgres-operator/pgo.yaml`
+Ensure you have checked out the latest {{< param operatorVersion >}} version of the source code and update the pgo.yaml file in `$PGOROOT/conf/postgres-operator/pgo.yaml`
 
-You will want to use the 4.4.0-beta.2 pgo.yaml file and update custom settings such as image locations, storage, and resource configs.
+You will want to use the {{< param operatorVersion >}} pgo.yaml file and update custom settings such as image locations, storage, and resource configs.
 
 ##### Step 9
 
@@ -359,7 +358,7 @@ You will need to update the `$HOME/.pgouser`file to match the values you set in 
 
 ##### Step 10
 
-Install the 4.4.0-beta.2 Operator:
+Install the {{< param operatorVersion >}} Operator:
 
 Setup the configured namespaces:
 
@@ -387,7 +386,7 @@ kubectl get pod -n <operator namespace>
 
 ##### Step 11
 
-Next, update the PGO client binary to 4.4.0-beta.2 by replacing the existing 4.X binary with the latest 4.4.0-beta.2 binary available.
+Next, update the PGO client binary to {{< param operatorVersion >}} by replacing the existing 4.X binary with the latest {{< param operatorVersion >}} binary available.
 
 You can run:
 
@@ -416,7 +415,7 @@ make deployoperator
 
 ##### Step 13
 
-The Operator is now upgraded to 4.4.0-beta.2 and all users and roles have been recreated.
+The Operator is now upgraded to {{< param operatorVersion >}} and all users and roles have been recreated.
 Verify this by running:
 
 ```
@@ -427,7 +426,7 @@ We strongly recommend that you create a test cluster before proceeding to the ne
 
 ##### Step 14
 
-Once the Operator is installed and functional, create a new 4.4.0-beta.2 cluster matching the cluster details recorded in Step 1. Be sure to use the same name and the same major PostgreSQL version as was used previously. This will allow the new clusters to utilize the existing PVCs. A simple example is given below, but more information on cluster creation can be found [here](/pgo-client/common-tasks#creating-a-postgresql-cluster)
+Once the Operator is installed and functional, create a new {{< param operatorVersion >}} cluster matching the cluster details recorded in Step 1. Be sure to use the same name and the same major PostgreSQL version as was used previously. This will allow the new clusters to utilize the existing PVCs. A simple example is given below, but more information on cluster creation can be found [here](/pgo-client/common-tasks#creating-a-postgresql-cluster)
 
 NOTE: If you have existing pgBackRest backups stored that you would like to have available in the upgraded cluster, you will need to follow the [PVC Renaming Procedure]( {{< relref "Upgrade/manual/upgrade4#pgbackrest-repo-pvc-renaming" >}}).
 
@@ -479,7 +478,7 @@ In 4.1 and later:
 kubectl -n <namespace> describe pvc mycluster-pgbr-repo
 ```
 
-for later use when recreating this PVC with the new name. In this output, note the "Volume" name, which is the name of the underlying PV. 
+for later use when recreating this PVC with the new name. In this output, note the "Volume" name, which is the name of the underlying PV.
 
 ##### Step 2
 
@@ -518,7 +517,7 @@ You will remove the "claimRef" section of the PV with
 kubectl -n <namespace> patch pv <PV name> --type=json -p='[{"op": "remove", "path": "/spec/claimRef"}]'
 ```
 
-which will make the PV "Available" so it may be reused by the new PVC. 
+which will make the PV "Available" so it may be reused by the new PVC.
 
 ##### Step 5
 
@@ -528,7 +527,7 @@ Now, create a file with contents similar to the following:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: mycluster-pgbr-repo 
+  name: mycluster-pgbr-repo
   namespace: demo
 spec:
   storageClassName: ""
@@ -557,4 +556,4 @@ To check that your PVC is "Bound", run
 kubectl -n <namespace> get pvc mycluster-pgbr-repo
 ```
 
-Congratulations, you have renamed your PVC! Once the PVC Status is "Bound", your cluster can be recreated. If you altered the Reclaim Policy on your PV in Step 1, you will want to reset it now. 
+Congratulations, you have renamed your PVC! Once the PVC Status is "Bound", your cluster can be recreated. If you altered the Reclaim Policy on your PV in Step 1, you will want to reset it now.

--- a/docs/content/Upgrade/manual/upgrade4.md
+++ b/docs/content/Upgrade/manual/upgrade4.md
@@ -55,7 +55,7 @@ For example, given the following output:
 ```
 $ pgo show cluster mycluster
 
-cluster : mycluster (crunchy-postgres:centos7-11.5-2.4.2)
+cluster : mycluster (crunchy-postgres:{{< param centosBase >}}-11.5-2.4.2)
         pod : mycluster-7bbf54d785-pk5dq (Running) on kubernetes1 (1/1) (replica)
         pvc : mycluster
         pod : mycluster-ypvq-5b9b8d645-nvlb6 (Running) on kubernetes1 (1/1) (primary)
@@ -220,7 +220,7 @@ For example, given the following output:
 ```
 $ pgo show cluster mycluster
 
-cluster : mycluster (crunchy-postgres:centos7-11.5-2.4.2)
+cluster : mycluster (crunchy-postgres:{{< param centosBase >}}-11.5-2.4.2)
         pod : mycluster-7bbf54d785-pk5dq (Running) on kubernetes1 (1/1) (replica)
         pvc : mycluster
         pod : mycluster-ypvq-5b9b8d645-nvlb6 (Running) on kubernetes1 (1/1) (primary)

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -10,7 +10,7 @@ draft: false
 
 ## Run your own production-grade PostgreSQL-as-a-Service on Kubernetes!
 
-Latest Release: 4.4.0-beta.2
+Latest Release: {{< param operatorVersion >}}
 
 The [Crunchy PostgreSQL Operator](https://www.crunchydata.com/developers/download-postgres/containers/postgres-operator) automates and simplifies deploying and managing open source PostgreSQL clusters on Kubernetes and other Kubernetes-enabled Platforms by providing the essential features you need to keep your PostgreSQL clusters up and running, including:
 

--- a/docs/content/advanced/direct-api-calls.md
+++ b/docs/content/advanced/direct-api-calls.md
@@ -27,7 +27,7 @@ You can create a cluster by sending a POST request to `$PGO_APISERVER_URL/cluste
 curl --cacert $PGO_CA_CERT --key $PGO_CLIENT_KEY --cert $PGO_CA_CERT \
 -u admin:examplepassword -H "Content-Type:application/json" --insecure \
 -X POST --data \
-  '{"ClientVersion":"4.4.0-beta.2",
+  '{"ClientVersion":"{{< param operatorVersion >}}",
   "Namespace":"pgouser1",
   "Name":"mycluster",
   "Series":1}' \
@@ -41,7 +41,7 @@ The last two examples show you how to `show` and `delete` a cluster. Notice how 
 curl --cacert $PGO_CA_CERT --key $PGO_CLIENT_KEY --cert $PGO_CA_CERT \
 -u admin:examplepassword -H "Content-Type:application/json" --insecure \
 -X POST --data \
-  '{"ClientVersion":"4.4.0-beta.2",
+  '{"ClientVersion":"{{< param operatorVersion >}}",
   "Namespace":"pgouser1",
   "Clustername":"mycluster"}' \
 $PGO_APISERVER_URL/showclusters
@@ -52,7 +52,7 @@ $PGO_APISERVER_URL/showclusters
 curl --cacert $PGO_CA_CERT --key $PGO_CLIENT_KEY --cert $PGO_CA_CERT \
 -u admin:examplepassword -H "Content-Type:application/json" --insecure \
 -X POST --data \
-  '{"ClientVersion":"4.4.0-beta.2",
+  '{"ClientVersion":"{{< param operatorVersion >}}",
   "Namespace":"pgouser1",
   "Clustername":"mycluster"}' \
 $PGO_APISERVER_URL/clustersdelete

--- a/docs/content/architecture/high-availability/multi-cluster-kubernetes.md
+++ b/docs/content/architecture/high-availability/multi-cluster-kubernetes.md
@@ -208,7 +208,7 @@ command.
 ```
 pgo show cluster hippo
 
-cluster : standby (crunchy-postgres-ha:centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}})
+cluster : standby (crunchy-postgres-ha:{{< param centosBase >}}-{{< param postgresVersion >}}-{{< param operatorVersion >}})
        standby : true
 ```
 ## Promoting a Standby Cluster

--- a/docs/content/architecture/high-availability/multi-cluster-kubernetes.md
+++ b/docs/content/architecture/high-availability/multi-cluster-kubernetes.md
@@ -208,7 +208,7 @@ command.
 ```
 pgo show cluster hippo
 
-cluster : standby (crunchy-postgres-ha:centos7-12.3-{{< param operatorVersion >}})
+cluster : standby (crunchy-postgres-ha:centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}})
        standby : true
 ```
 ## Promoting a Standby Cluster

--- a/docs/content/architecture/high-availability/multi-cluster-kubernetes.md
+++ b/docs/content/architecture/high-availability/multi-cluster-kubernetes.md
@@ -208,7 +208,7 @@ command.
 ```
 pgo show cluster hippo
 
-cluster : standby (crunchy-postgres-ha:centos7-12.3-4.4.0-beta.2)
+cluster : standby (crunchy-postgres-ha:centos7-12.3-{{< param operatorVersion >}})
        standby : true
 ```
 ## Promoting a Standby Cluster

--- a/docs/content/contributing/developer-setup.md
+++ b/docs/content/contributing/developer-setup.md
@@ -23,7 +23,7 @@ Variable | Example | Description
 -------- | ------- | -----------
 `GOPATH` | $HOME/odev | Golang project directory
 `PGOROOT` | $GOPATH/src/github.com/crunchydata/postgres-operator | Operator repository location
-`PGO_BASEOS` | centos7 | Base OS for container images
+`PGO_BASEOS` | {{< param centosBase >}} | Base OS for container images
 `PGO_CMD` | kubectl | Cluster management tool executable
 `PGO_IMAGE_PREFIX` | crunchydata | Container image prefix
 `PGO_OPERATOR_NAMESPACE` | pgo | Kubernetes namespace for the operator

--- a/docs/content/contributing/developer-setup.md
+++ b/docs/content/contributing/developer-setup.md
@@ -27,7 +27,7 @@ Variable | Example | Description
 `PGO_CMD` | kubectl | Cluster management tool executable
 `PGO_IMAGE_PREFIX` | crunchydata | Container image prefix
 `PGO_OPERATOR_NAMESPACE` | pgo | Kubernetes namespace for the operator
-`PGO_VERSION` | 4.4.0-beta.2 | Operator version
+`PGO_VERSION` | {{< param operatorVersion >}} | Operator version
 
 {{% notice tip %}}
 `examples/envs.sh` contains the above variable definitions as well as others used by postgres-operator tools

--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -87,7 +87,7 @@ make changes, as described below.
 | BackrestStorage | `create` | A specification that gives information about the storage attributes for the pgBackRest repository, which stores backups and archives, of the PostgreSQL cluster. For details, please see the `Storage Specification` section below. This is required. |
 | CCPImage | `create` | The name of the PostgreSQL container image to use, e.g. `crunchy-postgres-ha` or `crunchy-postgres-ha-gis`. |
 | CCPImagePrefix | `create` | If provided, the image prefix (or registry) of the PostgreSQL container image, e.g. `registry.developers.crunchydata.com/crunchydata`. The default is to use the image prefix set in the PostgreSQL Operator configuration. |
-| CCPImageTag | `create` | The tag of the PostgreSQL container image to use, e.g. `centos7-12.3-4.4.0-beta.2`. |
+| CCPImageTag | `create` | The tag of the PostgreSQL container image to use, e.g. `centos7-12.3-{{< param operatorVersion >}}`. |
 | CollectSecretName | `create` | An optional attribute unless `crunchy_collect` is specified in the `UserLabels`; contains the name of a Kubernetes Secret that contains the credentials for a PostgreSQL user that is used for metrics collection, and is created when the PostgreSQL cluster is first bootstrapped. For more information, please see `User Secret Specification`.|
 | ClusterName | `create` | The name of the PostgreSQL cluster, e.g. `hippo`. This is used to group PostgreSQL instances (primary, replicas) together. |
 | CustomConfig | `create` | If specified, references a custom ConfigMap to use when bootstrapping a PostgreSQL cluster. For the shape of this file, please see the section on [Custom Configuration]({{< relref "/advanced/custom-configuration.md" >}}) |
@@ -355,7 +355,7 @@ metadata:
     pg-cluster: ${pgo_cluster_name}
     pg-pod-anti-affinity: ""
     pgo-backrest: "true"
-    pgo-version: 4.4.0-beta.2
+    pgo-version: {{< param operatorVersion >}}
     pgouser: admin
   name: ${pgo_cluster_name}
   namespace: ${cluster_namespace}
@@ -432,7 +432,7 @@ spec:
   userlabels:
     crunchy_collect: "false"
     pg-pod-anti-affinity: ""
-    pgo-version: 4.4.0-beta.2
+    pgo-version: {{< param operatorVersion >}}
   usersecretname: ${pgo_cluster_name}-hippo-secret
 EOF
 
@@ -529,7 +529,7 @@ spec:
     NodeLabelValue: ""
     crunchy_collect: "false"
     pg-pod-anti-affinity: ""
-    pgo-version: 4.4.0-beta.2
+    pgo-version: {{< param operatorVersion >}}
 EOF
 
 kubectl apply -f "${pgo_cluster_name}-${pgo_cluster_replica_suffix}-pgreplica.yaml"

--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -87,7 +87,7 @@ make changes, as described below.
 | BackrestStorage | `create` | A specification that gives information about the storage attributes for the pgBackRest repository, which stores backups and archives, of the PostgreSQL cluster. For details, please see the `Storage Specification` section below. This is required. |
 | CCPImage | `create` | The name of the PostgreSQL container image to use, e.g. `crunchy-postgres-ha` or `crunchy-postgres-ha-gis`. |
 | CCPImagePrefix | `create` | If provided, the image prefix (or registry) of the PostgreSQL container image, e.g. `registry.developers.crunchydata.com/crunchydata`. The default is to use the image prefix set in the PostgreSQL Operator configuration. |
-| CCPImageTag | `create` | The tag of the PostgreSQL container image to use, e.g. `centos7-12.3-{{< param operatorVersion >}}`. |
+| CCPImageTag | `create` | The tag of the PostgreSQL container image to use, e.g. `centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}}`. |
 | CollectSecretName | `create` | An optional attribute unless `crunchy_collect` is specified in the `UserLabels`; contains the name of a Kubernetes Secret that contains the credentials for a PostgreSQL user that is used for metrics collection, and is created when the PostgreSQL cluster is first bootstrapped. For more information, please see `User Secret Specification`.|
 | ClusterName | `create` | The name of the PostgreSQL cluster, e.g. `hippo`. This is used to group PostgreSQL instances (primary, replicas) together. |
 | CustomConfig | `create` | If specified, references a custom ConfigMap to use when bootstrapping a PostgreSQL cluster. For the shape of this file, please see the section on [Custom Configuration]({{< relref "/advanced/custom-configuration.md" >}}) |
@@ -395,7 +395,7 @@ spec:
   backrestS3VerifyTLS: ""
   ccpimage: crunchy-postgres-ha
   ccpimageprefix: registry.developers.crunchydata.com/crunchydata
-  ccpimagetag: centos7-12.3-4.3.2
+  ccpimagetag: centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}}
   clustername: ${pgo_cluster_name}
   customconfig: ""
   database: ${pgo_cluster_name}

--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -87,7 +87,7 @@ make changes, as described below.
 | BackrestStorage | `create` | A specification that gives information about the storage attributes for the pgBackRest repository, which stores backups and archives, of the PostgreSQL cluster. For details, please see the `Storage Specification` section below. This is required. |
 | CCPImage | `create` | The name of the PostgreSQL container image to use, e.g. `crunchy-postgres-ha` or `crunchy-postgres-ha-gis`. |
 | CCPImagePrefix | `create` | If provided, the image prefix (or registry) of the PostgreSQL container image, e.g. `registry.developers.crunchydata.com/crunchydata`. The default is to use the image prefix set in the PostgreSQL Operator configuration. |
-| CCPImageTag | `create` | The tag of the PostgreSQL container image to use, e.g. `centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}}`. |
+| CCPImageTag | `create` | The tag of the PostgreSQL container image to use, e.g. `{{< param centosBase >}}-{{< param postgresVersion >}}-{{< param operatorVersion >}}`. |
 | CollectSecretName | `create` | An optional attribute unless `crunchy_collect` is specified in the `UserLabels`; contains the name of a Kubernetes Secret that contains the credentials for a PostgreSQL user that is used for metrics collection, and is created when the PostgreSQL cluster is first bootstrapped. For more information, please see `User Secret Specification`.|
 | ClusterName | `create` | The name of the PostgreSQL cluster, e.g. `hippo`. This is used to group PostgreSQL instances (primary, replicas) together. |
 | CustomConfig | `create` | If specified, references a custom ConfigMap to use when bootstrapping a PostgreSQL cluster. For the shape of this file, please see the section on [Custom Configuration]({{< relref "/advanced/custom-configuration.md" >}}) |
@@ -395,7 +395,7 @@ spec:
   backrestS3VerifyTLS: ""
   ccpimage: crunchy-postgres-ha
   ccpimageprefix: registry.developers.crunchydata.com/crunchydata
-  ccpimagetag: centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}}
+  ccpimagetag: {{< param centosBase >}}-{{< param postgresVersion >}}-{{< param operatorVersion >}}
   clustername: ${pgo_cluster_name}
   customconfig: ""
   database: ${pgo_cluster_name}

--- a/docs/content/installation/configuration.md
+++ b/docs/content/installation/configuration.md
@@ -31,7 +31,7 @@ Operator.
 | `ccp_image_prefix` | registry.developers.crunchydata.com/crunchydata | **Required** | Configures the image prefix used when creating containers from Crunchy Container Suite. |
 | `ccp_image_pull_secret` |  |  | Name of a Secret containing credentials for container image registries. |
 | `ccp_image_pull_secret_manifest` |  |  | Provide a path to the Secret manifest to be installed in each namespace. (optional) |
-| `ccp_image_tag` | centos7-12.3-{{< param operatorVersion >}} | **Required** | Configures the image tag (version) used when creating containers from Crunchy Container Suite. |
+| `ccp_image_tag` | {{< param centosBase >}}-12.3-{{< param operatorVersion >}} | **Required** | Configures the image tag (version) used when creating containers from Crunchy Container Suite. |
 | `create_rbac` | true | **Required** | Set to true if the installer should create the RBAC resources required to run the PostgreSQL Operator. |
 | `crunchy_debug` | false |  | Set to configure Operator to use debugging mode. Note: this can cause sensitive data such as passwords to appear in Operator logs. |
 | `db_name` |  |  | Set to a value to configure the default database name on all newly created clusters. By default, the PostgreSQL Operator will set it to the name of the cluster that is being created. |
@@ -77,7 +77,7 @@ Operator.
 | `pgo_image_prefix` | registry.developers.crunchydata.com/crunchydata | **Required** | Configures the image prefix used when creating containers for the Crunchy PostgreSQL Operator (apiserver, operator, scheduler..etc). |
 | `pgo_image_pull_secret` |  |  | Name of a Secret containing credentials for container image registries. |
 | `pgo_image_pull_secret_manifest` |  |  | Provide a path to the Secret manifest to be installed in each namespace. (optional) |
-| `pgo_image_tag` | centos7-{{< param operatorVersion >}} | **Required** | Configures the image tag used when creating containers for the Crunchy PostgreSQL Operator (apiserver, operator, scheduler..etc) |
+| `pgo_image_tag` | {{< param centosBase >}}-{{< param operatorVersion >}} | **Required** | Configures the image tag used when creating containers for the Crunchy PostgreSQL Operator (apiserver, operator, scheduler..etc) |
 | `pgo_installation_name` | devtest | **Required** | The name of the PGO installation. |
 | `pgo_noauth_routes` |  |  | Configures URL routes with mTLS and HTTP BasicAuth disabled. |
 | `pgo_operator_namespace` | pgo | **Required** | Set to configure the namespace where Operator will be deployed. |

--- a/docs/content/installation/configuration.md
+++ b/docs/content/installation/configuration.md
@@ -31,7 +31,7 @@ Operator.
 | `ccp_image_prefix` | registry.developers.crunchydata.com/crunchydata | **Required** | Configures the image prefix used when creating containers from Crunchy Container Suite. |
 | `ccp_image_pull_secret` |  |  | Name of a Secret containing credentials for container image registries. |
 | `ccp_image_pull_secret_manifest` |  |  | Provide a path to the Secret manifest to be installed in each namespace. (optional) |
-| `ccp_image_tag` | centos7-12.3-4.4.0-beta.2 | **Required** | Configures the image tag (version) used when creating containers from Crunchy Container Suite. |
+| `ccp_image_tag` | centos7-12.3-{{< param operatorVersion >}} | **Required** | Configures the image tag (version) used when creating containers from Crunchy Container Suite. |
 | `create_rbac` | true | **Required** | Set to true if the installer should create the RBAC resources required to run the PostgreSQL Operator. |
 | `crunchy_debug` | false |  | Set to configure Operator to use debugging mode. Note: this can cause sensitive data such as passwords to appear in Operator logs. |
 | `db_name` |  |  | Set to a value to configure the default database name on all newly created clusters. By default, the PostgreSQL Operator will set it to the name of the cluster that is being created. |
@@ -70,14 +70,14 @@ Operator.
 | `pgo_apiserver_url` | https://postgres-operator |  | Sets the `pgo_apiserver_url` for the `pgo-client` deployment. |
 | `pgo_client_cert_secret` | pgo.tls |  | Sets the secret that the `pgo-client` will use when connecting to the PostgreSQL Operator. |
 | `pgo_client_container_install` | false |  | Run the `pgo-client` deployment with the PostgreSQL Operator. |
-| `pgo_client_version` | 4.4.0-beta.2 | **Required** |  |
+| `pgo_client_version` | {{< param operatorVersion >}} | **Required** |  |
 | `pgo_cluster_admin` | false | **Required** | Determines whether or not the cluster-admin role is assigned to the PGO service account. Must be true to enable PGO namespace & role creation when installing in OpenShift. |
 | `pgo_disable_eventing` | false |  | Set to configure whether or not eventing should be enabled for the Crunchy PostgreSQL Operator installation. |
 | `pgo_disable_tls` | false |  | Set to configure whether or not TLS should be enabled for the Crunchy PostgreSQL Operator apiserver. |
 | `pgo_image_prefix` | registry.developers.crunchydata.com/crunchydata | **Required** | Configures the image prefix used when creating containers for the Crunchy PostgreSQL Operator (apiserver, operator, scheduler..etc). |
 | `pgo_image_pull_secret` |  |  | Name of a Secret containing credentials for container image registries. |
 | `pgo_image_pull_secret_manifest` |  |  | Provide a path to the Secret manifest to be installed in each namespace. (optional) |
-| `pgo_image_tag` | centos7-4.4.0-beta.2 | **Required** | Configures the image tag used when creating containers for the Crunchy PostgreSQL Operator (apiserver, operator, scheduler..etc) |
+| `pgo_image_tag` | centos7-{{< param operatorVersion >}} | **Required** | Configures the image tag used when creating containers for the Crunchy PostgreSQL Operator (apiserver, operator, scheduler..etc) |
 | `pgo_installation_name` | devtest | **Required** | The name of the PGO installation. |
 | `pgo_noauth_routes` |  |  | Configures URL routes with mTLS and HTTP BasicAuth disabled. |
 | `pgo_operator_namespace` | pgo | **Required** | Set to configure the namespace where Operator will be deployed. |

--- a/docs/content/installation/other/ansible/prerequisites.md
+++ b/docs/content/installation/other/ansible/prerequisites.md
@@ -90,7 +90,7 @@ kubectl config current-context
 ## Configuring - `values.yaml`
 
 The `values.yaml` file contains all of the configuration parameters
-for deploying the PostgreSQL Operator. The [example file](https://github.com/CrunchyData/postgres-operator/blob/v4.4.0-beta.2/installers/ansible/values.yaml)
+for deploying the PostgreSQL Operator. The [example file](https://github.com/CrunchyData/postgres-operator/blob/v{{< param operatorVersion >}}/installers/ansible/values.yaml)
 contains defaults that should work in most Kubernetes environments, but it may
 require some customization.
 

--- a/docs/content/installation/other/bash.md
+++ b/docs/content/installation/other/bash.md
@@ -31,7 +31,7 @@ The Operator follows a golang project structure, you can create a structure as f
     cd $HOME/odev/src/github.com/crunchydata
     git clone https://github.com/CrunchyData/postgres-operator.git
     cd postgres-operator
-	git checkout v4.4.0-beta.2
+	git checkout v{{< param operatorVersion >}}
 
 
 This creates a directory structure under your HOME directory name *odev* and clones the current Operator version to that structure.  

--- a/docs/content/installation/other/helm.md
+++ b/docs/content/installation/other/helm.md
@@ -172,8 +172,8 @@ pgo version
 If successful, you should see output similar to this:
 
 ```
-pgo client version 4.4.0-beta.2
-pgo-apiserver version 4.4.0-beta.2
+pgo client version {{< param operatorVersion >}}
+pgo-apiserver version {{< param operatorVersion >}}
 ```
 
 ## Metrics Chart

--- a/docs/content/installation/postgres-operator.md
+++ b/docs/content/installation/postgres-operator.md
@@ -15,7 +15,7 @@ repository:
 
 ```
 kubectl create namespace pgo
-kubectl apply -f https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml
+kubectl apply -f https://raw.githubusercontent.com/CrunchyData/postgres-operator/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml
 ```
 
 However, we still advise that you read onward to see how to properly configure
@@ -35,7 +35,7 @@ After configuring the Job template, the installer can be run using
 and takes care of setting up all of the objects required to run the PostgreSQL
 Operator.
 
-The installation manifest, called [`postgres-operator.yaml`](https://github.com/CrunchyData/postgres-operator/blob/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml), is available in the [`installers/kubectl/postgres-operator.yml`](https://github.com/CrunchyData/postgres-operator/blob/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml)
+The installation manifest, called [`postgres-operator.yaml`](https://github.com/CrunchyData/postgres-operator/blob/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml), is available in the [`installers/kubectl/postgres-operator.yml`](https://github.com/CrunchyData/postgres-operator/blob/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml)
 path in the PostgreSQL Operator repository.
 
 
@@ -55,9 +55,9 @@ permissions. This is required to create the [Custom Resource Definitions](https:
 that power the PostgreSQL Operator. While the PostgreSQL Operator itself can be
 scoped to a specific namespace, you will need to have `cluster-admin` for the
 initial deployment, or privileges that allow you to install Custom Resource
-Definitions. The required list of privileges are available in the [postgres-operator.yml](https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml) file:
+Definitions. The required list of privileges are available in the [postgres-operator.yml](https://raw.githubusercontent.com/CrunchyData/postgres-operator/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml) file:
 
-[https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml](https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml)
+[https://raw.githubusercontent.com/CrunchyData/postgres-operator/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml](https://raw.githubusercontent.com/CrunchyData/postgres-operator/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml)
 
 If you have already configured the ServiceAccount and ClusterRoleBinding for the
 installation process (e.g. from a previous installation), then you can remove
@@ -120,7 +120,7 @@ PostgreSQL Operator cannot create the RBAC itself.
 ## Configuration - `postgres-operator.yml`
 
 The `postgres-operator.yml` file contains all of the configuration parameters
-for deploying the PostgreSQL Operator. The [example file](https://github.com/CrunchyData/postgres-operator/blob/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml)
+for deploying the PostgreSQL Operator. The [example file](https://github.com/CrunchyData/postgres-operator/blob/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml)
 contains defaults that should work in most Kubernetes environments, but it may
 require some customization.
 
@@ -269,8 +269,8 @@ pgo version
 If successful, you should see output similar to this:
 
 ```
-pgo client version 4.4.0-beta.2
-pgo-apiserver version 4.4.0-beta.2
+pgo client version {{< param operatorVersion >}}
+pgo-apiserver version {{< param operatorVersion >}}
 ```
 ## Installing Metrics Infrastructure
 

--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -107,7 +107,7 @@ which yields output similar to:
 BasicAuth: ""
 Cluster:
   CCPImagePrefix: crunchydata
-  CCPImageTag: centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}}
+  CCPImageTag: {{< param centosBase >}}-{{< param postgresVersion >}}-{{< param operatorVersion >}}
   Policies: ""
   Metrics: false
   Badger: false
@@ -136,7 +136,7 @@ Cluster:
 Pgo:
   Audit: false
   PGOImagePrefix: crunchydata
-  PGOImageTag: centos7-{{< param operatorVersion >}}
+  PGOImageTag: {{< param centosBase >}}-{{< param operatorVersion >}}
 PrimaryStorage: nfsstorage
 BackupStorage: nfsstorage
 ReplicaStorage: nfsstorage
@@ -178,9 +178,9 @@ Claims:                  8
 Total Volume Size:       8Gi       
 
 Database Images:
-                         4	crunchydata/crunchy-postgres-ha:centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}}
-                         4	crunchydata/pgo-backrest-repo:centos7-{{< param operatorVersion >}}
-                         8	crunchydata/pgo-backrest:centos7-{{< param operatorVersion >}}
+                         4	crunchydata/crunchy-postgres-ha:{{< param centosBase >}}-{{< param postgresVersion >}}-{{< param operatorVersion >}}
+                         4	crunchydata/pgo-backrest-repo:{{< param centosBase >}}-{{< param operatorVersion >}}
+                         8	crunchydata/pgo-backrest:{{< param centosBase >}}-{{< param operatorVersion >}}
 
 Databases Not Ready:
 
@@ -420,7 +420,7 @@ pgo show cluster hacluster
 which will yield output similar to:
 
 ```
-cluster : hacluster (crunchy-postgres-ha:centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}})
+cluster : hacluster (crunchy-postgres-ha:{{< param centosBase >}}-{{< param postgresVersion >}}-{{< param operatorVersion >}})
 	pod : hacluster-6dc6cfcfb9-f9knq (Running) on node01 (1/1) (primary)
 	pvc : hacluster
 	resources : CPU Limit= Memory Limit=, CPU Request= Memory Request=

--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -84,8 +84,8 @@ pgo version
 which, if working, will yield results similar to:
 
 ```
-pgo client version 4.4.0-beta.2
-pgo-apiserver version 4.4.0-beta.2
+pgo client version {{< param operatorVersion >}}
+pgo-apiserver version {{< param operatorVersion >}}
 ```
 
 ### Inspecting the PostgreSQL Operator Configuration
@@ -107,7 +107,7 @@ which yields output similar to:
 BasicAuth: ""
 Cluster:
   CCPImagePrefix: crunchydata
-  CCPImageTag: centos7-12.3-4.4.0-beta.2
+  CCPImageTag: centos7-12.3-{{< param operatorVersion >}}
   Policies: ""
   Metrics: false
   Badger: false
@@ -136,7 +136,7 @@ Cluster:
 Pgo:
   Audit: false
   PGOImagePrefix: crunchydata
-  PGOImageTag: centos7-4.4.0-beta.2
+  PGOImageTag: centos7-{{< param operatorVersion >}}
 PrimaryStorage: nfsstorage
 BackupStorage: nfsstorage
 ReplicaStorage: nfsstorage
@@ -178,9 +178,9 @@ Claims:                  8
 Total Volume Size:       8Gi       
 
 Database Images:
-                         4	crunchydata/crunchy-postgres-ha:centos7-12.3-4.4.0-beta.2
-                         4	crunchydata/pgo-backrest-repo:centos7-4.4.0-beta.2
-                         8	crunchydata/pgo-backrest:centos7-4.4.0-beta.2
+                         4	crunchydata/crunchy-postgres-ha:centos7-12.3-{{< param operatorVersion >}}
+                         4	crunchydata/pgo-backrest-repo:centos7-{{< param operatorVersion >}}
+                         8	crunchydata/pgo-backrest:centos7-{{< param operatorVersion >}}
 
 Databases Not Ready:
 
@@ -191,7 +191,7 @@ Labels (count > 1): [count] [label]
 	[4]	[pgo-pg-database=true]
 	[4]	[crunchy_collect=false]
 	[4]	[pg-pod-anti-affinity=]
-	[4]	[pgo-version=4.4.0-beta.2]
+	[4]	[pgo-version={{< param operatorVersion >}}]
 	[4]	[archive-timeout=60]
 	[2]	[pg-cluster=hacluster]
 ```
@@ -420,7 +420,7 @@ pgo show cluster hacluster
 which will yield output similar to:
 
 ```
-cluster : hacluster (crunchy-postgres-ha:centos7-12.3-4.4.0-beta.2)
+cluster : hacluster (crunchy-postgres-ha:centos7-12.3-{{< param operatorVersion >}})
 	pod : hacluster-6dc6cfcfb9-f9knq (Running) on node01 (1/1) (primary)
 	pvc : hacluster
 	resources : CPU Limit= Memory Limit=, CPU Request= Memory Request=
@@ -428,7 +428,7 @@ cluster : hacluster (crunchy-postgres-ha:centos7-12.3-4.4.0-beta.2)
 	deployment : hacluster
 	deployment : hacluster-backrest-shared-repo
 	service : hacluster - ClusterIP (10.102.20.42)
-	labels : pg-pod-anti-affinity= archive-timeout=60 crunchy-pgbadger=false crunchy_collect=false deployment-name=hacluster pg-cluster=hacluster crunchy-pgha-scope=hacluster autofail=true pgo-backrest=true pgo-version=4.4.0-beta.2 current-primary=hacluster name=hacluster pgouser=admin workflowid=ae714d12-f5d0-4fa9-910f-21944b41dec8
+	labels : pg-pod-anti-affinity= archive-timeout=60 crunchy-pgbadger=false crunchy_collect=false deployment-name=hacluster pg-cluster=hacluster crunchy-pgha-scope=hacluster autofail=true pgo-backrest=true pgo-version={{< param operatorVersion >}} current-primary=hacluster name=hacluster pgouser=admin workflowid=ae714d12-f5d0-4fa9-910f-21944b41dec8
 ```
 
 ### Deleting a Cluster

--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -107,7 +107,7 @@ which yields output similar to:
 BasicAuth: ""
 Cluster:
   CCPImagePrefix: crunchydata
-  CCPImageTag: centos7-12.3-{{< param operatorVersion >}}
+  CCPImageTag: centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}}
   Policies: ""
   Metrics: false
   Badger: false
@@ -178,7 +178,7 @@ Claims:                  8
 Total Volume Size:       8Gi       
 
 Database Images:
-                         4	crunchydata/crunchy-postgres-ha:centos7-12.3-{{< param operatorVersion >}}
+                         4	crunchydata/crunchy-postgres-ha:centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}}
                          4	crunchydata/pgo-backrest-repo:centos7-{{< param operatorVersion >}}
                          8	crunchydata/pgo-backrest:centos7-{{< param operatorVersion >}}
 
@@ -360,7 +360,7 @@ pgo create cluster hacluster2 --restore-from=hacluster1
 ```
 
 When using this approach, a `pgbackrest restore` will be performed using the pgBackRest
-repository for the `restore-from` cluster specified in order to populate the initial 
+repository for the `restore-from` cluster specified in order to populate the initial
 `PGDATA` directory for the new PostgreSQL cluster.  By default, pgBackRest will restore
 to the latest backup available and replay all WAL.  However, a `restore-opts` option
 is also available that allows the `restore` command to be further customized, e.g. to
@@ -420,7 +420,7 @@ pgo show cluster hacluster
 which will yield output similar to:
 
 ```
-cluster : hacluster (crunchy-postgres-ha:centos7-12.3-{{< param operatorVersion >}})
+cluster : hacluster (crunchy-postgres-ha:centos7-{{< param postgresVersion >}}-{{< param operatorVersion >}})
 	pod : hacluster-6dc6cfcfb9-f9knq (Running) on node01 (1/1) (primary)
 	pvc : hacluster
 	resources : CPU Limit= Memory Limit=, CPU Request= Memory Request=

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -27,7 +27,7 @@ If your environment is set up to use hostpath storage (found in things like [min
 
 ```
 kubectl create namespace pgo
-kubectl apply -f https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml
+kubectl apply -f https://raw.githubusercontent.com/CrunchyData/postgres-operator/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml
 ```
 
 If not, please read onward: you can still get up and running fairly quickly with just a little bit of configuration.
@@ -39,13 +39,13 @@ If not, please read onward: you can still get up and running fairly quickly with
 You will need to download the PostgreSQL Operator Installer manifest to your environment, which you can do with the following command:
 
 ```
-curl https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml > postgres-operator.yml
+curl https://raw.githubusercontent.com/CrunchyData/postgres-operator/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml > postgres-operator.yml
 ```
 
 If you wish to download a specific version of the installer, you can substitute `master` with the version of the tag, i.e.
 
 ```
-curl https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.4.0-beta.2/installers/kubectl/postgres-operator.yml > postgres-operator.yml
+curl https://raw.githubusercontent.com/CrunchyData/postgres-operator/v{{< param operatorVersion >}}/installers/kubectl/postgres-operator.yml > postgres-operator.yml
 ```
 
 ### Configure the PostgreSQL Operator Installer
@@ -81,7 +81,7 @@ This will launch the `pgo-deployer` container that will run the various setup an
 While the installation is occurring, download the `pgo` client set up script. This will help set up your local environment for using the PostgreSQL Operator:
 
 ```
-curl https://raw.githubusercontent.com/CrunchyData/postgres-operator/v4.4.0-beta.2/installers/kubectl/client-setup.sh > client-setup.sh
+curl https://raw.githubusercontent.com/CrunchyData/postgres-operator/v{{< param operatorVersion >}}/installers/kubectl/client-setup.sh > client-setup.sh
 chmod +x client-setup.sh
 ```
 
@@ -167,8 +167,8 @@ pgo version
 If successful, you should see output similar to this:
 
 ```
-pgo client version 4.4.0-beta.2
-pgo-apiserver version 4.4.0-beta.2
+pgo client version {{< param operatorVersion >}}
+pgo-apiserver version {{< param operatorVersion >}}
 ```
 
 ## Step 4: Have Some Fun - Create a PostgreSQL Cluster
@@ -318,7 +318,7 @@ The [`pgo` client](/pgo-client/) provides a helpful command-line interface to pe
 
 The `pgo` client can be downloaded from GitHub [Releases](https://github.com/crunchydata/postgres-operator/releases) (subscribers can download it from the [Crunchy Data Customer Portal](https://access.crunchydata.com)).
 
-Note that the `pgo` client's version must match the version of the PostgreSQL Operator that you have deployed. For example, if you have deployed version 4.4.0-beta.2 of the PostgreSQL Operator, you must use the `pgo` for 4.4.0-beta.2.
+Note that the `pgo` client's version must match the version of the PostgreSQL Operator that you have deployed. For example, if you have deployed version {{< param operatorVersion >}} of the PostgreSQL Operator, you must use the `pgo` for {{< param operatorVersion >}}.
 
 Once you have download the `pgo` client, change the permissions on the file to be executable if need be as shown below:
 
@@ -345,8 +345,8 @@ pgo version
 If successful, you should see output similar to this:
 
 ```
-pgo client version 4.4.0-beta.2
-pgo-apiserver version 4.4.0-beta.2
+pgo client version {{< param operatorVersion >}}
+pgo-apiserver version {{< param operatorVersion >}}
 ```
 
 ### Step 7: Create a Namespace


### PR DESCRIPTION
This adds three new variables to the Hugo documentation configuration to limit how many places require changes each time there is a version bump:

- PostgreSQL Operator
- PostgreSQL
- Container base image