### PR TITLE
Default URI Style for S3 Bootstrap

### DIFF
--- a/internal/kubeapi/fake/fakeclients.go
+++ b/internal/kubeapi/fake/fakeclients.go
@@ -1,0 +1,123 @@
+package fake
+
+/*
+ Copyright 2020 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/crunchydata/postgres-operator/internal/config"
+	"github.com/crunchydata/postgres-operator/internal/kubeapi"
+	fakecrunchy "github.com/crunchydata/postgres-operator/pkg/generated/clientset/versioned/fake"
+)
+
+const (
+	// defaultPGOInstallationName is the default installation name for a fake PGO client
+	defaultPGOInstallationName = "test"
+	// pgoNamespace is the default operator namespace for a fake PGO client
+	defaultPGONamespace = "pgo"
+	// defaultTargetNamespaces are the default target namespaces for a fake PGO client
+	defaultTargetNamespaces = "pgouser1,pgouser2"
+)
+
+var (
+	// pgoRoot represents the root of the PostgreSQL Operator project repository
+	pgoRoot = os.Getenv("PGOROOT")
+	// templatePath defines the default location for the PostgreSQL Operator templates relative to
+	// env var PGOROOT
+	templatePath = pgoRoot + "/installers/ansible/roles/pgo-operator/files/pgo-configs/"
+	// pgoYAMLPath defines the default location for the default pgo.yaml configuration file
+	// relative to env var PGOROOT
+	pgoYAMLPath = pgoRoot + "/conf/postgres-operator/pgo.yaml"
+)
+
+// NewFakePGOClient creates a fake PostgreSQL Operator client.  Specifically, it creates
+// a fake client containing a 'pgo-config' ConfigMap as needed to initialize the Operator
+// (i.e. call the 'operator' packages 'Initialize()' function).  This allows for the proper
+// initialization of the Operator in various unit tests where the various resources loaded
+// during intialization (e.g. templates, config and/or global variables) are required.
+func NewFakePGOClient() (kubeapi.Interface, error) {
+
+	if pgoRoot == "" {
+		return nil, errors.New("Environment variable PGOROOT must be set to the root directory " +
+			"of the PostgreSQL Operator project repository in order to create a fake client")
+	}
+
+	os.Setenv("CRUNCHY_DEBUG", "false")
+	os.Setenv("NAMESPACE", defaultTargetNamespaces)
+	os.Setenv("PGO_INSTALLATION_NAME", defaultPGOInstallationName)
+	os.Setenv("PGO_OPERATOR_NAMESPACE", defaultPGONamespace)
+
+	// create a fake 'pgo-config' ConfigMap containing the operator templates and pgo.yaml
+	pgoConfig, err := createMockPGOConfigMap(defaultPGONamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	// now create and return a fake client containing the ConfigMap
+	return &Clientset{
+		Clientset:    fakekube.NewSimpleClientset(pgoConfig),
+		PGOClientset: fakecrunchy.NewSimpleClientset(),
+	}, nil
+}
+
+// createMockPGOConfigMap creates a mock 'pgo-config' ConfigMap containing the default pgo.yaml
+// and templates included in the PostgreSQL Operator project repository.  This ConfigMap can be
+// utilized when testing to similate and environment containing the various PostgreSQL Operator
+// configuration files (e.g. templates) required to run the Operator.
+func createMockPGOConfigMap(pgoNamespace string) (*v1.ConfigMap, error) {
+
+	// create a configMap that will hold the default configs
+	pgoConfigMap := &v1.ConfigMap{
+		Data: make(map[string]string),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.CustomConfigMapName,
+			Namespace: pgoNamespace,
+		},
+	}
+
+	// get all templates from the default template directory
+	templates, err := ioutil.ReadDir(templatePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// grab all file content so that it can be added to the ConfigMap
+	fileContent := make(map[string]string)
+	for _, t := range templates {
+		content, err := ioutil.ReadFile(templatePath + t.Name())
+		if err != nil {
+			return nil, err
+		}
+		fileContent[t.Name()] = string(content)
+	}
+
+	// add the default pgo.yaml
+	pgoContent, err := ioutil.ReadFile(pgoYAMLPath)
+	if err != nil {
+		return nil, err
+	}
+	fileContent["pgo.yaml"] = string(pgoContent)
+
+	pgoConfigMap.Data = fileContent
+
+	return pgoConfigMap, nil
+}

--- a/internal/operator/backrest/repo.go
+++ b/internal/operator/backrest/repo.go
@@ -190,8 +190,8 @@ func setBootstrapRepoOverrides(clientset kubernetes.Interface, cluster *crv1.Pgc
 	s3Restore := S3RepoTypeCLIOptionExists(cluster.Spec.PGDataSource.RestoreOpts)
 	if s3Restore {
 		// Now override any backrest S3 env vars for the bootstrap job
-		repoFields.PgbackrestS3EnvVars = operator.GetPgbackrestBootstrapS3EnvVars(cluster,
-			restoreFromSecret)
+		repoFields.PgbackrestS3EnvVars = operator.GetPgbackrestBootstrapS3EnvVars(
+			cluster.Spec.PGDataSource.RestoreFrom, restoreFromSecret)
 	} else {
 		repoFields.PgbackrestS3EnvVars = ""
 	}

--- a/internal/operator/cluster/clusterlogic.go
+++ b/internal/operator/cluster/clusterlogic.go
@@ -244,8 +244,8 @@ func getBootstrapJobFields(clientset kubeapi.Interface,
 	s3Restore := backrest.S3RepoTypeCLIOptionExists(cluster.Spec.PGDataSource.RestoreOpts)
 	if s3Restore {
 		// Now override any backrest S3 env vars for the bootstrap job
-		bootstrapFields.PgbackrestS3EnvVars = operator.GetPgbackrestBootstrapS3EnvVars(cluster,
-			restoreFromSecret)
+		bootstrapFields.PgbackrestS3EnvVars = operator.GetPgbackrestBootstrapS3EnvVars(
+			cluster.Spec.PGDataSource.RestoreFrom, restoreFromSecret)
 	} else {
 		bootstrapFields.PgbackrestS3EnvVars = ""
 	}


### PR DESCRIPTION
The proper default S3 URI style is now set when generating the pgBackRest S3 environment variables for a bootstrap Job (i.e. a Job created to bootstrap a cluster from an existing backup, such as when using the `--restore-from` flag with the `pgo` client). 
Specifically, if an empty string is detected in the `s3-uri-style` annotation for the pgBackRest repo secret for the cluster being bootstrapped/restored from, a proper default value of `host` is now set.  This ensures there is never an empty value for the `PGBACKREST_REPO1_S3_URI_STYLE` environment variable in a boostrap Pod, which can lead to problems when running various pgBackRest commands.

Additionally, tests have been created to verify the output of the `GetPgbackrestBootstrapS3EnvVars` function that is utilized to populate the proper S3 environment variables for a bootstrap Job (specifically using the pgBackRest repo secret from the cluster being bootstrapped from).  This includes ensuring the proper default URI style is set when the `s3-uri-style` annotation is empty, as well as ensuring all annotation values are properly reflected in the final S3 environment variable output.  In support of these tests, a `NewFakePGOClient` function has also been created in the `fake` package (underneath `kubeapi`).  This is needed to create a fake client containing the proper resources (i.e. a mock `pgo-config` ConfigMap) as need to initialize the Operator and therefore the various templates needed to properly call the `GetPgbackrestBootstrapS3EnvVars` function for these tests (`PGOROOT` must be properly set in the environment when running tests so that the proper default template files and `pgo.yaml` file can be found as needed to create the mock `pgo-config` ConfigMap).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `PGBACKREST_REPO1_S3_URI_STYLE` environment variable does not contain the proper default (`host`) when the `s3-uri-style` annotation is empty for the secret corresponding to the pgBackRest repo being utilized to bootstrap a new cluster.

[ch8915]

**What is the new behavior (if this is a feature change)?**

The `PGBACKREST_REPO1_S3_URI_STYLE` environment variable defaults to `host` when the `s3-uri-style` annotation is empty for the secret corresponding to the pgBackRest repo being utilized to bootstrap a new cluster.

**Other information**:

N/A