### PR TITLE
Enable cluster deletion from custom resource workflow

### DIFF
--- a/cmd/pgo-rmdata/README.txt
+++ b/cmd/pgo-rmdata/README.txt
@@ -1,6 +1,0 @@
-
-you can test this program outside of a container like so:
-
-cd $PGOROOT
-
-go run ./pgo-rmdata/pgo-rmdata.go -pg-cluster=mycluster -replica-name= -namespace=mynamespace -remove-data=true -remove-backup=true -is-replica=false -is-backup=false

--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -679,6 +679,15 @@ spec:
 Save your edits, and in a short period of time, you should see these annotations
 applied to the managed Deployments.
 
+### Delete a PostgreSQL Cluster
+
+A PostgreSQL cluster can be deleted by simply deleting the `pgclusters.crunchydata.com` resource.
+
+It is possible to keep both the PostgreSQL data directory as well as the pgBackRest backup repository when using this method by setting the following annotations on the `pgclusters.crunchydata.com` custom resource:
+
+- `keep-backups`: indicates to keep the pgBackRest PVC when deleting the cluster.
+- `keep-data`: indicates to keep the PostgreSQL data PVC when deleting the cluster.
+
 ## PostgreSQL Operator Custom Resource Definitions
 
 There are several PostgreSQL Operator Custom Resource Definitions (CRDs) that

--- a/internal/apiserver/backrestservice/backrestimpl.go
+++ b/internal/apiserver/backrestservice/backrestimpl.go
@@ -217,7 +217,6 @@ func CreateBackup(request *msgs.CreateBackrestBackupRequest, ns, pgouser string)
 
 		_, err = apiserver.Clientset.CrunchydataV1().Pgtasks(ns).Create(ctx,
 			getBackupParams(
-				cluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
 				clusterName, taskName, crv1.PgtaskBackrestBackup, podname, "database",
 				util.GetValueOrDefault(cluster.Spec.CCPImagePrefix, apiserver.Pgo.Cluster.CCPImagePrefix),
 				request.BackupOpts, request.BackrestStorageType, operator.GetS3VerifyTLSSetting(cluster), jobName, ns, pgouser),
@@ -283,7 +282,7 @@ func DeleteBackup(request msgs.DeleteBackrestBackupRequest) msgs.DeleteBackrestB
 	return response
 }
 
-func getBackupParams(identifier, clusterName, taskName, action, podName, containerName, imagePrefix, backupOpts, backrestStorageType, s3VerifyTLS, jobName, ns, pgouser string) *crv1.Pgtask {
+func getBackupParams(clusterName, taskName, action, podName, containerName, imagePrefix, backupOpts, backrestStorageType, s3VerifyTLS, jobName, ns, pgouser string) *crv1.Pgtask {
 	var newInstance *crv1.Pgtask
 	spec := crv1.PgtaskSpec{}
 	spec.Name = taskName
@@ -311,7 +310,6 @@ func getBackupParams(identifier, clusterName, taskName, action, podName, contain
 	}
 	newInstance.ObjectMeta.Labels = make(map[string]string)
 	newInstance.ObjectMeta.Labels[config.LABEL_PG_CLUSTER] = clusterName
-	newInstance.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER] = identifier
 	newInstance.ObjectMeta.Labels[config.LABEL_PGOUSER] = pgouser
 	return newInstance
 }
@@ -569,7 +567,6 @@ func Restore(request *msgs.RestoreRequest, ns, pgouser string) msgs.RestoreRespo
 		return resp
 	}
 
-	pgtask.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER] = cluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER]
 	pgtask.ObjectMeta.Labels[config.LABEL_PGOUSER] = pgouser
 	pgtask.Spec.Parameters[crv1.PgtaskWorkflowID] = id
 

--- a/internal/apiserver/clusterservice/clusterimpl.go
+++ b/internal/apiserver/clusterservice/clusterimpl.go
@@ -109,8 +109,7 @@ func DeleteCluster(name, selector string, deleteData, deleteBackups bool, ns, pg
 			return response
 		}
 
-		err := apiserver.CreateRMDataTask(cluster.Spec.Name, replicaName, taskName, deleteBackups, deleteData, isReplica, isBackup, ns, clusterPGHAScope)
-		if err != nil {
+		if err := util.CreateRMDataTask(apiserver.Clientset, cluster.Spec.Name, replicaName, taskName, deleteBackups, deleteData, isReplica, isBackup, ns, clusterPGHAScope); err != nil {
 			log.Debugf("error on creating rmdata task %s", err.Error())
 			response.Status.Code = msgs.Error
 			response.Status.Msg = err.Error()

--- a/internal/apiserver/clusterservice/scaleimpl.go
+++ b/internal/apiserver/clusterservice/scaleimpl.go
@@ -288,14 +288,7 @@ func ScaleDown(deleteData bool, clusterName, replicaName, ns string) msgs.ScaleD
 	}
 
 	// create the rmdata task which does the cleanup
-
-	clusterPGHAScope := cluster.ObjectMeta.Labels[config.LABEL_PGHA_SCOPE]
-	deleteBackups := false
-	isReplica := true
-	isBackup := false
-	taskName := replicaName + "-rmdata"
-
-	if err := util.CreateRMDataTask(apiserver.Clientset, clusterName, replicaName, taskName, deleteBackups, deleteData, isReplica, isBackup, ns, clusterPGHAScope); err != nil {
+	if err := util.CreateRMDataTask(apiserver.Clientset, cluster, replicaName, false, deleteData, true, false); err != nil {
 		response.Status.Code = msgs.Error
 		response.Status.Msg = err.Error()
 		return response

--- a/internal/apiserver/clusterservice/scaleimpl.go
+++ b/internal/apiserver/clusterservice/scaleimpl.go
@@ -119,7 +119,6 @@ func ScaleCluster(request msgs.ClusterScaleRequest, pgouser string) msgs.Cluster
 	spec.Tolerations = request.Tolerations
 
 	labels[config.LABEL_PGOUSER] = pgouser
-	labels[config.LABEL_PG_CLUSTER_IDENTIFIER] = cluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER]
 
 	for i := 0; i < request.ReplicaCount; i++ {
 		uniqueName := util.RandStringBytesRmndr(4)

--- a/internal/apiserver/clusterservice/scaleimpl.go
+++ b/internal/apiserver/clusterservice/scaleimpl.go
@@ -294,8 +294,8 @@ func ScaleDown(deleteData bool, clusterName, replicaName, ns string) msgs.ScaleD
 	isReplica := true
 	isBackup := false
 	taskName := replicaName + "-rmdata"
-	err = apiserver.CreateRMDataTask(clusterName, replicaName, taskName, deleteBackups, deleteData, isReplica, isBackup, ns, clusterPGHAScope)
-	if err != nil {
+
+	if err := util.CreateRMDataTask(apiserver.Clientset, clusterName, replicaName, taskName, deleteBackups, deleteData, isReplica, isBackup, ns, clusterPGHAScope); err != nil {
 		response.Status.Code = msgs.Error
 		response.Status.Msg = err.Error()
 		return response

--- a/internal/config/annotations.go
+++ b/internal/config/annotations.go
@@ -21,6 +21,12 @@ const (
 	ANNOTATION_BACKREST_RESTORE       = "pgo-backrest-restore"
 	ANNOTATION_PGHA_BOOTSTRAP_REPLICA = "pgo-pgha-bootstrap-replica"
 	ANNOTATION_PRIMARY_DEPLOYMENT     = "primary-deployment"
+	// ANNOTATION_CLUSTER_KEEP_BACKUPS indicates that if a custom resource is
+	// deleted, ensure the backups are kept
+	ANNOTATION_CLUSTER_KEEP_BACKUPS = "keep-backups"
+	// ANNOTATION_CLUSTER_KEEP_DATA indicates that if a custom resource is
+	// deleted, ensure the data directory is kept
+	ANNOTATION_CLUSTER_KEEP_DATA = "keep-data"
 	// annotation to track the cluster's current primary
 	ANNOTATION_CURRENT_PRIMARY = "current-primary"
 	// annotation to indicate whether a cluster has been upgraded

--- a/internal/config/labels.go
+++ b/internal/config/labels.go
@@ -17,12 +17,11 @@ package config
 
 // resource labels used by the operator
 const (
-	LABEL_NAME                  = "name"
-	LABEL_SELECTOR              = "selector"
-	LABEL_OPERATOR              = "postgres-operator"
-	LABEL_PG_CLUSTER            = "pg-cluster"
-	LABEL_PG_CLUSTER_IDENTIFIER = "pg-cluster-id"
-	LABEL_PG_DATABASE           = "pgo-pg-database"
+	LABEL_NAME        = "name"
+	LABEL_SELECTOR    = "selector"
+	LABEL_OPERATOR    = "postgres-operator"
+	LABEL_PG_CLUSTER  = "pg-cluster"
+	LABEL_PG_DATABASE = "pgo-pg-database"
 )
 
 const LABEL_PGTASK = "pg-task"

--- a/internal/controller/pgcluster/pgclustercontroller.go
+++ b/internal/controller/pgcluster/pgclustercontroller.go
@@ -18,7 +18,6 @@ limitations under the License.
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"reflect"
 	"strings"
 
@@ -117,8 +116,6 @@ func (c *Controller) processNextItem() bool {
 			"'initialized' or 'bootstrapping' state", cluster.GetName())
 		return true
 	}
-
-	addIdentifier(cluster)
 
 	// If bootstrapping from an existing data source then attempt to create the pgBackRest repository.
 	// If a repo already exists (e.g. because it is associated with a currently running cluster) then
@@ -414,15 +411,6 @@ func (c *Controller) AddPGClusterEventHandler() {
 	})
 
 	log.Debugf("pgcluster Controller: added event handler to informer")
-}
-
-func addIdentifier(clusterCopy *crv1.Pgcluster) {
-	u, err := ioutil.ReadFile("/proc/sys/kernel/random/uuid")
-	if err != nil {
-		log.Error(err)
-	}
-
-	clusterCopy.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER] = string(u[:len(u)-1])
 }
 
 // updateAnnotations updates any custom annitations that may be on the managed

--- a/internal/controller/pgtask/backresthandler.go
+++ b/internal/controller/pgtask/backresthandler.go
@@ -56,8 +56,7 @@ func (c *Controller) handleBackrestRestore(task *crv1.Pgtask) {
 	}
 	log.Debugf("pgtask Controller: added restore job for cluster %s", clusterName)
 
-	backrestoperator.PublishRestore(cluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER],
-		clusterName, task.ObjectMeta.Labels[config.LABEL_PGOUSER], namespace)
+	backrestoperator.PublishRestore(clusterName, task.ObjectMeta.Labels[config.LABEL_PGOUSER], namespace)
 
 	err = backrestoperator.UpdateWorkflow(c.Client, task.Spec.Parameters[crv1.PgtaskWorkflowID],
 		namespace, crv1.PgtaskWorkflowBackrestRestoreJobCreatedStatus)

--- a/internal/operator/backrest/backup.go
+++ b/internal/operator/backrest/backup.go
@@ -148,7 +148,6 @@ func Backrest(namespace string, clientset kubeapi.Interface, task *crv1.Pgtask) 
 		&newjob.Spec.Template.Spec.Containers[0])
 
 	newjob.ObjectMeta.Labels[config.LABEL_PGOUSER] = task.ObjectMeta.Labels[config.LABEL_PGOUSER]
-	newjob.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER] = task.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER]
 
 	backupType := task.Spec.Parameters[config.LABEL_PGHA_BACKUP_TYPE]
 	if backupType != "" {
@@ -242,7 +241,6 @@ func CreateBackup(clientset pgo.Interface, namespace, clusterName, podName strin
 	}
 	newInstance.ObjectMeta.Labels = make(map[string]string)
 	newInstance.ObjectMeta.Labels[config.LABEL_PG_CLUSTER] = cluster.Name
-	newInstance.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER] = cluster.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER]
 	newInstance.ObjectMeta.Labels[config.LABEL_PGOUSER] = cluster.ObjectMeta.Labels[config.LABEL_PGOUSER]
 
 	_, err = clientset.CrunchydataV1().Pgtasks(cluster.Namespace).Create(ctx, newInstance, metav1.CreateOptions{})

--- a/internal/operator/backrest/restore.go
+++ b/internal/operator/backrest/restore.go
@@ -317,7 +317,7 @@ func UpdateWorkflow(clientset pgo.Interface, workflowID, namespace, status strin
 }
 
 // PublishRestore is responsible for publishing the 'RestoreCluster' event for a restore
-func PublishRestore(id, clusterName, username, namespace string) {
+func PublishRestore(clusterName, username, namespace string) {
 	topics := make([]string, 1)
 	topics[0] = events.EventTopicCluster
 

--- a/internal/operator/cluster/clusterlogic.go
+++ b/internal/operator/cluster/clusterlogic.go
@@ -275,7 +275,6 @@ func getClusterDeploymentFields(clientset kubernetes.Interface,
 	}
 
 	cl.Spec.UserLabels[config.LABEL_PGOUSER] = cl.ObjectMeta.Labels[config.LABEL_PGOUSER]
-	cl.Spec.UserLabels[config.LABEL_PG_CLUSTER_IDENTIFIER] = cl.ObjectMeta.Labels[config.LABEL_PG_CLUSTER_IDENTIFIER]
 
 	// Set the Patroni scope to the name of the primary deployment.  Replicas will get scope using the
 	// 'crunchy-pgha-scope' label on the pgcluster


### PR DESCRIPTION
This behavior, which had been removed circa 4.1, is now reintroduced
to use the present machienry when a PostgreSQL cluster is being
deleted. Deleting a pgcluster resoruce directly will now delete a
PostgreSQL cluster and all of its associated objects.

To retain the PVCs for the PostgreSQL data directory or the backups
repository, one can set the following Annotations on a pgclusters
custom resource:

- `keep-backups`: indicates to keep the pgBackRest PVC when deleting
the cluster.
- `keep-data`: indicates to keep the PostgreSQL data PVC when deleting
the cluster.

Issue: [ch9435]
closes: #1203