### PR TITLE
Adjust replica creation logic as part of a standby cluster

### DIFF
--- a/internal/controller/job/backresthandler.go
+++ b/internal/controller/job/backresthandler.go
@@ -139,6 +139,9 @@ func (c *Controller) handleBackrestStanzaCreateUpdate(job *apiv1.Job) error {
 			log.Debugf("job Controller: standby cluster %s will now be set to an initialized "+
 				"status", clusterName)
 			_ = controller.SetClusterInitializedStatus(c.Client, clusterName, namespace)
+
+			// now initialize the creation of any replica
+			_ = controller.InitializeReplicaCreation(c.Client, clusterName, namespace)
 			return nil
 		}
 


### PR DESCRIPTION
This ensures an explicit call of standby creation after receiving
a notification that a stanza for the cluster was successfully
created.

Co-authored-by: @andrewlecuyer 