### PR TITLE
Update failover test

### DIFF
--- a/testing/pgo_cli/cluster_failover_test.go
+++ b/testing/pgo_cli/cluster_failover_test.go
@@ -68,7 +68,7 @@ func TestClusterFailover(t *testing.T) {
 						"--target="+before[0].Labels["deployment-name"], "--no-prompt",
 					).Exec(t)
 					require.NoError(t, err)
-					require.Contains(t, output, "created")
+					require.Contains(t, output, "success")
 
 					replaced := func() bool {
 						after := replicaPods(t, namespace(), cluster())


### PR DESCRIPTION
As part of the move from failover to switchover the output message from the `pgo failover` command was updated. This change updates the test to account for the new output message.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
cluster_failover_test fails when manually testing passes


**What is the new behavior (if this is a feature change)?**
TestClusterFailover passes using the updated output message from `pgo failover`


**Other information**:
