### PR TITLE
Logger no Longer Defaults to "debug" Log Level

### DIFF
--- a/internal/logging/loglib.go
+++ b/internal/logging/loglib.go
@@ -88,7 +88,4 @@ func CrunchyLogger(logDetails LogValues) {
 	// Output to stdout instead of the default stderr
 	// Can be any io.Writer, see below for File example
 	log.SetOutput(os.Stdout)
-
-	// Only log the debug severity or above.
-	log.SetLevel(log.DebugLevel)
 }


### PR DESCRIPTION
The logger utilized by the various Go applications comprising the PostgreSQL Operator no longer defaults to a `debug` logging level. Instead, by default the `info` logging level will be utilized (per the default set by the [Logrus](https://github.com/sirupsen/logrus) logging package), and the `debug` log level will now only be set if the `CRUNCHY_DEBUG` environment variable is set to `true`.

_This change will need to be backpatched._

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Debug logs are shown even when `CRUNCHY_DEBUG` is set to `false`.

[ch9476]

**What is the new behavior (if this is a feature change)?**

Debug logs are shown only when `CRUNCHY_DEBUG` is set to `true`.

**Other information**:

N/A