### PR TITLE
Updates prometheus cleanup to use correct sa name

### DIFF
--- a/installers/metrics/ansible/roles/pgo-metrics/tasks/cleanup.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/tasks/cleanup.yml
@@ -34,7 +34,7 @@
       loop:
         - alertmanager
         - grafana
-        - prometheus
+        - prometheus-sa
 
     - name: Delete Grafana Secret
       command: "{{ kubectl_or_oc }} delete secret grafana-secret -n {{ metrics_namespace }}"


### PR DESCRIPTION
The prometheus service account is named inconsistently with other metrics
service accounts. This commit reverts the cleanup task to use the old and
correct service account name. The original name was kept to limit
differences in naming between old and new metrics.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable? Tested install/uninstall with ocp 3.11 and prometheus service account is now cleaned up by base ansible



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
