### PR TITLE
Ensure PgBackRest env vars used index

### DIFF
--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
@@ -57,11 +57,11 @@
                         "name": "PGBACKREST_DB_PATH",
                         "value": "{{.PgbackrestDBPath}}"
                     }, {
-                        "name": "PGBACKREST_REPO_PATH",
-                        "value": "{{.PgbackrestRepoPath}}"
+                        "name": "PGBACKREST_REPO1_PATH",
+                        "value": "{{.PgbackrestRepo1Path}}"
                     }, {
-                        "name": "PGBACKREST_REPO_TYPE",
-                        "value": "{{.PgbackrestRepoType}}"
+                        "name": "PGBACKREST_REPO1_TYPE",
+                        "value": "{{.PgbackrestRepo1Type}}"
                     },{
                         "name": "PGHA_PGBACKREST_LOCAL_S3_STORAGE",
                         "value": "{{.BackrestLocalAndS3Storage}}"

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
@@ -69,8 +69,8 @@
                         "value": "{{.PgbackrestDBPath}}"
                       },
                       {
-                        "name": "PGBACKREST_REPO_PATH",
-                        "value": "{{.PgbackrestRepoPath}}"
+                        "name": "PGBACKREST_REPO1_PATH",
+                        "value": "{{.PgbackrestRepo1Path}}"
                       },
                       {
                         "name": "PGBACKREST_PG1_PORT",

--- a/internal/operator/backrest/backup.go
+++ b/internal/operator/backrest/backup.go
@@ -55,8 +55,8 @@ type backrestJobTemplateFields struct {
 	SecurityContext               string
 	PgbackrestStanza              string
 	PgbackrestDBPath              string
-	PgbackrestRepoPath            string
-	PgbackrestRepoType            string
+	PgbackrestRepo1Path           string
+	PgbackrestRepo1Type           string
 	BackrestLocalAndS3Storage     bool
 	PgbackrestS3VerifyTLS         string
 	PgbackrestRestoreVolumes      string
@@ -88,10 +88,10 @@ func Backrest(namespace string, clientset kubernetes.Interface, task *crv1.Pgtas
 		CCPImageTag:                   operator.Pgo.Cluster.CCPImageTag,
 		PgbackrestStanza:              task.Spec.Parameters[config.LABEL_PGBACKREST_STANZA],
 		PgbackrestDBPath:              task.Spec.Parameters[config.LABEL_PGBACKREST_DB_PATH],
-		PgbackrestRepoPath:            task.Spec.Parameters[config.LABEL_PGBACKREST_REPO_PATH],
+		PgbackrestRepo1Path:           task.Spec.Parameters[config.LABEL_PGBACKREST_REPO_PATH],
 		PgbackrestRestoreVolumes:      "",
 		PgbackrestRestoreVolumeMounts: "",
-		PgbackrestRepoType:            operator.GetRepoType(task.Spec.Parameters[config.LABEL_BACKREST_STORAGE_TYPE]),
+		PgbackrestRepo1Type:           operator.GetRepoType(task.Spec.Parameters[config.LABEL_BACKREST_STORAGE_TYPE]),
 		BackrestLocalAndS3Storage:     operator.IsLocalAndS3Storage(task.Spec.Parameters[config.LABEL_BACKREST_STORAGE_TYPE]),
 		PgbackrestS3VerifyTLS:         task.Spec.Parameters[config.LABEL_BACKREST_S3_VERIFY_TLS],
 	}

--- a/internal/operator/backrest/repo.go
+++ b/internal/operator/backrest/repo.go
@@ -50,12 +50,12 @@ type RepoDeploymentTemplateFields struct {
 	BackrestRepoClaimName     string
 	SshdSecretsName           string
 	PGbackrestDBHost          string
-	PgbackrestRepoPath        string
+	PgbackrestRepo1Path       string
 	PgbackrestDBPath          string
 	PgbackrestPGPort          string
 	SshdPort                  int
 	PgbackrestStanza          string
-	PgbackrestRepoType        string
+	PgbackrestRepo1Type       string
 	PgbackrestS3EnvVars       string
 	Name                      string
 	ClusterName               string
@@ -197,7 +197,7 @@ func setBootstrapRepoOverrides(clientset kubernetes.Interface, cluster *crv1.Pgc
 		return err
 	}
 
-	repoFields.PgbackrestRepoPath = restoreFromSecret.Annotations[config.ANNOTATION_REPO_PATH]
+	repoFields.PgbackrestRepo1Path = restoreFromSecret.Annotations[config.ANNOTATION_REPO_PATH]
 	repoFields.PgbackrestPGPort = restoreFromSecret.Annotations[config.ANNOTATION_PG_PORT]
 
 	sshdPort, err := strconv.Atoi(restoreFromSecret.Annotations[config.ANNOTATION_SSHD_PORT])
@@ -235,12 +235,12 @@ func getRepoDeploymentFields(clientset kubernetes.Interface, cluster *crv1.Pgclu
 		BackrestRepoClaimName: fmt.Sprintf(util.BackrestRepoPVCName, cluster.Name),
 		SshdSecretsName:       fmt.Sprintf(util.BackrestRepoSecretName, cluster.Name),
 		PGbackrestDBHost:      cluster.Name,
-		PgbackrestRepoPath:    util.GetPGBackRestRepoPath(*cluster),
+		PgbackrestRepo1Path:   util.GetPGBackRestRepoPath(*cluster),
 		PgbackrestDBPath:      "/pgdata/" + cluster.Name,
 		PgbackrestPGPort:      cluster.Spec.Port,
 		SshdPort:              operator.Pgo.Cluster.BackrestPort,
 		PgbackrestStanza:      "db",
-		PgbackrestRepoType:    operator.GetRepoType(cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE]),
+		PgbackrestRepo1Type:   operator.GetRepoType(cluster.Spec.UserLabels[config.LABEL_BACKREST_STORAGE_TYPE]),
 		PgbackrestS3EnvVars:   operator.GetPgbackrestS3EnvVars(*cluster, clientset, namespace),
 		Name:                  fmt.Sprintf(util.BackrestRepoServiceName, cluster.Name),
 		ClusterName:           cluster.Name,

--- a/internal/operator/clusterutilities.go
+++ b/internal/operator/clusterutilities.go
@@ -52,9 +52,9 @@ const (
 	PGHAConfigInitSetting = "init"
 	// PGHAConfigReplicaBootstrapRepoType defines an override for the type of repo (local, S3, etc.)
 	// that should be utilized when bootstrapping a replica (i.e. it override the
-	// PGBACKREST_REPO_TYPE env var in the environment).  Allows for dynamic changing of the
+	// PGBACKREST_REPO1_TYPE env var in the environment).  Allows for dynamic changing of the
 	// backrest repo type without requiring container restarts (as would be required to update
-	// PGBACKREST_REPO_TYPE).
+	// PGBACKREST_REPO1_TYPE).
 	PGHAConfigReplicaBootstrapRepoType = "replica-bootstrap-repo-type"
 )
 


### PR DESCRIPTION
The PostgreSQL Operator currently utilizes two different formats for defining
pgBackRest "repo" settings via environment variables. For instance, certain
variables are defined with an index (e.g. `PGBACKREST_REPO1_`), while others are
not(e.g. `PGBACKREST_REPO_`). This inconsistency has led to confusion when using
the operator. The operator will now standardize on using an indexed variable.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently we use both `PGBACKREST_REPO_` and `PGBACKREST_REPO<index>_` environment variables


**What is the new behavior (if this is a feature change)?**
Now we will only use `PGBACKREST_REPO<index>`


**Other information**:
[ch9871]