### PR TITLE
Enable Repository for 'openshift-clients' Package in the 'pgo-deployer' Container

### DIFF
--- a/build/pgo-deployer/Dockerfile
+++ b/build/pgo-deployer/Dockerfile
@@ -56,6 +56,7 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
         && ${PACKAGER} install -y https://download.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
         && ${PACKAGER} -y install \
                 --setopt=skip_missing_names_on_install=False \
+                --enablerepo='rhocp-4.5-for-rhel-8-x86_64-rpms' \
                 openshift-clients \
                 ansible-${ANSIBLE_VERSION} \
                 which \


### PR DESCRIPTION
Enables the `rhocp-4.5-for-rhel-8-x86_64-rpm` repo when installing various packages in the `pgo-deployer` container for UBI8 as needed to install the `openshift-clients` package.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `openshift-clients` package _cannot_ be installed in the `pgo-deployer` container.

**What is the new behavior (if this is a feature change)?**

The `openshift-clients` package _can_ be installed in the `pgo-deployer` container.

**Other information**:

N/A