### PR TITLE
Ensure Proper Replica Creation for Standby Clusters

### DIFF
--- a/internal/controller/job/backresthandler.go
+++ b/internal/controller/job/backresthandler.go
@@ -84,12 +84,18 @@ func (c *Controller) handleBackrestBackupUpdate(job *apiv1.Job) error {
 	if labels[config.LABEL_PGHA_BACKUP_TYPE] == crv1.BackupTypeBootstrap {
 		log.Debugf("jobController onUpdate initial backup complete")
 
-		_ = controller.SetClusterInitializedStatus(c.Client, labels[config.LABEL_PG_CLUSTER],
-			job.ObjectMeta.Namespace)
+		if err := controller.SetClusterInitializedStatus(c.Client, labels[config.LABEL_PG_CLUSTER],
+			job.ObjectMeta.Namespace); err != nil {
+			log.Error(err)
+			return err
+		}
 
-		// now initialize the creation of any replica
-		_ = controller.InitializeReplicaCreation(c.Client, labels[config.LABEL_PG_CLUSTER],
-			job.ObjectMeta.Namespace)
+		// now initialize the creation of any replicas
+		if err := controller.InitializeReplicaCreation(c.Client, labels[config.LABEL_PG_CLUSTER],
+			job.ObjectMeta.Namespace); err != nil {
+			log.Error(err)
+			return err
+		}
 
 	} else if labels[config.LABEL_PGHA_BACKUP_TYPE] == crv1.BackupTypeFailover {
 		if err := operator.RemovePrimaryOnRoleChangeTag(c.Client, c.Client.Config,
@@ -138,10 +144,18 @@ func (c *Controller) handleBackrestStanzaCreateUpdate(job *apiv1.Job) error {
 		if cluster.Spec.Standby {
 			log.Debugf("job Controller: standby cluster %s will now be set to an initialized "+
 				"status", clusterName)
-			_ = controller.SetClusterInitializedStatus(c.Client, clusterName, namespace)
+			if err := controller.SetClusterInitializedStatus(c.Client, clusterName,
+				namespace); err != nil {
+				log.Error(err)
+				return err
+			}
 
 			// now initialize the creation of any replica
-			_ = controller.InitializeReplicaCreation(c.Client, clusterName, namespace)
+			if err := controller.InitializeReplicaCreation(c.Client, clusterName,
+				namespace); err != nil {
+				log.Error(err)
+				return err
+			}
 			return nil
 		}
 

--- a/internal/controller/pod/inithandler.go
+++ b/internal/controller/pod/inithandler.go
@@ -208,15 +208,21 @@ func (c *Controller) handleStandbyInit(cluster *crv1.Pgcluster) error {
 		}
 		backrestoperator.StanzaCreate(namespace, clusterName, c.Client)
 	} else {
-		_ = controller.SetClusterInitializedStatus(c.Client, clusterName, namespace)
-	}
+		if err := controller.SetClusterInitializedStatus(c.Client, clusterName,
+			namespace); err != nil {
+			log.Error(err)
+		}
 
-	// If a standby cluster initialize the creation of any replicas.  Replicas
-	// can be initialized right away, i.e. there is no dependency on
-	// stanza-creation and/or the creation of any backups, since the replicas
-	// will be generated from the pgBackRest repository of an external PostgreSQL
-	// database (which should already exist).
-	_ = controller.InitializeReplicaCreation(c.Client, clusterName, namespace)
+		// If a standby cluster with s3 only initialize the creation of any replicas.  Replicas
+		// can be initialized right away, i.e. there is no dependency on
+		// stanza-creation and/or the creation of any backups, since the replicas
+		// will be generated from the pgBackRest repository of an external PostgreSQL
+		// database (which should already exist).
+		if err := controller.InitializeReplicaCreation(c.Client, clusterName,
+			namespace); err != nil {
+			log.Error(err)
+		}
+	}
 
 	// if this is a pgbouncer enabled cluster, add a pgbouncer
 	// Note: we only warn if we cannot create the pgBouncer, so eecution can


### PR DESCRIPTION
The operator will now only initialize replica creation prior to stanza creation if the cluster has s3-only enabled.  Otherwise replicas will be created following stanza-creation.

Additionally, the `InitializeReplicaCreation()` function (as used to trigger the creation of replicas via `pgreplica` custom resources) now uses a `Patch()` operation instead of an `Update()` operation.  This is to prevent potential conflicts when updating a `pgreplica`.

And finally, error logging has been added to add proper errors logs during standby cluster initialization.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Standby replicas do not consistently bootstrap when using `posix` and `s3` storage.

**What is the new behavior (if this is a feature change)?**

Standby replicas consistently bootstrap when using `posix` and `s3` storage.

**Other information**:

N/A