### PR TITLE
Enable Delta Restores for In-Place Cluster Restores

### DIFF
--- a/internal/operator/backrest/restore.go
+++ b/internal/operator/backrest/restore.go
@@ -116,7 +116,6 @@ func PrepareClusterForRestore(clientset kubeapi.Interface, cluster *crv1.Pgclust
 	patch, err := kubeapi.NewMergePatch().
 		Add("metadata", "annotations")(map[string]string{
 		config.ANNOTATION_BACKREST_RESTORE: "",
-		config.ANNOTATION_CURRENT_PRIMARY:  clusterName,
 	}).
 		Add("metadata", "labels")(map[string]string{
 		config.LABEL_DEPLOYMENT_NAME: clusterName,
@@ -200,7 +199,7 @@ func PrepareClusterForRestore(clientset kubeapi.Interface, cluster *crv1.Pgclust
 
 	// find all database PVCs for the entire PostgreSQL cluster.  Includes the PVCs for all PGDATA
 	// volumes, as well as the PVCs for any WAL and/or tablespace volumes
-	databasePVCList, err := getPGDatabasePVCNames(clientset, replicas, clusterName, namespace)
+	databasePVCList, err := getPGDatabasePVCNames(clientset, replicas, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -316,8 +315,11 @@ func PublishRestore(id, clusterName, username, namespace string) {
 // instances comprising the cluster, in addition to any additional volumes used by those
 // instances, e.g. PVCs for external WAL and/or tablespace volumes.
 func getPGDatabasePVCNames(clientset kubeapi.Interface, replicas *crv1.PgreplicaList,
-	clusterName, namespace string) ([]string, error) {
+	cluster *crv1.Pgcluster) ([]string, error) {
 	ctx := context.TODO()
+
+	namespace := cluster.Namespace
+	clusterName := cluster.Name
 
 	// create a slice with the names of all database instances in the cluster.  Even though the
 	// original primary database (with a name matching the cluster name) might no longer exist,
@@ -338,9 +340,20 @@ func getPGDatabasePVCNames(clientset kubeapi.Interface, replicas *crv1.Pgreplica
 	}
 
 	var databasePVCList []string
+	primary := cluster.Annotations[config.ANNOTATION_CURRENT_PRIMARY]
+
 	for _, instance := range instances {
 		for _, clusterPVC := range clusterPVCList.Items {
+
 			pvcName := clusterPVC.GetName()
+
+			// Keep the current primary PVC's in order to attempt a pgBackRest delta restore.
+			// Includes the PGDATA PVC, as well as any WAL and/or tablespace PVC's if present.
+			if pvcName == primary || pvcName == fmt.Sprintf(walPVCPattern, primary) ||
+				strings.HasPrefix(pvcName, fmt.Sprintf(tablespacePVCSuffixPattern, primary)) {
+				continue
+			}
+
 			if pvcName == instance || pvcName == fmt.Sprintf(walPVCPattern, instance) ||
 				strings.HasPrefix(pvcName, fmt.Sprintf(tablespacePVCSuffixPattern, instance)) {
 				databasePVCList = append(databasePVCList, pvcName)

--- a/internal/operator/cluster/clusterlogic.go
+++ b/internal/operator/cluster/clusterlogic.go
@@ -235,7 +235,7 @@ func getBootstrapJobFields(clientset kubeapi.Interface,
 
 	// Now override any backrest env vars for the bootstrap job
 	bootstrapBackrestVars, err := operator.GetPgbackrestBootstrapEnvVars(restoreClusterName,
-		cluster.GetName(), restoreFromSecret)
+		cluster.GetAnnotations()[config.ANNOTATION_CURRENT_PRIMARY], restoreFromSecret)
 	if err != nil {
 		return bootstrapFields, err
 	}


### PR DESCRIPTION
When performing an in-place PostgreSQL cluster restore (such as when using the `pgo restore` command), the PVC's for the current primary database (includes the PGDATA PVC, along with any WAL and/or tablespace PVCs) will now be preserved if found (as identified by the `current-primary` annotation on the pgcluster custom resource).  This will cause the `crunchy-postgres-ha` container to attempt a pgBackRest "delta" restore when bootstrapping the restored cluster, therefore leveraging any existing data within the `PGDATA` directory efficiently restore the database.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

All PVC's are recreated when performing an in-place cluster restore, resulting in pgBackRest performing a restore into an empty PGDATA volume (along with empty WAL and/or tablespace volumes as applicable).

[ch9878]

**What is the new behavior (if this is a feature change)?**

The PVC's for the current primary database will now be preserved if found, causing the `crunchy-postgres-ha` container to leverage any existing data to perform a pgBackRest delta restore.

**Other information**:

N/A