### PR TITLE
Catch error when generating default pgo-config

### DIFF
--- a/internal/config/pgoconfig.go
+++ b/internal/config/pgoconfig.go
@@ -516,6 +516,11 @@ func (c *PgoConfig) GetConfig(clientset kubernetes.Interface, namespace string) 
 
 	cMap, err := initialize(clientset, namespace)
 
+	if err != nil {
+		log.Errorf("could not get ConfigMap: %s", err.Error())
+		return err
+	}
+
 	//get the pgo.yaml config file
 	str := cMap.Data[CONFIG_PATH]
 	if str == "" {


### PR DESCRIPTION
During the initialization of the default "pgo-config" ConfigMap,
there exists a case (likely a race condition that I did not track
down) that triggered an error, but we were not catching the error.

Regardless, we should, given the next line could trigger a panic.
Immediate remediation without the patch should be just restarting
the Operator Pod.

Issue: [ch9826]
fixes #2075