### PR TITLE
Pgnodemx integration

### DIFF
--- a/bin/crunchy-postgres-exporter/start.sh
+++ b/bin/crunchy-postgres-exporter/start.sh
@@ -24,6 +24,7 @@ QUERIES=(
     queries_backrest
     queries_common
     queries_per_db
+    queries_nodemx
 )
 
 function trap_sigterm() {

--- a/bin/get-deps.sh
+++ b/bin/get-deps.sh
@@ -17,7 +17,7 @@ echo "Ensuring project dependencies..."
 BINDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 EVTDIR="$BINDIR/pgo-event"
 POSTGRES_EXPORTER_VERSION=0.8.0
-PGMONITOR_COMMIT='v4.2'
+PGMONITOR_COMMIT='v4.4-RC2'
 
 # Precondition checks
 if [ "$GOPATH" = "" ]; then
@@ -121,3 +121,4 @@ ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_pg11.yml $PGOROOT/docs/
 ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_pg10.yml $PGOROOT/docs/data/pgmonitor/queries_pg10.yml
 ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_pg96.yml $PGOROOT/docs/data/pgmonitor/queries_pg96.yml
 ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_pg95.yml $PGOROOT/docs/data/pgmonitor/queries_pg95.yml
+ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_nodemx.yml $PGOROOT/docs/data/pgmonitor/queries_nodemx.yml

--- a/bin/get-deps.sh
+++ b/bin/get-deps.sh
@@ -17,7 +17,6 @@ echo "Ensuring project dependencies..."
 BINDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 EVTDIR="$BINDIR/pgo-event"
 POSTGRES_EXPORTER_VERSION=0.8.0
-PGMONITOR_COMMIT='v4.4-RC2'
 
 # Precondition checks
 if [ "$GOPATH" = "" ]; then
@@ -94,31 +93,4 @@ fi
 wget -O $PGOROOT/postgres_exporter.tar.gz https://github.com/wrouesnel/postgres_exporter/releases/download/v${POSTGRES_EXPORTER_VERSION?}/postgres_exporter_v${POSTGRES_EXPORTER_VERSION?}_linux-amd64.tar.gz
 
 # pgMonitor Setup
-if [[ -d ${PGOROOT?}/tools/pgmonitor ]]
-then
-    rm -rf ${PGOROOT?}/tools/pgmonitor
-fi
-
-git clone https://github.com/CrunchyData/pgmonitor.git ${PGOROOT?}/tools/pgmonitor
-cd ${PGOROOT?}/tools/pgmonitor
-git checkout ${PGMONITOR_COMMIT?}
-
-# create pgMonitor documentation data directory, if it doesn't exist
-if [[ ! -d ${PGOROOT?}/docs/data/pgmonitor ]]
-then
-    mkdir -p ${PGOROOT?}/docs/data/pgmonitor
-fi
-
-# pgMonitor Script Documentation Setup
-rm -rf ${PGOROOT?}/docs/data/pgmonitor/*
-
-# link pgMonitor metrics files to Hugo data directory
-ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_common.yml $PGOROOT/docs/data/pgmonitor/queries_common.yml
-ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_per_db.yml $PGOROOT/docs/data/pgmonitor/queries_per_db.yml
-ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_backrest.yml $PGOROOT/docs/data/pgmonitor/queries_backrest.yml
-ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_pg12.yml $PGOROOT/docs/data/pgmonitor/queries_pg12.yml
-ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_pg11.yml $PGOROOT/docs/data/pgmonitor/queries_pg11.yml
-ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_pg10.yml $PGOROOT/docs/data/pgmonitor/queries_pg10.yml
-ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_pg96.yml $PGOROOT/docs/data/pgmonitor/queries_pg96.yml
-ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_pg95.yml $PGOROOT/docs/data/pgmonitor/queries_pg95.yml
-ln -s $PGOROOT/tools/pgmonitor/exporter/postgres/queries_nodemx.yml $PGOROOT/docs/data/pgmonitor/queries_nodemx.yml
+source $BINDIR/get-pgmonitor.sh

--- a/bin/get-pgmonitor.sh
+++ b/bin/get-pgmonitor.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+# Copyright 2017 - 2020 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Getting pgMonitor..."
+PGMONITOR_COMMIT='v4.4-RC3'
+
+# pgMonitor Setup
+if [[ -d ${PGOROOT?}/tools/pgmonitor ]]
+then
+    rm -rf ${PGOROOT?}/tools/pgmonitor
+fi
+
+git clone https://github.com/CrunchyData/pgmonitor.git ${PGOROOT?}/tools/pgmonitor
+cd ${PGOROOT?}/tools/pgmonitor
+git checkout ${PGMONITOR_COMMIT?}

--- a/docs/content/advanced/crunchy-postgres-exporter.md
+++ b/docs/content/advanced/crunchy-postgres-exporter.md
@@ -69,3 +69,11 @@ Below are details on the various metrics available from the crunchy-postgres-exp
 The name, SQL query and metric details are given for each available item.
 
 {{< exporter_metrics >}}
+
+# [pgnodemx](https://github.com/CrunchyData/pgnodemx)
+
+In addition to the metrics above, the [pgnodemx](https://github.com/CrunchyData/pgnodemx) PostgreSQL extension provides SQL functions to allow the capture of node OS metrics via SQL queries. For more information, please see the [pgnodemx](https://github.com/CrunchyData/pgnodemx) project page:
+
+[https://github.com/CrunchyData/pgnodemx](https://github.com/CrunchyData/pgnodemx)
+
+{{< pgnodemx_metrics >}}

--- a/docs/data/pgmonitor/general/queries_backrest.yml
+++ b/docs/data/pgmonitor/general/queries_backrest.yml
@@ -1,0 +1,1 @@
+../../../../tools/pgmonitor/exporter/postgres/queries_backrest.yml

--- a/docs/data/pgmonitor/general/queries_common.yml
+++ b/docs/data/pgmonitor/general/queries_common.yml
@@ -1,0 +1,1 @@
+../../../../tools/pgmonitor/exporter/postgres/queries_common.yml

--- a/docs/data/pgmonitor/general/queries_per_db.yml
+++ b/docs/data/pgmonitor/general/queries_per_db.yml
@@ -1,0 +1,1 @@
+../../../../tools/pgmonitor/exporter/postgres/queries_per_db.yml

--- a/docs/data/pgmonitor/general/queries_pg10.yml
+++ b/docs/data/pgmonitor/general/queries_pg10.yml
@@ -1,0 +1,1 @@
+../../../../tools/pgmonitor/exporter/postgres/queries_pg10.yml

--- a/docs/data/pgmonitor/general/queries_pg11.yml
+++ b/docs/data/pgmonitor/general/queries_pg11.yml
@@ -1,0 +1,1 @@
+../../../../tools/pgmonitor/exporter/postgres/queries_pg11.yml

--- a/docs/data/pgmonitor/general/queries_pg12.yml
+++ b/docs/data/pgmonitor/general/queries_pg12.yml
@@ -1,0 +1,1 @@
+../../../../tools/pgmonitor/exporter/postgres/queries_pg12.yml

--- a/docs/data/pgmonitor/general/queries_pg95.yml
+++ b/docs/data/pgmonitor/general/queries_pg95.yml
@@ -1,0 +1,1 @@
+../../../../tools/pgmonitor/exporter/postgres/queries_pg95.yml

--- a/docs/data/pgmonitor/general/queries_pg96.yml
+++ b/docs/data/pgmonitor/general/queries_pg96.yml
@@ -1,0 +1,1 @@
+../../../../tools/pgmonitor/exporter/postgres/queries_pg96.yml

--- a/docs/data/pgmonitor/pgnodemx/queries_nodemx.yml
+++ b/docs/data/pgmonitor/pgnodemx/queries_nodemx.yml
@@ -1,0 +1,1 @@
+../../../../tools/pgmonitor/exporter/postgres/queries_nodemx.yml

--- a/docs/layouts/shortcodes/pgnodemx_metrics.html
+++ b/docs/layouts/shortcodes/pgnodemx_metrics.html
@@ -1,4 +1,4 @@
-{{ range $metricsfile, $value0 := .Site.Data.pgmonitor.general }}
+{{ range $metricsfile, $value0 := .Site.Data.pgmonitor.pgnodemx }}
 <h2>{{ $metricsfile }}</h2>
 
 {{ range $query, $value1 := $value0 }}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Pgnodemx is not integrated into the Postgres Operator.


**What is the new behavior (if this is a feature change)?**
This PR updates the pgMonitor version used by the PostgreSQL
Operator, enables the pgnodemx queries to be used by the
Crunchy Postgres Exporter container and adds these queries to
the automated exporter documentation.


**Other information**:
[ch8768]