### PR TITLE
Postgres Operator upgrade version bump and validation update

### DIFF
--- a/internal/apiserver/upgradeservice/upgradeimpl.go
+++ b/internal/apiserver/upgradeservice/upgradeimpl.go
@@ -149,7 +149,10 @@ func CreateUpgrade(request *msgs.CreateUpgradeRequest, ns, pgouser string) msgs.
 			return response
 		}
 
-		if !supportedOperatorVersion(cl.ObjectMeta.Labels[config.LABEL_PGO_VERSION]) {
+		// for the upgrade procedure, we only upgrade to the current image used by the
+		// Postgres Operator. As such, we will validate that the Postgres Operator version is
+		// is supported by the upgrade, unless the --ignore-validation flag is set.
+		if !supportedOperatorVersion(cl.ObjectMeta.Labels[config.LABEL_PGO_VERSION]) && !request.IgnoreValidation {
 			response.Status.Code = msgs.Error
 			response.Status.Msg = "Cannot upgrade " + clusterName + " from Postgres Operator version " + cl.ObjectMeta.Labels[config.LABEL_PGO_VERSION]
 			return response

--- a/internal/apiserver/upgradeservice/upgradeimpl.go
+++ b/internal/apiserver/upgradeservice/upgradeimpl.go
@@ -36,7 +36,7 @@ import (
 // Currently supported version information for upgrades
 const (
 	REQUIRED_MAJOR_PGO_VERSION = 4
-	MAXIMUM_MINOR_PGO_VERSION  = 3
+	MAXIMUM_MINOR_PGO_VERSION  = 4
 	MINIMUM_MINOR_PGO_VERSION  = 1
 )
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
With the new minor version of the Postgres Operator (4.4), the allowed
version value used for the upgrade compatibility check needs to be
updated from 3 to 4.

Also, the validation check can currently be disabled for the Postgres
version in the image tag, but not for the Postgres Operator version.


**What is the new behavior (if this is a feature change)?**
The supported version value has been updated.

This update also changes the 'ignore-validation' behavior to
ignore the Postgres Operator version in addition to the PostgreSQL
version of the images being used.





**Other information**:
[ch8660]