### PR TITLE
Update installer to pull container alert rules

### DIFF
--- a/bin/get-pgmonitor.sh
+++ b/bin/get-pgmonitor.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 echo "Getting pgMonitor..."
-PGMONITOR_COMMIT='v4.4-RC4'
+PGMONITOR_COMMIT='v4.4-RC5'
 
 # pgMonitor Setup
 if [[ -d ${PGOROOT?}/tools/pgmonitor ]]

--- a/installers/metrics/ansible/roles/pgo-metrics/defaults/main.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/defaults/main.yml
@@ -9,7 +9,7 @@ delete_metrics_namespace: "false"
 metrics_namespace: "pgo"
 metrics_image_pull_secret: ""
 metrics_image_pull_secret_manifest: ""
-pgmonitor_version: "v4.4-RC4"
+pgmonitor_version: "v4.4-RC5"
 
 alertmanager_configmap: "alertmanager-config"
 alertmanager_rules_configmap: "alertmanager-rules-config"

--- a/installers/metrics/ansible/roles/pgo-metrics/tasks/alertmanager.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/tasks/alertmanager.yml
@@ -22,7 +22,7 @@
       command: "cp {{ pgmonitor_prometheus_dir }}/{{ item.src }} {{ alertmanager_output_dir }}/{{ item.dst }}"
       loop:
         - { src: 'crunchy-alertmanager.yml', dst: 'alertmanager.yml'}
-        - { src: 'alert-rules.d/crunchy-alert-rules-pg.yml.example', dst: 'crunchy-alert-rules-pg.yml'}
+        - { src: 'alert-rules.d/crunchy-alert-rules-pg.yml.containers.example', dst: 'crunchy-alert-rules-pg.yml'}
 
     - name: Create Alertmanager Config ConfigMap
       shell: |


### PR DESCRIPTION
The alert rules now reside in a file in pgMonitor. This change
reflects that change and updates the version of pgMonitor
required.

Co-authored-by: Joseph Mckulka <joseph.mckulka@crunchydata.com>