### PR TITLE
Fix typos identified by go vet in internal package

### DIFF
--- a/internal/apiserver/clusterservice/clusterimpl.go
+++ b/internal/apiserver/clusterservice/clusterimpl.go
@@ -339,7 +339,7 @@ func getServices(cluster *crv1.Pgcluster, ns string) ([]msgs.ShowClusterService,
 func TestCluster(name, selector, ns, pgouser string, allFlag bool) msgs.ClusterTestResponse {
 	var err error
 
-	log.Debugf("TestCluster(%s,%s,%s,%s,%s): Called",
+	log.Debugf("TestCluster(%s,%s,%s,%s,%v): Called",
 		name, selector, ns, pgouser, allFlag)
 
 	response := msgs.ClusterTestResponse{}
@@ -355,7 +355,7 @@ func TestCluster(name, selector, ns, pgouser string, allFlag bool) msgs.ClusterT
 	// be used
 	if selector == "" {
 		if allFlag {
-			log.Debug("selector is : all clusters in %s", ns)
+			log.Debugf("selector is : all clusters in %s", ns)
 		} else {
 			selector = "name=" + name
 			log.Debugf("selector is: %s", selector)
@@ -446,7 +446,7 @@ func TestCluster(name, selector, ns, pgouser string, allFlag bool) msgs.ClusterT
 			case msgs.PodTypeReplica:
 				instance.InstanceType = msgs.ClusterTestInstanceTypeReplica
 			}
-			log.Debugf("Instance found with attributes: (%s, %s, %s)",
+			log.Debugf("Instance found with attributes: (%s, %s, %v)",
 				instance.InstanceType, instance.Message, instance.Available)
 			// Add the report on the pods to this set
 			result.Instances = append(result.Instances, instance)
@@ -514,7 +514,7 @@ func TestCluster(name, selector, ns, pgouser string, allFlag bool) msgs.ClusterT
 				}
 			}
 
-			log.Debugf("Endpoint found with attributes: (%s, %s, %s)",
+			log.Debugf("Endpoint found with attributes: (%s, %s, %v)",
 				endpoint.InstanceType, endpoint.Message, endpoint.Available)
 
 			// append the endpoint to the list
@@ -1699,7 +1699,7 @@ func UpdateCluster(request *msgs.UpdateClusterRequest) msgs.UpdateClusterRespons
 	response.Status = msgs.Status{Code: msgs.Ok, Msg: ""}
 	response.Results = make([]string, 0)
 
-	log.Debugf("autofail is [%t]\n", request.Autofail)
+	log.Debugf("autofail is [%v]\n", request.Autofail)
 
 	switch {
 	case request.Startup && request.Shutdown:

--- a/internal/apiserver/clusterservice/clusterservice.go
+++ b/internal/apiserver/clusterservice/clusterservice.go
@@ -131,7 +131,7 @@ func ShowClusterHandler(w http.ResponseWriter, r *http.Request) {
 	namespace := request.Namespace
 	allflag := request.AllFlag
 
-	log.Debugf("ShowClusterHandler: parameters name [%s] selector [%s] ccpimagetag [%s] version [%s] namespace [%s] allflag [%s]", clustername, selector, ccpimagetag, clientVersion, namespace, allflag)
+	log.Debugf("ShowClusterHandler: parameters name [%s] selector [%s] ccpimagetag [%s] version [%s] namespace [%s] allflag [%v]", clustername, selector, ccpimagetag, clientVersion, namespace, allflag)
 
 	username, err := apiserver.Authn(apiserver.SHOW_CLUSTER_PERM, w, r)
 	if err != nil {
@@ -206,7 +206,7 @@ func DeleteClusterHandler(w http.ResponseWriter, r *http.Request) {
 	deleteData := request.DeleteData
 	deleteBackups := request.DeleteBackups
 
-	log.Debugf("DeleteClusterHandler: parameters namespace [%s] selector [%s] delete-data [%t] delete-backups [%t]", namespace, selector, clientVersion, deleteData, deleteBackups)
+	log.Debugf("DeleteClusterHandler: parameters namespace [%s] selector [%s] delete-data [%t] delete-backups [%t]", namespace, selector, deleteData, deleteBackups)
 
 	username, err := apiserver.Authn(apiserver.DELETE_CLUSTER_PERM, w, r)
 	if err != nil {

--- a/internal/apiserver/labelservice/labelimpl.go
+++ b/internal/apiserver/labelservice/labelimpl.go
@@ -483,7 +483,7 @@ func deleteTheLabel(deployment *v1.Deployment, clusterName string, labelsMap map
 
 	_, err = apiserver.Clientset.AppsV1().Deployments(ns).Patch(deployment.Name, types.MergePatchType, patchBytes, "")
 	if err != nil {
-		log.Debugf("error patching deployment ", err.Error())
+		log.Debugf("error patching deployment: %v", err.Error())
 	}
 	return err
 

--- a/internal/apiserver/pgdumpservice/pgdumpimpl.go
+++ b/internal/apiserver/pgdumpservice/pgdumpimpl.go
@@ -237,7 +237,7 @@ func ShowpgDump(clusterName string, selector string, ns string) msgs.ShowBackupR
 			// nothing found, no error
 			log.Debugf("pgTask %s not found, no erros", pgTaskName)
 			response.Status.Code = msgs.Ok
-			response.Status.Msg = fmt.Sprintln("pgDump %s not found.", pgTaskName)
+			response.Status.Msg = fmt.Sprintf("pgDump %s not found.", pgTaskName)
 		}
 
 	}

--- a/internal/apiserver/pgouserservice/pgouserimpl.go
+++ b/internal/apiserver/pgouserservice/pgouserimpl.go
@@ -244,7 +244,7 @@ func UpdatePgouser(clientset kubernetes.Interface, updatedBy string, request *ms
 	log.Info("Updating secret for: ", request.PgouserName)
 	_, err = clientset.CoreV1().Secrets(apiserver.PgoNamespace).Update(secret)
 	if err != nil {
-		log.Debug("Error updating pgouser secret: ", err.Error)
+		log.Debug("Error updating pgouser secret: ", err.Error())
 		resp.Status.Code = msgs.Error
 		resp.Status.Msg = err.Error()
 		return resp

--- a/internal/apiserver/policyservice/policyimpl.go
+++ b/internal/apiserver/policyservice/policyimpl.go
@@ -220,7 +220,7 @@ func ApplyPolicy(request *msgs.ApplyPolicyRequest, ns, pgouser string) msgs.Appl
 			return resp
 		}
 		if len(deployments.Items) < 1 {
-			log.Error("%s  did not have a deployment for some reason", c.Name)
+			log.Errorf("%s  did not have a deployment for some reason", c.Name)
 		} else {
 			allDeployments = append(allDeployments, deployments.Items[0])
 		}
@@ -239,7 +239,7 @@ func ApplyPolicy(request *msgs.ApplyPolicyRequest, ns, pgouser string) msgs.Appl
 
 	for _, d := range allDeployments {
 		if d.ObjectMeta.Labels[config.LABEL_SERVICE_NAME] != d.ObjectMeta.Labels[config.LABEL_PG_CLUSTER] {
-			log.Debug("skipping apply policy on deployment %s", d.Name)
+			log.Debugf("skipping apply policy on deployment %s", d.Name)
 			continue
 			//skip non primary deployments
 		}

--- a/internal/apiserver/pvcservice/pvcservice.go
+++ b/internal/apiserver/pvcservice/pvcservice.go
@@ -53,7 +53,7 @@ func ShowPVCHandler(w http.ResponseWriter, r *http.Request) {
 	clientVersion := request.ClientVersion
 	namespace := request.Namespace
 
-	log.Debugf("ShowPVCHandler parameters version [%s] namespace [%s] pvcname [%s] nodeLabel [%]", clientVersion, namespace, clusterName)
+	log.Debugf("ShowPVCHandler parameters version [%s] namespace [%s] pvcname [%s]", clientVersion, namespace, clusterName)
 
 	switch r.Method {
 	case "GET":

--- a/internal/apiserver/statusservice/statusimpl.go
+++ b/internal/apiserver/statusservice/statusimpl.go
@@ -174,7 +174,7 @@ func getLabels(ns string) []msgs.KeyValue {
 	}
 
 	for k, v := range results {
-		ss = append(ss, msgs.KeyValue{k, v})
+		ss = append(ss, msgs.KeyValue{Key: k, Value: v})
 	}
 
 	sort.Slice(ss, func(i, j int) bool {

--- a/internal/apiserver/upgradeservice/upgradeimpl.go
+++ b/internal/apiserver/upgradeservice/upgradeimpl.go
@@ -222,7 +222,7 @@ func supportedOperatorVersion(version string) bool {
 	// then the upgrade cannot continue
 	minor, err := strconv.Atoi(operatorVersion[2])
 	if err != nil {
-		log.Errorf("Cannot convert Postgres Operator's minor version to an integer. Error: ", err)
+		log.Errorf("Cannot convert Postgres Operator's minor version to an integer. Error: %v", err)
 		return false
 	}
 	if minor < MINIMUM_MINOR_PGO_VERSION || minor > MAXIMUM_MINOR_PGO_VERSION {

--- a/internal/controller/manager/controllermanager.go
+++ b/internal/controller/manager/controllermanager.go
@@ -304,7 +304,7 @@ func (c *ControllerManager) addControllerGroup(namespace string) error {
 		pgoInformerFactory.Crunchydata().V1().Pgclusters(),
 		*c.pgoConfig.Pgo.ConfigMapWorkerCount)
 	if err != nil {
-		log.Errorf("Unable to create ConfigMap controller: %w", err)
+		log.Errorf("Unable to create ConfigMap controller: %v", err)
 		return err
 	}
 

--- a/internal/controller/pgtask/pgtaskcontroller.go
+++ b/internal/controller/pgtask/pgtaskcontroller.go
@@ -117,7 +117,7 @@ func (c *Controller) processNextItem() bool {
 		if !dupeFailover(c.PgtaskClient, &tmpTask, keyNamespace) {
 			clusteroperator.FailoverBase(keyNamespace, c.PgtaskClientset, c.PgtaskClient, &tmpTask, c.PgtaskConfig)
 		} else {
-			log.Debug("skipping duplicate onAdd failover task %s/%s", keyNamespace, keyResourceName)
+			log.Debugf("skipping duplicate onAdd failover task %s/%s", keyNamespace, keyResourceName)
 		}
 
 	case crv1.PgtaskDeleteData:
@@ -125,7 +125,7 @@ func (c *Controller) processNextItem() bool {
 		if !dupeDeleteData(c.PgtaskClient, &tmpTask, keyNamespace) {
 			taskoperator.RemoveData(keyNamespace, c.PgtaskClientset, c.PgtaskClient, &tmpTask)
 		} else {
-			log.Debug("skipping duplicate onAdd delete data task %s/%s", keyNamespace, keyResourceName)
+			log.Debugf("skipping duplicate onAdd delete data task %s/%s", keyNamespace, keyResourceName)
 		}
 	case crv1.PgtaskDeleteBackups:
 		log.Debug("delete backups task added")
@@ -150,7 +150,7 @@ func (c *Controller) processNextItem() bool {
 		log.Debugf("workflow task added [%s] ID [%s]", keyResourceName, tmpTask.Spec.Parameters[crv1.PgtaskWorkflowID])
 
 	case crv1.PgtaskCloneStep1, crv1.PgtaskCloneStep2, crv1.PgtaskCloneStep3:
-		log.Debug("clone task added [%s]", keyResourceName)
+		log.Debugf("clone task added [%s]", keyResourceName)
 		clusteroperator.Clone(c.PgtaskClientset, c.PgtaskClient, c.PgtaskConfig, keyNamespace, &tmpTask)
 
 	default:

--- a/internal/operator/common.go
+++ b/internal/operator/common.go
@@ -369,7 +369,7 @@ func SetupNamespaces(clientset kubernetes.Interface) ([]string, error) {
 	// First set the proper namespace operating mode for the Operator install.  The mode identified
 	// determines whether or not certain namespace capabilities are enabled.
 	if err := setNamespaceOperatingMode(clientset); err != nil {
-		log.Errorf("Error detecting namespace operating mode: %w", err)
+		log.Errorf("Error detecting namespace operating mode: %v", err)
 		return nil, err
 	}
 	log.Debugf("Namespace operating mode is '%s'", NamespaceOperatingMode())
@@ -383,7 +383,7 @@ func SetupNamespaces(clientset kubernetes.Interface) ([]string, error) {
 	// proceed with creating and/or updating any namespaces provided for the installation
 	if err := ns.ConfigureInstallNamespaces(clientset, InstallationName,
 		PgoNamespace, namespaceList, NamespaceOperatingMode()); err != nil {
-		log.Errorf("Unable to setup namespaces: %w", err)
+		log.Errorf("Unable to setup namespaces: %v", err)
 		return nil, err
 	}
 

--- a/internal/operator/task/rmdata.go
+++ b/internal/operator/task/rmdata.go
@@ -56,7 +56,7 @@ func RemoveData(namespace string, clientset kubernetes.Interface, restclient *re
 	//create marker (clustername, namespace)
 	err := PatchpgtaskDeleteDataStatus(restclient, task, namespace)
 	if err != nil {
-		log.Error("could not set delete data started marker for task %s cluster %s", task.Spec.Name, task.Spec.Parameters[config.LABEL_PG_CLUSTER])
+		log.Errorf("could not set delete data started marker for task %s cluster %s", task.Spec.Name, task.Spec.Parameters[config.LABEL_PG_CLUSTER])
 		return
 	}
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)

**What is the current behavior? (link to any open issues here)**

- Tests pass when running `go test ./internal/...` with Go 1.13, but it emits warnings and exits non-zero.
- `./internal/operator` fails to build with Go 1.14 due to `%w` verb in formatted log messages.

**What is the new behavior (if this is a feature change)?**

`go test ./internal/... ./pkg/...` now exits zero in both Go 1.13 and Go 1.14.