### PR TITLE
No Post-Failover Backups for Standby Clusters

### DIFF
--- a/internal/controller/pod/promotionhandler.go
+++ b/internal/controller/pod/promotionhandler.go
@@ -63,7 +63,8 @@ func (c *Controller) handlePostgresPodPromotion(newPod *apiv1.Pod, cluster crv1.
 		}
 	}
 
-	if cluster.Status.State == crv1.PgclusterStateInitialized {
+	// create a post-failover backup if not a standby cluster
+	if !cluster.Spec.Standby && cluster.Status.State == crv1.PgclusterStateInitialized {
 		if err := cleanAndCreatePostFailoverBackup(c.Client,
 			cluster.Name, newPod.Namespace); err != nil {
 			log.Error(err)


### PR DESCRIPTION
A post-failover backup is now only triggered for non-standby clusters.  Therefore, if a failover occurs within a standby cluster, and automatic backup will no longer be run.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

A post-failover backup is attempted when a failover occurs within a standby cluster.

Fixes #2102 
[ch9912]

**What is the new behavior (if this is a feature change)?**

A post-failover backup is no longer attempted when a failover occurs within a standby cluster.

**Other information**:

N/A