### PR TITLE
Add Explicit 'else' to Jinja Inline If Expression

### DIFF
--- a/installers/metrics/ansible/roles/pgo-metrics/tasks/main.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/tasks/main.yml
@@ -96,7 +96,7 @@
     - name: Wait for Metrics to Finish Deploying
       command: |
         {{ kubectl_or_oc }} rollout status deployment/{{ item }} -n {{ metrics_namespace }} \
-          {{ '--timeout=600s' if not 'unknown flag: --timeout' in timeout_flag_result.stderr }}
+          {{ '--timeout=600s' if not 'unknown flag: --timeout' in timeout_flag_result.stderr else '' }}
       async: 610  # must be > or = to the rollout status timeout (600s) to ensure proper timeout behavior
       poll: 0
       loop: "{{ deployments }}"


### PR DESCRIPTION
Per the Jinja documentation, the `else` for an inline If expression should default to an undefined object if not explicitly specified:

https://jinja.palletsprojects.com/en/2.11.x/templates/#if-expression

However, with certain versions/combinations of Ansible and Python, this default is not occurring, leading to errors when the "Wait for Metrics to Finish Deploying" task is run during a metrics installation.

This commit therefore adds an explicit `else` condition to the inline If expression within this task, ensuring maximum compatibility and proper behavior with various combinations/versions of Ansible and Python.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Certain versions/combinations of Ansible and Python error when running the "Wait for Metrics to Finish Deploying" task in the Ansible installer.

**What is the new behavior (if this is a feature change)?**

All supported versions/combinations of Ansible and Python are able to properly run the "Wait for Metrics to Finish Deploying" task.

**Other information**:

N/A