### PR TITLE
Unix socket directory and script paths update during upgrade

### DIFF
--- a/internal/operator/config/configutil.go
+++ b/internal/operator/config/configutil.go
@@ -51,9 +51,9 @@ type Syncer interface {
 	Sync() error
 }
 
-// patchConfigMapData replaces the configuration stored the configuration specified with the
+// PatchConfigMapData replaces the configuration stored the configuration specified with the
 // provided content
-func patchConfigMapData(kubeclientset kubernetes.Interface, configMap *corev1.ConfigMap,
+func PatchConfigMapData(kubeclientset kubernetes.Interface, configMap *corev1.ConfigMap,
 	configName string, content []byte) error {
 	ctx := context.TODO()
 

--- a/internal/operator/config/dcs.go
+++ b/internal/operator/config/dcs.go
@@ -148,7 +148,7 @@ func (d *DCS) Update(dcsConfig *DCSConfig) error {
 		return err
 	}
 
-	if err := patchConfigMapData(d.kubeclientset, d.configMap, d.configName, content); err != nil {
+	if err := PatchConfigMapData(d.kubeclientset, d.configMap, d.configName, content); err != nil {
 		return err
 	}
 
@@ -301,7 +301,7 @@ func (d *DCS) refresh() error {
 		return err
 	}
 
-	if err := patchConfigMapData(d.kubeclientset, d.configMap, d.configName,
+	if err := PatchConfigMapData(d.kubeclientset, d.configMap, d.configName,
 		clusterDCSBytes); err != nil {
 		return err
 	}

--- a/internal/operator/config/localdb.go
+++ b/internal/operator/config/localdb.go
@@ -48,9 +48,9 @@ var (
 	// when the script is called.
 	applyAndReloadConfigCMD []string = []string{"/opt/crunchy/bin/postgres-ha/common/pgha-reload-local.sh"}
 
-	// pghaLocalConfigName represents the name of the local configuration stored for each database
+	// PGHALocalConfigName represents the name of the local configuration stored for each database
 	// server in the "<clustername>-pgha-config" configMap, which is "<clusterName>-local-config"
-	pghaLocalConfigName = "%s-local-config"
+	PGHALocalConfigName = "%s-local-config"
 	// pghaLocalConfigSuffix is the suffix for a local server configuration
 	pghaLocalConfigSuffix = "-local-config"
 )
@@ -203,7 +203,7 @@ func (l *LocalDB) Update(configName string, localDBConfig LocalDBConfig) error {
 		return err
 	}
 
-	if err := patchConfigMapData(l.kubeclientset, l.configMap, configName, content); err != nil {
+	if err := PatchConfigMapData(l.kubeclientset, l.configMap, configName, content); err != nil {
 		return err
 	}
 
@@ -388,7 +388,7 @@ func (l *LocalDB) refresh(configName string) error {
 		return err
 	}
 
-	if err := patchConfigMapData(l.kubeclientset, l.configMap, configName,
+	if err := PatchConfigMapData(l.kubeclientset, l.configMap, configName,
 		localConfigYAML); err != nil {
 		return err
 	}
@@ -418,7 +418,7 @@ func GetLocalDBConfigNames(kubeclientset kubernetes.Interface, clusterName,
 
 	localConfigNames := make([]string, len(dbDeploymentList.Items))
 	for i, deployment := range dbDeploymentList.Items {
-		localConfigNames[i] = fmt.Sprintf(pghaLocalConfigName, deployment.GetName())
+		localConfigNames[i] = fmt.Sprintf(PGHALocalConfigName, deployment.GetName())
 	}
 
 	return localConfigNames, nil


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
The unix socket directory and script paths stored in the existing
configmaps after an upgrade are referencing directories that 
are no longer in use.


**What is the new behavior (if this is a feature change)?**
This update set the unix_socket_directories parameter
in the PG configuration to /tmp.
    
This is done to ensure any existing references to the /crunchyadm
directory are no longer set in the PG configuration when a cluster
is upgraded.
    
As this value is stored in the DCS according to the key/value pairs
defined in the PG configmap, it is corrected by updating the
<clusterName>-pgha-config ConfigMap to no longer reference the
removed directory.
    
Similarly, any existing references to scripts in the previous
/opt/cpm paths stored in existing configmaps will be updated and
synchronized with the DCS to the current /opt/crunchy paths currently
defined in the associated containers.


**Other information**:

Issue: [ch10283]
fixes #2239