### PR TITLE
Cluster bootstrap fixes

### DIFF
--- a/internal/apiserver/dfservice/dfimpl.go
+++ b/internal/apiserver/dfservice/dfimpl.go
@@ -147,7 +147,8 @@ func getClusterDf(cluster *crv1.Pgcluster, clusterResultsChannel chan msgs.DfDet
 	ctx := context.TODO()
 	log.Debugf("pod df: %s", cluster.Spec.Name)
 
-	selector := fmt.Sprintf("%s=%s", config.LABEL_PG_CLUSTER, cluster.Spec.Name)
+	selector := fmt.Sprintf("%s=%s,!%s",
+		config.LABEL_PG_CLUSTER, cluster.Spec.Name, config.LABEL_PGHA_BOOTSTRAP)
 
 	pods, err := apiserver.Clientset.CoreV1().Pods(cluster.Spec.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

- `pgo df` will fail on clusters created using `pgo create cluster --restore-from`
- The cluster bootstrap Job persists even after it successfully runs

**What is the new behavior (if this is a feature change)?**

- `pgo df` works on clusters with lingering bootstrap jobs
- The cluster bootstrap Job is removed after it successfully completes

**Other information**:

Issue: [ch9919]
Fixes #2029