### PR TITLE
Gracefully handle names with "replica" in `pgo test`

### DIFF
--- a/internal/apiserver/clusterservice/clusterimpl.go
+++ b/internal/apiserver/clusterservice/clusterimpl.go
@@ -483,7 +483,7 @@ func TestCluster(name, selector, ns, pgouser string, allFlag bool) msgs.ClusterT
 			switch {
 			default:
 				endpoint.InstanceType = msgs.ClusterTestInstanceTypePrimary
-			case strings.HasSuffix(service.Name, msgs.PodTypeReplica):
+			case (strings.HasSuffix(service.Name, "-"+msgs.PodTypeReplica) && strings.Count(service.Name, "-"+msgs.PodTypeReplica) == 1):
 				endpoint.InstanceType = msgs.ClusterTestInstanceTypeReplica
 			case service.Pgbouncer:
 				endpoint.InstanceType = msgs.ClusterTestInstanceTypePGBouncer


### PR DESCRIPTION
This provides an even tighter check than the one introduced in
b0a276ab1 to determine what is a primary vs. replica Service.

Issue: [ch9764]
Issue: #2047