### PR TITLE
Add app.kubernetes.io/name Label & Remove Vendor Label from Monitoring Resources

### DIFF
--- a/docs/content/installation/metrics/metrics-configuration.md
+++ b/docs/content/installation/metrics/metrics-configuration.md
@@ -116,29 +116,6 @@ and tag as needed to use the RedHat certified containers:
 Additionally, these same settings can be utilized as needed to support custom image names,
 tags, and additional container registries.
 
-## Disabling Default Dashboards
-
-By default, the following Grafana Dashboards are enabled as provided by the [pgmonitor project](https://github.com/CrunchyData/pgmonitor):
-
-- Bloat_Details.json
-- CRUD_Details.json
-- PGBackrest.json
-- PG_Details.json
-- PG_Overview.json
-- TableSize_Details.json
-
-Using the `grafana-dashboard` configuration setting, it is possible to customize this list
-of dashboards, and therefore further control which dashboards are loaded into Grafana
-(specifically via the `grafana-dashboards` ConfigMap) by default.  For instance, the following
-setting can be utilized to enable only a subset of the default dashboards defined above:
-
-```yaml
-grafana_dashboards:
-  - CRUD_Details.json
-  - PG_Details.json
-  - PG_Overview.json
-```
-
 ## Helm Only Configuration Settings
 
 When using Helm, the following settings can be defined to control the image prefix and image tag

--- a/installers/metrics/ansible/roles/pgo-metrics/defaults/main.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+app_name: postgres-operator-monitoring
+
 kubernetes_context: ""
 kubernetes_in_cluster: "false"
 openshift_host: ""

--- a/installers/metrics/ansible/roles/pgo-metrics/tasks/alertmanager.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/tasks/alertmanager.yml
@@ -28,7 +28,8 @@
       shell: |
         {{ kubectl_or_oc }} create configmap {{ alertmanager_configmap }} --dry-run --output=yaml \ \
           --from-file={{ alertmanager_output_dir }}/alertmanager.yml \
-        | {{ kubectl_or_oc }} label --filename=- --local --dry-run --output=yaml vendor=crunchydata \
+        | {{ kubectl_or_oc }} label --filename=- --local --dry-run --output=yaml \
+          app.kubernetes.io/name={{ app_name }} \
         | {{ kubectl_or_oc }} create --filename=- -n {{ metrics_namespace }}
       when: alertmanager_custom_config == ""
       register: create_alertmanager_result
@@ -45,7 +46,8 @@
       shell: |
         {{ kubectl_or_oc }} create configmap {{ alertmanager_rules_configmap }} --dry-run --output=yaml \
           --from-file={{ alertmanager_output_dir }}/crunchy-alert-rules-pg.yml \
-        | {{ kubectl_or_oc }} label --filename=- --local --dry-run --output=yaml vendor=crunchydata \
+        | {{ kubectl_or_oc }} label --filename=- --local --dry-run --output=yaml \
+          app.kubernetes.io/name={{ app_name }} \
         | {{ kubectl_or_oc }} create --filename=- -n {{ metrics_namespace }}
       when: alertmanager_custom_rules_config == ""
       register: create_alertmanager_result

--- a/installers/metrics/ansible/roles/pgo-metrics/tasks/grafana.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/tasks/grafana.yml
@@ -72,7 +72,8 @@
       shell: |
         {{ kubectl_or_oc }} create configmap {{ grafana_datasources_configmap }} --dry-run --output=yaml \
           --from-file={{ grafana_output_dir }}/crunchy_grafana_datasource.yml \
-        | {{ kubectl_or_oc }} label --filename=- --local --dry-run --output=yaml vendor=crunchydata \
+        | {{ kubectl_or_oc }} label --filename=- --local --dry-run --output=yaml \
+          app.kubernetes.io/name={{ app_name }} \
         | {{ kubectl_or_oc }} create --filename=- -n {{ metrics_namespace }}
       when: grafana_datasources_custom_config == ""
       register: create_grafana_datasources_result
@@ -86,7 +87,8 @@
           --from-file={{ grafana_output_dir }}/crunchy_grafana_dashboards.yml \
           --from-file={{ pgmonitor_grafana_dir }}/containers/ \
         | sed -e 's,${DS_PROMETHEUS},PROMETHEUS,' \
-        | {{ kubectl_or_oc }} label --filename=- --local --dry-run --output=yaml vendor=crunchydata \
+        | {{ kubectl_or_oc }} label --filename=- --local --dry-run --output=yaml \
+          app.kubernetes.io/name={{ app_name }} \
         | {{ kubectl_or_oc }} create --filename=- -n {{ metrics_namespace }}
       when: grafana_dashboards_custom_config == ""
       register: create_grafana_dashboards_result

--- a/installers/metrics/ansible/roles/pgo-metrics/tasks/prometheus.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/tasks/prometheus.yml
@@ -69,7 +69,8 @@
       shell: |
         {{ kubectl_or_oc }} create configmap crunchy-prometheus --dry-run --output=yaml \
           --from-file={{ prom_output_dir }}/prometheus.yml \
-        | {{ kubectl_or_oc }} label --filename=- --local --dry-run --output=yaml vendor=crunchydata \
+        | {{ kubectl_or_oc }} label --filename=- --local --dry-run --output=yaml \
+          app.kubernetes.io/name={{ app_name }} \
         | {{ kubectl_or_oc }} create --filename=- -n {{ metrics_namespace }}
       when: prometheus_custom_config == ""
       register: create_prometheus_datasources_result

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/alertmanager-deployment.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/alertmanager-deployment.json.j2
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "crunchy-alertmanager",
         "labels": {
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "spec": {
@@ -12,14 +12,14 @@
         "selector": {
           "matchLabels": {
             "name": "{{ alertmanager_service_name }}",
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
           }
         },
         "template": {
             "metadata": {
                 "labels": {
                     "name": "{{ alertmanager_service_name }}",
-                    "vendor": "crunchydata"
+                    "app.kubernetes.io/name": "{{ app_name }}"
                 }
             },
             "spec": {

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/alertmanager-pvc.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/alertmanager-pvc.json.j2
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "alertmanagerdata",
         "labels": {
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "spec": {

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/alertmanager-rbac.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/alertmanager-rbac.json.j2
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "alertmanager",
         "labels": {
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "automountServiceAccountToken": false,

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/alertmanager-service.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/alertmanager-service.json.j2
@@ -5,7 +5,7 @@
         "name": "{{ alertmanager_service_name }}",
         "labels": {
             "name": "{{ alertmanager_service_name }}",
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "spec": {

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-deployment.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-deployment.json.j2
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "crunchy-grafana",
         "labels": {
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "spec": {
@@ -12,14 +12,14 @@
         "selector": {
           "matchLabels": {
             "name": "{{ grafana_service_name }}",
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
           }
         },
         "template": {
             "metadata": {
                 "labels": {
                     "name": "{{ grafana_service_name }}",
-                    "vendor": "crunchydata"
+                    "app.kubernetes.io/name": "{{ app_name }}"
                 }
             },
             "spec": {

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-pvc.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-pvc.json.j2
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "grafanadata",
         "labels": {
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "spec": {

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-rbac.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-rbac.json.j2
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "grafana",
         "labels": {
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "automountServiceAccountToken": false,

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-secret.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-secret.json.j2
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "grafana-secret",
         "labels": {
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "type": "Opaque",

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-service.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-service.json.j2
@@ -5,7 +5,7 @@
         "name": "{{ grafana_service_name }}",
         "labels": {
             "name": "{{ grafana_service_name }}",
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "spec": {

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/prometheus-deployment.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/prometheus-deployment.json.j2
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "crunchy-prometheus",
         "labels": {
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "spec": {
@@ -12,14 +12,14 @@
         "selector": {
           "matchLabels": {
             "name": "{{ prometheus_service_name }}",
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
           }
         },
         "template": {
             "metadata": {
                 "labels": {
                     "name": "{{ prometheus_service_name }}",
-                    "vendor": "crunchydata"
+                    "app.kubernetes.io/name": "{{ app_name }}"
                 }
             },
             "spec": {

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/prometheus-pvc.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/prometheus-pvc.json.j2
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "prometheusdata",
         "labels": {
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "spec": {

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/prometheus-rbac.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/prometheus-rbac.json.j2
@@ -2,7 +2,10 @@
     "apiVersion": "rbac.authorization.k8s.io/v1",
     "kind": "ClusterRole",
     "metadata": {
-        "name": "{{ metrics_namespace }}-prometheus-sa"
+        "name": "{{ metrics_namespace }}-prometheus-sa",
+        "labels": {
+            "app.kubernetes.io/name": "{{ app_name }}"
+        }
     },
     "rules": [
         {
@@ -27,7 +30,7 @@
     "metadata": {
         "name": "prometheus-sa",
         "labels": {
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "imagePullSecrets": [

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/prometheus-service.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/prometheus-service.json.j2
@@ -5,7 +5,7 @@
         "name": "{{ prometheus_service_name }}",
         "labels": {
             "name": "{{ prometheus_service_name }}",
-            "vendor": "crunchydata"
+            "app.kubernetes.io/name": "{{ app_name }}"
         }
     },
     "spec": {

--- a/installers/metrics/helm/Chart.yaml
+++ b/installers/metrics/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: postgres-operator-metrics
+name: postgres-operator-monitoring
 description: Install for Crunchy PostgreSQL Operator Monitoring
 type: application
 version: 0.1.0

--- a/installers/metrics/kubectl/postgres-operator-metrics-ocp311.yml
+++ b/installers/metrics/kubectl/postgres-operator-metrics-ocp311.yml
@@ -3,12 +3,16 @@ kind: ServiceAccount
 metadata:
   name: pgo-metrics-deployer-sa
   namespace: pgo
+  labels:
+    app.kubernetes.io/name: postgres-operator-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pgo-metrics-deployer-crb
   namespace: pgo
+  labels:
+    app.kubernetes.io/name: postgres-operator-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -23,6 +27,8 @@ kind: ConfigMap
 metadata:
   name: pgo-metrics-deployer-cm
   namespace: pgo
+  labels:
+    app.kubernetes.io/name: postgres-operator-monitoring
 data:
   values.yaml: |-
     # =====================
@@ -76,11 +82,15 @@ kind: Job
 metadata:
   name: pgo-metrics-deploy
   namespace: pgo
+  labels:
+    app.kubernetes.io/name: postgres-operator-monitoring
 spec:
   backoffLimit: 0
   template:
     metadata:
       name: pgo-metrics-deploy
+      labels:
+        app.kubernetes.io/name: postgres-operator-monitoring
     spec:
       serviceAccountName: pgo-metrics-deployer-sa
       restartPolicy: Never

--- a/installers/metrics/kubectl/postgres-operator-metrics.yml
+++ b/installers/metrics/kubectl/postgres-operator-metrics.yml
@@ -3,11 +3,15 @@ kind: ServiceAccount
 metadata:
   name: pgo-metrics-deployer-sa
   namespace: pgo
+  labels:
+    app.kubernetes.io/name: postgres-operator-monitoring
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-metrics-deployer-cr
+  labels:
+    app.kubernetes.io/name: postgres-operator-monitoring
 rules:
   - apiGroups:
       - ''
@@ -77,6 +81,8 @@ kind: ConfigMap
 metadata:
   name: pgo-metrics-deployer-cm
   namespace: pgo
+  labels:
+    app.kubernetes.io/name: postgres-operator-monitoring
 data:
   values.yaml: |-
     # =====================
@@ -129,6 +135,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pgo-metrics-deployer-crb
+  labels:
+    app.kubernetes.io/name: postgres-operator-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -143,11 +151,15 @@ kind: Job
 metadata:
   name: pgo-metrics-deploy
   namespace: pgo
+  labels:
+    app.kubernetes.io/name: postgres-operator-monitoring
 spec:
   backoffLimit: 0
   template:
     metadata:
       name: pgo-metrics-deploy
+      labels:
+        app.kubernetes.io/name: postgres-operator-monitoring
     spec:
       serviceAccountName: pgo-metrics-deployer-sa
       restartPolicy: Never


### PR DESCRIPTION
The `vendor=crunchydata` label has been removed from all PostgreSQL Operator Monitoring resources.  This ensures that PostgreSQL Operator Monitoring resources are not inadvertently deleted when uninstalling the PostgreSQL Operator, specifically in scenarios where the same namespace utilized to deploy the PostgreSQL Operator Monitoring infrastructure is also utilized to deploy PostgreSQL clusters.

Additionally, all resources created by the PostgreSQL Operator Monitoring installer now have the following label:

```
app.kubernetes.io/name=postgres-operator-monitoring
```

This new label allows all PostgreSQL Operator Monitoring resources within a Kubernetes cluster to be easily identified, and is also a recommended label for Kubernetes resources per the Kubernetes documentation.  It should be noted that this label is already being applied to any installation resources created by Helm (however, this commit does change "metrics" to "monitoring" in the Chart name, and therefore this label, for all PostgreSQL Operator Monitoring Helm installation resources).

Also removes the "Disabling Default Dashboards" section from the PostgreSQL Operator Monitoring documentation since the `grafana_dashboards` installation setting this section references no longer exists (Grafana dashboards are now customized solely via ConfigMaps).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- PostgreSQL Operator Monitoring resources are deleted when uninstalling the PostgreSQL Operator, specifically in scenarios where the same namespace utilized to deploy the PostgreSQL Operator Monitoring infrastructure is also utilized to deploy PostgreSQL clusters.
- The "Disabling Default Dashboards" section in the the PostgreSQL Operator Monitoring documentation references the `grafana_dashboards` installation setting, which no longer exists.

[ch9190]
[ch9216]

**What is the new behavior (if this is a feature change)?**

- PostgreSQL Operator Monitoring resources are never deleted when uninstalling the PostgreSQL Operator, inlcuding in scenarios where the same namespace utilized to deploy the PostgreSQL Operator Monitoring infrastructure is also utilized to deploy PostgreSQL clusters.
- The "Disabling Default Dashboards" section in the the PostgreSQL Operator Monitoring documentation has been deleted.

**Other information**:
