### PR TITLE
Ensure ECDSA keygen explicitly specifies a named curve

### DIFF
--- a/deploy/gen-api-keys.sh
+++ b/deploy/gen-api-keys.sh
@@ -19,6 +19,7 @@ openssl req \
   -nodes \
   -newkey ec \
   -pkeyopt ec_paramgen_curve:prime256v1 \
+  -pkeyopt ec_param_enc:named_curve \
   -sha384 \
   -keyout $PGOROOT/conf/postgres-operator/server.key \
   -out $PGOROOT/conf/postgres-operator/server.crt \

--- a/installers/ansible/roles/pgo-operator/tasks/certs.yml
+++ b/installers/ansible/roles/pgo-operator/tasks/certs.yml
@@ -12,6 +12,7 @@
     -nodes \
     -newkey ec \
     -pkeyopt ec_paramgen_curve:prime256v1 \
+    -pkeyopt ec_param_enc:named_curve \
     -sha384 \
     -days 1825 \
     -subj "/CN=*" \


### PR DESCRIPTION
In the EL7 base images, OpenSSL does not appear to explicitly
state that the generated ECDSA key is generated using a named
curve, whereas Go explicitly expects this to be the case:

https://github.com/golang/go/issues/21502#issuecomment-323400475

The issue manifests itself as part of the "pgo-deployer" when the
API server key/certificate pair is created using
`kubectl create secrets tls`, which does some level of introspection.

The fix is to explicitly specify using a named curve, which works
both in the EL7 and EL8 images.

Issue: [ch10097]