### PR TITLE
Only consider running Pods for `pgo test`

### DIFF
--- a/internal/apiserver/clusterservice/clusterimpl.go
+++ b/internal/apiserver/clusterservice/clusterimpl.go
@@ -38,6 +38,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 )
@@ -2065,10 +2066,16 @@ func GetPrimaryAndReplicaPods(cluster *crv1.Pgcluster, ns string) ([]msgs.ShowCl
 	ctx := context.TODO()
 	output := make([]msgs.ShowClusterPod, 0)
 
+	// find all of the Pods that represent Postgres primary and replicas.
+	// only consider running Pods
 	selector := config.LABEL_SERVICE_NAME + "=" + cluster.Spec.Name + "," + config.LABEL_DEPLOYMENT_NAME
-	log.Debugf("selector for GetPrimaryAndReplicaPods is %s", selector)
 
-	pods, err := apiserver.Clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	options := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("status.phase", string(v1.PodRunning)).String(),
+		LabelSelector: selector,
+	}
+
+	pods, err := apiserver.Clientset.CoreV1().Pods(ns).List(ctx, options)
 	if err != nil {
 		return output, err
 	}
@@ -2088,9 +2095,12 @@ func GetPrimaryAndReplicaPods(cluster *crv1.Pgcluster, ns string) ([]msgs.ShowCl
 
 	}
 	selector = config.LABEL_SERVICE_NAME + "=" + cluster.Spec.Name + "-replica" + "," + config.LABEL_DEPLOYMENT_NAME
-	log.Debugf("selector for GetPrimaryAndReplicaPods is %s", selector)
+	options = metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("status.phase", string(v1.PodRunning)).String(),
+		LabelSelector: selector,
+	}
 
-	pods, err = apiserver.Clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	pods, err = apiserver.Clientset.CoreV1().Pods(ns).List(ctx, options)
 	if err != nil {
 		return output, err
 	}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

`pgo test` would report that an Evicted Pod counted as a primary.

**What is the new behavior (if this is a feature change)?**


By adding this limitation, Pods such as Evicted Pods would not
be considered as a part of `pgo test` output, as this could
present some odd scenarios, such as the presence of two primaries.

**Other information**:

Issue: [ch9931]
Fixes #2095