### PR TITLE
Rewrite docs to promote "pgo create cluster --restore-from" & deprecate clone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Choose between [asynchronous replication](https://access.crunchydata.com/documen
 
 #### Clone
 
-Create new clusters from your existing clusters with a simple [`pgo clone`](https://access.crunchydata.com/documentation/postgres-operator/latest/pgo-client/reference/pgo_clone/) command.
+Create new clusters from your existing clusters or backups with [`pgo create cluster --restore-from`](https://access.crunchydata.com/documentation/postgres-operator/latest/pgo_create_cluster).
 
 #### Connection Pooling
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -50,7 +50,7 @@ Choose between [asynchronous replication](/architecture/high-availability/) and 
 
 #### Clone
 
-Create new clusters from your existing clusters with a simple [`pgo clone`](/pgo-client/reference/pgo_clone/) command.
+Create new clusters from your existing clusters or backups with [`pgo create cluster --restore-from`](/pgo-client/reference/pgo_create_cluster/).
 
 #### Connection Pooling
 

--- a/docs/content/architecture/disaster-recovery.md
+++ b/docs/content/architecture/disaster-recovery.md
@@ -86,18 +86,86 @@ pgo backup hacluster --backup-opts="--type=full --repo1-retention-full=7"
 ## Restores
 
 The PostgreSQL Operator supports the ability to perform a full restore on a
-PostgreSQL cluster as well as a point-in-time-recovery using the `pgo restore`
-command. Note that both of these options are **destructive** to the existing
-PostgreSQL cluster; to "restore" the PostgreSQL cluster to a new deployment,
-please see the [Clone](/pgo-client/common-tasks/#clone-a-postgresql-cluster) section.
+PostgreSQL cluster as well as a point-in-time-recovery. There are two types of
+ways to restore a cluster:
 
-The `pgo restore` command lets you specify the point at which you want to
-restore your database using the `--pitr-target` flag with the `pgo restore`
+- Restore to a new cluster using the `--restore-from` flag in the
+[`pgo create cluster`]({{< relref "/pgo-client/reference/pgo_create_cluster.md" >}})
 command.
+- Restore in-place using the [`pgo restore`]({{< relref "/pgo-client/reference/pgo_restore.md" >}})
+command. Note that this is **destructive**.
 
 **NOTE**: Ensure you are backing up your PostgreSQL cluster regularly, as this
 will help expedite your restore times. The next section will cover scheduling
 regular backups.
+
+The following explains how to perform restores based on the restoration method
+you chose.
+
+### Restore to a New Cluster
+
+Restoring to a new PostgreSQL cluster allows one to take a backup and create a
+new PostgreSQL cluster that can run alongside an existing PostgreSQL cluster.
+There are several scenarios where using this technique is helpful:
+
+- Creating a copy of a PostgreSQL cluster that can be used for other purposes.
+Another way of putting this is "creating a clone."
+- Restore to a point-in-time and inspect the state of the data without affecting
+the current cluster
+
+and more.
+
+Restoring to a new cluster can be accomplished using the [`pgo create cluster`]({{< relref "/pgo-client/reference/pgo_create_cluster.md" >}})
+command with several flags:
+
+- `--restore-from`: specifies the name of a PostgreSQL cluster (either one that
+is active, or a former cluster whose pgBackRest repository still exists) to
+restore from.
+- `--restore-opts`: used to specify additional options, similar to the ones that
+are passed into [`pgbackrest restore`](https://pgbackrest.org/command.html#command-restore).
+
+One can copy an entire PostgreSQL cluster into a new cluster with a command as
+simple as the one below:
+
+```
+pgo create cluster newcluster --restore-from oldcluster
+```
+
+To perform a point-in-time-recovery, you have to pass in the pgBackRest `--type`
+and `--target` options, where `--type` indicates the type of recovery to
+perform, and `--target` indicates the point in time to recover to:
+
+```
+pgo create cluster newcluster \
+  --restore-from oldcluster \
+  --restore-opts "--type=time --target='2019-12-31 11:59:59.999999+00'"
+```
+
+Note that when using this method, the PostgreSQL Operator can only restore one
+cluster from each pgBackRest repository at a time. Using the above example, one
+can only perform one restore from `oldcluster` at a given time.
+
+When using the restore to a new cluster method, the PostgreSQL Operator takes
+the following actions:
+
+- After running the normal cluster creation tasks, the PostgreSQL Operator
+creates a "bootstrap" job that performs a pgBackRest restore to the newly
+created PVC.
+- The PostgreSQL Operator kicks off the new PostgreSQL cluster, which enters
+into recovery mode until it has recovered to a specified point-in-time or
+finishes replaying all available write-ahead logs.
+- When this is done, the PostgreSQL cluster performs its regular operations when
+starting up.
+
+### Restore in-place
+
+Restoring a PostgreSQL cluster in-place is a **destructive** action that will
+perform a recovery on your existing data directory. This is accomplished using
+the [`pgo restore`]({{< relref "/pgo-client/reference/pgo_restore.md" >}})
+command.
+
+`pgo restore` lets you specify the point at which you want to restore your
+database using the `--pitr-target` flag.
 
 When the PostgreSQL Operator issues a restore, the following actions are taken
 on the cluster:

--- a/docs/content/architecture/overview.md
+++ b/docs/content/architecture/overview.md
@@ -34,8 +34,8 @@ how to maintain a high-availability cluster, etc.
 replicas within a PostgreSQL cluster. This includes things like the number of
 replicas, what storage and resource classes to use, special affinity rules, etc.
 - `pgtasks.crunchydata.com`: A general purpose CRD that accepts a type of task
-that is needed to run against a cluster (e.g. take a backup, perform a clone)
-and tracks the state of said task through its workflow.
+that is needed to run against a cluster (e.g. take a backup) and tracks the
+state of said task through its workflow.
 - `pgpolicies.crunchydata.com`: Stores a reference to a SQL file that can be
 executed against a PostgreSQL cluster. In the past, this was used to manage RLS
 policies on PostgreSQL clusters.
@@ -63,7 +63,7 @@ user to schedule repeatable tasks, such as backups (because it is important to
 - `event` (image: pgo-event, optional) - A container that provides an interface
 to the `nsq` message queue and transmits information about lifecycle events that
 occur within the PostgreSQL Operator (e.g. a cluster is created, a backup is
-  taken, a clone fails to create)
+taken, etc.)
 
 The main purpose of the PostgreSQL Operator is to create and update information
 around the structure of a PostgreSQL Cluster, and to relay information about the

--- a/docs/content/architecture/tablespaces.md
+++ b/docs/content/architecture/tablespaces.md
@@ -69,7 +69,7 @@ different lifecycle events that occur on a PostgreSQL cluster, including:
 and is available after a downtime event
 - Disaster Recovery: Tablespaces are backed up and are properly restored during
 a recovery
-- Clone: Tablespaces are created in any cloned cluster
+- Clone: Tablespaces are created in any cloned or restored cluster
 - Deprovisioining: Tablespaces are deleted when a PostgreSQL instance or cluster
 is deleted
 

--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -48,8 +48,8 @@ how to maintain a high-availability cluster, etc.
 replicas within a PostgreSQL cluster. This includes things like the number of
 replicas, what storage and resource classes to use, special affinity rules, etc.
 - `pgtasks.crunchydata.com`: A general purpose CRD that accepts a type of task
-that is needed to run against a cluster (e.g. take a backup, perform a clone)
-and tracks the state of said task through its workflow.
+that is needed to run against a cluster (e.g. take a backup) and tracks the
+state of said task through its workflow.
 - `pgpolicies.crunchydata.com`: Stores a reference to a SQL file that can be
 executed against a PostgreSQL cluster. In the past, this was used to manage RLS
 policies on PostgreSQL clusters.

--- a/docs/content/pgo-client/_index.md
+++ b/docs/content/pgo-client/_index.md
@@ -107,7 +107,7 @@ provides:
 | apply       | `pgo apply mypolicy --selector=name=mycluster`               | Apply a SQL policy on a Postgres cluster(s) that have a label matching `service-name=mycluster` |
 | backup      | `pgo backup mycluster`                                       | Perform a backup on a Postgres cluster(s)                                                       |
 | cat         | `pgo cat mycluster filepath`                                 | Perform a Linux `cat` command on the cluster.                                                   |
-| clone      | `pgo clone oldcluster newcluster`                             | Copies the primary database of an existing cluster to a new cluster                         |
+| clone      | `pgo clone oldcluster newcluster`                             | DEPRECATED: Copies the primary database of an existing cluster to a new cluster. For a more robust method to copy data, use `pgo create cluster newcluster --restore-from oldcluster `                         |
 | create      | `pgo create cluster mycluster`                               | Create an Operator resource type (e.g. cluster, policy, schedule, user, namespace, pgouser, pgorole)                         |
 | delete      | `pgo delete cluster mycluster`                               | Delete an Operator resource type (e.g. cluster, policy, user, schedule, namespace, pgouser, pgorole)                         |
 | df          | `pgo df mycluster`                                           | Display the disk status/capacity of a Postgres cluster.                                         |

--- a/internal/apiserver/cloneservice/cloneservice.go
+++ b/internal/apiserver/cloneservice/cloneservice.go
@@ -45,7 +45,8 @@ func CloneHandler(w http.ResponseWriter, r *http.Request) {
 	var err error
 	var username, ns string
 
-	log.Debug("cloneservice.CloneHanlder called")
+	log.Debug("cloneservice.CloneHandler called")
+	log.Warn(`cloneservice.CloneHandler is deprecated. Please use "pgo create cluster --restore-from" instead.`)
 
 	var request msgs.CloneRequest
 	_ = json.NewDecoder(r.Body).Decode(&request)

--- a/pgo/cmd/clone.go
+++ b/pgo/cmd/clone.go
@@ -37,10 +37,12 @@ var (
 )
 
 var cloneCmd = &cobra.Command{
-	Use:   "clone",
-	Short: "Copies the primary database of an existing cluster to a new cluster",
+	Use:        "clone",
+	Deprecated: `Use "pgo create cluster newcluster --restore-from=oldcluster" instead. "pgo clone" will be removed in a future release.`,
+	Short:      "Copies the primary database of an existing cluster to a new cluster",
 	Long: `Clone makes a copy of an existing PostgreSQL cluster managed by the Operator and creates a new PostgreSQL cluster managed by the Operator, with the data from the old cluster.
 
+	pgo create cluster newcluster --restore-from=oldcluster
 	pgo clone oldcluster newcluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// if the namespace is not specified, default to the PGONamespace specified


### PR DESCRIPTION
"pgo create cluster --restore-from" is equivalent to "pgo clone"
but is much more robust, as it provides the ability to use the
full set of "pgo create cluster" options. As such, techniques
that use "pgo clone" are rewritten to showcase
"pgo create cluster --restore-from".

This also makes it much clearer how the request of #1305 can
be leveraged, as both the architecture of the feature and several
use cases are further fleshed out.