### PR TITLE
Clean Stanza Create pgtask & Job After Cluster Initialization

### DIFF
--- a/internal/controller/job/backresthandler.go
+++ b/internal/controller/job/backresthandler.go
@@ -167,8 +167,11 @@ func (c *Controller) handleBackrestStanzaCreateUpdate(job *apiv1.Job) error {
 			return err
 		}
 
-		_, _ = backrest.CreateInitialBackup(c.Client, job.ObjectMeta.Namespace,
-			clusterName, backrestRepoPodName)
+		if _, err := backrest.CreateInitialBackup(c.Client, job.ObjectMeta.Namespace,
+			clusterName, backrestRepoPodName); err != nil {
+			log.Error(err)
+			return err
+		}
 
 		// now that the initial backup has been initiated, proceed with deleting the stanza-create
 		// pgtask and associated Job.  This will ensure any subsequent updates to the stanza-create

--- a/internal/controller/job/backresthandler.go
+++ b/internal/controller/job/backresthandler.go
@@ -170,6 +170,14 @@ func (c *Controller) handleBackrestStanzaCreateUpdate(job *apiv1.Job) error {
 		_, _ = backrest.CreateInitialBackup(c.Client, job.ObjectMeta.Namespace,
 			clusterName, backrestRepoPodName)
 
+		// now that the initial backup has been initiated, proceed with deleting the stanza-create
+		// pgtask and associated Job.  This will ensure any subsequent updates to the stanza-create
+		// Job do not trigger more initial backup Jobs.
+		if err := backrest.CleanStanzaCreateResources(namespace, clusterName, c.Client); err != nil {
+			log.Error(err)
+			return err
+		}
+
 	}
 	return nil
 }


### PR DESCRIPTION
When a PostgreSQL cluster is initialized for the first time, the stanza create pgtask and the Kubernetes Job associated with it are now automatically deleted.  This ensures that subsequent update events in the Job controller for a stanza-create Job do not trigger additional "initial backup" Jobs for the cluster.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

In OpenShift 3.11, periodic update events are sent to the Job controller for all Jobs, which can trigger the automated full backup that is typically only run once during PostgreSQL cluster initialization.

Issue: [ch10277]
fixes #2106

**What is the new behavior (if this is a feature change)?**

The stanza create Job is removed when successfully completed, preventing any subsequent Job update events from triggering a full backup for the cluster.

**Other information**:

N/A