### PR TITLE
Add Deployment Watch Permission to Deployer ServiceAccount

### DIFF
--- a/installers/helm/metrics/templates/rbac.yaml
+++ b/installers/helm/metrics/templates/rbac.yaml
@@ -76,6 +76,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
       - create
       - delete
   - apiGroups:

--- a/installers/helm/postgres-operator/templates/rbac.yaml
+++ b/installers/helm/postgres-operator/templates/rbac.yaml
@@ -76,6 +76,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
       - create
       - delete
   - apiGroups:

--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -63,6 +63,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
       - create
       - delete
   - apiGroups:


### PR DESCRIPTION
This commit assigns the `pgo-deployer-sa` ServiceAccount `watch` permissions for Deployments, ensuring it is able to properly detect a successful rollout of the `postgres-operator` Deployment when performing an installation.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The following error occurs within the Deployer container when monitoring for a successful rollout of the `postgres-operator` Deployment:

```bash
Failed to watch *unstructured.Unstructured: unknown 
```

**What is the new behavior (if this is a feature change)?**

The `pgo-deployer-sa` ServiceAccount has been assigned the proper `watch` permissions for Deployments, allowing preventing the `Failed to watch` error from occurring.

**Other information**:

N/A