### PR TITLE
Use autogenerated pgouser password if not set

### DIFF
--- a/docs/content/installation/configuration.md
+++ b/docs/content/installation/configuration.md
@@ -53,7 +53,7 @@ Operator.
 | `namespace_mode` | dynamic |  | Determines which namespace permissions are assigned to the PostgreSQL Operator using a ClusterRole. Options: `dynamic`, `readonly`, and `disabled` |
 | `pgbadgerport` | 10000 | **Required** | Set to configure the default port used to connect to pgbadger. |
 | `pgo_add_os_ca_store` | false | **Required** | When true, includes system default certificate authorities. |
-| `pgo_admin_password` | examplepassword | **Required** | Configures the pgo administrator password. |
+| `pgo_admin_password` | examplepassword |  | Configures the pgo administrator password. When blank, a random password is generated. |
 | `pgo_admin_perms` | * | **Required** | Sets the access control rules provided by the PostgreSQL Operator RBAC resources for the PostgreSQL Operator administrative account that is created by this installer. Defaults to allowing all of the permissions, which is represented with the * |
 | `pgo_admin_role_name` | pgoadmin | **Required** | Sets the name of the PostgreSQL Operator role that is utilized for administrative operations performed by the PostgreSQL Operator. |
 | `pgo_admin_username` | admin | **Required** | Configures the pgo administrator username. |

--- a/installers/ansible/roles/pgo-operator/templates/pgouser-admin.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/pgouser-admin.yaml.j2
@@ -10,6 +10,6 @@ metadata:
   namespace: {{ pgo_operator_namespace }}
 type: Opaque
 data:
-  password: {{ pgo_admin_password | b64encode }}
-  username: {{ pgo_admin_username | b64encode }}
-  roles: {{ pgo_admin_role_name | b64encode }}
+  password: '{{ pgo_admin_password | b64encode }}'
+  username: '{{ pgo_admin_username | b64encode }}'
+  roles: '{{ pgo_admin_role_name | b64encode }}'

--- a/installers/ansible/roles/pgo-preflight/tasks/check_vars.yml
+++ b/installers/ansible/roles/pgo-preflight/tasks/check_vars.yml
@@ -8,7 +8,6 @@
     - pgo_operator_namespace
     - pgo_installation_name
     - pgo_admin_username
-    - pgo_admin_password
     - pgo_admin_role_name
     - pgo_admin_perms
     - ccp_image_prefix

--- a/internal/apiserver/root.go
+++ b/internal/apiserver/root.go
@@ -31,9 +31,11 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/kubeapi"
 	"github.com/crunchydata/postgres-operator/internal/ns"
 	"github.com/crunchydata/postgres-operator/internal/tlsutil"
+	"github.com/crunchydata/postgres-operator/internal/util"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -128,6 +130,11 @@ func Initialize() {
 
 	initConfig()
 
+	// look through all the pgouser secrets in the Operator's
+	// namespace and set a generated password for any that currently
+	// have an empty password set
+	setRandomPgouserPasswords()
+
 	if err := setNamespaceOperatingMode(); err != nil {
 		log.Error(err)
 		os.Exit(2)
@@ -155,7 +162,6 @@ func connectToKube() {
 }
 
 func initConfig() {
-
 	AuditFlag = Pgo.Pgo.Audit
 	if AuditFlag {
 		log.Info("audit flag is set to true")
@@ -301,6 +307,7 @@ func Authn(perm string, w http.ResponseWriter, r *http.Request) (string, error) 
 	// this function currently encapsulates authorization as well, and this is
 	// the call where we get the username to check the RBAC settings
 	username, password, authOK := r.BasicAuth()
+
 	if AuditFlag {
 		log.Infof("[audit] %s username=[%s] method=[%s] ip=[%s] ok=[%t] ", perm, username, r.Method, r.RemoteAddr, authOK)
 	}
@@ -496,6 +503,56 @@ func setNamespaceOperatingMode() error {
 	namespaceOperatingMode = nsOpMode
 
 	return nil
+}
+
+// setRandomPgouserPasswords looks through the pgouser secrets in the Operator's
+// namespace. If any have an empty password, it generates a random password,
+// Base64 encodes it, then stores it in the relevant PGO user's secret
+func setRandomPgouserPasswords() {
+	ctx := context.TODO()
+
+	selector := "pgo-pgouser=true,vendor=crunchydata"
+	secrets, err := Clientset.CoreV1().Secrets(PgoNamespace).
+		List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		log.Warnf("Could not get pgouser secrets in namespace: %s", PgoNamespace)
+		return
+	}
+
+	for _, secret := range secrets.Items {
+		// check if password is set. if it is, continue.
+		if len(secret.Data["password"]) > 0 {
+			continue
+		}
+
+		log.Infof("Password in pgouser secret %s for operator installation %s in namespace %s is empty. "+
+			"Setting a generated password.", secret.Name, InstallationName, PgoNamespace)
+
+		// generate the password using the default password length
+		generatedPassword, err := util.GeneratePassword(util.DefaultGeneratedPasswordLength)
+
+		if err != nil {
+			log.Errorf("Could not generate password for pgouser secret %s for operator installation %s in "+
+				"namespace %s", secret.Name, InstallationName, PgoNamespace)
+			continue
+		}
+
+		// create the password patch
+		patch, err := kubeapi.NewMergePatch().Add("stringData", "password")(generatedPassword).Bytes()
+
+		if err != nil {
+			log.Errorf("Could not generate password patch for pgouser secret %s for operator installation "+
+				"%s in namespace %s", secret.Name, InstallationName, PgoNamespace)
+			continue
+		}
+
+		// patch the pgouser secret with the new password
+		if _, err := Clientset.CoreV1().Secrets(PgoNamespace).Patch(ctx, secret.Name, types.MergePatchType,
+			patch, metav1.PatchOptions{}); err != nil {
+			log.Errorf("Could not patch pgouser secret %s with generated password for operator installation "+
+				"%s in namespace %s", secret.Name, InstallationName, PgoNamespace)
+		}
+	}
 }
 
 // NamespaceOperatingMode returns the namespace operating mode for the current Operator


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently, the PostgreSQL Operator requires a pgouser's
password to be set during the installation process.


**What is the new behavior (if this is a feature change)?**
This update allows for the password to be unset during installation,
and, during Operator initialization, any pgouser that currently has an
empty password will be given an autogenerated password, stored in the
relevant pgouser secret.


**Other information**:
[ch9510]