### PR TITLE
Fix metrics update job name

### DIFF
--- a/installers/metrics/helm/templates/postgres-operator-metrics-upgrade.yaml
+++ b/installers/metrics/helm/templates/postgres-operator-metrics-upgrade.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: pgo-deploy
+  name: pgo-metrics-deploy
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "postgres-operator.labels" . | indent 4 }}


### PR DESCRIPTION
This change updates the update job name to be consistent with the install and uninstall metrics jobs
