### PR TITLE
Update OLM packaging to use python-yq

### DIFF
--- a/installers/olm/Dockerfile
+++ b/installers/olm/Dockerfile
@@ -4,16 +4,12 @@ RUN curl -Lo /usr/local/bin/jq -s "https://github.com/stedolan/jq/releases/downl
  && chmod +x /usr/local/bin/jq \
  && sha256sum -c <<< "SHA256 (/usr/local/bin/jq) = af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44"
 
-RUN curl -Lo /usr/local/bin/yq -s "https://github.com/mikefarah/yq/releases/download/2.4.1/yq_linux_amd64" \
- && chmod +x /usr/local/bin/yq \
- && sha256sum -c <<< "SHA256 (/usr/local/bin/yq) = 754c6e6a7ef92b00ef73b8b0bb1d76d651e04d26aa6c6625e272201afa889f8b"
-
 RUN dnf update -d1 -y \
  && dnf install -d1 -y gettext glibc-langpack-en make ncurses python3 tree zip \
  && dnf clean all
 
 ARG OLM_SDK_VERSION
-RUN python3 -m pip install operator-courier \
+RUN python3 -m pip install operator-courier yq \
  && curl -Lo /usr/local/bin/operator-sdk -s "https://github.com/operator-framework/operator-sdk/releases/download/v${OLM_SDK_VERSION}/operator-sdk-v${OLM_SDK_VERSION}-x86_64-linux-gnu" \
  && chmod +x /usr/local/bin/operator-sdk \
  && sha256sum -c <<< "SHA256 (/usr/local/bin/operator-sdk) = 5c8c06bd8a0c47f359aa56f85fe4e3ee2066d4e51b60b75e131dec601b7b3cd6"

--- a/installers/olm/Makefile
+++ b/installers/olm/Makefile
@@ -4,6 +4,7 @@
 CCP_IMAGE_PREFIX ?= registry.developers.crunchydata.com/crunchydata
 CCP_PG_FULLVERSION ?= 12.4
 CCP_POSTGIS_VERSION ?= 3.0
+CONTAINER ?= docker
 KUBECONFIG ?= $(HOME)/.kube/config
 OLM_SDK_VERSION ?= 0.15.1
 OLM_TOOLS ?= registry.localhost:5000/postgres-operator-olm-tools:$(OLM_SDK_VERSION)
@@ -15,7 +16,7 @@ PGO_IMAGE_TAG ?= $(PGO_BASEOS)-$(PGO_VERSION)
 CCP_IMAGE_TAG ?= $(PGO_BASEOS)-$(CCP_PG_FULLVERSION)-$(PGO_VERSION)
 CCP_POSTGIS_IMAGE_TAG ?= $(PGO_BASEOS)-$(CCP_PG_FULLVERSION)-$(CCP_POSTGIS_VERSION)-$(PGO_VERSION)
 
-OLM_TOOLS_BASH = docker run --net=host --rm --tty $(DOCKER_ARGS) \
+OLM_TOOLS_BASH = $(CONTAINER) run --net=host --rm --tty $(CONTAINER_ARGS) \
 		 --mount 'type=bind,source=$(KUBECONFIG),target=/root/.kube/config,ro' \
 		 --mount 'type=bind,source=$(CURDIR)/..,target=/mnt/installers' \
 		 --workdir '/mnt/installers/$(basename $(notdir $(CURDIR)))' \
@@ -47,7 +48,7 @@ docker-package: ## Build package and version bundle from inside a container
 
 .PHONY: docker-shell
 docker-shell: image-tools
-docker-shell: DOCKER_ARGS = --interactive
+docker-shell: CONTAINER_ARGS = --interactive
 docker-shell: ## Start a shell inside a container with all the tools needed to build and test
 	$(OLM_TOOLS_BASH)
 
@@ -62,7 +63,7 @@ help: ## Print this message
 
 .PHONY: image-tools
 image-tools:
-	docker build --file Dockerfile --tag '$(OLM_TOOLS)' --build-arg OLM_SDK_VERSION='$(OLM_SDK_VERSION)' .
+	$(CONTAINER) build --file Dockerfile --tag '$(OLM_TOOLS)' --build-arg OLM_SDK_VERSION='$(OLM_SDK_VERSION)' .
 
 .PHONY: install
 install: ## Install the package in a Kubernetes namespace

--- a/installers/olm/generate.sh
+++ b/installers/olm/generate.sh
@@ -12,42 +12,38 @@ render < postgresql.package.yaml > "./package/${PACKAGE_NAME}.package.yaml"
 # ClusterServiceVersion filenames must end with '.clusterserviceversion.yaml'
 render < postgresoperator.csv.yaml > "./package/${PGO_VERSION}/postgresoperator.v${PGO_VERSION}.clusterserviceversion.yaml"
 
-crd_array="$( yq read --doc='*' --tojson postgresoperator.crd.yaml )"
-crd_names="$( jq <<< "$crd_array" --raw-output 'to_entries[] | [.key, .value.metadata.name] | @tsv' )"
+crd_names="$( yq --raw-output --slurp 'to_entries[] | [.key, .value.metadata.name] | @tsv' postgresoperator.crd.yaml )"
 
 # `operator-courier verify` expects only one CustomResourceDefinition per file.
 while IFS=$'\t' read index name; do
-	yq read --doc="$index" postgresoperator.crd.yaml > "./package/${PGO_VERSION}/${name}.crd.yaml"
+	yq --slurp --yaml-roundtrip ".[$index]" postgresoperator.crd.yaml > "./package/${PGO_VERSION}/${name}.crd.yaml"
 done <<< "$crd_names"
 
-yq_script="$( yq read --tojson "./package/${PGO_VERSION}/postgresoperator.v${PGO_VERSION}.clusterserviceversion.yaml" | jq \
-	--argjson images "$( yq read --tojson postgresoperator.csv.images.yaml | render )" \
-	--argjson crds "$( yq read --tojson postgresoperator.crd.descriptions.yaml | render )" \
-	--arg examples "$( yq read --tojson postgresoperator.crd.examples.yaml --doc='*' | render | jq . )" \
+yq --in-place --yaml-roundtrip \
+	--argjson images "$( yq '.' postgresoperator.csv.images.yaml | render )" \
+	--argjson crds "$( yq '.' postgresoperator.crd.descriptions.yaml | render )" \
+	--arg examples "$( yq --slurp '.' postgresoperator.crd.examples.yaml | render )" \
 	--arg description "$( render < description.upstream.md )" \
 	--arg icon "$( base64 ../seal.svg | tr -d '\n' )" \
-'{
-	"metadata.annotations.alm-examples": $examples,
-	"spec.customresourcedefinitions.owned": $crds,
-	"spec.description": $description,
-	"spec.icon": [{ mediatype: "image/svg+xml", base64data: $icon }],
+'
+	.metadata.annotations["alm-examples"] = $examples |
+	.spec.customresourcedefinitions.owned = $crds |
+	.spec.description = $description |
+	.spec.icon = [{ mediatype: "image/svg+xml", base64data: $icon }] |
 
-	"spec.install.spec.deployments[0].spec.template.spec.containers[0].env": (
-	.spec.install.spec.deployments[0].spec.template.spec.containers[0].env + $images),
-
-	"spec.install.spec.deployments[0].spec.template.spec.containers[1].env": (
-	.spec.install.spec.deployments[0].spec.template.spec.containers[1].env + $images)
-}' )"
-yq write --inplace --script=- <<< "$yq_script" "./package/${PGO_VERSION}/postgresoperator.v${PGO_VERSION}.clusterserviceversion.yaml"
+	.spec.install.spec.deployments[0].spec.template.spec.containers[0].env += $images |
+	.spec.install.spec.deployments[0].spec.template.spec.containers[1].env += $images |
+.' \
+	"./package/${PGO_VERSION}/postgresoperator.v${PGO_VERSION}.clusterserviceversion.yaml"
 
 if [ "${K8S_DISTRIBUTION:-}" = 'openshift' ]; then
-	yq_script="$( jq <<< '{}' \
+	yq --in-place --yaml-roundtrip \
 		--arg description "$( render < description.openshift.md )" \
-	'{
-		"spec.description": $description,
-		"spec.displayName": "Crunchy PostgreSQL for OpenShift",
-	}' )"
-	yq write --inplace --script=- <<< "$yq_script" "./package/${PGO_VERSION}/postgresoperator.v${PGO_VERSION}.clusterserviceversion.yaml"
+	'
+		.spec.description = $description |
+		.spec.displayName = "Crunchy PostgreSQL for OpenShift" |
+	.' \
+		"./package/${PGO_VERSION}/postgresoperator.v${PGO_VERSION}.clusterserviceversion.yaml"
 fi
 
 if > /dev/null command -v tree; then tree -C './package'; fi

--- a/installers/olm/postgresoperator.csv.yaml
+++ b/installers/olm/postgresoperator.csv.yaml
@@ -19,6 +19,8 @@ metadata:
     containerImage: '${PGO_IMAGE_PREFIX}/postgres-operator:${PGO_IMAGE_TAG}'
     repository: https://github.com/CrunchyData/postgres-operator
 
+    alm-examples: |- # postgresoperator.crd.examples.yaml
+
 spec:
   # The following affect how the package is indexed at OperatorHub.io:
   # https://operatorhub.io/
@@ -34,7 +36,7 @@ spec:
 
   # The following appear on the details page at OperatorHub.io:
   # https://operatorhub.io/operator/postgresql
-  description: '' # description.*.md
+  description: |- # description.*.md
   version: '${PGO_VERSION}'
   links:
     - name: Crunchy Data
@@ -52,7 +54,7 @@ spec:
     alm-status-descriptors: 'postgres-operator.v${PGO_VERSION}'
 
   customresourcedefinitions:
-    owned: {} # postgresoperator.crd.descriptions.yaml
+    owned: # postgresoperator.crd.descriptions.yaml
 
   installModes:
     - { type: OwnNamespace,    supported: true  }

--- a/installers/olm/verify.sh
+++ b/installers/olm/verify.sh
@@ -63,9 +63,8 @@ kubectl --namespace="$olm_namespace" rollout status deploy olm-operator --timeou
 
 
 # Run the OLM test suite against each example stored in CSV annotations.
-examples_array="$( yq read \
-	"./package/${PGO_VERSION}/postgresoperator.v${PGO_VERSION}.clusterserviceversion.yaml" \
-	metadata.annotations.alm-examples )"
+examples_array="$( yq --raw-output '.metadata.annotations["alm-examples"]' \
+	"./package/${PGO_VERSION}/postgresoperator.v${PGO_VERSION}.clusterserviceversion.yaml" )"
 
 error=0
 for index in $(seq 0 $(jq <<< "$examples_array" 'length - 1')); do


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**What is the current behavior? (link to any open issues here)**

The scripts that make and test OLM CSVs rely heavily on an old version of `yq`. New contributors don't (and won't) have this version installed.

**What is the new behavior (if this is a feature change)?**

Those scripts now rely on a recent version of a _different_ `yq` that can be installed with `pip`. It behaves more consistently than the other utility and leverages `jq` to provide the same syntax and features we're already using.