### PR TITLE
Add 'openssl' package to all versions of the PGO Deployer

### DIFF
--- a/build/pgo-deployer/Dockerfile
+++ b/build/pgo-deployer/Dockerfile
@@ -22,20 +22,22 @@ RUN if [ "$DFSET" = "centos" ] ; then \
                 ansible-${ANSIBLE_VERSION} \
                 which \
                 gettext \
+                openssl \
         && ${PACKAGER} -y clean all ; \
 fi
 
 RUN if [ "$BASEOS" = "rhel7" ] ; then \
-	rm /etc/yum.repos.d/kubernetes.repo \
-	&& ${PACKAGER} install -y https://download.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-	&& ${PACKAGER} -y install \
-		--setopt=skip_missing_names_on_install=False \
-		--enablerepo='rhel-7-server-ose-4.4-rpms' \
-		openshift-clients \
-		ansible-${ANSIBLE_VERSION} \
-		which \
-		gettext \
-	&& ${PACKAGER} -y clean all --enablerepo='rhel-7-server-ose-4.4-rpms' ; \
+        rm /etc/yum.repos.d/kubernetes.repo \
+        && ${PACKAGER} install -y https://download.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+        && ${PACKAGER} -y install \
+                --setopt=skip_missing_names_on_install=False \
+                --enablerepo='rhel-7-server-ose-4.4-rpms' \
+                openshift-clients \
+                ansible-${ANSIBLE_VERSION} \
+                which \
+                gettext \
+                openssl \
+        && ${PACKAGER} -y clean all --enablerepo='rhel-7-server-ose-4.4-rpms' ; \
 fi
 
 RUN if [ "$BASEOS" = "ubi7" ] ; then \
@@ -48,6 +50,7 @@ RUN if [ "$BASEOS" = "ubi7" ] ; then \
                 ansible-${ANSIBLE_VERSION} \
                 which \
                 gettext \
+                openssl \
 	&& ${PACKAGER} -y clean all --enablerepo='rhel-7-server-ose-4.4-rpms' ; \
 fi
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Openssl is not installed for all pgo-deployer containers.


**What is the new behavior (if this is a feature change)?**
The 'openssl' package is now explicitly installed in the
for all versions of the deployer container, as needed to
generate various certificates when the Ansible installer is
run run within the container.


**Other information**:
