### PR TITLE
4.3: Have pgBouncer come up with specified # of replicas after restore

### DIFF
--- a/operator/cluster/clusterlogic.go
+++ b/operator/cluster/clusterlogic.go
@@ -632,6 +632,11 @@ func ScaleClusterDeployments(clientset *kubernetes.Clientset, cluster crv1.Pgclu
 			if !scalePGBouncer {
 				continue
 			}
+			// if the replica total is greater than 0, set number of pgBouncer
+			// replicas to the number that is specified in the cluster entry
+			if replicas > 0 {
+				replicas = int(cluster.Spec.PgBouncer.Replicas)
+			}
 		case deployment.Labels[config.LABEL_PGO_BACKREST_REPO] == "true":
 			clusterInfo.PGBackRestRepoDeployment = deployment.Name
 			// if not scaling services simply move on to the next deployment


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the new behavior (if this is a feature change)?**

This was defaulting to 1 instead of taking the value that was in
the pgcluster CRD.

**Other information**:

This not an issue on `master`, only `REL_4_3`.

Issue: [ch8675] 