### PR TITLE
Existence check for primary Deployment before scaling

### DIFF
--- a/internal/operator/cluster/clusterlogic.go
+++ b/internal/operator/cluster/clusterlogic.go
@@ -143,13 +143,13 @@ func addClusterDeployments(clientset kubeapi.Interface,
 	deploymentFields := getClusterDeploymentFields(clientset, cl,
 		dataVolume, tablespaceVolumes)
 
+	if operator.CRUNCHY_DEBUG {
+		_ = config.DeploymentTemplate.Execute(os.Stdout, deploymentFields)
+	}
+
 	var primaryDoc bytes.Buffer
 	if err := config.DeploymentTemplate.Execute(&primaryDoc, deploymentFields); err != nil {
 		return err
-	}
-
-	if operator.CRUNCHY_DEBUG {
-		_ = config.DeploymentTemplate.Execute(os.Stdout, deploymentFields)
 	}
 
 	deployment := &appsv1.Deployment{}


### PR DESCRIPTION
During the cluster initialization process, there is a step where
the Deployment object representing the primary is explicitly
scaled from 0 to 1 Pods. However, there is a case that may
trigger the Deployment scaling before the Deployment is created.
As such, we can add a guard to check that the Deployment is
actually created before proceeding with the scaling operation.

This patch also modifies a debug line around the cluster
Deployment creation, as the debug output came after the
point at which the code may have exited due to error.