### PR TITLE
Quiet warning from Go 1.15

### DIFF
--- a/internal/util/secrets.go
+++ b/internal/util/secrets.go
@@ -76,9 +76,7 @@ func CreateSecret(clientset kubernetes.Interface, db, secretName, username, pass
 // GeneratePassword generates a password of a given length out of the acceptable
 // ASCII characters suitable for a password
 func GeneratePassword(length int) (string, error) {
-	// for "length" times, we are going to get a random ASCII character, and
-	// append it to the  "password" string
-	password := ""
+	password := make([]byte, length)
 
 	for i := 0; i < length; i++ {
 		char, err := rand.Int(rand.Reader, passwordCharSelector)
@@ -88,10 +86,10 @@ func GeneratePassword(length int) (string, error) {
 			return "", err
 		}
 
-		password += string(passwordCharLower + char.Int64())
+		password[i] = byte(passwordCharLower + char.Int64())
 	}
 
-	return password, nil
+	return string(password), nil
 }
 
 // GeneratedPasswordLength returns the value for what the length of a

--- a/internal/util/secrets_test.go
+++ b/internal/util/secrets_test.go
@@ -22,15 +22,27 @@ import (
 )
 
 func TestGeneratePassword(t *testing.T) {
-	previous := []string{}
-
-	for i := 0; i < 10; i++ {
-		password, err := GeneratePassword(i + 10)
+	// different lengths
+	for _, length := range []int{1, 2, 3, 5, 20} {
+		password, err := GeneratePassword(length)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		if expected, actual := i+10, len(password); expected != actual {
+		if expected, actual := length, len(password); expected != actual {
 			t.Fatalf("expected length %v, got %v", expected, actual)
+		}
+		if i := strings.IndexFunc(password, unicode.IsPrint); i > 0 {
+			t.Fatalf("expected only printable characters, got %q in %q", password[i], password)
+		}
+	}
+
+	// random contents
+	previous := []string{}
+
+	for i := 0; i < 10; i++ {
+		password, err := GeneratePassword(5)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
 		}
 		if i := strings.IndexFunc(password, unicode.IsPrint); i > 0 {
 			t.Fatalf("expected only printable characters, got %q in %q", password[i], password)

--- a/internal/util/secrets_test.go
+++ b/internal/util/secrets_test.go
@@ -1,0 +1,46 @@
+package util
+
+/*
+ Copyright 2020 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+)
+
+func TestGeneratePassword(t *testing.T) {
+	previous := []string{}
+
+	for i := 0; i < 10; i++ {
+		password, err := GeneratePassword(i + 10)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if expected, actual := i+10, len(password); expected != actual {
+			t.Fatalf("expected length %v, got %v", expected, actual)
+		}
+		if i := strings.IndexFunc(password, unicode.IsPrint); i > 0 {
+			t.Fatalf("expected only printable characters, got %q in %q", password[i], password)
+		}
+
+		for i := range previous {
+			if password == previous[i] {
+				t.Fatalf("expected passwords to not repeat, got %q after %q", password, previous)
+			}
+		}
+		previous = append(previous, password)
+	}
+}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)

**What is the current behavior? (link to any open issues here)**

Go 1.15 warns when running `go test ./internal/...`:

```
# github.com/crunchydata/postgres-operator/internal/util
internal/util/secrets.go:91:15: conversion from int64 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```

**What is the new behavior (if this is a feature change)?**

No warnings.