### PR TITLE
Ansible Auto-Detect Python Version & Install 'openssl' in Deployer for UBI 8

### DIFF
--- a/build/pgo-deployer/Dockerfile
+++ b/build/pgo-deployer/Dockerfile
@@ -60,6 +60,7 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
                 ansible-${ANSIBLE_VERSION} \
                 which \
                 gettext \
+                openssl \
 	&& ${PACKAGER} -y clean all ; \
 fi
 

--- a/installers/ansible/inventory.yaml
+++ b/installers/ansible/inventory.yaml
@@ -4,7 +4,6 @@
             localhost:
         vars:
             ansible_connection: local
-            ansible_python_interpreter: "/usr/bin/env python"
             config_path: "{{ playbook_dir }}/values.yaml"
             # ==================
             # Installation Methods


### PR DESCRIPTION
The `ansible_python_interpreter` setting has been removed from the `inventory` file for the PostgreSQL Operator Ansible installer, which allows Ansible to auto-detect Python within the environment it is running.  This ensures the proper detection and use of Python by Ansible within the deployer container across the various versions of UBI and CentOS supported by the PostgreSQL Operator.

Additionally, the `openssl` package is now explicitly installed in the UBI8 deployer container, as needed to generate various certificates when the Ansible installer is run run within the container.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- The `ansible_python_interpreter` setting is present in the `inventory` to explicitly configure a Python interpreter, which leads to the following error when run on UBI 8:

```bash
TASK [Gathering Facts] *********************************************************
fatal: [localhost]: FAILED! => {"ansible_facts": {}, "changed": false, "failed_modules": {"setup": {"failed": true, "module_stderr": "env: 'python': No such file or directory\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 127}}, "msg": "The following modules failed to execute: setup\n"}
```

- `openssl` is not installed in the `pgo-deployer` container, leading to the following error when the Ansible installer attempts to generate certificates:

```bash
TASK [pgo-operator : Generate RSA Key] *****************************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "openssl genrsa -out /tmp/.pgo/pgo/output/server.key 2048", "msg": "[Errno 2] No such file or directory: b'openssl': b'openssl'", "rc": 2}
```

**What is the new behavior (if this is a feature change)?**

- The `ansible_python_interpreter` setting is no longer present in the `inventory`, allowing Ansible to auto-detect a Python intepreter across various CentOS and UBI environments.
- `openssl` is explicitly installed in the `pgo-deployer` container for UBI 8, ensuring the Ansible installer is able to successfully generate certificates during installation.

**Other information**:

N/A
