### PR TITLE
Ensure Proper Replica Creation During PostgreSQL Cluster Startup

### DIFF
--- a/internal/controller/pod/podcontroller.go
+++ b/internal/controller/pod/podcontroller.go
@@ -111,12 +111,6 @@ func (c *Controller) onUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	// the handlers called below are only applicable to PG pods when the cluster is
-	// in an initialized status
-	if cluster.Status.State != crv1.PgclusterStateInitialized || !isPostgresPod(newPod) {
-		return
-	}
-
 	// Handle the "role" label change from "replica" to "primary" following a failover.  This
 	// logic is only triggered when the cluster has already been initialized, which implies
 	// a failover or switchover has occurred.


### PR DESCRIPTION
With this PR, logic to return from the `onUpdate()` function of the Pod controller if the cluster is not in an initialized status, or if the Pod is not a PostgreSQL Pod (i.e. a primary or replica), has been removed.  This is because the same logic is built into the function calls below it, i.e. functions `isPromotedPostgresPod()` and `isPromotedStandby()` both verify that the Pod is a PostgreSQL Pod, while the subsequent handler functions check the current status of the pgcluster as needed.

This ensures that the proper initialization logic is executed to create the clusters replicas when starting up a `pgcluster` that was previously shutdown (i.e. by using the `--startup` flag with the `pgo update cluster` command).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Existing replicas are not created, and new replicas cannot be created, when starting up a cluster using the `--startup` flag.

[ch8692]

**What is the new behavior (if this is a feature change)?**

Existing and new replicas are are properly created when starting up a cluster using the `--startup` flag.

**Other information**:

N/A