### PR TITLE
Modify check for primary before taking backup

### DIFF
--- a/internal/apiserver/backrestservice/backrestimpl.go
+++ b/internal/apiserver/backrestservice/backrestimpl.go
@@ -205,10 +205,9 @@ func CreateBackup(request *msgs.CreateBackrestBackupRequest, ns, pgouser string)
 		}
 
 		// check if primary is ready
-		if err := isPrimaryReady(cluster, ns); err != nil {
-			log.Error(err)
+		if !isPrimaryReady(cluster) {
 			resp.Status.Code = msgs.Error
-			resp.Status.Msg = err.Error()
+			resp.Status.Msg = "primary pod is not in Ready state"
 			return resp
 		}
 
@@ -342,49 +341,29 @@ func getBackrestRepoPodName(cluster *crv1.Pgcluster) (string, error) {
 	return repopodName, err
 }
 
-func isPrimary(pod *v1.Pod, clusterName string) bool {
-	return pod.ObjectMeta.Labels[config.LABEL_SERVICE_NAME] == clusterName
-}
-
-func isReady(pod *v1.Pod) bool {
-	readyCount := 0
-	containerCount := 0
-	for _, stat := range pod.Status.ContainerStatuses {
-		containerCount++
-		if stat.Ready {
-			readyCount++
-		}
-	}
-
-	return readyCount == containerCount
-}
-
 // isPrimaryReady goes through the pod list to first identify the
 // Primary pod and, once identified, determine if it is in a
 // ready state. If not, it returns an error, otherwise it returns
 // a nil value
-func isPrimaryReady(cluster *crv1.Pgcluster, ns string) error {
+func isPrimaryReady(cluster *crv1.Pgcluster) bool {
 	ctx := context.TODO()
-	primaryReady := false
 
-	selector := fmt.Sprintf("%s=%s,%s=%s", config.LABEL_PG_CLUSTER, cluster.Name,
-		config.LABEL_PGHA_ROLE, config.LABEL_PGHA_ROLE_PRIMARY)
+	options := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("status.phase", string(v1.PodRunning)).String(),
+		LabelSelector: fields.AndSelectors(
+			fields.OneTermEqualSelector(config.LABEL_PG_CLUSTER, cluster.Name),
+			fields.OneTermEqualSelector(config.LABEL_PGHA_ROLE, config.LABEL_PGHA_ROLE_PRIMARY),
+		).String(),
+	}
 
-	pods, err := apiserver.Clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	pods, err := apiserver.Clientset.CoreV1().Pods(cluster.Namespace).List(ctx, options)
+
 	if err != nil {
-		return err
-	}
-	for i := range pods.Items {
-		p := &pods.Items[i]
-		if isPrimary(p, cluster.Spec.Name) && isReady(p) {
-			primaryReady = true
-		}
+		log.Error(err)
+		return false
 	}
 
-	if !primaryReady {
-		return errors.New("primary pod is not in Ready state")
-	}
-	return nil
+	return len(pods.Items) > 0
 }
 
 // ShowBackrest ...


### PR DESCRIPTION
This was using a legacy method and is now modified to use
the method used by other Operator operations to check for
both the primary cluster and its availability.

closes #2272