### PR TITLE
Fix --target Option Detection for Restores

### DIFF
--- a/internal/operator/backrest/restore.go
+++ b/internal/operator/backrest/restore.go
@@ -18,6 +18,7 @@ package backrest
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -34,6 +35,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
+
+// restoreTargetRegex defines a regex to detect if a restore target has been specified
+// for pgBackRest using the '--target' option
+var restoreTargetRegex = regexp.MustCompile("--target(=| +)")
 
 type BackrestRestoreJobTemplateFields struct {
 	JobName                string
@@ -67,7 +72,7 @@ func UpdatePGClusterSpecForRestore(clientset kubeapi.Interface, cluster *crv1.Pg
 
 	// set the proper target for the restore job
 	pitrTarget := task.Spec.Parameters[config.LABEL_BACKREST_PITR_TARGET]
-	if pitrTarget != "" && !strings.Contains(restoreOpts, "--target") {
+	if pitrTarget != "" && !restoreTargetRegex.MatchString(restoreOpts) {
 		restoreOpts = fmt.Sprintf("%s --target=%s", restoreOpts, strconv.Quote(pitrTarget))
 	}
 


### PR DESCRIPTION
A regex is now used to determine whether or not a `--target` flag already exists in the options provided for a pgBackRest restore. This avoids conflicts with other options containing the string "target" (e.g. `--target-action`), therefore ensuring the PITR target is properly injected into the pgBackRest options as needed.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

PITR's fail if the `--target-action` flag is specified.

[ch9162]

**What is the new behavior (if this is a feature change)?**

PITR's no longer fail if the `--target-action` flag is specified.

**Other information**:

N/A