### PR TITLE
Upgrade pgBackRest settings from 4.2 and earlier

### DIFF
--- a/internal/operator/cluster/upgrade.go
+++ b/internal/operator/cluster/upgrade.go
@@ -36,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
 )
 
 // Store image names as constants to use later
@@ -411,6 +412,23 @@ func recreateBackrestRepoSecret(clientset kubernetes.Interface, clustername, nam
 	secretName := clustername + "-backrest-repo-config"
 	secret, err := clientset.CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
 
+	// 4.1, 4.2
+	if err == nil {
+		if b, ok := secret.Data["aws-s3-ca.crt"]; ok {
+			config.BackrestS3CA = b
+		}
+		if b, ok := secret.Data["aws-s3-credentials.yaml"]; ok {
+			var parsed struct {
+				Key       string `yaml:"aws-s3-key"`
+				KeySecret string `yaml:"aws-s3-key-secret"`
+			}
+			if err = yaml.Unmarshal(b, &parsed); err == nil {
+				config.BackrestS3Key = parsed.Key
+				config.BackrestS3KeySecret = parsed.KeySecret
+			}
+		}
+	}
+
 	// >= 4.3
 	if err == nil {
 		if b, ok := secret.Data["aws-s3-ca.crt"]; ok {
@@ -513,6 +531,17 @@ func preparePgclusterForUpgrade(pgcluster *crv1.Pgcluster, parameters map[string
 	// ensure that the pgo-backrest label is set to 'true' since pgbackrest is required for normal
 	// cluster operations in this version of the Postgres Operator
 	pgcluster.ObjectMeta.Labels[config.LABEL_BACKREST] = "true"
+
+	// added in 4.2 and copied from configuration in 4.4
+	if pgcluster.Spec.BackrestS3Bucket == "" {
+		pgcluster.Spec.BackrestS3Bucket = operator.Pgo.Cluster.BackrestS3Bucket
+	}
+	if pgcluster.Spec.BackrestS3Endpoint == "" {
+		pgcluster.Spec.BackrestS3Endpoint = operator.Pgo.Cluster.BackrestS3Endpoint
+	}
+	if pgcluster.Spec.BackrestS3Region == "" {
+		pgcluster.Spec.BackrestS3Region = operator.Pgo.Cluster.BackrestS3Region
+	}
 
 	// added in 4.4
 	if pgcluster.Spec.BackrestS3VerifyTLS == "" {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)

**What is the current behavior? (link to any open issues here)**

When upgrading from a cluster created in 4.2 or 4.1, pgBackRest secrets are regenerated but lack any S3 credentials.

**What is the new behavior (if this is a feature change)?**

Cluster-specific S3 secrets are copied during an upgrade, and pgBackRest settings are stored on the PgCluster object.
