### PR TITLE
Fix typos identified by go vet in internal package

### DIFF
--- a/internal/controller/configmap/configmapcontroller.go
+++ b/internal/controller/configmap/configmapcontroller.go
@@ -152,7 +152,7 @@ func (c *Controller) processNextWorkItem() bool {
 	if err := c.handleConfigMapSync(key); err != nil {
 		// Put the item back on the workqueue to handle any transient errors
 		c.workqueue.AddRateLimited(key)
-		log.Errorf("ConfigMap Controller: error syncing ConfigMap '%s', will now requeue: %w"+
+		log.Errorf("ConfigMap Controller: error syncing ConfigMap '%s', will now requeue: %v",
 			key, err)
 		return true
 	}

--- a/internal/operator/cluster/standby.go
+++ b/internal/operator/cluster/standby.go
@@ -216,7 +216,7 @@ func EnableStandby(clientset kubernetes.Interface, cluster crv1.Pgcluster) error
 	if err = clientset.CoreV1().ConfigMaps(namespace).Delete(leaderConfigMapName, &metav1.DeleteOptions{}); err != nil &&
 		!kerrors.IsNotFound(err) {
 		log.Error("Unable to delete configMap %s while enabling standby mode for cluster "+
-			"%s: %w", leaderConfigMapName, clusterName, err)
+			"%s: %v", leaderConfigMapName, clusterName, err)
 		return err
 	}
 

--- a/pgo-scheduler/pgo-scheduler.go
+++ b/pgo-scheduler/pgo-scheduler.go
@@ -118,7 +118,7 @@ func init() {
 	// Configure namespaces for the Scheduler.  This includes determining the namespace
 	// operating mode and obtaining a valid list of target namespaces for the operator install.
 	if err := setNamespaceOperatingMode(clientset); err != nil {
-		log.Errorf("Error configuring operator namespaces: %w", err)
+		log.Errorf("Error configuring operator namespaces: %v", err)
 		os.Exit(2)
 	}
 }

--- a/postgres-operator.go
+++ b/postgres-operator.go
@@ -66,7 +66,7 @@ func main() {
 	// list of target namespaces for the operator install
 	namespaceList, err := operator.SetupNamespaces(client)
 	if err != nil {
-		log.Errorf("Error configuring operator namespaces: %w", err)
+		log.Errorf("Error configuring operator namespaces: %v", err)
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

Errors logged with `%w` do not necessarily include their error message:

```
level=error msg="Error configuring operator namespaces: %!w(*url.Error=&{...})"
```

Not all these changes were detected by `go vet`; in the end I also grep'd for `%w`. Tools will work better when `main()` are in their own directories, `./cmd/...`.