### PR TITLE
Ensure external WAL PVC is deleted when replica is destroyed

### DIFF
--- a/pgo-rmdata/rmdata/process.go
+++ b/pgo-rmdata/rmdata/process.go
@@ -40,6 +40,8 @@ const (
 	tablespacePathFormat = "/tablespaces/%s/%s"
 	// the tablespace on a replcia follows the pattern "<replicaName-tablespace-.."
 	tablespaceReplicaPVCPattern = "%s-tablespace-"
+	// the WAL PVC has the following suffix
+	walPVCSuffix = "-wal"
 
 	// the following constants define the suffixes for the various configMaps created by Patroni
 	configConfigMapSuffix   = "config"
@@ -522,11 +524,12 @@ func getReplicaPVC(request Request) ([]string, error) {
 	//when isReplica=true
 	pvcList = append(pvcList, request.ReplicaName)
 
-	// see if there are any tablespaces assigned to this replica, and add them to
-	// the list
+	// see if there are any tablespaces or WAL volumes assigned to this replica,
+	// and add them to the list.
+	//
 	// ...this is a bit janky, as we have to iterate through ALL the PVCs
 	// associated with this managed cluster, and pull out anyones that have a name
-	// with the pattern "<replicaName-tablespace>"
+	// with the pattern "<replicaName-tablespace>" or "<replicaName-wal>"
 	selector := fmt.Sprintf("%s=%s", config.LABEL_PG_CLUSTER, request.ClusterName)
 
 	// get all of the PVCs that are specific to this replica and remove them
@@ -547,7 +550,7 @@ func getReplicaPVC(request Request) ([]string, error) {
 		pvcName := pvc.ObjectMeta.Name
 
 		// it does not start with the tablespace replica PVC pattern, continue
-		if !strings.HasPrefix(pvcName, tablespaceReplicaPVCPrefix) {
+		if !(strings.HasPrefix(pvcName, tablespaceReplicaPVCPrefix) || strings.HasSuffix(pvcName, walPVCSuffix)) {
 			continue
 		}
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The WAL PVC was lingering even after a replica was removed with
the "pgo scaledown" command.

**What is the new behavior (if this is a feature change)?**

The WAL PVC is now removed by a `pgo scaledown`.

**Other information**:

Issue: [ch8676]