### PR TITLE
Add --enable-repo to 'clean' Command in pgo-deployer Dockerfile for UBI 8

### DIFF
--- a/build/pgo-deployer/Dockerfile
+++ b/build/pgo-deployer/Dockerfile
@@ -62,7 +62,7 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
                 which \
                 gettext \
                 openssl \
-	&& ${PACKAGER} -y clean all ; \
+	&& ${PACKAGER} -y clean all --enablerepo='rhocp-4.5-for-rhel-8-x86_64-rpms' ; \
 fi
 
 COPY installers/ansible /ansible/postgres-operator


### PR DESCRIPTION
Adds `--enable-repo='rhocp-4.5-for-rhel-8-x86_64-rpms'` to the clean command for UBI 8 in the `pgo-deployer` container to ensure metadata for the repo does not remain in the container.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Metadata for the `rhocp-4.5-for-rhel-8-x86_64-rpms` repo remains in the `pgo-deployer` container.


**What is the new behavior (if this is a feature change)?**

Metadata for the `rhocp-4.5-for-rhel-8-x86_64-rpms` repo _does not_ remain the `pgo-deployer` container.

**Other information**:

N/A