### PR TITLE
Add DFSET & PACKAGER ARGs to Exporter Dockerfile

### DIFF
--- a/build/crunchy-postgres-exporter/Dockerfile
+++ b/build/crunchy-postgres-exporter/Dockerfile
@@ -4,6 +4,8 @@ ARG PREFIX
 FROM ${PREFIX}/pgo-base:${BASEOS}-${BASEVER}
 
 ARG PGVERSION
+ARG PACKAGER
+ARG DFSET
 
 LABEL name="crunchy-postgres-exporter" \
 	summary="Metrics exporter for PostgreSQL" \


### PR DESCRIPTION
Adds the `DFSET` and `PACKAGER` ARG instructions to the `crunchy-postgres-exporter` Dockerfile as needed to ensure the proper detection of `rhel` or `centos` for the `DFSET` environment  variable, and the use of the proper package manager when installing the packages required by the Crunchy PostgreSQL Exporter.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

When building `crunchy-postgres-exporter` with buildah v1.14.9 the proper packages are _not_ installed.

**What is the new behavior (if this is a feature change)?**

When building `crunchy-postgres-exporter` with buildah v1.14.9 the proper packages are installed.

**Other information**:

N/A