### PR TITLE
Copy pgBackRest S3 secrets during cluster upgrade

### DIFF
--- a/internal/operator/pgbackrest.go
+++ b/internal/operator/pgbackrest.go
@@ -82,8 +82,8 @@ func AddBackRestConfigVolumeAndMounts(podSpec *v1.PodSpec, clusterName string, p
 	combined = append(combined, v1.VolumeProjection{Secret: &secret})
 
 	// The built-in configurations above also happen to bypass a bug in Kubernetes.
-	// Kubernetes 1.15 through 1.18 store an empty list of sources as `null` which
-	// breaks some clients, notably the Python client used by Patroni.
+	// Kubernetes 1.15 through 1.19 store an empty list of sources as `null` which
+	// breaks some clients, notably the Python client used by Patroni 1.6.5.
 	// - https://issue.k8s.io/93903
 
 	addBackRestConfigDirectoryVolumeAndMounts(podSpec, "pgbackrest-config", combined, "backrest", "database")

--- a/internal/util/cluster.go
+++ b/internal/util/cluster.go
@@ -176,6 +176,9 @@ func CreateBackrestRepoSecrets(clientset kubernetes.Interface,
 	}
 
 	_, err = clientset.CoreV1().Secrets(backrestRepoConfig.ClusterNamespace).Create(&secret)
+	if kubeapi.IsAlreadyExists(err) {
+		_, err = clientset.CoreV1().Secrets(backrestRepoConfig.ClusterNamespace).Update(&secret)
+	}
 	return err
 }
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

When upgrading from a cluster created in 4.3, pgBackRest secrets are regenerated but lack any S3 credentials.

**What is the new behavior (if this is a feature change)?**

Cluster-specific S3 secrets are copied during an upgrade.