### PR TITLE
Update Init Flag if PGHA ConfigMap Already Exists

### DIFF
--- a/internal/controller/pod/inithandler.go
+++ b/internal/controller/pod/inithandler.go
@@ -115,8 +115,10 @@ func (c *Controller) handleCommonInit(cluster *crv1.Pgcluster) error {
 			cluster.ObjectMeta.Labels[config.LABEL_PGHA_SCOPE], cluster.Namespace)
 	}
 
-	operator.UpdatePGHAConfigInitFlag(c.Client, false, cluster.Name,
-		cluster.Namespace)
+	if err := operator.UpdatePGHAConfigInitFlag(c.Client, false, cluster.Name,
+		cluster.Namespace); err != nil {
+		log.Error(err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
If an existing PGHA ConfigMap is identified when bootstrapping a new PostgreSQL cluster, the Operator now updates the ` init`flag within the existing ConfigMap (specifically by setting it to `true`).  This ensures proper configuration of the `init` flag (and therefore the proper functionality of any logic within the Operator that relies on it, e.g. the execution of init logic within the `crunchy-postgres-ha` container) when the PGHA ConfigMap is pre-defined prior to PostgreSQL cluster initialization.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

If an existing PGHA ConfigMap is identified when bootstrapping a new PostgreSQL cluster, the `init` flag is not set.

Issue: [ch9986]

**What is the new behavior (if this is a feature change)?**

If an existing PGHA ConfigMap is identified when bootstrapping a new PostgreSQL cluster, the `init` flag is set to `true`.

**Other information**:

N/A