### PR TITLE
Fix crash in cluster shutdown logic

### DIFF
--- a/internal/operator/cluster/clusterlogic.go
+++ b/internal/operator/cluster/clusterlogic.go
@@ -630,7 +630,10 @@ func ShutdownCluster(clientset kubeapi.Interface, cluster crv1.Pgcluster) error 
 		return err
 	}
 
-	if len(pods.Items) > 1 {
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("Cluster Operator: Could not find primary pod for shutdown of "+
+			"cluster %s", cluster.Name)
+	} else if len(pods.Items) > 1 {
 		return fmt.Errorf("Cluster Operator: Invalid number of primary pods (%d) found when "+
 			"shutting down cluster %s", len(pods.Items), cluster.Name)
 	}


### PR DESCRIPTION
The Operator would crash if a shutdown was issued but there was
no in the cluster.

Issue: [ch9825]
fixes #2073