### PR TITLE
Prevent Panic if All PG Deployments Scaled Down Outside of the PostgreSQL Operator

### DIFF
--- a/internal/operator/config/localdb.go
+++ b/internal/operator/config/localdb.go
@@ -217,10 +217,10 @@ func (l *LocalDB) Update(configName string, localDBConfig LocalDBConfig) error {
 	return nil
 }
 
-// apply applies the configuration stored in the CusterConig's configMap for a
-// specific database server to that server.  This is done by updating the contents of that
-// database server's local configuration with the configuration for that cluster stored in
-// the LocalDB's configMap, and the issuing a Patroni "reload" for that specific server.
+// apply applies the configuration stored in the cluster ConfigMap for a specific database server
+// to that server.  This is done by updating the contents of that database server's local
+// configuration with the configuration for that cluster stored in the LocalDB's configMap, and
+// then issuing a Patroni "reload" for that specific server.
 func (l *LocalDB) apply(configName string) error {
 
 	clusterName := l.configMap.GetObjectMeta().GetLabels()[config.LABEL_PG_CLUSTER]
@@ -243,6 +243,11 @@ func (l *LocalDB) apply(configName string) error {
 	if err != nil {
 		return err
 	}
+	// if the pod list is empty, also return an error
+	if len(dbPodList.Items) == 0 {
+		return fmt.Errorf("no pod found for %q", clusterName)
+	}
+
 	dbPod := &dbPodList.Items[0]
 
 	// add the config name and patroni port as params for the call to the apply & reload script


### PR DESCRIPTION
If the primary and all replica Deployments are scaled to zero outside of the context of the PostgreSQL Operator (e.g. by using
`kubectl scale deployment --replicas=0` instead of `pgo update cluster --shutdown`) and the associated `pgcluster` for the Deployment(s) being scaled is not manually set to the proper `shutdown` status, then the PostgreSQL Operator could panic as it continues to attempt to synchronize Patroni/PostgreSQL configuration for the PostgreSQL cluster (specifically because no pods are found for the cluster).  This commit protects against a panic in this scenario by simply logging an error when no Pods are found during an attempt to sync configuration.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

A panic can occur if the primary and all replica Deployments are scaled to zero outside of the context of the PostgreSQL Operator and the associated `pgcluster` for the Deployment(s) being scaled is not manually set to the proper `shutdown` status.

[ch9278]

**What is the new behavior (if this is a feature change)?**

A panic will no longer occur if the primary and all replica Deployments are scaled to zero outside of the context of the PostgreSQL Operator, and instead an error will be logged when the Operator attempts to synchronize configuration for the PG cluster.

**Other information**:

N/A