### PR TITLE
Tighten up ephemeral storage limits

### DIFF
--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -176,9 +176,6 @@
                         }, {
                             "mountPath": "/pgconf",
                             "name": "pgconf-volume"
-                        }, {
-                            "mountPath": "/recover",
-                            "name": "recover-volume"
                         },
                         {
                             "mountPath": "/dev/shm",
@@ -282,11 +279,11 @@
                       {{ end }}
                     {{ end }}
                     {
-                        "name": "recover-volume",
-                        "emptyDir": { "medium": "Memory" }
-                    }, {
                         "name": "report",
-                        "emptyDir": { "medium": "Memory" }
+                        "emptyDir": {
+                          "medium": "Memory",
+                          "sizeLimit": "64Mi"
+                        }
                     },
                     {
                       "name": "dshm",


### PR DESCRIPTION
This removes an ephemeral storage volume that is no longer used
and places a cap of 64Mi on the pgBadger ephemeral storage
is not mounted unless there is a pgBadger instance directory.

This does not add a size limit to shared memory (dshm), as that
is a much more complicated topic.

closes #2188