### PR TITLE
Add Crunchy Postgres Exporter to GCR push and pull scripts

### DIFF
--- a/bin/pull-from-gcr.sh
+++ b/bin/pull-from-gcr.sh
@@ -30,6 +30,7 @@ IMAGES=(
     pgo-backrest
     pgo-client
     pgo-deployer
+    crunchy-postgres-exporter
 )
 
 function echo_green() {

--- a/bin/push-to-gcr.sh
+++ b/bin/push-to-gcr.sh
@@ -28,6 +28,7 @@ pgo-rmdata
 pgo-backrest
 pgo-client
 pgo-deployer
+crunchy-postgres-exporter
 )
 
 for image in "${IMAGES[@]}"


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The Crunchy Postgres Exporter image is missing from the GCR scripts.


**What is the new behavior (if this is a feature change)?**
Updates the pull-from-gcr.sh and push-to-gcr.sh scripts to
include the Crunchy Postgres Exporter image that is now maintained
in the Postgres Operator project.


**Other information**:
