### PR TITLE
Preserve cluster-level resources in a multi-Operator environment

### DIFF
--- a/installers/ansible/roles/pgo-operator/tasks/cleanup.yml
+++ b/installers/ansible/roles/pgo-operator/tasks/cleanup.yml
@@ -6,6 +6,20 @@
   - uninstall
   - update
 
+- name: Get number of Operator instances in this cluster
+  shell: |
+    {{ kubectl_or_oc }} get deployment --field-selector=metadata.name=postgres-operator --selector=vendor=crunchydata --all-namespaces -o name | wc -l
+  register: num_operators
+  tags:
+  - uninstall
+  - update
+
+- name: Set boolean for multi-operator environment
+  set_fact: multi_operator_env="{{ 'true' if num_operators.stdout | int > 1 else 'false' }}"    
+  tags:
+  - uninstall
+  - update
+
 - name: Find watched namespaces
   shell: |
     {{ kubectl_or_oc }} get namespaces -o json --selector=vendor=crunchydata,pgo-installation-name={{ pgo_installation_name }}
@@ -152,7 +166,8 @@
   tags:
   - uninstall
   - update
-  when: create_rbac|bool
+  when: not multi_operator_env|bool and
+        create_rbac|bool
 
 - name: Delete cluster-admin Cluster Role Binding for PGO Service Account
   command: "{{ kubectl_or_oc }} delete clusterrolebinding pgo-cluster-admin"
@@ -161,7 +176,8 @@
   tags:
   - uninstall
   - update
-  when: create_rbac|bool
+  when: not multi_operator_env|bool and
+        create_rbac|bool
 
 - name: Delete existing Cluster Roles
   shell: |
@@ -173,7 +189,8 @@
   tags:
   - uninstall
   - update
-  when: create_rbac|bool
+  when: not multi_operator_env|bool and
+        create_rbac|bool
 
 - name: Delete existing PGO Role Bindings (Watched Namespaces)
   shell: |
@@ -233,6 +250,7 @@
         pgpolicies.crunchydata.com pgreplicas.crunchydata.com pgtasks.crunchydata.com
   ignore_errors: yes
   no_log: false
+  when: not multi_operator_env|bool
   tags: uninstall
 
 - name: Remove Labels from Watched Namespaces
@@ -276,7 +294,8 @@
   file:
     state: absent
     path: "/usr/local/bin/pgo"
-  when: pgo_client_install == "true"
+  when: pgo_client_install == "true" and
+        not multi_operator_env|bool
   ignore_errors: yes
   no_log: false
   tags: uninstall


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently, uninstalling an instance of the PostgreSQL Operator
from one namespace will remove all Kubernetes/Openshift cluster-
level resources as well. This impairs the functionality of any other
Operators that may be installed.


**What is the new behavior (if this is a feature change)?**
This update adds a check to see if there are any other PostgreSQL
Operators installed on the cluster and, if so, adds a flag to skip
the removal of cluster-level resources.


**Other information**:
[ch9389]