### PR TITLE
Provide additional context around pgBackRest Secret

### DIFF
--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -260,6 +260,12 @@ export pgbackrest_public_key="${public_key_temp//[$'\n']}" pgbackrest_private_ke
 
 # create the backrest-repo-config example file and substitute in the newly
 # created keys
+#
+# (Note: that the "config" / "sshd_config" entries contain configuration to
+# ensure that PostgreSQL instances are able to communicate with the pgBackRest
+# repository, which houses backups and archives, and vice versa. Most of the
+# settings follow the sshd defaults, with a few overrides. Edit at your own
+# discretion.)
 cat <<-EOF > "${pgo_cluster_name}-backrest-repo-config.yaml"
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
To provide more transparency around the configuration files that
are loaded into the pgBackRest secret, this includes a note to
explain the context of the config and sshd_config files.

closes #1741 