### PR TITLE
Ensure consistent permissions for mounting repo Secret

### DIFF
--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
@@ -166,8 +166,7 @@
                 }, {
                     "name": "sshd",
                     "secret": {
-                        "secretName": "{{.RestoreFrom}}-backrest-repo-config",
-                        "defaultMode": 511
+                        "secretName": "{{.RestoreFrom}}-backrest-repo-config"
                     }
                 },
                 {{if .TLSEnabled}}

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -259,8 +259,7 @@
                     }, {
                         "name": "sshd",
                         "secret": {
-                            "secretName": "{{.ClusterName}}-backrest-repo-config",
-                            "defaultMode": 511
+                            "secretName": "{{.ClusterName}}-backrest-repo-config"
                         }
                     }, {
                         "name": "root-volume",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
@@ -102,8 +102,7 @@
                 "volumes": [{
                     "name": "sshd",
                     "secret": {
-                        "secretName": "{{.SshdSecretsName}}",
-                        "defaultMode": 511
+                        "secretName": "{{.SshdSecretsName}}"
                     }
                 }, {
                     "name": "backrestrepo",


### PR DESCRIPTION
While the Secret volume mount is set to be readonly for the
pgBackRest Secret information, the defaultMode on the volume itself
was set to be more permissive. While it appears that the vast
majority of Kubernetes distributions give precedence to the value
of the volume mount, so flavors do use the values set on the volume.

As such, it's prudent to remove the more permissive settings, which
this patch does.

Issue: [ch9989]
fixes #2140