### PR TITLE
Remove Obsolete Exporter Function Call

### DIFF
--- a/bin/crunchy-postgres-exporter/start.sh
+++ b/bin/crunchy-postgres-exporter/start.sh
@@ -79,7 +79,6 @@ set_default_postgres_exporter_env
 
 if [[ ! -v DATA_SOURCE_NAME ]]
 then
-    set_exporter_pg_credentials
     set_default_pg_exporter_env
     if [[ ! -z "${EXPORTER_PG_PARAMS}" ]]
     then


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
There is an obsolete function reference.


**What is the new behavior (if this is a feature change)?**
This commit removes an obsolete reference to the
'set_exporter_pg_credentials' function from the Crunchy Postgres
Exporter container's start.sh script. This function was previously
needed to read the credential values from the containers volume, but
these values are now set in the deployment. While the function itself was
previously removed, this reference was missed, resulting in a misleading
error in the logs.


**Other information**:
