### PR TITLE
Update annotation update behavior

### DIFF
--- a/internal/controller/pgcluster/pgclustercontroller.go
+++ b/internal/controller/pgcluster/pgclustercontroller.go
@@ -346,31 +346,42 @@ func updateAnnotations(c *Controller, oldCluster *crv1.Pgcluster, newCluster *cr
 	annotationsBackrest := map[string]string{}
 	annotationsPgBouncer := map[string]string{}
 
-	// if the global ones differ, make the changes for all of the annotations
-	if !reflect.DeepEqual(oldCluster.Spec.Annotations.Global, newCluster.Spec.Annotations.Global) {
-		// set the annotations for all of them
+	// check the individual deployment groups. If the annotations differ in either the specific group or
+	// in the global group, set them in their respective map
+	if !reflect.DeepEqual(oldCluster.Spec.Annotations.Postgres, newCluster.Spec.Annotations.Postgres) ||
+		!reflect.DeepEqual(oldCluster.Spec.Annotations.Global, newCluster.Spec.Annotations.Global) {
+		// store the global annotations first
 		for k, v := range newCluster.Spec.Annotations.Global {
 			annotationsPostgres[k] = v
-			annotationsBackrest[k] = v
-			annotationsPgBouncer[k] = v
 		}
-	}
 
-	// check the individual deployment groups. If the annotations differ, set them
-	// in their respective map
-	if !reflect.DeepEqual(oldCluster.Spec.Annotations.Postgres, newCluster.Spec.Annotations.Postgres) {
+		// then store the postgres specific annotations
 		for k, v := range newCluster.Spec.Annotations.Postgres {
 			annotationsPostgres[k] = v
 		}
 	}
 
-	if !reflect.DeepEqual(oldCluster.Spec.Annotations.Backrest, newCluster.Spec.Annotations.Backrest) {
+	if !reflect.DeepEqual(oldCluster.Spec.Annotations.Backrest, newCluster.Spec.Annotations.Backrest) ||
+		!reflect.DeepEqual(oldCluster.Spec.Annotations.Global, newCluster.Spec.Annotations.Global) {
+		// store the global annotations first
+		for k, v := range newCluster.Spec.Annotations.Global {
+			annotationsBackrest[k] = v
+		}
+
+		// then store the pgbackrest specific annotations
 		for k, v := range newCluster.Spec.Annotations.Backrest {
 			annotationsBackrest[k] = v
 		}
 	}
 
-	if !reflect.DeepEqual(oldCluster.Spec.Annotations.PgBouncer, newCluster.Spec.Annotations.PgBouncer) {
+	if !reflect.DeepEqual(oldCluster.Spec.Annotations.PgBouncer, newCluster.Spec.Annotations.PgBouncer) ||
+		!reflect.DeepEqual(oldCluster.Spec.Annotations.Global, newCluster.Spec.Annotations.Global) {
+		// store the global annotations first
+		for k, v := range newCluster.Spec.Annotations.Global {
+			annotationsPgBouncer[k] = v
+		}
+
+		// then store the pgbouncer specific annotations
 		for k, v := range newCluster.Spec.Annotations.PgBouncer {
 			annotationsPgBouncer[k] = v
 		}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The existing annotation update logic is unable to maintain
existing 'global' annotations when a 'specific' (postgres, pgbackrest or
pgbouncer) deployment annotation is updated (e.g. the Postgres only
annotation is updated, but replaces any existing 'global' annotations
that were made previously) and vice versa.


**What is the new behavior (if this is a feature change)?**
To remedy this, if either 'global' or 'specific' deployment annotations
are updated, the relevant map is updated to include all existing 'global'
or 'specific' annotations from the pgcluster CRD. 'Global' annotations with
the same key value of a 'specific' annotation will be overwritten, so that
the more specific annotation is authoritative.


**Other information**:
[ch9327]