### PR TITLE
Ensure pgo-rmdata runs as non-root user

### DIFF
--- a/centos7/Dockerfile.pgo-rmdata.centos7
+++ b/centos7/Dockerfile.pgo-rmdata.centos7
@@ -11,6 +11,6 @@ LABEL name="pgo-rmdata" \
 
 ADD bin/pgo-rmdata/ /usr/local/bin
 
-USER 0
+USER 2
 
 CMD ["/usr/local/bin/start.sh"]

--- a/rhel7/Dockerfile.pgo-rmdata.rhel7
+++ b/rhel7/Dockerfile.pgo-rmdata.rhel7
@@ -11,6 +11,6 @@ LABEL name="pgo-rmdata" \
 
 ADD bin/pgo-rmdata/ /usr/local/bin
 
-USER 0
+USER 2
 
 CMD ["/usr/local/bin/start.sh"]


### PR DESCRIPTION
This was likely in place when pgo-rmdata was explicitly calling
"rm -rf" on the PostgreSQL PVCs. This is no longer done, and
ergo we do no need to run the container as a root user.