### PR TITLE
Ensure standby cluster creates pgBouncer Secret

### DIFF
--- a/internal/operator/cluster/pgbouncer.go
+++ b/internal/operator/cluster/pgbouncer.go
@@ -164,6 +164,12 @@ func AddPgbouncer(clientset kubernetes.Interface, restconfig *rest.Config, clust
 		if err := setPostgreSQLPassword(clientset, restconfig, pod, cluster.Spec.Port, crv1.PGUserPgBouncer, pgBouncerPassword); err != nil {
 			return err
 		}
+	} else {
+		// if this is a standby cluster, we still need to create a pgBouncer Secret,
+		// but no credentials are available
+		if err := createPgbouncerSecret(clientset, cluster, ""); err != nil {
+			return err
+		}
 	}
 
 	// next, create the pgBouncer config map that will allow pgBouncer to be


### PR DESCRIPTION
The code was not allowing for this to happen. Even though the
pgBouncer credential will need to be rotated after a standby is
promoted, we can still create the credential with a nonworking
default.

Issue: [ch10083]