### PR TITLE
Shorter pgrestore Job Names

### DIFF
--- a/internal/operator/pgdump/restore.go
+++ b/internal/operator/pgdump/restore.go
@@ -18,6 +18,7 @@ package pgdump
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/crunchydata/postgres-operator/internal/config"
@@ -75,7 +76,8 @@ func Restore(namespace string, clientset kubeapi.Interface, task *crv1.Pgtask) {
 	taskName := task.Name
 
 	jobFields := restorejobTemplateFields{
-		JobName:             "pgrestore-" + task.Spec.Parameters[config.LABEL_PGRESTORE_FROM_CLUSTER] + "-from-" + fromPvcName + "-" + util.RandStringBytesRmndr(4),
+		JobName: fmt.Sprintf("pgrestore-%s-%s", task.Spec.Parameters[config.LABEL_PGRESTORE_FROM_CLUSTER],
+			util.RandStringBytesRmndr(4)),
 		TaskName:            taskName,
 		ClusterName:         clusterName,
 		SecurityContext:     operator.GetPodSecurityContext(storage.GetSupplementalGroups()),


### PR DESCRIPTION
The name of the PVC being utilized for a pgrestore Job is now no longer included in the Job name.  This ensures the 63 character limit for Kubernetes Job naming is not easily exceeded when creating pgrestore Jobs, i.e. for clusters with names 
longer than simply a few characters.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

pgrestore Jobs fail to create with a `must be no more than 63 characters` error if the cluster name is longer than a few characters.

[ch9163]

**What is the new behavior (if this is a feature change)?**

pgrestore Jobs no longer fail to create if the cluster name is longer than a few characters.

**Other information**:

N/A