### PR TITLE
Upgrade fixes for 4.6

### DIFF
--- a/internal/apiserver/upgradeservice/upgradeimpl.go
+++ b/internal/apiserver/upgradeservice/upgradeimpl.go
@@ -36,7 +36,6 @@ import (
 // Currently supported version information for upgrades
 const (
 	REQUIRED_MAJOR_PGO_VERSION = 4
-	MAXIMUM_MINOR_PGO_VERSION  = 5
 	MINIMUM_MINOR_PGO_VERSION  = 1
 )
 
@@ -224,12 +223,9 @@ func supportedOperatorVersion(version string) bool {
 		log.Errorf("Cannot convert Postgres Operator's minor version to an integer. Error: %v", err)
 		return false
 	}
-	if minor < MINIMUM_MINOR_PGO_VERSION || minor > MAXIMUM_MINOR_PGO_VERSION {
-		return false
-	}
 
 	// If none of the above is true, the upgrade can continue
-	return true
+	return minor >= MINIMUM_MINOR_PGO_VERSION
 }
 
 // upgradeTagValid compares and validates the PostgreSQL version values stored

--- a/internal/config/annotations.go
+++ b/internal/config/annotations.go
@@ -31,6 +31,9 @@ const (
 	ANNOTATION_CURRENT_PRIMARY = "current-primary"
 	// annotation to indicate whether a cluster has been upgraded
 	ANNOTATION_IS_UPGRADED = "is-upgraded"
+	// annotation to indicate an upgrade is in progress. this has the effect
+	// of causeing the rmdata job in pgcluster to not run
+	ANNOTATION_UPGRADE_IN_PROGRESS = "upgrade-in-progress"
 	// annotation to store the Operator versions upgraded from and to
 	ANNOTATION_UPGRADE_INFO = "upgrade-info"
 	// annotation to store the string boolean, used when checking upgrade status

--- a/internal/controller/pgcluster/pgclustercontroller.go
+++ b/internal/controller/pgcluster/pgclustercontroller.go
@@ -350,7 +350,13 @@ func (c *Controller) onDelete(obj interface{}) {
 
 	log.Debugf("pgcluster onDelete for cluster %s (namespace %s)", cluster.Name, cluster.Namespace)
 
-	// a quick guard: see if the "rmdata Job" is running.
+	// guard: if an upgrade is in progress, do not do any of the rest
+	if _, ok := cluster.ObjectMeta.GetAnnotations()[config.ANNOTATION_UPGRADE_IN_PROGRESS]; ok {
+		log.Debug("upgrade in progress, not proceeding with additional cleanups")
+		return
+	}
+
+	// guard: see if the "rmdata Job" is running.
 	options := metav1.ListOptions{
 		LabelSelector: fields.AndSelectors(
 			fields.OneTermEqualSelector(config.LABEL_PG_CLUSTER, cluster.Name),


### PR DESCRIPTION
- Do not restrict max upgrade version when running `pgo upgrade`. This is primarily an internal change.
- Do not delete primary/backup PVCs during upgrade.
- Ensure a PostgreSQL cluster comes back up as a leader once the upgrade is complete.