### PR TITLE
Documentation update, the force TLS command had values reversed

### DIFF
--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -1106,7 +1106,7 @@ executing the following command:
 ```shell
 pgo create cluster hacluster-tls-only \
   --tls-only \
-  --server-ca-secret=hacluster-tls-keypair --server-tls-secret=postgresql-ca
+  --server-ca-secret=postgresql-ca --server-tls-secret=hacluster-tls-keypair
 ```
 
 If deployed successfully, when you connect to the PostgreSQL cluster, assuming


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ x] Have you updated or added documentation for the change, as applicable?
 - [x ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
document currently says
```
pgo create cluster hacluster-tls-only \
  --tls-only \
  --server-ca-secret=hacluster-tls-keypair --server-tls-secret=postgresql-ca
```


**What is the new behavior (if this is a feature change)?**
the correct values being used in the create cluster command

```
pgo create cluster hacluster-tls-only \
  --tls-only \
  --server-ca-secret=postgresql-ca --server-tls-secret=hacluster-tls-keypair
```


**Other information**:
