### PR TITLE
Fix labeling clusters with multiple labels

### DIFF
--- a/internal/apiserver/labelservice/labelimpl.go
+++ b/internal/apiserver/labelservice/labelimpl.go
@@ -125,7 +125,7 @@ func addLabels(items []crv1.Pgcluster, DryRun bool, LabelCmdLabel string, newLab
 			log.Debug("dry run only")
 		} else {
 			log.Debugf("adding label to cluster %s", items[i].Spec.Name)
-			err := PatchPgcluster(LabelCmdLabel, items[i], ns)
+			err := PatchPgcluster(newLabels, items[i], ns)
 			if err != nil {
 				log.Error(err.Error())
 			}
@@ -224,11 +224,8 @@ func updateLabels(deployment *v1.Deployment, clusterName string, newLabels map[s
 
 }
 
-func PatchPgcluster(newLabel string, oldCRD crv1.Pgcluster, ns string) error {
+func PatchPgcluster(newLabels map[string]string, oldCRD crv1.Pgcluster, ns string) error {
 
-	fields := strings.Split(newLabel, "=")
-	labelKey := fields[0]
-	labelValue := fields[1]
 	oldData, err := json.Marshal(oldCRD)
 	if err != nil {
 		return err
@@ -236,7 +233,9 @@ func PatchPgcluster(newLabel string, oldCRD crv1.Pgcluster, ns string) error {
 	if oldCRD.ObjectMeta.Labels == nil {
 		oldCRD.ObjectMeta.Labels = make(map[string]string)
 	}
-	oldCRD.ObjectMeta.Labels[labelKey] = labelValue
+	for key, value := range newLabels {
+		oldCRD.ObjectMeta.Labels[key] = value
+	}
 	var newData, patchBytes []byte
 	newData, err = json.Marshal(oldCRD)
 	if err != nil {
@@ -377,7 +376,7 @@ func deleteLabels(items []crv1.Pgcluster, LabelCmdLabel string, labelsMap map[st
 
 	for i := 0; i < len(items); i++ {
 		log.Debugf("deleting label from %s", items[i].Spec.Name)
-		err = deletePatchPgcluster(LabelCmdLabel, items[i], ns)
+		err = deletePatchPgcluster(labelsMap, items[i], ns)
 		if err != nil {
 			log.Error(err.Error())
 			return err
@@ -406,11 +405,8 @@ func deleteLabels(items []crv1.Pgcluster, LabelCmdLabel string, labelsMap map[st
 	return err
 }
 
-func deletePatchPgcluster(newLabel string, oldCRD crv1.Pgcluster, ns string) error {
+func deletePatchPgcluster(labelsMap map[string]string, oldCRD crv1.Pgcluster, ns string) error {
 
-	fields := strings.Split(newLabel, "=")
-	labelKey := fields[0]
-	//labelValue := fields[1]
 	oldData, err := json.Marshal(oldCRD)
 	if err != nil {
 		return err
@@ -418,7 +414,9 @@ func deletePatchPgcluster(newLabel string, oldCRD crv1.Pgcluster, ns string) err
 	if oldCRD.ObjectMeta.Labels == nil {
 		oldCRD.ObjectMeta.Labels = make(map[string]string)
 	}
-	delete(oldCRD.ObjectMeta.Labels, labelKey)
+	for k := range labelsMap {
+		delete(oldCRD.ObjectMeta.Labels, k)
+	}
 
 	var newData, patchBytes []byte
 	newData, err = json.Marshal(oldCRD)

--- a/internal/apiserver/policyservice/policyimpl.go
+++ b/internal/apiserver/policyservice/policyimpl.go
@@ -270,7 +270,7 @@ func ApplyPolicy(request *msgs.ApplyPolicyRequest, ns, pgouser string) msgs.Appl
 		}
 
 		//update the pgcluster crd labels with the new policy
-		err = labelservice.PatchPgcluster(request.Name+"="+config.LABEL_PGPOLICY, cl, ns)
+		err = labelservice.PatchPgcluster(map[string]string{request.Name: config.LABEL_PGPOLICY}, cl, ns)
 		if err != nil {
 			log.Error(err)
 		}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)

**What is the current behavior?**

When using `pgo label` with a list of labels, PgCluster is getting different labels than its Deployments.

**What is the new behavior?**

All labels are applied to both PgCluster and its Deployments.

**Other information**:

Issue: [ch8740]