### PR TITLE
Move TLS key generation to ECDSA

### DIFF
--- a/deploy/gen-api-keys.sh
+++ b/deploy/gen-api-keys.sh
@@ -13,28 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
 # generate self signed cert for apiserver REST service
-#
-
 openssl req \
--x509 \
--nodes \
--newkey rsa:2048 \
--keyout $PGOROOT/conf/postgres-operator/server.key \
--out $PGOROOT/conf/postgres-operator/server.crt \
--days 3650 \
--subj "/C=US/ST=Texas/L=Austin/O=TestOrg/OU=TestDepartment/CN=*"
-
-# generate CA
-#openssl genrsa -out $PGOROOT/conf/apiserver/rootCA.key 4096
-#openssl req -x509 -new -key $PGOROOT/conf/apiserver/rootCA.key -days 3650 -out $PGOROOT/conf/apiserver/rootCA.crt
-
-# generate cert for secure.domain.com signed with the created CA
-#openssl genrsa -out $PGOROOT/conf/apiserver/secure.domain.com.key 2048
-#openssl req -new -key $PGOROOT/conf/apiserver/secure.domain.com.key -out $PGOROOT/conf/apiserver/secure.domain.com.csr
-#In answer to question `Common Name (e.g. server FQDN or YOUR name) []:` you should set `secure.domain.com` (your real domain name)
-#openssl x509 -req -in $PGOROOT/conf/apiserver/secure.domain.com.csr -CA $PGOROOT/conf/apiserver/rootCA.crt -CAkey $PGOROOT/conf/apiserver/rootCA.key -CAcreateserial -days 365 -out $PGOROOT/conf/apiserver/secure.domain.com.crt
-
-#openssl genrsa 2048 > $PGOROOT/conf/apiserver/key.pem
-#openssl req -new -x509 -key $PGOROOT/conf/apiserver/key.pem -out $PGOROOT/conf/apiserver/cert.pem -days 1095
+  -x509 \
+  -nodes \
+  -newkey ec \
+  -pkeyopt ec_paramgen_curve:prime256v1 \
+  -sha384 \
+  -keyout $PGOROOT/conf/postgres-operator/server.key \
+  -out $PGOROOT/conf/postgres-operator/server.crt \
+  -days 3650 \
+  -subj "/CN=*"

--- a/installers/ansible/roles/pgo-operator/tasks/certs.yml
+++ b/installers/ansible/roles/pgo-operator/tasks/certs.yml
@@ -6,33 +6,19 @@
   tags:
     - install
 
-- name: Generate RSA Key
-  command: openssl genrsa -out "{{ output_dir }}/server.key" 2048
-  args:
-    creates: "{{ output_dir }}/server.key"
-  tags:
-    - install
-
-- name: Generate CSR
-  command: openssl req \
-    -new \
-    -subj '/C=US/ST=SC/L=Charleston/O=CrunchyData/CN=pg-operator' \
-    -key "{{ output_dir }}/server.key" \
-    -out "{{ output_dir }}/server.csr"
-  args:
-    creates: "{{ output_dir }}/server.csr"
-  tags:
-    - install
-
 - name: Generate Self-signed Certificate
   command: openssl req \
     -x509 \
+    -nodes \
+    -newkey ec \
+    -pkeyopt ec_paramgen_curve:prime256v1 \
+    -sha384 \
     -days 1825 \
-    -key "{{ output_dir }}/server.key" \
-    -in "{{ output_dir }}/server.csr" \
-    -out "{{ output_dir }}/server.crt"
+    -subj "/CN=*" \
+    -keyout {{ output_dir }}/server.key \
+    -out {{ output_dir }}/server.crt
   args:
-    creates: "{{ output_dir }}/server.crt"
+    creates: "{{ output_dir }}/server.[kc][er][yt]"
   tags:
     - install
 

--- a/internal/apiserver/root.go
+++ b/internal/apiserver/root.go
@@ -17,7 +17,7 @@ limitations under the License.
 
 import (
 	"context"
-	"crypto/rsa"
+	"crypto/ecdsa"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -438,7 +438,7 @@ func generateTLSCert(certPath, keyPath string) error {
 	var err error
 
 	// generate private key
-	var privateKey *rsa.PrivateKey
+	var privateKey *ecdsa.PrivateKey
 	privateKey, err = tlsutil.NewPrivateKey()
 	if err != nil {
 		fmt.Println(err.Error())

--- a/internal/tlsutil/primitives_test.go
+++ b/internal/tlsutil/primitives_test.go
@@ -18,7 +18,6 @@ limitations under the License.
 import (
 	"bytes"
 	"context"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -43,7 +42,7 @@ func TestKeyPEMSymmetry(t *testing.T) {
 
 	t.Log(base64.StdEncoding.EncodeToString(pemKey))
 
-	if !keysEq(oldKey, newKey) {
+	if !(oldKey.Equal(newKey) && oldKey.PublicKey.Equal(newKey.Public())) {
 		t.Fatal("Decoded key did not match its input source")
 	}
 }
@@ -144,31 +143,4 @@ func TestExtendedTrust(t *testing.T) {
 	if recv := string(bytes.TrimSpace(body)); recv != expected {
 		t.Fatalf("expected [%s], got [%s] instead\n", expected, recv)
 	}
-}
-
-func keysEq(a, b *rsa.PrivateKey) bool {
-	if a.E != b.E {
-		// PublicKey exponent different
-		return false
-	}
-	if a.N.Cmp(b.N) != 0 {
-		// PublicKey modulus different
-		return false
-	}
-	if a.D.Cmp(b.D) != 0 {
-		// PrivateKey exponent different
-		return false
-	}
-	if len(a.Primes) != len(b.Primes) {
-		// Prime factor difference (Tier 1)
-		return false
-	}
-	for i, aPrime := range a.Primes {
-		if aPrime.Cmp(b.Primes[i]) != 0 {
-			// Prime factor difference (Tier 2)
-			return false
-		}
-	}
-
-	return true
 }


### PR DESCRIPTION
This moves the default TLS key generation for the API server
to use ECDSA keys with a P-256 curve and a SHA384 signature.
This only affects newly created Operator deployments, or
Operator deployments that have deleted their TLS secret.