### PR TITLE
Fix several edge case out-of-index panics

### DIFF
--- a/internal/operator/cluster/failoverlogic.go
+++ b/internal/operator/cluster/failoverlogic.go
@@ -210,6 +210,8 @@ func RemovePrimaryOnRoleChangeTag(clientset kubernetes.Interface, restconfig *re
 	if err != nil {
 		log.Error(err)
 		return err
+	} else if len(pods.Items) == 0 {
+		return fmt.Errorf("no pods found for cluster %q", clusterName)
 	} else if len(pods.Items) > 1 {
 		log.Error("More than one primary found after completing the post-failover backup")
 	}

--- a/internal/operator/clusterutilities.go
+++ b/internal/operator/clusterutilities.go
@@ -941,6 +941,9 @@ func UpdatePGHAConfigInitFlag(clientset kubernetes.Interface, initVal bool, clus
 	case err != nil:
 		return fmt.Errorf("unable to find the default pgha configMap found for cluster %s using selector %s, unable to set "+
 			"init value to false", clusterName, selector)
+	case len(configMapList.Items) == 0:
+		return fmt.Errorf("no pgha configMaps found for cluster %s using selector %s, unable to set "+
+			"init value to false", clusterName, selector)
 	case len(configMapList.Items) > 1:
 		return fmt.Errorf("more than one default pgha configMap found for cluster %s using selector %s, unable to set "+
 			"init value to false", clusterName, selector)


### PR DESCRIPTION
While these should rarely, if ever, happen, the world of distributed
computing is unpredictable and we should ensure our code can fail
gracefully in these scenarios.