### PR TITLE
Modify character space for random password generation

### DIFF
--- a/internal/util/secrets.go
+++ b/internal/util/secrets.go
@@ -46,6 +46,10 @@ const (
 	// passwordCharUpper is the highest ASCII character to use for generating a
 	// password, which is 126
 	passwordCharUpper = 126
+	// passwordCharExclude is a map of characters that we choose to exclude from
+	// the password to simplify usage in the shell. There is still enough entropy
+	// that exclusion of these characters is OK.
+	passwordCharExclude = "`\\"
 )
 
 // passwordCharSelector is a "big int" that we need to select the random ASCII
@@ -75,15 +79,24 @@ func CreateSecret(clientset kubernetes.Interface, db, secretName, username, pass
 // ASCII characters suitable for a password
 func GeneratePassword(length int) (string, error) {
 	password := make([]byte, length)
+	i := 0
 
-	for i := 0; i < length; i++ {
-		char, err := rand.Int(rand.Reader, passwordCharSelector)
+	for i < length {
+		val, err := rand.Int(rand.Reader, passwordCharSelector)
 		// if there is an error generating the random integer, return
 		if err != nil {
 			return "", err
 		}
 
-		password[i] = byte(passwordCharLower + char.Int64())
+		char := byte(passwordCharLower + val.Int64())
+
+		// if the character is in the exclusion list, continue
+		if idx := strings.IndexAny(string(char), passwordCharExclude); idx > -1 {
+			continue
+		}
+
+		password[i] = char
+		i++
 	}
 
 	return string(password), nil

--- a/internal/util/secrets_test.go
+++ b/internal/util/secrets_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestGeneratePassword(t *testing.T) {
 	// different lengths
-	for _, length := range []int{1, 2, 3, 5, 20} {
+	for _, length := range []int{1, 2, 3, 5, 20, 200} {
 		password, err := GeneratePassword(length)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
@@ -31,8 +31,11 @@ func TestGeneratePassword(t *testing.T) {
 		if expected, actual := length, len(password); expected != actual {
 			t.Fatalf("expected length %v, got %v", expected, actual)
 		}
-		if i := strings.IndexFunc(password, unicode.IsPrint); i > 0 {
+		if i := strings.IndexFunc(password, func(r rune) bool { return !unicode.IsPrint(r) }); i > -1 {
 			t.Fatalf("expected only printable characters, got %q in %q", password[i], password)
+		}
+		if i := strings.IndexAny(password, passwordCharExclude); i > -1 {
+			t.Fatalf("expected no exclude characters, got %q in %q", password[i], password)
 		}
 	}
 
@@ -44,8 +47,11 @@ func TestGeneratePassword(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		if i := strings.IndexFunc(password, unicode.IsPrint); i > 0 {
+		if i := strings.IndexFunc(password, func(r rune) bool { return !unicode.IsPrint(r) }); i > -1 {
 			t.Fatalf("expected only printable characters, got %q in %q", password[i], password)
+		}
+		if i := strings.IndexAny(password, passwordCharExclude); i > -1 {
+			t.Fatalf("expected no exclude characters, got %q in %q", password[i], password)
 		}
 
 		for i := range previous {


### PR DESCRIPTION
This removes a couple of characters from consideration for
the randomly generated passwords, as these characters could pose
problems when applying them in shell environments. The character
entropy is still quite large even with this removal.