### PR TITLE
Update perms on deployer working directory

### DIFF
--- a/build/pgo-deployer/Dockerfile
+++ b/build/pgo-deployer/Dockerfile
@@ -79,7 +79,7 @@ ENV HOME="/tmp"
 
 RUN chmod g=u /etc/passwd
 RUN chmod g=u /uid_daemon.sh
-RUN chown -R 2:2 /tmp/.pgo/metrics
+RUN chown -R 2:2 /tmp/.pgo
 
 ENTRYPOINT ["/uid_daemon.sh"]
 


### PR DESCRIPTION
The working directory for pgo-deployer (`/tmp/.pgo`) is now created at build time
instead of install time. When building, the directory is created with `root:root`
as `user:group` meaning the installer does not have permission to create the
required sub-directories. This change recursively updates the user and group on
`/tmp/.pgo` so that the installer can make changes.