### PR TITLE
Remove Disabling of Autofailover from rmdata

### DIFF
--- a/cmd/pgo-rmdata/process.go
+++ b/cmd/pgo-rmdata/process.go
@@ -49,15 +49,6 @@ func Delete(request Request) {
 	ctx := context.TODO()
 	log.Infof("rmdata.Process %v", request)
 
-	// if, check to see if this is a full cluster removal...i.e. "IsReplica"
-	// and "IsBackup" is set to false
-	//
-	// if this is a full cluster removal, first disable autofailover
-	if !(request.IsReplica || request.IsBackup) {
-		log.Debug("disabling autofailover for cluster removal")
-		util.ToggleAutoFailover(request.Clientset, false, request.ClusterPGHAScope, request.Namespace)
-	}
-
 	//the case of 'pgo scaledown'
 	if request.IsReplica {
 		log.Info("rmdata.Process scaledown replica use case")


### PR DESCRIPTION
The `rmdata` application no longer disables autofailover when deleting a PostgreSQL cluster.  In past versions of the PostgreSQL Operator, it was necessary to first disable autofailover prior to cluster deletion since the `rmdata` application itself would stop the PostgreSQL database using `pg_ctl stop`.  However, since Patroni is now responsible for cleanly shutting down the database (specifically upon receipt of a `SIGTERM` signal), autofailover should no longer be disabled (if it is, Patroni will not respond to the `SIGTERM` and will therefore not attempt to cleanly shutdown the database).

This change therefore ensures an attempt is made to cleanly shutdown the database when deleting a PostgreSQL cluster.  This, in turn, will increase the likeliness that the cluster can later be recreated and cleanly restarted.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Autofailover is disabled prior to deleting any resources via the `rmdata` process.

[ch9856]

**What is the new behavior (if this is a feature change)?**

Autofailover is no longer disabled prior to deleting any resources via the `rmdata` process.

**Other information**:

N/A