### PR TITLE
Add support for the pgBackRest `--compress-type` flag

### DIFF
--- a/internal/apiserver/backupoptions/backupoptionsutil.go
+++ b/internal/apiserver/backupoptions/backupoptionsutil.go
@@ -164,6 +164,13 @@ func isValidCompressLevel(compressLevel int) bool {
 	}
 }
 
+// isValidCompressType checks that the compression type passed in matches one
+// of the ones supported by pgBackRest. However, it presently does not support
+// `zst`
+func isValidCompressType(compressType string) bool {
+	return compressType == "gz" || compressType == "bz2" || compressType == "lz4" || compressType == "none"
+}
+
 // isValidRetentionRange validates that pgBackrest Full, Diff or Archive
 // retention option value is set within the allowable range.
 // allowed: 1-9999999

--- a/internal/apiserver/backupoptions/backupoptionsutil_test.go
+++ b/internal/apiserver/backupoptions/backupoptionsutil_test.go
@@ -1,0 +1,40 @@
+package backupoptions
+
+/*
+Copyright 2021 Crunchy Data Solutions, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import "testing"
+
+func TestIsValidCompressType(t *testing.T) {
+	tests := []struct {
+		compressType string
+		expected     bool
+	}{
+		{compressType: "bz2", expected: true},
+		{compressType: "gz", expected: true},
+		{compressType: "none", expected: true},
+		{compressType: "lz4", expected: true},
+		{compressType: "zst", expected: false},
+		{compressType: "bogus", expected: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.compressType, func(t *testing.T) {
+			if isValidCompressType(test.compressType) != test.expected {
+				t.Fatalf("expected %q to be %t", test.compressType, test.expected)
+			}
+		})
+	}
+}

--- a/internal/apiserver/backupoptions/pgbackrestoptions.go
+++ b/internal/apiserver/backupoptions/pgbackrestoptions.go
@@ -78,10 +78,9 @@ type pgBackRestBackupOptions struct {
 	NoStopAuto               bool   `flag:"no-stop-auto"`
 	BackupType               string `flag:"type"`
 	BufferSize               string `flag:"buffer-size"`
-	Compress                 bool   `flag:"compress"`
-	NoCompress               bool   `flag:"no-compress"`
 	CompressLevel            int    `flag:"compress-level"`
 	CompressLevelNetwork     int    `flag:"compress-level-network"`
+	CompressType             string `flag:"compress-type"`
 	DBTimeout                int    `flag:"db-timeout"`
 	Delta                    bool   `flag:"no-delta"`
 	ProcessMax               int    `flag:"process-max"`
@@ -108,9 +107,6 @@ type pgBackRestRestoreOptions struct {
 	TargetTimeline       int    `flag:"target-timeline"`
 	RestoreType          string `flag:"type"`
 	BufferSize           string `flag:"buffer-size"`
-	Compress             bool   `flag:"compress"`
-	NoCompress           bool   `flag:"no-compress"`
-	CompressLevel        int    `flag:"compress-level"`
 	CompressLevelNetwork int    `flag:"compress-level-network"`
 	DBTimeout            int    `flag:"db-timeout"`
 	Delta                bool   `flag:"no-delta"`
@@ -143,6 +139,11 @@ func (backRestBackupOpts pgBackRestBackupOptions) validate(setFlagFieldNames []s
 		case "CompressLevelNetwork":
 			if !isValidCompressLevel(backRestBackupOpts.CompressLevelNetwork) {
 				err := errors.New("Invalid network compress level for pgBackRest backup")
+				errstrings = append(errstrings, err.Error())
+			}
+		case "CompressType":
+			if !isValidCompressType(backRestBackupOpts.CompressType) {
+				err := errors.New("Invalid compress type for pgBackRest backup")
 				errstrings = append(errstrings, err.Error())
 			}
 		case "LogLevelConsole":
@@ -210,11 +211,6 @@ func (backRestRestoreOpts pgBackRestRestoreOptions) validate(setFlagFieldNames [
 			validRestoreTypes := []string{"default", "immediate", "name", "xid", "time", "preserve", "none"}
 			if !isValidValue(validRestoreTypes, backRestRestoreOpts.RestoreType) {
 				err := errors.New("Invalid type provided for pgBackRest restore")
-				errstrings = append(errstrings, err.Error())
-			}
-		case "CompressLevel":
-			if !isValidCompressLevel(backRestRestoreOpts.CompressLevel) {
-				err := errors.New("Invalid compress level for pgBackRest restore")
 				errstrings = append(errstrings, err.Error())
 			}
 		case "CompressLevelNetwork":


### PR DESCRIPTION
Selecting the compression type for pgBackRest is supported across
recent Postgres Operator releases, but the CLI was not allowing for
this flag to be passed through.

This allows for the selection of pgBackRest compression type amongst
the allowable methods in the container, which are none, bz2, gz, and
lz4. Currently zst does not ship within the container.

This also removes the `--compress` and `--no-compress` flags, and
removes `--compress-level` from being considered in the "restore"
command, as pgBackRest does not use that flag there.

Issue: [ch10287]