### PR TITLE
Proper Detection of Previously Processed pgcluster (v4.4 backpatch)

### DIFF
--- a/internal/operator/cluster/cluster.go
+++ b/internal/operator/cluster/cluster.go
@@ -67,13 +67,6 @@ const (
 func AddClusterBase(clientset kubernetes.Interface, client *rest.RESTClient, cl *crv1.Pgcluster, namespace string) {
 	var err error
 
-	if cl.Spec.Status == crv1.CompletedStatus {
-		errorMsg := "crv1 pgcluster " + cl.Spec.ClusterName + " is already marked complete, will not recreate"
-		log.Warn(errorMsg)
-		publishClusterCreateFailure(cl, errorMsg)
-		return
-	}
-
 	dataVolume, walVolume, tablespaceVolumes, err := pvc.CreateMissingPostgreSQLVolumes(
 		clientset, cl, namespace, cl.Annotations[config.ANNOTATION_CURRENT_PRIMARY], cl.Spec.PrimaryStorage)
 	if err != nil {


### PR DESCRIPTION
The `pgcluster` controller has been updated to properly detect whether or not a specific pgcluster custom resource was previously processed via the controller's `onAdd` function.  Specifically, the `onAdd` function will now no longer place a `pgcluster` in a `processed` status and attempt to call `AddClusterBase` if it determines that the a previous call to `AddClusterBase` completed successfully.  This is indicated by either a value of `completed` in the `/spec/status` field of the `pgcluster` (which indicates that a previous call to `AddClusterBase` successfully created the resources needed to bootstrap the PG cluster), or a value of `pgcluster Initialized` in the  `/status/state` field (which indicates that the cluster has been fully initialized).

In addition, the check for an existing Kubernetes Deployment matching the name of the `pgcluster`, as well as the check to determine whether or not a `pgcluster` custom resource is in a `processed` status prior to enqueuing it from the pgcluster controller's `onAdd` function, have been removed, since both are no longer valid methods for determining whether or not to process a `pgcluster`.  For instance, a Deployment matching the `pgcluster` name (i.e. the original primary for the cluster) might no longer exist if it was since scaled down and removed, while the `processed` status does not properly indicate whether or not the various Kubernetes resources (e.g. Deployments) for the initial primary utilized to bootstrap the cluster have been created, nor does it properly indicate whether or not the PG cluster has been fully initialized.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `pgcluster` controller's worker queue (as used by the `onAdd` function) does not properly detect whether or not a `pgcluster` was previously processed.  Therefore, on restarts of the PostgreSQL Operator, a previously processed `pgcluster` can be placed back into a `pgcluster Processed` status (specifically if the orginal primary Deployment for the PG cluster has been scaled down and removed), leading to the potential re-execution of cluster initialization logic (e.g. the operator may attempt to install `pgbouncer` again when the current primary Pod for the cluster enters a `Ready` status).

[ch9574]
[ch9457]

**What is the new behavior (if this is a feature change)?**

The `pgcluster` controller has been updated to properly detect whether or not a specific pgcluster custom resource was previously processed, preventing the re-execution of cluster initialization logic.

**Other information**:

N/A
