### PR TITLE
Change PGBACKREST_REPO_TYPE to PGBACKREST_REPO1_TYPE in pgBackRest Template

### DIFF
--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbackrest-env-vars.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbackrest-env-vars.json
@@ -39,7 +39,7 @@
   "value": "{{.PgbackrestPGPort}}"
 },
 {
-  "name": "PGBACKREST_REPO_TYPE",
+  "name": "PGBACKREST_REPO1_TYPE",
   "value": "{{.PgbackrestRepo1Type}}"
 },
 {


### PR DESCRIPTION
Changes `PGBACKREST_REPO_TYPE` to `PGBACKREST_REPO1_TYPE` in the `pgbackrest-env-vars.json` template as used to define pgBackRest environment variables for PG deployments, pgBackRest repository deployments, database bootstrap jobs and database restore jobs.  This prevents duplicate pgBackRest "repo type" environment variables from being set when the environment is being set to run a `pgbackrest` command within the `crunchy-postgres-ha` container (specifically using the `pgbackrest-set-env.sh` script).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `pgbackrest-env-vars.json` template utilizes `PGBACKREST_REPO_TYPE` to configure a pgBackRest repository type, leading to duplicate pgBackRest "repo type" environment variables when the environment is set to run a `pgbackrest` command within the `crunchy-postgres-ha` container.

Issue: #1953

**What is the new behavior (if this is a feature change)?**

The `pgbackrest-env-vars.json` template utilizes `PGBACKREST_REPO1_TYPE` to configure a pgBackRest repository type, preventing duplicate pgBackRest "repo type" environment variables when the environment is set to run a `pgbackrest` command within the `crunchy-postgres-ha` container.

**Other information**:

N/A