### PR TITLE
Updates client-setup.sh to handle an existing pgo file

### DIFF
--- a/installers/kubectl/client-setup.sh
+++ b/installers/kubectl/client-setup.sh
@@ -37,9 +37,15 @@ fi
 OUTPUT_DIR="${HOME}/.pgo/${PGO_OPERATOR_NAMESPACE}"
 install -d -m a-rwx,u+rwx "${OUTPUT_DIR}"
 
-echo "Operating System found is ${UNAME_RESULT}. Downloading ${BIN_NAME} client binary..."
+if [ -f "${OUTPUT_DIR}/pgo" ]
+then
+	echo "pgo Client Binary detected at: ${OUTPUT_DIR}"
+	echo "Updating Binary..."
+fi
 
-curl -C - -Lo "${OUTPUT_DIR}/pgo" "${PGO_CLIENT_URL}/${BIN_NAME}"
+echo "Operating System found is ${UNAME_RESULT}..."
+echo "Downloading ${BIN_NAME} version: ${PGO_CLIENT_VERSION}..."
+curl -Lo "${OUTPUT_DIR}/pgo" "${PGO_CLIENT_URL}/${BIN_NAME}"
 chmod +x "${OUTPUT_DIR}/pgo"
 
 


### PR DESCRIPTION
Currently the script will throw an error if the pgo binary file exists. This
change updates the script to overwrite the original file and download the new
binary in its place. In this case a message is printed telling the user that the
binary is being updated. Considering the binary is downloaded into a namespaced
directory overwriting the file is considered a safe option.

[ch8648]