### PR TITLE
Remove reference to deprecated CRD attribute

### DIFF
--- a/examples/create-by-resource/fromcrd.json
+++ b/examples/create-by-resource/fromcrd.json
@@ -24,15 +24,6 @@
     "namespace": "pgouser1"
   },
   "spec": {
-    "ArchiveStorage": {
-      "accessmode": "",
-      "matchLabels": "",
-      "name": "",
-      "size": "",
-      "storageclass": "",
-      "storagetype": "",
-      "supplementalgroups": ""
-    },
     "BackrestStorage": {
       "accessmode": "ReadWriteOnce",
       "matchLabels": "",

--- a/pkg/apis/crunchydata.com/v1/cluster.go
+++ b/pkg/apis/crunchydata.com/v1/cluster.go
@@ -56,7 +56,6 @@ type PgclusterSpec struct {
 
 	PrimaryStorage  PgStorageSpec
 	WALStorage      PgStorageSpec
-	ArchiveStorage  PgStorageSpec
 	ReplicaStorage  PgStorageSpec
 	BackrestStorage PgStorageSpec
 

--- a/pkg/apis/crunchydata.com/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/crunchydata.com/v1/zz_generated.deepcopy.go
@@ -196,7 +196,6 @@ func (in *PgclusterSpec) DeepCopyInto(out *PgclusterSpec) {
 	*out = *in
 	out.PrimaryStorage = in.PrimaryStorage
 	out.WALStorage = in.WALStorage
-	out.ArchiveStorage = in.ArchiveStorage
 	out.ReplicaStorage = in.ReplicaStorage
 	out.BackrestStorage = in.BackrestStorage
 	if in.Resources != nil {


### PR DESCRIPTION
"ArchiveStorage" is no longer used, so there is no need to
continue to carry this CRD attribute forward.