### PR TITLE
Update BASEOS & PGVERSION ARGs in 'crunchy-postgres-exporter' Dockerfile

### DIFF
--- a/build/crunchy-postgres-exporter/Dockerfile
+++ b/build/crunchy-postgres-exporter/Dockerfile
@@ -1,7 +1,9 @@
+ARG BASEOS
 ARG BASEVER
 ARG PREFIX
-ARG PGVERSION
 FROM ${PREFIX}/pgo-base:${BASEOS}-${BASEVER}
+
+ARG PGVERSION
 
 LABEL name="crunchy-postgres-exporter" \
 	summary="Metrics exporter for PostgreSQL" \


### PR DESCRIPTION
Adds the `BASEOS` ARG to the `crunchy-postgres-exporter` Dockerfile, while also moving the `PGVERSION` ARG down below the FROM instruction within the same Dockerfile, as needed to support building with Buildah 1.14.9.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `BASEOS` & `PGVERSION` ARGs in 'crunchy-postgres-exporter' Dockerfile are invalid when building with Buildah 1.14.9.

**What is the new behavior (if this is a feature change)?**

The `BASEOS` & `PGVERSION` ARGs in 'crunchy-postgres-exporter' Dockerfile now properly support building with Buildah 1.14.9.

**Other information**:

N/A