### PR TITLE
Remove orphaned error check

### DIFF
--- a/internal/apiserver/clusterservice/clusterimpl.go
+++ b/internal/apiserver/clusterservice/clusterimpl.go
@@ -722,9 +722,6 @@ func CreateCluster(request *msgs.CreateClusterRequest, ns, pgouser string) msgs.
 
 	//set the metrics flag with the global setting first
 	userLabelsMap[config.LABEL_EXPORTER] = strconv.FormatBool(apiserver.MetricsFlag)
-	if err != nil {
-		log.Error(err)
-	}
 
 	//if metrics is chosen on the pgo command, stick it into the user labels
 	if request.MetricsFlag {


### PR DESCRIPTION
This error check is using an `err` variable that is defined and handled earlier in the code. This leads to an extra error in the logs:

```
time="2020-12-02T16:31:12Z" level=debug msg="pgcluster pgo-test-mntzw not found so we will create it" func="internal/apiserver/clusterservice.CreateCluster()" file="internal/apiserver/clusterservice/clusterimpl.go:578" version=4.5.1
time="2020-12-02T16:31:12Z" level=error msg="pgclusters.crunchydata.com \"pgo-test-mntzw\" not found" func="internal/apiserver/clusterservice.CreateCluster()" file="internal/apiserver/clusterservice/clusterimpl.go:726" version=4.5.1
```

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
