### PR TITLE
Adds downwardAPI to the cluster-deployment manifest

### DIFF
--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -180,6 +180,10 @@
                         {
                             "mountPath": "/crunchyadm",
                             "name": "crunchyadm"
+                        },
+                        {
+                            "mountPath": "/etc/podinfo",
+                            "name": "podinfo"
                         }
                         {{.TablespaceVolumeMounts}}
                     ],
@@ -337,6 +341,58 @@
                                         "name": "{{.ClusterName}}-pgha-config",
                                         "optional": true
                                     }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "podinfo",
+                        "downwardAPI": {
+                            "defaultMode": 420,
+                            "items": [
+                                {
+                                    "path": "cpu_limit",
+                                    "resourceFieldRef": {
+                                        "containerName": "database",
+                                        "divisor": "1m",
+                                        "resource": "limits.cpu"
+                                    }
+                                },
+                                {
+                                    "path": "cpu_request",
+                                    "resourceFieldRef": {
+                                        "containerName": "database",
+                                        "divisor": "1m",
+                                        "resource": "requests.cpu"
+                                    }
+                                },
+                                {
+                                    "path": "mem_limit",
+                                    "resourceFieldRef": {
+                                        "containerName": "database",
+                                        "resource": "limits.memory"
+                                    }
+                                },
+                                {
+                                    "path": "mem_request",
+                                    "resourceFieldRef": {
+                                        "containerName": "database",
+                                        "resource": "requests.memory"
+                                    }
+                                },
+                                {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.labels"
+                                    },
+                                    "path": "labels"
+                                },
+                                {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.annotations"
+                                    },
+                                    "path": "annotations"
                                 }
                             ]
                         }


### PR DESCRIPTION
Allows the database pod to expose information about itself to containers running
in the Pod.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable? tested in local kube and OCP 3.11



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
[ch8896]