### PR TITLE
Allow pgBouncer to connect to "postgres" database

### DIFF
--- a/internal/operator/cluster/pgbouncer.go
+++ b/internal/operator/cluster/pgbouncer.go
@@ -114,7 +114,7 @@ const (
 
 	// sqlGetDatabasesForPgBouncer gets all the databases where pgBouncer can be
 	// installed or uninstalled
-	sqlGetDatabasesForPgBouncer = `SELECT datname FROM pg_catalog.pg_database WHERE datname NOT IN ('postgres', 'template0') AND datallowconn;`
+	sqlGetDatabasesForPgBouncer = `SELECT datname FROM pg_catalog.pg_database WHERE datname NOT IN ('template0') AND datallowconn;`
 )
 
 var (


### PR DESCRIPTION
Though this database is typically reserved for administrative
purposes, there can be reasons where not only does one want
to connect to the "postgres" database, they may want to do so
via pgBouncer.

closes #1887