### PR TITLE
Safely error if "pgo df" does not find any clusters

### DIFF
--- a/docs/content/releases/4.5.0.md
+++ b/docs/content/releases/4.5.0.md
@@ -143,6 +143,7 @@ To remove an annotation, one follows the format:
 - The pgBackRest URI style defaults to `host` if it is not set.
 - pgBackRest commands can now be executed even if there are multiple pgBackRest Pods available in a Deployment, so long as there is only one "running" pgBackRest Pod.
 - Ensure pgBackRest S3 Secrets can be upgraded from PostgreSQL Operator 4.3.
+- Return an error if a cluster is not found when using `pgo df` instead of timing out.
 - pgBadger now has a default memory limit of 64Mi, which should help avoid a visit from the OOM killer.
 - Fix `pgo label` when applying multiple labels at once.
 - Fix `pgo create pgorole` so that the expression `--permissions=*` works.

--- a/docs/content/releases/4.5.0.md
+++ b/docs/content/releases/4.5.0.md
@@ -135,6 +135,7 @@ To remove an annotation, one follows the format:
   - Any customizations for the cluster (e.g. custom PostgreSQL configuration) will be available.
   - This also fixes several bugs that were reported with the `pgo restore` functionality, some of which are captured further down in these release notes.
 - The [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/) is now available to PostgreSQL instances.
+- The `pgo df` command will round values over 1000 up to the next unit type, e.g. `1GiB` instead of `1024MiB`.
 
 ## Fixes
 

--- a/internal/apiserver/dfservice/dfimpl.go
+++ b/internal/apiserver/dfservice/dfimpl.go
@@ -57,7 +57,18 @@ func DfCluster(request msgs.DfRequest) msgs.DfResponse {
 		return CreateErrorResponse(err.Error())
 	}
 
-	log.Debugf("df clusters found len is %d", len(clusterList.Items))
+	totalClusters := len(clusterList.Items)
+
+	log.Debugf("df clusters found len is %d", totalClusters)
+
+	// if there are no clusters found, exit early
+	if totalClusters == 0 {
+		response.Status = msgs.Status{
+			Code: msgs.Error,
+			Msg:  fmt.Sprintf("no clusters found for selector %q in namespace %q", selector, namespace),
+		}
+		return response
+	}
 
 	// iterate through each cluster and get the information about the disk
 	// utilization. As there could be a lot of clusters doing this, we opt for
@@ -76,7 +87,6 @@ func DfCluster(request msgs.DfRequest) msgs.DfResponse {
 
 	// track the progress / completion, so we know when to exit
 	processed := 0
-	totalClusters := len(clusterList.Items)
 
 loop:
 	for {

--- a/pgo/cmd/common.go
+++ b/pgo/cmd/common.go
@@ -107,12 +107,11 @@ func getSizeAndUnit(size int64) (float64, unitType) {
 	normalizedSize := float64(size)
 
 	// We keep dividing by "unitSize" which is 1024. Once it is less than the unit
-	// size, that is the normalized unit we will use.
-	// The astute observer will note that "du" returns in units of 1024, but we
-	// want to attempt to keep things in the 3-digit area
+	// size, or really, once it's less than "1000" of that unit size, that is
+	// normalized unit we will use.
 	//
 	// of course, eventually this will get too big...so bail after yotta bytes
-	for unit = unitB; normalizedSize > unitSize && unit < unitYB; unit++ {
+	for unit = unitB; normalizedSize > 1000 && unit < unitYB; unit++ {
 		normalizedSize /= unitSize
 	}
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)

**What is the current behavior? (link to any open issues here)**

`pgo df` with an invalid cluster name would time out with an obscure error.

**What is the new behavior (if this is a feature change)?**

Now `pgo df` will promptly error and indicate it has done so:

```
[vagrant@centos8 postgres-operator]$ pgo df hippo gr

PVC             INSTANCE                   POD                                        TYPE        USED      CAPACITY  % USED
--------------- -------------------------- ------------------------------------------ ----------- --------- --------- ------
hippo           hippo                      hippo-64b5665555-xj5qz                     data        493MiB    1024MiB   48%
hippo-pgbr-repo hippo-backrest-shared-repo hippo-backrest-shared-repo-55d4f645c-4wvsv pgbackrest  316MiB    1024MiB   31%
hippo-krhx      hippo-krhx                 hippo-krhx-94846986d-zdm8g                 data        509MiB    1024MiB   50%
Error: no clusters found for selector "name=gr" in namespace "jkatz"
```

**Other information**:

Issue: [ch9202]