### PR TITLE
Embed pgMonitor assets into pgo-deployer container

### DIFF
--- a/build/pgo-deployer/Dockerfile
+++ b/build/pgo-deployer/Dockerfile
@@ -70,6 +70,7 @@ fi
 
 COPY installers/ansible /ansible/postgres-operator
 COPY installers/metrics/ansible /ansible/metrics
+ADD tools/pgmonitor /tmp/.pgo/metrics/pgmonitor
 COPY installers/image/bin/pgo-deploy.sh /pgo-deploy.sh
 COPY bin/uid_daemon.sh /uid_daemon.sh
 
@@ -78,6 +79,7 @@ ENV HOME="/tmp"
 
 RUN chmod g=u /etc/passwd
 RUN chmod g=u /uid_daemon.sh
+RUN chown -R 2:2 /tmp/.pgo/metrics
 
 ENTRYPOINT ["/uid_daemon.sh"]
 

--- a/installers/metrics/ansible/roles/pgo-metrics/tasks/alertmanager.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/tasks/alertmanager.yml
@@ -16,7 +16,7 @@
 
     - name: Set pgmonitor Prometheus Directory Fact
       set_fact:
-        pgmonitor_prometheus_dir: "{{ metrics_dir }}/pgmonitor-{{ pgmonitor_version | replace('v','') }}/prometheus"
+        pgmonitor_prometheus_dir: "{{ metrics_dir }}/pgmonitor/prometheus"
 
     - name: Copy Alertmanger Config to Output Directory
       command: "cp {{ pgmonitor_prometheus_dir }}/{{ item.src }} {{ alertmanager_output_dir }}/{{ item.dst }}"

--- a/installers/metrics/ansible/roles/pgo-metrics/tasks/grafana.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/tasks/grafana.yml
@@ -9,7 +9,7 @@
         grafana_output_dir: "{{ metrics_dir }}/output/grafana"
 
     - name: Ensure Output Directory Exists
-      file: 
+      file:
         path: "{{ grafana_output_dir }}"
         state: "directory"
         mode: "0700"
@@ -48,7 +48,7 @@
 
     - name: Set pgmonitor Grafana Directory Fact
       set_fact:
-        pgmonitor_grafana_dir: "{{ metrics_dir }}/pgmonitor-{{ pgmonitor_version | replace('v','') }}/grafana"
+        pgmonitor_grafana_dir: "{{ metrics_dir }}/pgmonitor/grafana"
 
     - name: Copy Grafana Config to Output Directory
       command: "cp {{ pgmonitor_grafana_dir }}/{{ item }} {{ grafana_output_dir }}"
@@ -111,7 +111,7 @@
         src: "{{ item }}"
         dest: "{{ grafana_output_dir }}/{{ item | replace('.j2', '') }}"
         mode: "0600"
-      loop: 
+      loop:
         - grafana-pvc.json.j2
         - grafana-service.json.j2
         - grafana-deployment.json.j2

--- a/installers/metrics/ansible/roles/pgo-metrics/tasks/main.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set Metrics Directory Fact
   set_fact:
-    metrics_dir: "{{ ansible_env.HOME }}/.pgo/metrics/{{ metrics_namespace }}"
+    metrics_dir: "{{ ansible_env.HOME }}/.pgo/metrics"
   tags: always
 
 - name: Ensure Output Directory Exists
@@ -54,16 +54,23 @@
     - install-metrics
     - update-metrics
   block:
+    - name: Check for pgmonitor
+      stat:
+        path: "{{ metrics_dir }}/pgmonitor"
+      register: pgmonitor_dir
+
     - name: Download pgmonitor {{ pgmonitor_version }}
       get_url:
         url: https://github.com/CrunchyData/pgmonitor/archive/{{ pgmonitor_version }}.tar.gz
         dest: "{{ metrics_dir }}"
         mode: "0600"
+      when: not pgmonitor_dir.stat.exists
 
     - name: Extract pgmonitor
       unarchive:
         src: "{{ metrics_dir }}/pgmonitor-{{ pgmonitor_version | replace('v','') }}.tar.gz"
-        dest: "{{ metrics_dir }}"
+        dest: "{{ metrics_dir }}/pgmonitor"
+      when: not pgmonitor_dir.stat.exists
 
     - name: Create Metrics Image Pull Secret
       shell: >

--- a/installers/metrics/ansible/roles/pgo-metrics/tasks/prometheus.yml
+++ b/installers/metrics/ansible/roles/pgo-metrics/tasks/prometheus.yml
@@ -9,7 +9,7 @@
         prom_output_dir: "{{ metrics_dir }}/output/prom"
 
     - name: Ensure Output Directory Exists
-      file: 
+      file:
         path: "{{ prom_output_dir }}"
         state: "directory"
         mode: "0700"
@@ -22,7 +22,7 @@
       loop:
         - prometheus-rbac.json.j2
       when: create_rbac | bool
-      
+
     - name: Create Prometheus RBAC
       command: "{{ kubectl_or_oc }} create -f {{ prom_output_dir }}/{{ item }} -n {{ metrics_namespace }}"
       loop:
@@ -35,7 +35,7 @@
 
     - name: Set pgmonitor Prometheus Directory Fact
       set_fact:
-        pgmonitor_prometheus_dir: "{{ metrics_dir }}/pgmonitor-{{ pgmonitor_version | replace('v','') }}/prometheus"
+        pgmonitor_prometheus_dir: "{{ metrics_dir }}/pgmonitor/prometheus"
 
     - name: Copy Prometheus Config to Output Directory
       command: "cp {{ pgmonitor_prometheus_dir }}/{{ item.src }} {{ prom_output_dir }}/{{ item.dst }}"
@@ -88,7 +88,7 @@
         src: "{{ item }}"
         dest: "{{ prom_output_dir }}/{{ item | replace('.j2', '') }}"
         mode: "0600"
-      loop: 
+      loop:
         - prometheus-pvc.json.j2
         - prometheus-service.json.j2
         - prometheus-deployment.json.j2


### PR DESCRIPTION
This allows for the pgo-deployer container to install the monitoring
stack without making any additional calls to the Internet. If the
installation script does not detect the presence of the asset files,
it will attempt to download them from the Internet.

Issue: [ch10107]
closes #1987
closes #2186 