### PR TITLE
Fix for panic if config syncs when Pod unavailable

### DIFF
--- a/internal/operator/config/localdb.go
+++ b/internal/operator/config/localdb.go
@@ -320,9 +320,16 @@ func (l *LocalDB) getLocalConfigFromCluster(configName string) (*LocalDBConfig, 
 	dbPodList, err := l.kubeclientset.CoreV1().Pods(namespace).List(metav1.ListOptions{
 		LabelSelector: selector,
 	})
+
 	if err != nil {
 		return nil, err
 	}
+
+	// if the pod list is empty, also return an error
+	if len(dbPodList.Items) == 0 {
+		return nil, fmt.Errorf("no pod found for %q", clusterName)
+	}
+
 	dbPod := &dbPodList.Items[0]
 
 	stdout, stderr, err := kubeapi.ExecToPodThroughAPI(l.restConfig, l.kubeclientset, readConfigCMD,


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

There is a potential race condition in which the PostgreSQL HA
configuration attempts to sync with a Pod, but the Pod is
currently unavailable. This causes the PostgreSQL Operator to
crash and potentially halt an operation (e.g. this was discovered
during an upgrade).

**What is the new behavior (if this is a feature change)?**

If no Pods matching the selector are found, we abort the HA
ConfigMap synchronization.

**Other information**:

Closes #1682