### PR TITLE
Update restore e2e test

### DIFF
--- a/testing/pgo_cli/cluster_backup_test.go
+++ b/testing/pgo_cli/cluster_backup_test.go
@@ -168,7 +168,7 @@ func TestClusterBackup(t *testing.T) {
 		})
 
 		t.Run("restore", func(t *testing.T) {
-			t.Run("replaces the cluster", func(t *testing.T) {
+			t.Run("keeps existing pvc", func(t *testing.T) {
 				t.Parallel()
 				withCluster(t, namespace, func(cluster func() string) {
 					requireClusterReady(t, namespace(), cluster(), time.Minute)
@@ -195,10 +195,10 @@ func TestClusterBackup(t *testing.T) {
 						after := clusterPVCs(t, namespace(), cluster())
 						for _, pvc := range after {
 							// check to see if the PVC for the primary is bound, and has a timestamp
-							// after the original timestamp for the primary PVC timestamp captured above,
-							// indicating that it been re-created
+							// equal to the original timestamp for the primary PVC timestamp captured above,
+							// indicating that it has not been re-created
 							if pvc.GetName() == cluster() && kubeapi.IsPVCBound(pvc) &&
-								pvc.GetCreationTimestamp().Time.After(primaryPVCCreationTimestamp) {
+								pvc.GetCreationTimestamp().Time.Equal(primaryPVCCreationTimestamp) {
 								return true
 							}
 						}


### PR DESCRIPTION
Restores now keep the original pvc and perform a delta restore instead of
re-creating the pvc and running a full restore. This test was checking to
confirm that the pvc was re-created as part of the restore process. Since the
original pvc is not re-created, we should now check that the creation time for
the cluster pvc pre-restore and post-restore is the same.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
_The updated test passed using the default installation of the operator on a gke cluster._


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently the test is checking that the pvc is re-created during a restore and failing when it isn't.


**What is the new behavior (if this is a feature change)?**
The test now checks that the creation time for the pvc being used post-restore matches the pre-restore creation time.


**Other information**:
[ch10250]