### PR TITLE
Sync the Ansible Installer pgmonitor Template With the Bash Installer

### DIFF
--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgmonitor-env-vars.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgmonitor-env-vars.json
@@ -1,4 +1,9 @@
 {
   "name": "PGMONITOR_PASSWORD",
-  "value": "{{.PgmonitorPassword}}"
+  "valueFrom": {
+    "secretKeyRef": {
+        "name": "{{.CollectSecret}}",
+        "key": "password"
+    }
+  }
 },


### PR DESCRIPTION
This commit syncs the `pgmonitor-env-vars.json` template in the Ansible installer with the same template in the Bash installer.  This ensures that the Ansible installer installs the proper pgmonitor template as needed to support enabling metrics (i.e. the `collect` sidecar) in a PostgreSQL cluster.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The Ansible installer installs the wrong `pgmonitor-env-vars.json` template, resulting in invalid environment variables as needed to support enabling metrics in a PostgreSQL cluster.

[ch8664]

**What is the new behavior (if this is a feature change)?**

The Ansible installer now installs the correct `pgmonitor-env-vars.json` template as needed to properly enable metrics in a PostgreSQL cluster.

**Other information**:

N/A