### PR TITLE
Move pgBouncer configuration to use ConfigMaps

### DIFF
--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
@@ -65,13 +65,26 @@
                         "readOnly": false
                     }]
                 }],
-                "volumes": [{
-                "name": "pgbouncer-conf",
-                "secret": {
-                    "secretName": "{{.PGBouncerSecret}}",
-                    "defaultMode": 511
+                "volumes": [
+                  {
+                    "name": "pgbouncer-conf",
+                    "projected": {
+                      "sources": [
+                        {
+                          "configMap": {
+                            "name": "{{.PGBouncerConfigMap}}"
+                          }
+                        },
+                        {
+                          "secret": {
+                            "name": "{{.PGBouncerSecret}}",
+                            "defaultMode": 511
+                          }
+                        }
+                      ]
                     }
-                }],
+                  }
+                ],
                 "affinity": {
                   {{.PodAntiAffinity}}
                 },

--- a/internal/operator/cluster/pgbouncer.go
+++ b/internal/operator/cluster/pgbouncer.go
@@ -555,7 +555,7 @@ func createPgBouncerDeployment(clientset kubernetes.Interface, cluster *crv1.Pgc
 		ClusterName:        cluster.Name,
 		CCPImagePrefix:     util.GetValueOrDefault(cluster.Spec.CCPImagePrefix, operator.Pgo.Cluster.CCPImagePrefix),
 		CCPImageTag:        cluster.Spec.CCPImageTag,
-		Port:               operator.Pgo.Cluster.Port,
+		Port:               cluster.Spec.Port,
 		PGBouncerConfigMap: util.GeneratePgBouncerConfigMapName(cluster.Name),
 		PGBouncerSecret:    util.GeneratePgBouncerSecretName(cluster.Name),
 		ContainerResources: operator.GetResourcesJSON(cluster.Spec.PgBouncer.Resources,

--- a/internal/util/pgbouncer.go
+++ b/internal/util/pgbouncer.go
@@ -21,6 +21,11 @@ import (
 	crv1 "github.com/crunchydata/postgres-operator/pkg/apis/crunchydata.com/v1"
 )
 
+// pgBouncerConfigMapFormat is the format used for the name of the config
+// map associated with a pgBouncer cluster, and follows the pattern
+// "<clusterName>-pgbouncer-cm"
+const pgBouncerConfigMapFormat = "%s-pgbouncer-cm"
+
 // pgBouncerSecretFormat is the name of the Kubernetes Secret that pgBouncer
 // uses that stores configuration and pgbouncer user information, and follows
 // the format "<clusterName>-pgbouncer-secret"
@@ -29,6 +34,12 @@ const pgBouncerSecretFormat = "%s-pgbouncer-secret"
 // pgBouncerUserFileFormat is the format of what the pgBouncer user management
 // file looks like, i.e. `"username" "password"``
 const pgBouncerUserFileFormat = `"%s" "%s"`
+
+// GeneratePgBouncerConfigMapName generates the name of the configmap file
+// associated with the pgBouncer Deployment
+func GeneratePgBouncerConfigMapName(clusterName string) string {
+	return fmt.Sprintf(pgBouncerConfigMapFormat, clusterName)
+}
 
 // GeneratePgBouncerSecretName returns the name of the secret that contains
 // information around a pgBouncer deployment


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the new behavior (if this is a feature change)?**

This moves nonsensitive pgBouncer configuration to be located
in a ConfigMap that sits alongside an Operator managed cluser
in the same namespace. Specifically, this moves two entries:

- pgbouncer.ini - controls the general configuration
- pg_hba.conf - controls how one can connect to pgBouncer

This presently does not handle any automatic updates if the
ConfigMap entry is changed, but rather is just a step to move
the nonsensitive configurations out of the Secret.

**Other information**:

Issue: [ch568]