### PR TITLE
Allow for the existence of no labels when creating a cluster

### DIFF
--- a/internal/apiserver/common.go
+++ b/internal/apiserver/common.go
@@ -155,6 +155,11 @@ func IsValidPVC(pvcName, ns string) bool {
 func ValidateLabel(labelStr string) (map[string]string, error) {
 	labelMap := map[string]string{}
 
+	// if this is an empty string, return
+	if strings.TrimSpace(labelStr) == "" {
+		return labelMap, nil
+	}
+
 	for _, v := range strings.Split(labelStr, ",") {
 		pair := strings.Split(v, "=")
 		if len(pair) != 2 {

--- a/internal/apiserver/common_test.go
+++ b/internal/apiserver/common_test.go
@@ -72,12 +72,17 @@ func TestValidateLabel(t *testing.T) {
 			map[string]string{"key": "value"},
 			map[string]string{"example.com/key": "value"},
 			map[string]string{"key1": "value1", "key2": "value2"},
+			map[string]string{"": ""},
 		}
 
 		for _, input := range inputs {
 			labelStr := ""
 
 			for k, v := range input {
+				if k == "" && v == "" {
+					continue
+				}
+
 				labelStr += fmt.Sprintf("%s=%s,", k, v)
 			}
 


### PR DESCRIPTION
This fell on the trap of the "empty string being split", which
by default creates a single entry in an array. As an empty string
is not a valid label, this would fail on the default command.