### PR TITLE
Reconcile API server permissions list

### DIFF
--- a/docs/content/Security/configure-postgres-operator-rbac.md
+++ b/docs/content/Security/configure-postgres-operator-rbac.md
@@ -72,6 +72,7 @@ The following list shows the current complete list of possible pgo permissions t
 |DfCluster | allow *pgo df*|
 |Label | allow *pgo label*|
 |Reload | allow *pgo reload*|
+|Restart | allow *pgo restart*|
 |Restore | allow *pgo restore*|
 |RestoreDump | allow *pgo restore* for pgdumps|
 |ShowBackup | allow *pgo show backup*|

--- a/internal/apiserver/perms.go
+++ b/internal/apiserver/perms.go
@@ -40,7 +40,6 @@ const (
 	CREATE_CLUSTER_PERM   = "CreateCluster"
 	CREATE_DUMP_PERM      = "CreateDump"
 	CREATE_FAILOVER_PERM  = "CreateFailover"
-	CREATE_INGEST_PERM    = "CreateIngest"
 	CREATE_NAMESPACE_PERM = "CreateNamespace"
 	CREATE_PGADMIN_PERM   = "CreatePgAdmin"
 	CREATE_PGBOUNCER_PERM = "CreatePgbouncer"
@@ -57,7 +56,6 @@ const (
 	// DELETE
 	DELETE_BACKUP_PERM    = "DeleteBackup"
 	DELETE_CLUSTER_PERM   = "DeleteCluster"
-	DELETE_INGEST_PERM    = "DeleteIngest"
 	DELETE_NAMESPACE_PERM = "DeleteNamespace"
 	DELETE_PGADMIN_PERM   = "DeletePgAdmin"
 	DELETE_PGBOUNCER_PERM = "DeletePgbouncer"
@@ -71,7 +69,6 @@ const (
 	SHOW_BACKUP_PERM          = "ShowBackup"
 	SHOW_CLUSTER_PERM         = "ShowCluster"
 	SHOW_CONFIG_PERM          = "ShowConfig"
-	SHOW_INGEST_PERM          = "ShowIngest"
 	SHOW_NAMESPACE_PERM       = "ShowNamespace"
 	SHOW_PGADMIN_PERM         = "ShowPgAdmin"
 	SHOW_PGBOUNCER_PERM       = "ShowPgBouncer"
@@ -114,6 +111,7 @@ func initializePerms() {
 		DF_CLUSTER_PERM:   "yes",
 		LABEL_PERM:        "yes",
 		RELOAD_PERM:       "yes",
+		RESTART_PERM:      "yes",
 		RESTORE_PERM:      "yes",
 		STATUS_PERM:       "yes",
 		TEST_CLUSTER_PERM: "yes",
@@ -124,7 +122,6 @@ func initializePerms() {
 		CREATE_DUMP_PERM:      "yes",
 		CREATE_CLUSTER_PERM:   "yes",
 		CREATE_FAILOVER_PERM:  "yes",
-		CREATE_INGEST_PERM:    "yes",
 		CREATE_NAMESPACE_PERM: "yes",
 		CREATE_PGADMIN_PERM:   "yes",
 		CREATE_PGBOUNCER_PERM: "yes",
@@ -141,7 +138,6 @@ func initializePerms() {
 		// DELETE
 		DELETE_BACKUP_PERM:    "yes",
 		DELETE_CLUSTER_PERM:   "yes",
-		DELETE_INGEST_PERM:    "yes",
 		DELETE_NAMESPACE_PERM: "yes",
 		DELETE_PGADMIN_PERM:   "yes",
 		DELETE_PGBOUNCER_PERM: "yes",
@@ -155,7 +151,6 @@ func initializePerms() {
 		SHOW_BACKUP_PERM:          "yes",
 		SHOW_CLUSTER_PERM:         "yes",
 		SHOW_CONFIG_PERM:          "yes",
-		SHOW_INGEST_PERM:          "yes",
 		SHOW_NAMESPACE_PERM:       "yes",
 		SHOW_PGADMIN_PERM:         "yes",
 		SHOW_PGBOUNCER_PERM:       "yes",


### PR DESCRIPTION
Of note is the "Restart" permission which was not added to the
validation list, and removing some permissions for calls that are
no longer available.

fixes #2203
closes #2201 