### PR TITLE
Revert label change

### DIFF
--- a/cmd/pgo-scheduler/scheduler/pgbackrest.go
+++ b/cmd/pgo-scheduler/scheduler/pgbackrest.go
@@ -115,7 +115,7 @@ func (b BackRestBackupJob) Run() {
 		return
 	}
 
-	selector := fmt.Sprintf("%s=%s,crunchy-pgbackrest-repo=true", config.LABEL_PG_CLUSTER, b.cluster)
+	selector := fmt.Sprintf("%s=%s,pgo-backrest-repo=true", config.LABEL_PG_CLUSTER, b.cluster)
 	pods, err := clientset.CoreV1().Pods(b.namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		contextLogger.WithFields(log.Fields{

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
@@ -5,7 +5,7 @@
         "name": "{{.JobName}}",
         "labels": {
             "vendor": "crunchydata",
-            "sqlrunner": "true",
+            "pgo-sqlrunner": "true",
             "pg-cluster": "{{.ClusterName}}"
         }
     },
@@ -15,7 +15,7 @@
                 "name": "{{.JobName}}",
                 "labels": {
                     "vendor": "crunchydata",
-                    "sqlrunner": "true",
+                    "pgo-sqlrunner": "true",
                     "pg-cluster": "{{.ClusterName}}"
                 }
             },


### PR DESCRIPTION
As part of the compaction changes some labels and label checks were changed. This pr reverts these changes.

The `pgo-scheduler` code was updated to check for a `crunchy-pgbackrest-repo` label instead of the `pgo-backrest-repo` label. The deployment templates were not updated to use the updated label so the scheduler would fail to create a backup job when scheduling a backup.

the `pgo.sqlrunner` template was updated to have the `sqlrunner` label instead of `pgo-sqlrunner`
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
