### PR TITLE
broken link to the metrics installation instructions

### DIFF
--- a/docs/content/architecture/monitoring.md
+++ b/docs/content/architecture/monitoring.md
@@ -235,5 +235,5 @@ previous state.
 PostgreSQL instance. This could be a sign of data corruption.
 
 You can modify these alerts as you see fit, and add your own alerts as well!
-Please see the [installation instructions]((({{< relref "installation/metrics/_index.md" >}}))
+Please see the [installation instructions]({{< relref "installation/metrics/_index.md" >}})
 for general setup of the PostgreSQL Operator Monitoring stack.


### PR DESCRIPTION
the link for installing metrics was broken at the bottom of the monitoring.md page, this pr fixes the broken link

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ x] Have you updated or added documentation for the change, as applicable?
 - [ x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
a link to the metrics installation instructions was broken


**What is the new behavior (if this is a feature change)?**
fixed the link and tested with hugo 

**Other information**:
