### PR TITLE
Install Package glibc-langpack-en in pgo-base Container for UBI 8/CentOS 8

### DIFF
--- a/build/pgo-base/Dockerfile
+++ b/build/pgo-base/Dockerfile
@@ -26,9 +26,18 @@ COPY redhat/atomic/help.1 /help.1
 COPY redhat/atomic/help.md /help.md
 COPY licenses /licenses
 
-RUN if [ "$DFSET" = "centos" ] ; then \
-        ${PACKAGER} -y update \
-        && ${PACKAGER} -y clean all ; \
+RUN if [ "$BASEOS" = "centos7" ]; then \
+    ${PACKAGER} -y update \
+    && ${PACKAGER} -y clean all ; \
+fi
+
+RUN if [ "$BASEOS" = "centos8" ]; then \
+    ${PACKAGER} -y update \
+    && ${PACKAGER} -y install \
+        --setopt=skip_missing_names_on_install=False \
+        glibc-langpack-en \
+    && ${PACKAGER} -y clean all \
+    && ${PACKAGER} -qy module disable postgresql ; \
 fi
 
 RUN if [ "$BASEOS" = "rhel7" ] ; then \
@@ -41,21 +50,16 @@ RUN if [ "$BASEOS" = "ubi7" ] ; then \
         && ${PACKAGER} -y --enablerepo=rhel-7-server-ose-3.11-rpms clean all ; \
 fi
 
-RUN if [ "$BASEOS" = "ubi8" ] ; then \
-        ${PACKAGER} -y update \
-        && ${PACKAGER} -y clean all ; \
+RUN if  [ "$BASEOS" = "ubi8" ]; then \
+    ${PACKAGER} -y update \
+    && ${PACKAGER} -y install \
+        --setopt=skip_missing_names_on_install=False \
+        glibc-langpack-en \
+    && ${PACKAGER} -y clean all \
+    && ${PACKAGER} -qy module disable postgresql ; \
 fi
 
 # Crunchy PostgreSQL repository
 ADD conf/RPM-GPG-KEY-crunchydata* /
 ADD conf/crunchypg${PGVERSION}.repo /etc/yum.repos.d/
 RUN rpm --import RPM-GPG-KEY-crunchydata*
-
-# disable the EL 8 modularity feature
-RUN if [ "$BASEOS" = "centos8" ]; then \
-        ${PACKAGER} -qy module disable postgresql ; \
-fi
-
-RUN if  [ "$BASEOS" = "ubi8" ]; then \
-        ${PACKAGER} -qy module disable postgresql ; \
-fi


### PR DESCRIPTION
Package `glibc-langpack-en` is now installed in the `pgo-base` image for both UBI 8 and CentOS 8.  This prevents `cannot change locale` warnings from being displayed when connecting from a PostgreSQL database Pod to a pgBackRest repository Pod using SSH.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

When connecting from a PostgreSQL Pod to a pgBackRest repo Pod over SSH, `cannot change locale` warnings are displayed:

```bash
bash-4.4$ ssh mycluster1-backrest-shared-repo
-bash: warning: setlocale: LC_ALL: cannot change locale (en_US.utf-8)
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.utf-8)
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.utf-8)
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.utf-8)
```

[ch9337]

**What is the new behavior (if this is a feature change)?**

Warnings are no longer displayed when connecting from a PostgreSQL Pod to a pgBackRest repo Pod over SSH.

**Other information**:

N/A