### PR TITLE
Delete WAL PVC for Replica Only on PG Cluster Scale Down

### DIFF
--- a/pgo-rmdata/rmdata/process.go
+++ b/pgo-rmdata/rmdata/process.go
@@ -38,8 +38,8 @@ const (
 	tablespacePathFormat = "/tablespaces/%s/%s"
 	// the tablespace on a replcia follows the pattern "<replicaName-tablespace-.."
 	tablespaceReplicaPVCPattern = "%s-tablespace-"
-	// the WAL PVC has the following suffix
-	walPVCSuffix = "-wal"
+	// the WAL PVC on a replcia follows the pattern "<replicaName-wal>"
+	walReplicaPVCPattern = "%s-wal"
 
 	// the following constants define the suffixes for the various configMaps created by Patroni
 	configConfigMapSuffix   = "config"
@@ -547,13 +547,16 @@ func getReplicaPVC(request Request) ([]string, error) {
 
 	// ...and where the fun begins
 	tablespaceReplicaPVCPrefix := fmt.Sprintf(tablespaceReplicaPVCPattern, request.ReplicaName)
+	walReplicaPVCName := fmt.Sprintf(walReplicaPVCPattern, request.ReplicaName)
 
 	// iterate over the PVC list and append the tablespace PVCs
 	for _, pvc := range pvcs.Items {
 		pvcName := pvc.ObjectMeta.Name
 
-		// it does not start with the tablespace replica PVC pattern, continue
-		if !(strings.HasPrefix(pvcName, tablespaceReplicaPVCPrefix) || strings.HasSuffix(pvcName, walPVCSuffix)) {
+		// if it does not start with the tablespace replica PVC pattern and does not equal the WAL
+		// PVC pattern then continue
+		if !(strings.HasPrefix(pvcName, tablespaceReplicaPVCPrefix) ||
+			pvcName == walReplicaPVCName) {
 			continue
 		}
 


### PR DESCRIPTION
When scaling down a replica within a PostgreSQL cluster that utilizes external PVC's for write-ahead-logs (WAL), only the WAL PVC for the replica being removed is deleted, and the WAL PVC's for all other PostgreSQL instances within the cluster now remain in place.

_Please note that this change will also be backpatched for v4.3.x and v4.4.x._

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

When scaling down a replica within a PostgreSQL cluster that utilizes external PVC's for write-ahead-logs (WAL), the WAL PVC's for all PostgreSQL instances within the cluster are deleted.

fixes #1915 
[ch9338]

**What is the new behavior (if this is a feature change)?**

When scaling down a replica within a PostgreSQL cluster that utilizes external PVC's for write-ahead-logs (WAL), only the WAL PVC for replica being removed is deleted, and the WAL PVC's for all other PostgreSQL instances within the cluster remain in place.

**Other information**:

N/A