### PR TITLE
Tighter check for replica service in `pgo test`

### DIFF
--- a/internal/apiserver/clusterservice/clusterimpl.go
+++ b/internal/apiserver/clusterservice/clusterimpl.go
@@ -489,7 +489,7 @@ func TestCluster(name, selector, ns, pgouser string, allFlag bool) msgs.ClusterT
 			switch {
 			default:
 				endpoint.InstanceType = msgs.ClusterTestInstanceTypePrimary
-			case strings.Contains(service.Name, msgs.PodTypeReplica):
+			case strings.HasSuffix(service.Name, msgs.PodTypeReplica):
 				endpoint.InstanceType = msgs.ClusterTestInstanceTypeReplica
 			case service.Pgbouncer:
 				endpoint.InstanceType = msgs.ClusterTestInstanceTypePGBouncer


### PR DESCRIPTION
The check looked to see if the word "replica" existed in one
of the Service Labels, when really we shold be checking for a
suffix of "replica".

Issue: [ch9764]
fixes #2047