### PR TITLE
Fix Ports for Prometheus & Grafana in the Prerequisites Section of the Monitoring Install Documentation

### DIFF
--- a/docs/content/installation/metrics/metrics-prerequisites.md
+++ b/docs/content/installation/metrics/metrics-prerequisites.md
@@ -26,6 +26,6 @@ and their default Service ports.
 
 | Service | Port |
 | --- | --- |
-| Grafana | 9090 |
-| Prometheus | 3000 |
+| Grafana | 3000 |
+| Prometheus | 9090 |
 | Alertmanager | 9093 |


### PR DESCRIPTION
Defines the proper ports for Grafana (port 3000) and Prometheus (port 9090) in the prerequisites section of the documentation for installing the PostgreSQL Operator monitoring infrastructure.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The wrong ports are defined for Prometheus and Grafana in the prerequisites section of the monitoring installation documentation.

**What is the new behavior (if this is a feature change)?**

The correct ports are defined for Prometheus and Grafana in the prerequisites section of the monitoring installation documentation.

**Other information**:

N/A