### PR TITLE
Update image standard image tag when using a GIS enabled pgcluster

### DIFF
--- a/internal/operator/cluster/pgadmin.go
+++ b/internal/operator/cluster/pgadmin.go
@@ -355,7 +355,7 @@ func createPgAdminDeployment(clientset kubernetes.Interface, cluster *crv1.Pgclu
 		Name:           pgAdminDeploymentName,
 		ClusterName:    cluster.Name,
 		CCPImagePrefix: operator.Pgo.Cluster.CCPImagePrefix,
-		CCPImageTag:    cluster.Spec.CCPImageTag,
+		CCPImageTag:    util.GetStandardImageTag(cluster.Spec.CCPImage, cluster.Spec.CCPImageTag),
 		DisableFSGroup: operator.Pgo.Cluster.DisableFSGroup,
 		Port:           defPgAdminPort,
 		InitUser:       defSetupUsername,

--- a/internal/operator/cluster/pgbouncer.go
+++ b/internal/operator/cluster/pgbouncer.go
@@ -554,7 +554,7 @@ func createPgBouncerDeployment(clientset kubernetes.Interface, cluster *crv1.Pgc
 		Name:               pgbouncerDeploymentName,
 		ClusterName:        cluster.Name,
 		CCPImagePrefix:     util.GetValueOrDefault(cluster.Spec.CCPImagePrefix, operator.Pgo.Cluster.CCPImagePrefix),
-		CCPImageTag:        cluster.Spec.CCPImageTag,
+		CCPImageTag:        util.GetStandardImageTag(cluster.Spec.CCPImage, cluster.Spec.CCPImageTag),
 		Port:               cluster.Spec.Port,
 		PGBouncerConfigMap: util.GeneratePgBouncerConfigMapName(cluster.Name),
 		PGBouncerSecret:    util.GeneratePgBouncerSecretName(cluster.Name),

--- a/internal/operator/clusterutilities.go
+++ b/internal/operator/clusterutilities.go
@@ -337,7 +337,7 @@ func GetBadgerAddon(clientset kubernetes.Interface, namespace string, cluster *c
 	if cluster.Labels[config.LABEL_BADGER] == "true" {
 		log.Debug("crunchy_badger was found as a label on cluster create")
 		badgerTemplateFields := badgerTemplateFields{}
-		badgerTemplateFields.CCPImageTag = spec.CCPImageTag
+		badgerTemplateFields.CCPImageTag = util.GetStandardImageTag(spec.CCPImage, spec.CCPImageTag)
 		badgerTemplateFields.BadgerTarget = pgbadger_target
 		badgerTemplateFields.PGBadgerPort = spec.PGBadgerPort
 		badgerTemplateFields.CCPImagePrefix = util.GetValueOrDefault(spec.CCPImagePrefix, Pgo.Cluster.CCPImagePrefix)

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,75 @@
+package util
+
+import "testing"
+
+func TestGetStandardImageTag(t *testing.T) {
+
+	assertCorrectMessage := func(t testing.TB, got, want string) {
+		t.Helper()
+		if got != want {
+			t.Errorf("got %q want %q", got, want)
+		}
+	}
+
+	imageTagTests := []struct {
+		description string
+		imageName   string
+		imageTag    string
+		expected    string
+	}{
+		{
+			"image: crunchy-postgres-ha, tag: centos7-12.4-4.5.0",
+			"crunchy-postgres-ha",
+			"centos7-12.4-4.5.0",
+			"centos7-12.4-4.5.0",
+		}, {
+			"image: crunchy-postgres-gis-ha, tag: centos7-12.4-3.0-4.5.0",
+			"crunchy-postgres-gis-ha",
+			"centos7-12.4-3.0-4.5.0",
+			"centos7-12.4-4.5.0",
+		}, {
+			"image: crunchy-postgres-ha, tag: centos7-12.4-4.5.0-beta.1",
+			"crunchy-postgres-ha",
+			"centos7-12.4-4.5.0-beta.1",
+			"centos7-12.4-4.5.0-beta.1",
+		}, {
+			"image: crunchy-postgres-gis-ha, tag: centos7-12.4-3.0-4.5.0-beta.2",
+			"crunchy-postgres-gis-ha",
+			"centos7-12.4-3.0-4.5.0-beta.2",
+			"centos7-12.4-4.5.0-beta.2",
+		}, {
+			"image: crunchy-postgres-ha, tag: centos8-9.5.23-4.5.0-rc.1",
+			"crunchy-postgres-ha",
+			"centos8-9.5.23-4.5.0-rc.1",
+			"centos8-9.5.23-4.5.0-rc.1",
+		}, {
+			"image: crunchy-postgres-gis-ha, tag: centos8-9.5.23-2.4-4.5.0-rc.1",
+			"crunchy-postgres-gis-ha",
+			"centos8-9.5.23-2.4-4.5.0-rc.1",
+			"centos8-9.5.23-4.5.0-rc.1",
+		}, {
+			"image: crunchy-postgres-gis-ha, tag: centos8-13.0-3.0-4.5.0-rc.1",
+			"crunchy-postgres-gis-ha",
+			"centos8-13.0-3.0-4.5.0-rc.1",
+			"centos8-13.0-4.5.0-rc.1",
+		}, {
+			"image: crunchy-postgres-gis-ha, tag: centos8-custom123",
+			"crunchy-postgres-gis-ha",
+			"centos8-custom123",
+			"centos8-custom123",
+		}, {
+			"image: crunchy-postgres-gis-ha, tag: centos8-custom123-moreinfo-789",
+			"crunchy-postgres-gis-ha",
+			"centos8-custom123-moreinfo-789",
+			"centos8-custom123-moreinfo-789",
+		},
+	}
+
+	for _, itt := range imageTagTests {
+		t.Run(itt.description, func(t *testing.T) {
+			got := GetStandardImageTag(itt.imageName, itt.imageTag)
+			want := itt.expected
+			assertCorrectMessage(t, got, want)
+		})
+	}
+}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Currently, the image tag value used by GIS enabled pgclusters is
being used when creating sidecontainers. Since the standard and
GIS enable PostgreSQL containers use different tags, this causes
an image pull error.


**What is the new behavior (if this is a feature change)?**

This update takes the current image name and the image tag value
stored in the pgcluster CRD and, if the image being used is the
crunchy-postgres-gis-ha container with the corresponding tag, it uses
an updated tag without the addition of the GIS version when provisioning
sidecars containers for the cluster.


**Other information**:
[ch9393]
fixes #1749