### PR TITLE
Silence Disable Autofail ConfigMap Errors During Cluster Initialization

### DIFF
--- a/internal/controller/pgcluster/pgclustercontroller.go
+++ b/internal/controller/pgcluster/pgclustercontroller.go
@@ -198,7 +198,7 @@ func (c *Controller) onUpdate(oldObj, newObj interface{}) {
 	if newcluster.Spec.Shutdown && newcluster.Status.State != crv1.PgclusterStateShutdown {
 		clusteroperator.ShutdownCluster(c.PgclusterClientset, c.PgclusterClient, *newcluster)
 	} else if !newcluster.Spec.Shutdown &&
-		newcluster.Status.State != crv1.PgclusterStateInitialized {
+		newcluster.Status.State == crv1.PgclusterStateShutdown {
 		clusteroperator.StartupCluster(c.PgclusterClientset, *newcluster)
 	}
 

--- a/internal/operator/cluster/clusterlogic.go
+++ b/internal/operator/cluster/clusterlogic.go
@@ -681,8 +681,8 @@ func StartupCluster(clientset kubernetes.Interface, cluster crv1.Pgcluster) erro
 	// ensure autofailover is enabled to ensure proper startup of the cluster
 	if err := util.ToggleAutoFailover(clientset, true, cluster.Labels[config.LABEL_PGHA_SCOPE],
 		cluster.Namespace); err != nil {
-		return fmt.Errorf("Cluster Operator: Unable to toggle autofailover when shutting "+
-			"down cluster %s", cluster.Name)
+		return fmt.Errorf("Cluster Operator: Unable to toggle autofailover when starting "+
+			"cluster %s", cluster.Name)
 	}
 
 	// Scale up the primary and supporting services, but not the replicas.  Replicas will be


### PR DESCRIPTION
With this commit, certain "ConfigMap not found" errors seen during cluster initialization have been silenced.  Specifically, the function call to startup a cluster within the `pgcluster` `onUpdate` controller logic is now only executed when the cluster is in a `Shutdown` status, preventing the startup logic (which includes an attempt to modify the DCS ConfigMap to enable autofailover) from executing during cluster initialization (and therefore possibly before the DCS ConfigMap exists).

Additionally, an error message in the in the StartupCluster function has been updated to indicate that the error occurred while attempting to start the cluster (and not when shutting it down).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

"ConfigMap not found" errors are displayed during cluster initialization.

**What is the new behavior (if this is a feature change)?**

"ConfigMap not found" errors are no longer displayed during cluster initialization.

[ch8568]

**Other information**:

N/A