### PR TITLE
Make "Effect" optional when setting a toleration via `pgo` client

### DIFF
--- a/cmd/pgo/cmd/create.go
+++ b/cmd/pgo/cmd/create.go
@@ -153,6 +153,8 @@ var (
 // Exists - key:Effect
 // Equals - key=value:Effect
 //
+// Effect can be optional.
+//
 // Example:
 //
 // zone=east:NoSchedule,highspeed:NoSchedule

--- a/docs/content/tutorial/customize-cluster.md
+++ b/docs/content/tutorial/customize-cluster.md
@@ -146,6 +146,12 @@ The PostgreSQL Operator supports adding tolerations to PostgreSQL instances usin
 rule:Effect
 ```
 
+or
+
+```
+rule
+```
+
 where a `rule` can represent existence (e.g. `key`) or equality (`key=value`) and `Effect` is one of `NoSchedule`, `PreferNoSchedule`, or `NoExecute`. For more information on how tolerations work, please refer to the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 
 You can assign multiple tolerations to a PostgreSQL cluster.


### PR DESCRIPTION
Per Kubernetes documentation, one does not need to set an Effect
when setting a Toleration, so four CLI should allow for
this to be optional.

[ch10147]