### PR TITLE
Update installer to pull container alert rules

### DIFF
--- a/installers/metrics/ansible/roles/pgo-metrics/tasks/alertmanager.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/tasks/alertmanager.yml
@@ -22,7 +22,7 @@
       command: "cp {{ pgmonitor_prometheus_dir }}/{{ item.src }} {{ alertmanager_output_dir }}/{{ item.dst }}"
       loop:
         - { src: 'crunchy-alertmanager.yml', dst: 'alertmanager.yml'}
-        - { src: 'alert-rules.d/crunchy-alert-rules-pg.yml.example', dst: 'crunchy-alert-rules-pg.yml'}
+        - { src: 'alert-rules.d/crunchy-alert-rules-pg.yml.containers.example', dst: 'crunchy-alert-rules-pg.yml'}
 
     - name: Create Alertmanager Config ConfigMap
       shell: |


### PR DESCRIPTION
In changes to pgMonitor the alerting rules file that will be used with
containers is different. This change updates the installer to to reference this
new file: `crunchy-alert-rules-pg.yml.containers.example`