### PR TITLE
Remove restrictions on generic linking options for pgBackRest

### DIFF
--- a/internal/apiserver/backupoptions/pgbackrestoptions.go
+++ b/internal/apiserver/backupoptions/pgbackrestoptions.go
@@ -25,8 +25,6 @@ var pgBackRestOptsDenyList = []string{
 	"--config",
 	"--config-include-path",
 	"--config-path",
-	"--link-all",
-	"--link-map",
 	"--lock-path",
 	"--log-timestamp",
 	"--neutral-umask",


### PR DESCRIPTION
This is useful for creating a new cluster with an external WAL
volume from a cluster that lacks one.

Issue: [ch10157]