### PR TITLE
Fix Environment Variable for Configuring Custom Grafana Admin Username

### DIFF
--- a/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-deployment.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-deployment.json.j2
@@ -65,7 +65,7 @@
                                 "value": "/data/grafana/data"
                             },
                             {
-                                "name": "GF_SECURITY_ADMIN_USERNAME__FILE",
+                                "name": "GF_SECURITY_ADMIN_USER__FILE",
                                 "value": "/conf/admin/username"
                             },
                             {


### PR DESCRIPTION
The environment variable used to configure the Grafana admin username in the Grafana deployment spec has been updated to
`GF_SECURITY_ADMIN_USER__FILE`.  This ensures that the Grafana admin username defined using `grafana_admin_username` is properly reflected in the Grafana deployment.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- A custom admin username defined using `grafana_admin_username` is not reflected in the Grafana deployment.

 [ch9210]

**What is the new behavior (if this is a feature change)?**

- A custom admin username defined using `grafana_admin_username` is now properly reflected in the Grafana deployment.

**Other information**:

N/A