### PR TITLE
Updates to the upgrade procedure and documentation for the new PostGIS container tag

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -27,6 +27,7 @@ menushortcutsnewtab = false # set true to open shortcuts links to a new tab/wind
 enableGitInfo = true
 operatorVersion = "4.4.0-beta.2"
 postgresVersion = "12.3"
+postgisVersion = "3.0"
 centosBase = "centos7"
 
 [outputs]

--- a/docs/content/Upgrade/automatedupgrade.md
+++ b/docs/content/Upgrade/automatedupgrade.md
@@ -104,10 +104,19 @@ Previously, the existing cluster upgrade focused on updating a cluster's underly
 
 The automated upgrade process provides a mechanism where, instead of being deleted, the existing PostgreSQL clusters will be left in place during the PostgreSQL Operator upgrade. While normal Operator functionality will be restricted on these existing clusters until they are upgraded to the currently installed PostgreSQL Operator version, the pods, services, etc will still be in place and accessible via other methods (e.g. kubectl, service IP, etc).
 
-To upgrade a particular cluster, use
+To upgrade a PostgreSQL cluster using the standard (`crunchy-postgres-ha`) image, you can run the following command:
 ```    
 pgo upgrade mycluster
 ```
+
+If you are using the PostGIS-enabled image (i.e. `crunchy-postgres-gis-ha`) or any other custom images, you will need to add the `--ccp-image-tag`:
+```    
+pgo upgrade --ccp-image-tag={{< param centosBase >}}-{{< param postgresVersion >}}-{{< param postgisVersion >}}-{{< param operatorVersion >}} mygiscluster
+```
+Where `{{< param postgresVersion >}}` is the PostgreSQL version, `{{< param postgisVersion >}}` is the PostGIS version and `{{< param operatorVersion >}}` is the PostgreSQL Operator version.
+Please note, no tag validation will be performed and additional steps may be required to upgrade your PostGIS extension implementation. For more information on PostGIS upgrade considerations, please see
+[PostGIS Upgrade Documentation](https://access.crunchydata.com/documentation/postgis/latest/postgis_installation.html#upgrading).
+
 This will follow a similar process to the documented manual process, where the pods, deployments, replicasets, pgtasks and jobs are deleted, the cluster's replicas are scaled down and replica PVCs deleted, but the primary PVC and backrest-repo PVC are left in place. Existing services for the primary, replica and backrest-shared-repo are also kept and will be updated to the requirements of the current version. Configmaps and secrets are kept except where deletion is required. For a cluster 'mycluster', the following configmaps will be deleted (if they exist) and recreated:
 ```    
 mycluster-leader

--- a/docs/content/Upgrade/manual/upgrade35.md
+++ b/docs/content/Upgrade/manual/upgrade35.md
@@ -14,11 +14,14 @@ Using the PostgreSQL Operator {{< param operatorVersion >}} requires replacing y
 
 A major change to this container is that the PostgreSQL process is now managed by Patroni. This allows a PostgreSQL cluster that is deployed by the PostgreSQL Operator to manage its own uptime and availability, to elect a new leader in the event of a downtime scenario, and to automatically heal after a failover event.
 
-When creating your new clusters using version {{< param operatorVersion >}} of the PostgreSQL Operator, the `pgo create cluster` command will automatically use the new `crunchy-postgres-ha` image if the image is unspecified. If you are creating a PostGIS enabled cluster, please be sure to use the updated image name, as with the command:
+When creating your new clusters using version {{< param operatorVersion >}} of the PostgreSQL Operator, the `pgo create cluster` command will automatically use the new `crunchy-postgres-ha` image if the image is unspecified. If you are creating a PostGIS enabled cluster, please be sure to use the updated image name and image tag, as with the command:
 
 ```
-pgo create cluster mygiscluster --ccp-image=crunchy-postgres-gis-ha
+pgo create cluster mygiscluster --ccp-image=crunchy-postgres-gis-ha --ccp-image-tag={{< param centosBase >}}-{{< param postgresVersion >}}-{{< param postgisVersion >}}-{{< param operatorVersion >}}
 ```
+Where `{{< param postgresVersion >}}` is the PostgreSQL version, `{{< param postgisVersion >}}` is the PostGIS version and `{{< param operatorVersion >}}` is the PostgreSQL Operator version.
+Please note, no tag validation will be performed and additional steps may be required to upgrade your PostGIS extension implementation. For more information on PostGIS upgrade considerations, please see
+[PostGIS Upgrade Documentation](https://access.crunchydata.com/documentation/postgis/latest/postgis_installation.html#upgrading).
 
 NOTE: As with any upgrade procedure, it is strongly recommended that a full logical backup is taken before any upgrade procedure is started. Please see the [Logical Backups](/pgo-client/common-tasks#logical-backups-pg_dump--pg_dumpall) section of the Common Tasks page for more information.
 

--- a/docs/content/Upgrade/manual/upgrade4.md
+++ b/docs/content/Upgrade/manual/upgrade4.md
@@ -16,11 +16,14 @@ Using the PostgreSQL Operator {{< param operatorVersion >}} requires replacing y
 
 A major change to this container is that the PostgreSQL process is now managed by Patroni. This allows a PostgreSQL cluster that is deployed by the PostgreSQL Operator to manage its own uptime and availability, to elect a new leader in the event of a downtime scenario, and to automatically heal after a failover event.
 
-When creating your new clusters using version {{< param operatorVersion >}} of the PostgreSQL Operator, the `pgo create cluster` command will automatically use the new `crunchy-postgres-ha` image if the image is unspecified. If you are creating a PostGIS enabled cluster, please be sure to use the updated image name, as with the command:
+When creating your new clusters using version {{< param operatorVersion >}} of the PostgreSQL Operator, the `pgo create cluster` command will automatically use the new `crunchy-postgres-ha` image if the image is unspecified. If you are creating a PostGIS enabled cluster, please be sure to use the updated image name and image tag, as with the command:
 
 ```
-pgo create cluster mygiscluster --ccp-image=crunchy-postgres-gis-ha
+pgo create cluster mygiscluster --ccp-image=crunchy-postgres-gis-ha --ccp-image-tag={{< param centosBase >}}-{{< param postgresVersion >}}-{{< param postgisVersion >}}-{{< param operatorVersion >}}
 ```
+Where `{{< param postgresVersion >}}` is the PostgreSQL version, `{{< param postgisVersion >}}` is the PostGIS version and `{{< param operatorVersion >}}` is the PostgreSQL Operator version.
+Please note, no tag validation will be performed and additional steps may be required to upgrade your PostGIS extension implementation. For more information on PostGIS upgrade considerations, please see
+[PostGIS Upgrade Documentation](https://access.crunchydata.com/documentation/postgis/latest/postgis_installation.html#upgrading).
 
 NOTE: As with any upgrade procedure, it is strongly recommended that a full logical backup is taken before any upgrade procedure is started. Please see the [Logical Backups](/pgo-client/common-tasks#logical-backups-pg_dump--pg_dumpall) section of the Common Tasks page for more information.
 

--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -292,10 +292,13 @@ pgo create cluster hacluster --cpu=4 --memory=16Gi
 #### Create a PostgreSQL Cluster with PostGIS
 
 To create a PostgreSQL cluster that uses the geospatial extension PostGIS, you
-can execute the following command:
+can execute the following command, updated with your desired image tag. In the
+example below, the cluster will use PostgreSQL {{< param postgresVersion >}} and PostGIS {{< param postgisVersion >}}:
 
 ```shell
-pgo create cluster hagiscluster --ccp-image=crunchy-postgres-gis-ha
+pgo create cluster hagiscluster \
+  --ccp-image=crunchy-postgres-gis-ha \
+  --ccp-image-tag={{< param centosBase >}}-{{< param postgresVersion >}}-{{< param postgisVersion >}}-{{< param operatorVersion >}}
 ```
 
 #### Create a PostgreSQL Cluster with a Tablespace

--- a/internal/operator/cluster/upgrade.go
+++ b/internal/operator/cluster/upgrade.go
@@ -459,8 +459,10 @@ func preparePgclusterForUpgrade(pgcluster *crv1.Pgcluster, parameters map[string
 	// for this cluster.
 	pgcluster.ObjectMeta.Labels[config.LABEL_DEPLOYMENT_NAME] = currentPrimary
 
-	// update the image tag to the standard value set in the Postgres Operator's main
-	// configuration (which has already been verified to match the MAJOR PostgreSQL version)
+	// update the image tag to the value provided with the upgrade task. This will either be
+	// the standard value set in the Postgres Operator's main configuration (which will have already
+	// been verified to match the MAJOR PostgreSQL version) or the value provided by the user for
+	// use with PostGIS enabled pgclusters
 	pgcluster.Spec.CCPImageTag = parameters[config.LABEL_CCP_IMAGE_KEY]
 
 	// set a default autofail value of "true" to enable Patroni's replication. If left to an existing

--- a/pgo/cmd/upgrade.go
+++ b/pgo/cmd/upgrade.go
@@ -32,6 +32,12 @@ import (
 // to continue
 var IgnoreValidation bool
 
+// UpgradeCCPImageTag stores the image tag for the cluster being upgraded.
+// This is specifically required when upgrading PostGIS clusters because
+// that tag will necessarily differ from the other images tags due to the
+// inclusion of the PostGIS version.
+var UpgradeCCPImageTag string
+
 var UpgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Perform a cluster upgrade.",
@@ -64,6 +70,7 @@ func init() {
 
 	// flags for "pgo upgrade"
 	UpgradeCmd.Flags().BoolVarP(&IgnoreValidation, "ignore-validation", "", false, "Disables version checking against the image tags when performing an cluster upgrade.")
+	UpgradeCmd.Flags().StringVarP(&UpgradeCCPImageTag, "ccp-image-tag", "", "", "The image tag to use for cluster creation. If specified, it overrides the default configuration setting and disables tag validation checking.")
 }
 
 func createUpgrade(args []string, ns string) {
@@ -80,6 +87,7 @@ func createUpgrade(args []string, ns string) {
 	request.Selector = Selector
 	request.ClientVersion = msgs.PGO_VERSION
 	request.IgnoreValidation = IgnoreValidation
+	request.UpgradeCCPImageTag = UpgradeCCPImageTag
 
 	response, err := api.CreateUpgrade(httpclient, &SessionCredentials, &request)
 

--- a/pkg/apiservermsgs/upgrademsgs.go
+++ b/pkg/apiservermsgs/upgrademsgs.go
@@ -18,11 +18,12 @@ limitations under the License.
 // CreateUpgradeRequest ...
 // swagger:model
 type CreateUpgradeRequest struct {
-	Args             []string
-	Selector         string
-	Namespace        string
-	ClientVersion    string
-	IgnoreValidation bool
+	Args               []string
+	Selector           string
+	Namespace          string
+	ClientVersion      string
+	IgnoreValidation   bool
+	UpgradeCCPImageTag string
 }
 
 // CreateUpgradeResponse ...


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently, the updated create command for the new PostGIS enabled
Crunchy Postgres GIS HA container tag format is not fully documented.

Also, the automated upgrade procedure is unable to accept the
new tag when a pgcluster upgrade is performed.


**What is the new behavior (if this is a feature change)?**
Due to the new tag value on the Crunchy Postgres GIS HA container, the 
specific tag now must be supplied when created a PostGIS enabled pgcluster. 
An example command is below:
    
pgo create cluster hagiscluster  --ccp-image=crunchy-postgres-gis-ha  --ccp-image-tag=centos7-11.8-2.5-4.4.0
    
Where "11.8" is the PostgreSQL version, "2.5" is the PostGIS version
and "4.4.0" is the PostgreSQL Operator version.

Additionally, the Postgres Operator automated upgrade has been
updated to allow for this new tag during the upgrade process.
    
To upgrade a PostGIS enabled pgcluster, a new flag,
'--post-gis-image-tag' will be required to specify the specific
container tag value, as in the command below:
    
pgo upgrade --post-gis-image-tag=centos7-11.8-2.5-4.4.0 mygiscluster


**Other information**:
