### PR TITLE
Ensure metrics collection works in TLS only setups

### DIFF
--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/exporter.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/exporter.json
@@ -21,7 +21,7 @@
         },
         {
             "name": "EXPORTER_PG_PARAMS",
-            "value": "sslmode=disable"
+            "value": {{ if .TLSOnly }}"sslmode=require"{{ else }}"sslmode=disable"{{ end }}
         },
         {
             "name": "JOB_NAME",

--- a/internal/operator/clusterutilities.go
+++ b/internal/operator/clusterutilities.go
@@ -95,6 +95,7 @@ type exporterTemplateFields struct {
 	ExporterPort       string
 	CollectSecretName  string
 	ContainerResources string
+	TLSOnly            bool
 }
 
 //consolidate
@@ -372,6 +373,11 @@ func GetExporterAddon(clientset kubernetes.Interface, namespace string, spec *cr
 		exporterTemplateFields.PgPort = spec.Port
 		exporterTemplateFields.CollectSecretName = spec.CollectSecretName
 		exporterTemplateFields.ContainerResources = GetResourcesJSON(spec.ExporterResources, spec.ExporterLimits)
+		// see if TLS only is set. however, this also requires checking to see if
+		// TLS is enabled in this case. The reason is that even if TLS is only just
+		// enabled, because the connection is over an internal interface, we do not
+		// need to have the overhead of a TLS connection
+		exporterTemplateFields.TLSOnly = spec.TLS.IsTLSEnabled() && spec.TLSOnly
 
 		var exporterDoc bytes.Buffer
 		err = config.ExporterTemplate.Execute(&exporterDoc, exporterTemplateFields)


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Though the connection from the exporter to the database occurs
only over an internal NIC, a TLS only environment still requires
that the connection have TLS.

In other words, something like the below would lead to errors in the `exporter` container:

```
pgo create cluster hippo --server-tls-secret=<blah> --server-ca-secret=<blah> --tls-only --metrics
```

**What is the new behavior (if this is a feature change)?**

The most straightforward to accomplish this is to have the exporter
use "sslmode=require" to ensure that the connection attempt is made
over TLS.

**Other information**:

Issue: [ch9300]
fixes #1902