### PR TITLE
Remove Env Var used in Ansible Based Deployments

### DIFF
--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-restore-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-restore-job.json
@@ -81,9 +81,6 @@
                         "name": "PGBACKREST_REPO1_HOST",
                         "value": "{{.PgbackrestRepo1Host}}"
                     }, {
-                        "name": "PGBACKREST_REPO_TYPE",
-                        "value": "{{.PgbackrestRepoType}}"
-                    }, {
                         "name": "PGBACKREST_LOG_PATH",
                         "value": "/tmp"
                     }, {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The PGBACKREST_REPO_TYPE is still defined in the Ansible deployment
template for the pgBackrest restore job. This causes an error when a
restore is attempted.


**What is the new behavior (if this is a feature change)?**
This update remove the PGBACKREST_REPO_TYPE Environment Variable
from backrest-restore-job.json file used by the Ansible based
deployments of the Postgres Operator. This brings that file in
line with the changes made in PR 1691, Ensure pgBackRest Settings
Work When Local & S3 Storage is Enabled.


**Other information**:
