### PR TITLE
Security context modifications

### DIFF
--- a/deploy/deployment.json
+++ b/deploy/deployment.json
@@ -33,7 +33,8 @@
                         "image": "$PGO_IMAGE_PREFIX/pgo-apiserver:$PGO_IMAGE_TAG",
                         "imagePullPolicy": "IfNotPresent",
                         "securityContext": {
-                          "allowPrivilegeEscalation": false
+                          "allowPrivilegeEscalation": false,
+                          "readOnlyRootFilesystem": true
                         },
                         "ports": [
                             { "containerPort": $PGO_APISERVER_PORT }
@@ -110,13 +111,19 @@
                                 "value": "localhost:4150"
                             }
                         ],
-                        "volumeMounts": []
+                        "volumeMounts": [
+                          {
+                            "mountPath": "/tmp",
+                            "name": "tmp"
+                          }
+                        ]
                     }, {
                         "name": "operator",
                         "image": "$PGO_IMAGE_PREFIX/postgres-operator:$PGO_IMAGE_TAG",
                         "imagePullPolicy": "IfNotPresent",
                         "securityContext": {
-                          "allowPrivilegeEscalation": false
+                          "allowPrivilegeEscalation": false,
+                          "readOnlyRootFilesystem": true
                         },
                         "readinessProbe": {
                             "exec": {
@@ -171,7 +178,8 @@
                         "name": "scheduler",
                         "image": "$PGO_IMAGE_PREFIX/pgo-scheduler:$PGO_IMAGE_TAG",
                         "securityContext": {
-                          "allowPrivilegeEscalation": false
+                          "allowPrivilegeEscalation": false,
+                          "readOnlyRootFilesystem": true
                         },
                         "livenessProbe": {
                             "exec": {
@@ -215,14 +223,20 @@
                                 "value": "localhost:4150"
                             }
                         ],
-                        "volumeMounts": [],
+                        "volumeMounts": [
+                          {
+                            "mountPath": "/tmp",
+                            "name": "tmp"
+                          }
+                        ],
                         "imagePullPolicy": "IfNotPresent"
                     },
                     {
                         "name": "event",
                         "image": "$PGO_IMAGE_PREFIX/pgo-event:$PGO_IMAGE_TAG",
                         "securityContext": {
-                          "allowPrivilegeEscalation": false
+                          "allowPrivilegeEscalation": false,
+                          "readOnlyRootFilesystem": true
                         },
                         "livenessProbe": {
                             "httpGet": {
@@ -238,11 +252,24 @@
                                 "value": "3600"
                             }
                         ],
-                        "volumeMounts": [],
+                        "volumeMounts": [
+                          {
+                            "mountPath": "/tmp",
+                            "name": "tmp"
+                          }
+                        ],
                         "imagePullPolicy": "IfNotPresent"
                     }
                 ],
-                "volumes": []
+                "volumes": [
+                  {
+                    "name": "tmp",
+                    "emptyDir": {
+                      "medium": "Memory",
+                      "sizeLimit": "16Mi"
+                    }
+                  }
+                ]
             }
         }
     }

--- a/deploy/deployment.json
+++ b/deploy/deployment.json
@@ -34,6 +34,7 @@
                         "imagePullPolicy": "IfNotPresent",
                         "securityContext": {
                           "allowPrivilegeEscalation": false,
+                          "privileged": false,
                           "readOnlyRootFilesystem": true
                         },
                         "ports": [
@@ -123,6 +124,7 @@
                         "imagePullPolicy": "IfNotPresent",
                         "securityContext": {
                           "allowPrivilegeEscalation": false,
+                          "privileged": false,
                           "readOnlyRootFilesystem": true
                         },
                         "readinessProbe": {
@@ -179,6 +181,7 @@
                         "image": "$PGO_IMAGE_PREFIX/pgo-scheduler:$PGO_IMAGE_TAG",
                         "securityContext": {
                           "allowPrivilegeEscalation": false,
+                          "privileged": false,
                           "readOnlyRootFilesystem": true
                         },
                         "livenessProbe": {
@@ -236,6 +239,7 @@
                         "image": "$PGO_IMAGE_PREFIX/pgo-event:$PGO_IMAGE_TAG",
                         "securityContext": {
                           "allowPrivilegeEscalation": false,
+                          "privileged": false,
                           "readOnlyRootFilesystem": true
                         },
                         "livenessProbe": {

--- a/deploy/deployment.json
+++ b/deploy/deployment.json
@@ -24,6 +24,9 @@
             },
             "spec": {
                 "serviceAccountName": "postgres-operator",
+                "securityContext": {
+                  "runAsNonRoot": true
+                },
                 "containers": [
                     {
                         "name": "apiserver",

--- a/deploy/deployment.json
+++ b/deploy/deployment.json
@@ -32,6 +32,9 @@
                         "name": "apiserver",
                         "image": "$PGO_IMAGE_PREFIX/pgo-apiserver:$PGO_IMAGE_TAG",
                         "imagePullPolicy": "IfNotPresent",
+                        "securityContext": {
+                          "allowPrivilegeEscalation": false
+                        },
                         "ports": [
                             { "containerPort": $PGO_APISERVER_PORT }
                         ],
@@ -112,6 +115,9 @@
                         "name": "operator",
                         "image": "$PGO_IMAGE_PREFIX/postgres-operator:$PGO_IMAGE_TAG",
                         "imagePullPolicy": "IfNotPresent",
+                        "securityContext": {
+                          "allowPrivilegeEscalation": false
+                        },
                         "readinessProbe": {
                             "exec": {
                                 "command": [
@@ -164,6 +170,9 @@
                     }, {
                         "name": "scheduler",
                         "image": "$PGO_IMAGE_PREFIX/pgo-scheduler:$PGO_IMAGE_TAG",
+                        "securityContext": {
+                          "allowPrivilegeEscalation": false
+                        },
                         "livenessProbe": {
                             "exec": {
                                 "command": [
@@ -212,6 +221,9 @@
                     {
                         "name": "event",
                         "image": "$PGO_IMAGE_PREFIX/pgo-event:$PGO_IMAGE_TAG",
+                        "securityContext": {
+                          "allowPrivilegeEscalation": false
+                        },
                         "livenessProbe": {
                             "httpGet": {
                                 "path": "/ping",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
@@ -35,6 +35,9 @@
                 "containers": [{
                     "name": "backrest",
                     "image": "{{.CCPImagePrefix}}/crunchy-pgbackrest:{{.CCPImageTag}}",
+                    "securityContext": {
+                      "allowPrivilegeEscalation": false
+                    },
                     "volumeMounts": [
                         {{.PgbackrestRestoreVolumeMounts}}
                     ],

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
@@ -25,6 +25,13 @@
             },
             "spec": {
                 "volumes": [
+                    {
+                      "name": "tmp",
+                      "emptyDir": {
+                        "medium": "Memory",
+                        "sizeLimit": "16Mi"
+                      }
+                    }{{ if .PgbackrestRestoreVolumes }},{{ end }}
                     {{.PgbackrestRestoreVolumes}}
                 ],
                 "securityContext": {{.SecurityContext}},
@@ -36,9 +43,14 @@
                     "name": "backrest",
                     "image": "{{.CCPImagePrefix}}/crunchy-pgbackrest:{{.CCPImageTag}}",
                     "securityContext": {
-                      "allowPrivilegeEscalation": false
+                      "allowPrivilegeEscalation": false,
+                      "readOnlyRootFilesystem": true
                     },
                     "volumeMounts": [
+                        {
+                            "mountPath": "/tmp",
+                            "name": "tmp"
+                        }{{ if .PgbackrestRestoreVolumeMounts }},{{ end }}
                         {{.PgbackrestRestoreVolumeMounts}}
                     ],
                     "env": [{

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/backrest-job.json
@@ -44,6 +44,7 @@
                     "image": "{{.CCPImagePrefix}}/crunchy-pgbackrest:{{.CCPImageTag}}",
                     "securityContext": {
                       "allowPrivilegeEscalation": false,
+                      "privileged": false,
                       "readOnlyRootFilesystem": true
                     },
                     "volumeMounts": [

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
@@ -30,7 +30,8 @@
                     "name": "database",
                     "image": "{{.CCPImagePrefix}}/{{.CCPImage}}:{{.CCPImageTag}}",
                     "securityContext": {
-                      "allowPrivilegeEscalation": false
+                      "allowPrivilegeEscalation": false,
+                      "readOnlyRootFilesystem": true
                     },
                     {{.ContainerResources}}
                     "env": [{
@@ -137,6 +138,14 @@
                     }, {
                         "mountPath": "/dev/shm",
                         "name": "dshm"
+                    },
+                    {
+                        "mountPath": "/tmp",
+                        "name": "tmp"
+                    },
+                    {
+                        "mountPath": "/var/lib/pgsql/.ssh",
+                        "name": "pgbackrest-ssh"
                     }, {
                         "mountPath": "/etc/pgbackrest/conf.d",
                         "name": "pgbackrest-config"
@@ -168,6 +177,13 @@
                     "secret": {
                         "secretName": "{{.RestoreFrom}}-backrest-repo-config"
                     }
+                },
+                {
+                  "name": "pgbackrest-ssh",
+                  "emptyDir": {
+                    "medium": "Memory",
+                    "sizeLimit": "128Ki"
+                  }
                 },
                 {{if .TLSEnabled}}
                 {
@@ -218,6 +234,13 @@
                             }
                         ]
                     }
+                },
+                {
+                  "name": "tmp",
+                  "emptyDir": {
+                    "medium": "Memory",
+                    "sizeLimit": "16Mi"
+                  }
                 }
                 {{.TablespaceVolumes}}],
                 "affinity": {

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
@@ -31,6 +31,7 @@
                     "image": "{{.CCPImagePrefix}}/{{.CCPImage}}:{{.CCPImageTag}}",
                     "securityContext": {
                       "allowPrivilegeEscalation": false,
+                      "privileged": false,
                       "readOnlyRootFilesystem": true
                     },
                     {{.ContainerResources}}

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
@@ -29,6 +29,9 @@
                 "containers": [{
                     "name": "database",
                     "image": "{{.CCPImagePrefix}}/{{.CCPImage}}:{{.CCPImageTag}}",
+                    "securityContext": {
+                      "allowPrivilegeEscalation": false
+                    },
                     {{.ContainerResources}}
                     "env": [{
                         "name": "PGHA_PG_PORT",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -43,7 +43,8 @@
                     "name": "database",
                     "image": "{{.CCPImagePrefix}}/{{.CCPImage}}:{{.CCPImageTag}}",
                     "securityContext": {
-                      "allowPrivilegeEscalation": false
+                      "allowPrivilegeEscalation": false,
+                      "readOnlyRootFilesystem": true
                     },
                     "readinessProbe": {
                         "exec": {
@@ -191,6 +192,14 @@
                         {
                             "mountPath": "/etc/podinfo",
                             "name": "podinfo"
+                        },
+                        {
+                            "mountPath": "/tmp",
+                            "name": "tmp"
+                        },
+                        {
+                            "mountPath": "/var/lib/pgsql/.ssh",
+                            "name": "pgbackrest-ssh"
                         }
                         {{.TablespaceVolumeMounts}}
                     ],
@@ -292,6 +301,20 @@
                       "name": "dshm",
                       "emptyDir": {
                         "medium": "Memory"
+                      }
+                    },
+                    {
+                      "name": "tmp",
+                      "emptyDir": {
+                        "medium": "Memory",
+                        "sizeLimit": "16Mi"
+                      }
+                    },
+                    {
+                      "name": "pgbackrest-ssh",
+                      "emptyDir": {
+                        "medium": "Memory",
+                        "sizeLimit": "128Ki"
                       }
                     },
                     {

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -44,6 +44,7 @@
                     "image": "{{.CCPImagePrefix}}/{{.CCPImage}}:{{.CCPImageTag}}",
                     "securityContext": {
                       "allowPrivilegeEscalation": false,
+                      "privileged": false,
                       "readOnlyRootFilesystem": true
                     },
                     "readinessProbe": {

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-deployment.json
@@ -42,6 +42,9 @@
             {
                     "name": "database",
                     "image": "{{.CCPImagePrefix}}/{{.CCPImage}}:{{.CCPImageTag}}",
+                    "securityContext": {
+                      "allowPrivilegeEscalation": false
+                    },
                     "readinessProbe": {
                         "exec": {
                             "command": [

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/exporter.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/exporter.json
@@ -2,7 +2,8 @@
     "name": "exporter",
     "image": "{{.PGOImagePrefix}}/crunchy-postgres-exporter:{{.PGOImageTag}}",
     "securityContext": {
-      "allowPrivilegeEscalation": false
+      "allowPrivilegeEscalation": false,
+      "readOnlyRootFilesystem": true
     },
     "ports": [{
         "containerPort": {{.ExporterPort}},
@@ -52,5 +53,11 @@
               }
             }
           }
+    ],
+    "volumeMounts": [
+      {
+        "mountPath": "/tmp",
+        "name": "tmp"
+      }
     ]
 }

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/exporter.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/exporter.json
@@ -3,6 +3,7 @@
     "image": "{{.PGOImagePrefix}}/crunchy-postgres-exporter:{{.PGOImageTag}}",
     "securityContext": {
       "allowPrivilegeEscalation": false,
+      "privileged": false,
       "readOnlyRootFilesystem": true
     },
     "ports": [{

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/exporter.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/exporter.json
@@ -1,6 +1,9 @@
 {
     "name": "exporter",
     "image": "{{.PGOImagePrefix}}/crunchy-postgres-exporter:{{.PGOImageTag}}",
+    "securityContext": {
+      "allowPrivilegeEscalation": false
+    },
     "ports": [{
         "containerPort": {{.ExporterPort}},
         "protocol": "TCP"

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgadmin-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgadmin-template.json
@@ -45,6 +45,7 @@
           "image": "{{.CCPImagePrefix}}/crunchy-pgadmin4:{{.CCPImageTag}}",
           "securityContext": {
             "allowPrivilegeEscalation": false,
+            "privileged": false,
             "readOnlyRootFilesystem": true
           },
           "ports": [{

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgadmin-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgadmin-template.json
@@ -43,6 +43,9 @@
         "containers": [{
           "name": "pgadminweb",
           "image": "{{.CCPImagePrefix}}/crunchy-pgadmin4:{{.CCPImageTag}}",
+          "securityContext": {
+            "allowPrivilegeEscalation": false
+          },
           "ports": [{
             "containerPort": {{.Port}},
             "protocol": "TCP"

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgadmin-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgadmin-template.json
@@ -44,7 +44,8 @@
           "name": "pgadminweb",
           "image": "{{.CCPImagePrefix}}/crunchy-pgadmin4:{{.CCPImageTag}}",
           "securityContext": {
-            "allowPrivilegeEscalation": false
+            "allowPrivilegeEscalation": false,
+            "readOnlyRootFilesystem": true
           },
           "ports": [{
             "containerPort": {{.Port}},
@@ -58,12 +59,37 @@
             "value": "{{.InitPass}}"
           }],
           "volumeMounts": [{
+              "name": "tmp",
+              "mountPath": "/tmp"
+            },
+            {
+              "name": "pgadmin-log",
+              "mountPath": "/var/log/pgadmin"
+            },
+            {
+              "name": "tmp",
+              "mountPath": "/etc/httpd/run"
+            },
+            {
             "name": "pgadmin-datadir",
-            "mountPath": "/var/lib/pgadmin",
-            "readOnly": false
-          }]
+            "mountPath": "/var/lib/pgadmin"
+            }]
         }],
         "volumes": [{
+            "name": "tmp",
+            "emptyDir": {
+              "medium": "Memory",
+              "sizeLimit": "16Mi"
+            }
+          },
+          {
+            "name": "pgadmin-log",
+            "emptyDir": {
+              "medium": "Memory",
+              "sizeLimit": "16Mi"
+            }
+          },
+          {
           "name": "pgadmin-datadir",
           "persistentVolumeClaim": {
             "claimName": "{{.PVCName}}"

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgadmin-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgadmin-template.json
@@ -34,11 +34,12 @@
       },
       "spec": {
         "serviceAccountName": "pgo-default",
-        {{ if not .DisableFSGroup }}
         "securityContext": {
-          "fsGroup": 2
+          {{ if not .DisableFSGroup }}
+          "fsGroup": 2,
+          {{ end }}
+          "runAsNonRoot": true
         },
-        {{ end }}
         "containers": [{
           "name": "pgadminweb",
           "image": "{{.CCPImagePrefix}}/crunchy-pgadmin4:{{.CCPImageTag}}",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbadger.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbadger.json
@@ -2,7 +2,8 @@
     "name": "pgbadger",
     "image": "{{.CCPImagePrefix}}/crunchy-pgbadger:{{.CCPImageTag}}",
     "securityContext": {
-        "allowPrivilegeEscalation": false
+        "allowPrivilegeEscalation": false,
+        "readOnlyRootFilesystem": true
     },
     "ports": [ {
             "containerPort": {{.PGBadgerPort}},
@@ -30,6 +31,10 @@
       }
     },
     "volumeMounts": [
+        {
+            "mountPath": "/tmp",
+            "name": "tmp"
+        },
         {
             "mountPath": "/pgdata",
             "name": "pgdata",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbadger.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbadger.json
@@ -1,6 +1,9 @@
 {
     "name": "pgbadger",
     "image": "{{.CCPImagePrefix}}/crunchy-pgbadger:{{.CCPImageTag}}",
+    "securityContext": {
+        "allowPrivilegeEscalation": false
+    },
     "ports": [ {
             "containerPort": {{.PGBadgerPort}},
             "protocol": "TCP"

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbadger.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbadger.json
@@ -3,6 +3,7 @@
     "image": "{{.CCPImagePrefix}}/crunchy-pgbadger:{{.CCPImageTag}}",
     "securityContext": {
         "allowPrivilegeEscalation": false,
+        "privileged": false,
         "readOnlyRootFilesystem": true
     },
     "ports": [ {

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
@@ -49,7 +49,8 @@
                     "name": "pgbouncer",
                     "image": "{{.CCPImagePrefix}}/crunchy-pgbouncer:{{.CCPImageTag}}",
                     "securityContext": {
-                      "allowPrivilegeEscalation": false
+                      "allowPrivilegeEscalation": false,
+                      "readOnlyRootFilesystem": true
                     },
                     "ports": [{
                         "containerPort": {{.Port}},
@@ -69,6 +70,10 @@
                         "value": "{{.PrimaryServiceName}}"
                     }],
                     "volumeMounts": [
+                      {
+                          "mountPath": "/tmp",
+                          "name": "tmp"
+                      },
                       {{if .TLSEnabled}}
                       {
                         "mountPath": "/pgconf/tls/pgbouncer",
@@ -83,6 +88,13 @@
                     ]
                 }],
                 "volumes": [
+                  {
+                    "name": "tmp",
+                    "emptyDir": {
+                      "medium": "Memory",
+                      "sizeLimit": "1Mi"
+                    }
+                  },
                   {{if .TLSEnabled}}
                   {
                     "name": "tls-pgbouncer",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
@@ -48,6 +48,9 @@
                 "containers": [{
                     "name": "pgbouncer",
                     "image": "{{.CCPImagePrefix}}/crunchy-pgbouncer:{{.CCPImageTag}}",
+                    "securityContext": {
+                      "allowPrivilegeEscalation": false
+                    },
                     "ports": [{
                         "containerPort": {{.Port}},
                         "protocol": "TCP"

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
@@ -50,6 +50,7 @@
                     "image": "{{.CCPImagePrefix}}/crunchy-pgbouncer:{{.CCPImageTag}}",
                     "securityContext": {
                       "allowPrivilegeEscalation": false,
+                      "privileged": false,
                       "readOnlyRootFilesystem": true
                     },
                     "ports": [{

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgbouncer-template.json
@@ -39,11 +39,12 @@
             },
             "spec": {
                 "serviceAccountName": "pgo-default",
-                {{ if not .DisableFSGroup }}
                 "securityContext": {
-                  "fsGroup": 2
+                  {{ if not .DisableFSGroup }}
+                  "fsGroup": 2,
+                  {{ end }}
+                  "runAsNonRoot": true
                 },
-                {{ end }}
                 "containers": [{
                     "name": "pgbouncer",
                     "image": "{{.CCPImagePrefix}}/crunchy-pgbouncer:{{.CCPImageTag}}",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgdump-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgdump-job.json
@@ -46,6 +46,7 @@
                         "image": "{{.CCPImagePrefix}}/crunchy-postgres-ha:{{.CCPImageTag}}",
                         "securityContext": {
                           "allowPrivilegeEscalation": false,
+                          "privileged": false,
                           "readOnlyRootFilesystem": true
                         },
                         "command": ["/opt/crunchy/bin/uid_postgres.sh"],

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgdump-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgdump-job.json
@@ -37,6 +37,9 @@
                 "containers": [{
                         "name": "pgdump",
                         "image": "{{.CCPImagePrefix}}/crunchy-postgres-ha:{{.CCPImageTag}}",
+                        "securityContext": {
+                          "allowPrivilegeEscalation": false
+                        },
                         "command": ["/opt/crunchy/bin/uid_postgres.sh"],
                         "args": ["/opt/crunchy/bin/start.sh"],
                         "volumeMounts": [

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgdump-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgdump-job.json
@@ -23,6 +23,13 @@
             "spec": {
                 "volumes": [
                     {
+                        "name": "tmp",
+                        "emptyDir": {
+                          "medium": "Memory",
+                          "sizeLimit": "1Mi"
+                        }
+                    },
+                    {
                         "name": "pgdata",
                         "persistentVolumeClaim": {
                             "claimName": "{{.PgDumpPVC}}"
@@ -38,15 +45,19 @@
                         "name": "pgdump",
                         "image": "{{.CCPImagePrefix}}/crunchy-postgres-ha:{{.CCPImageTag}}",
                         "securityContext": {
-                          "allowPrivilegeEscalation": false
+                          "allowPrivilegeEscalation": false,
+                          "readOnlyRootFilesystem": true
                         },
                         "command": ["/opt/crunchy/bin/uid_postgres.sh"],
                         "args": ["/opt/crunchy/bin/start.sh"],
                         "volumeMounts": [
                             {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
                                 "mountPath": "/pgdata",
-                                "name": "pgdata",
-                                "readOnly": false
+                                "name": "pgdata"
                             }
                         ],
                         "env": [

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
@@ -53,7 +53,8 @@
                     "name": "database",
                     "image": "{{.CCPImagePrefix}}/crunchy-pgbackrest-repo:{{.CCPImageTag}}",
                     "securityContext": {
-                      "allowPrivilegeEscalation": false
+                      "allowPrivilegeEscalation": false,
+                      "readOnlyRootFilesystem": true
                     },
                     "ports": [{
                         "containerPort": {{.SshdPort}},
@@ -103,7 +104,20 @@
                         "name": "backrestrepo",
                         "mountPath": "/backrestrepo",
                         "readOnly": false
-                    }]
+                    },
+                    {
+                      "name": "tmp",
+                      "mountPath": "/tmp"
+                    },
+                    {
+                      "name": "pgbackrest-home",
+                      "mountPath": "/home/pgbackrest"
+                    },
+                    {
+                      "name": "pgbackrest-conf",
+                      "mountPath": "/etc/pgbackrest"
+                    }
+                  ]
                 }],
                 "volumes": [{
                     "name": "sshd",
@@ -115,6 +129,27 @@
                     "persistentVolumeClaim": {
                         "claimName": "{{.BackrestRepoClaimName}}"
                     }
+                },
+                {
+                  "name": "tmp",
+                  "emptyDir": {
+                    "medium": "Memory",
+                    "sizeLimit": "64Mi"
+                  }
+                },
+                {
+                  "name": "pgbackrest-home",
+                  "emptyDir": {
+                    "medium": "Memory",
+                    "sizeLimit": "128Ki"
+                  }
+                },
+                {
+                  "name": "pgbackrest-conf",
+                  "emptyDir": {
+                    "medium": "Memory",
+                    "sizeLimit": "128Ki"
+                  }
                 }],
                 "affinity": {
         {{.PodAntiAffinity}}

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
@@ -54,6 +54,7 @@
                     "image": "{{.CCPImagePrefix}}/crunchy-pgbackrest-repo:{{.CCPImageTag}}",
                     "securityContext": {
                       "allowPrivilegeEscalation": false,
+                      "privileged": false,
                       "readOnlyRootFilesystem": true
                     },
                     "ports": [{

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
@@ -52,6 +52,9 @@
                 "containers": [{
                     "name": "database",
                     "image": "{{.CCPImagePrefix}}/crunchy-pgbackrest-repo:{{.CCPImageTag}}",
+                    "securityContext": {
+                      "allowPrivilegeEscalation": false
+                    },
                     "ports": [{
                         "containerPort": {{.SshdPort}},
                         "protocol": "TCP"

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
@@ -32,7 +32,8 @@
                         "name": "sqlrunner",
                         "image": "{{.CCPImagePrefix}}/crunchy-postgres-ha:{{.CCPImageTag}}",
                         "securityContext": {
-                          "allowPrivilegeEscalation": false
+                          "allowPrivilegeEscalation": false,
+                          "readOnlyRootFilesystem": true
                         },
                         "command": ["/opt/crunchy/bin/uid_postgres.sh"],
                         "args": ["/opt/crunchy/bin/start.sh"],

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
@@ -33,6 +33,7 @@
                         "image": "{{.CCPImagePrefix}}/crunchy-postgres-ha:{{.CCPImageTag}}",
                         "securityContext": {
                           "allowPrivilegeEscalation": false,
+                          "privileged": false,
                           "readOnlyRootFilesystem": true
                         },
                         "command": ["/opt/crunchy/bin/uid_postgres.sh"],

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
@@ -21,6 +21,9 @@
             },
             "spec": {
                 "serviceAccountName": "pgo-default",
+                "securityContext": {
+                  "runAsNonRoot": true
+                },
                 {{ if .Tolerations }}
                 "tolerations": {{ .Tolerations }},
                 {{ end }}

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo.sqlrunner-template.json
@@ -31,6 +31,9 @@
                     {
                         "name": "sqlrunner",
                         "image": "{{.CCPImagePrefix}}/crunchy-postgres-ha:{{.CCPImageTag}}",
+                        "securityContext": {
+                          "allowPrivilegeEscalation": false
+                        },
                         "command": ["/opt/crunchy/bin/uid_postgres.sh"],
                         "args": ["/opt/crunchy/bin/start.sh"],
                         "env": [

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
@@ -23,6 +23,13 @@
             "spec": {
                 "volumes": [
                     {
+                        "name": "tmp",
+                        "emptyDir": {
+                          "medium": "Memory",
+                          "sizeLimit": "1Mi"
+                        }
+                    },
+                    {
                         "name": "pgdata",
                         "persistentVolumeClaim": {
                             "claimName": "{{.FromClusterPVCName}}"
@@ -39,11 +46,16 @@
                         "name": "pgrestore",
                         "image": "{{.CCPImagePrefix}}/crunchy-postgres-ha:{{.CCPImageTag}}",
                         "securityContext": {
-                          "allowPrivilegeEscalation": false
+                          "allowPrivilegeEscalation": false,
+                          "readOnlyRootFilesystem": true
                         },
                         "command": ["/opt/crunchy/bin/uid_postgres.sh"],
                         "args": ["/opt/crunchy/bin/start.sh"],
                         "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
                             {
                                 "mountPath": "/pgdata",
                                 "name": "pgdata",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
@@ -47,6 +47,7 @@
                         "image": "{{.CCPImagePrefix}}/crunchy-postgres-ha:{{.CCPImageTag}}",
                         "securityContext": {
                           "allowPrivilegeEscalation": false,
+                          "privileged": false,
                           "readOnlyRootFilesystem": true
                         },
                         "command": ["/opt/crunchy/bin/uid_postgres.sh"],

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgrestore-job.json
@@ -38,6 +38,9 @@
                     {
                         "name": "pgrestore",
                         "image": "{{.CCPImagePrefix}}/crunchy-postgres-ha:{{.CCPImageTag}}",
+                        "securityContext": {
+                          "allowPrivilegeEscalation": false
+                        },
                         "command": ["/opt/crunchy/bin/uid_postgres.sh"],
                         "args": ["/opt/crunchy/bin/start.sh"],
                         "volumeMounts": [

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/rmdata-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/rmdata-job.json
@@ -31,7 +31,8 @@
                     "name": "rmdata",
                     "image": "{{.PGOImagePrefix}}/pgo-rmdata:{{.PGOImageTag}}",
                     "securityContext": {
-                      "allowPrivilegeEscalation": false
+                      "allowPrivilegeEscalation": false,
+                      "readOnlyRootFilesystem": true
                     },
                     "env": [{
                         "name": "PG_CLUSTER",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/rmdata-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/rmdata-job.json
@@ -21,6 +21,9 @@
             },
             "spec": {
                 "serviceAccountName": "pgo-target",
+                "securityContext": {
+                  "runAsNonRoot": true
+                },
                 {{ if .Tolerations }}
                 "tolerations": {{ .Tolerations }},
                 {{ end }}

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/rmdata-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/rmdata-job.json
@@ -32,6 +32,7 @@
                     "image": "{{.PGOImagePrefix}}/pgo-rmdata:{{.PGOImageTag}}",
                     "securityContext": {
                       "allowPrivilegeEscalation": false,
+                      "privileged": false,
                       "readOnlyRootFilesystem": true
                     },
                     "env": [{

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/rmdata-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/rmdata-job.json
@@ -30,6 +30,9 @@
                 "containers": [{
                     "name": "rmdata",
                     "image": "{{.PGOImagePrefix}}/pgo-rmdata:{{.PGOImageTag}}",
+                    "securityContext": {
+                      "allowPrivilegeEscalation": false
+                    },
                     "env": [{
                         "name": "PG_CLUSTER",
                         "value": "{{.ClusterName}}"

--- a/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -35,7 +35,8 @@
                                 {%- endif %}",
                         "imagePullPolicy": "IfNotPresent",
                         "securityContext": {
-                          "allowPrivilegeEscalation": false
+                          "allowPrivilegeEscalation": false,
+                          "readOnlyRootFilesystem": true
                         },
                         "ports": [
                             { "containerPort": {{ pgo_apiserver_port }} }
@@ -112,7 +113,12 @@
                                 "value": "localhost:4150"
                             }
                         ],
-                        "volumeMounts": []
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            }
+                        ]
                     }, {
                         "name": "operator",
                         "image": "{% if pgo_image | default('') != '' %}{{ pgo_image }}
@@ -120,7 +126,8 @@
                                 {%- endif %}",
                         "imagePullPolicy": "IfNotPresent",
                         "securityContext": {
-                          "allowPrivilegeEscalation": false
+                          "allowPrivilegeEscalation": false,
+                          "readOnlyRootFilesystem": true
                         },
                         "readinessProbe": {
                             "exec": {
@@ -177,7 +184,8 @@
                                 {%- else %}{{ pgo_image_prefix }}/pgo-scheduler:{{ pgo_image_tag }}
                                 {%- endif %}",
                         "securityContext": {
-                          "allowPrivilegeEscalation": false
+                          "allowPrivilegeEscalation": false,
+                          "readOnlyRootFilesystem": true
                         },
                         "livenessProbe": {
                             "exec": {
@@ -221,7 +229,12 @@
                                 "value": "localhost:4150"
                             }
                         ],
-                        "volumeMounts": [],
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            }
+                        ],
                         "imagePullPolicy": "IfNotPresent"
                     }, {
                         "name": "event",
@@ -229,7 +242,8 @@
                                 {%- else %}{{ pgo_image_prefix }}/pgo-event:{{ pgo_image_tag }}
                                 {%- endif %}",
                         "securityContext": {
-                          "allowPrivilegeEscalation": false
+                          "allowPrivilegeEscalation": false,
+                          "readOnlyRootFilesystem": true
                         },
                         "livenessProbe": {
                             "httpGet": {
@@ -245,11 +259,24 @@
                                 "value": "3600"
                             }
                         ],
-                        "volumeMounts": [],
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            }
+                        ],
                         "imagePullPolicy": "IfNotPresent"
                     }
                 ],
-                "volumes": []
+                "volumes": [
+                    {
+                        "name": "tmp",
+                        "emptyDir": {
+                            "medium": "Memory",
+                            "sizeLimit": "16Mi"
+                        }
+                    }
+                ]
             }
         }
     }

--- a/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -24,6 +24,9 @@
             },
             "spec": {
                 "serviceAccountName": "postgres-operator",
+                "securityContext": {
+                  "runAsNonRoot": true
+                },
                 "containers": [
                     {
                         "name": "apiserver",

--- a/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -34,6 +34,9 @@
                                 {%- else %}{{ pgo_image_prefix }}/pgo-apiserver:{{ pgo_image_tag }}
                                 {%- endif %}",
                         "imagePullPolicy": "IfNotPresent",
+                        "securityContext": {
+                          "allowPrivilegeEscalation": false
+                        },
                         "ports": [
                             { "containerPort": {{ pgo_apiserver_port }} }
                         ],
@@ -116,6 +119,9 @@
                                 {%- else %}{{ pgo_image_prefix }}/postgres-operator:{{ pgo_image_tag }}
                                 {%- endif %}",
                         "imagePullPolicy": "IfNotPresent",
+                        "securityContext": {
+                          "allowPrivilegeEscalation": false
+                        },
                         "readinessProbe": {
                             "exec": {
                                 "command": [
@@ -170,6 +176,9 @@
                         "image": "{% if pgo_scheduler_image | default('') != '' %}{{ pgo_scheduler_image }}
                                 {%- else %}{{ pgo_image_prefix }}/pgo-scheduler:{{ pgo_image_tag }}
                                 {%- endif %}",
+                        "securityContext": {
+                          "allowPrivilegeEscalation": false
+                        },
                         "livenessProbe": {
                             "exec": {
                                 "command": [
@@ -219,6 +228,9 @@
                         "image": "{% if pgo_event_image | default('') != '' %}{{ pgo_event_image }}
                                 {%- else %}{{ pgo_image_prefix }}/pgo-event:{{ pgo_image_tag }}
                                 {%- endif %}",
+                        "securityContext": {
+                          "allowPrivilegeEscalation": false
+                        },
                         "livenessProbe": {
                             "httpGet": {
                                 "path": "/ping",

--- a/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -36,6 +36,7 @@
                         "imagePullPolicy": "IfNotPresent",
                         "securityContext": {
                           "allowPrivilegeEscalation": false,
+                          "privileged": false,
                           "readOnlyRootFilesystem": true
                         },
                         "ports": [
@@ -127,6 +128,7 @@
                         "imagePullPolicy": "IfNotPresent",
                         "securityContext": {
                           "allowPrivilegeEscalation": false,
+                          "privileged": false,
                           "readOnlyRootFilesystem": true
                         },
                         "readinessProbe": {
@@ -185,6 +187,7 @@
                                 {%- endif %}",
                         "securityContext": {
                           "allowPrivilegeEscalation": false,
+                          "privileged": false,
                           "readOnlyRootFilesystem": true
                         },
                         "livenessProbe": {
@@ -243,6 +246,7 @@
                                 {%- endif %}",
                         "securityContext": {
                           "allowPrivilegeEscalation": false,
+                          "privileged": false,
                           "readOnlyRootFilesystem": true
                         },
                         "livenessProbe": {

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/alertmanager-deployment.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/alertmanager-deployment.json.j2
@@ -30,7 +30,8 @@
 {% if not (disable_fsgroup | default(false) | bool) %}
                     {% if (alertmanager_supplemental_groups | default('')) != '' %},{% endif -%}
                     "fsGroup": 26,
-                    "runAsUser": 2
+                    "runAsUser": 2,
+                    "runAsNonRoot": true
 {% endif %}
                 },
                 "serviceAccountName": "alertmanager",

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-deployment.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/grafana-deployment.json.j2
@@ -30,7 +30,8 @@
 {% if not (disable_fsgroup | default(false) | bool) %}
                     {% if (grafana_supplemental_groups | default('')) != '' %},{% endif -%}
                     "fsGroup": 26,
-                    "runAsUser": 2
+                    "runAsUser": 2,
+                    "runAsNonRoot": true
 {% endif %}
                 },
                 "serviceAccountName": "grafana",

--- a/installers/metrics/ansible/roles/pgo-metrics/templates/prometheus-deployment.json.j2
+++ b/installers/metrics/ansible/roles/pgo-metrics/templates/prometheus-deployment.json.j2
@@ -30,7 +30,8 @@
 {% if not (disable_fsgroup | default(false) | bool) %}
                     {% if (prometheus_supplemental_groups | default('')) != '' %},{% endif -%}
                     "fsGroup": 26,
-                    "runAsUser": 2
+                    "runAsUser": 2,
+                    "runAsNonRoot": true,
 {% endif %}
                 },
                 "serviceAccountName": "prometheus-sa",

--- a/installers/olm/postgresoperator.csv.yaml
+++ b/installers/olm/postgresoperator.csv.yaml
@@ -208,6 +208,7 @@ spec:
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
                     ports:
                       - containerPort: 8443
                     readinessProbe:
@@ -232,12 +233,16 @@ spec:
                       - { name: CRUNCHY_DEBUG, value: 'false' }
                       - { name: EVENT_ADDR, value: 'localhost:4150' }
                       - { name: PORT, value: '8443' }
+                    volumeMounts:
+                      - mountPath: /tmp
+                        name: tmp
 
                   - name: operator
                     image: '${PGO_IMAGE_PREFIX}/postgres-operator:${PGO_IMAGE_TAG}'
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
                     env:
                       - { name: NAMESPACE, valueFrom: { fieldRef: { fieldPath: "metadata.annotations['olm.targetNamespaces']" } } }
                       - { name: PGO_INSTALLATION_NAME, valueFrom: { fieldRef: { fieldPath: "metadata.namespace" } } }
@@ -251,6 +256,7 @@ spec:
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
                     livenessProbe:
                       exec:
                         command: [
@@ -269,12 +275,16 @@ spec:
                       - { name: CRUNCHY_DEBUG, value: 'false' }
                       - { name: EVENT_ADDR, value: 'localhost:4150' }
                       - { name: TIMEOUT, value: '3600' }
+                    volumeMounts:
+                      - mountPath: /tmp
+                        name: tmp
 
                   - name: event
                     image: '${PGO_IMAGE_PREFIX}/pgo-event:${PGO_IMAGE_TAG}'
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
                     livenessProbe:
                       httpGet:
                         path: /ping
@@ -283,3 +293,11 @@ spec:
                       periodSeconds: 5
                     env:
                       - { name: TIMEOUT, value: '3600' }
+                    volumeMounts:
+                      - mountPath: /tmp
+                        name: tmp
+                volumes:
+                  - name: tmp
+                    emptyDir:
+                      medium: Memory
+                      sizeLimit: 16Mi

--- a/installers/olm/postgresoperator.csv.yaml
+++ b/installers/olm/postgresoperator.csv.yaml
@@ -200,6 +200,8 @@ spec:
                   vendor: crunchydata
               spec:
                 serviceAccountName: postgres-operator
+                securityContext:
+                  runAsNonRoot: true
                 containers:
                   - name: apiserver
                     image: '${PGO_IMAGE_PREFIX}/pgo-apiserver:${PGO_IMAGE_TAG}'

--- a/installers/olm/postgresoperator.csv.yaml
+++ b/installers/olm/postgresoperator.csv.yaml
@@ -206,6 +206,8 @@ spec:
                   - name: apiserver
                     image: '${PGO_IMAGE_PREFIX}/pgo-apiserver:${PGO_IMAGE_TAG}'
                     imagePullPolicy: IfNotPresent
+                    securityContext:
+                      allowPrivilegeEscalation: false
                     ports:
                       - containerPort: 8443
                     readinessProbe:
@@ -234,6 +236,8 @@ spec:
                   - name: operator
                     image: '${PGO_IMAGE_PREFIX}/postgres-operator:${PGO_IMAGE_TAG}'
                     imagePullPolicy: IfNotPresent
+                    securityContext:
+                      allowPrivilegeEscalation: false
                     env:
                       - { name: NAMESPACE, valueFrom: { fieldRef: { fieldPath: "metadata.annotations['olm.targetNamespaces']" } } }
                       - { name: PGO_INSTALLATION_NAME, valueFrom: { fieldRef: { fieldPath: "metadata.namespace" } } }
@@ -245,6 +249,8 @@ spec:
                   - name: scheduler
                     image: '${PGO_IMAGE_PREFIX}/pgo-scheduler:${PGO_IMAGE_TAG}'
                     imagePullPolicy: IfNotPresent
+                    securityContext:
+                      allowPrivilegeEscalation: false
                     livenessProbe:
                       exec:
                         command: [
@@ -267,6 +273,8 @@ spec:
                   - name: event
                     image: '${PGO_IMAGE_PREFIX}/pgo-event:${PGO_IMAGE_TAG}'
                     imagePullPolicy: IfNotPresent
+                    securityContext:
+                      allowPrivilegeEscalation: false
                     livenessProbe:
                       httpGet:
                         path: /ping

--- a/installers/olm/postgresoperator.csv.yaml
+++ b/installers/olm/postgresoperator.csv.yaml
@@ -208,6 +208,7 @@ spec:
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
+                      privileged: false
                       readOnlyRootFilesystem: true
                     ports:
                       - containerPort: 8443
@@ -242,6 +243,7 @@ spec:
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
+                      privileged: false
                       readOnlyRootFilesystem: true
                     env:
                       - { name: NAMESPACE, valueFrom: { fieldRef: { fieldPath: "metadata.annotations['olm.targetNamespaces']" } } }
@@ -256,6 +258,7 @@ spec:
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
+                      privileged: false
                       readOnlyRootFilesystem: true
                     livenessProbe:
                       exec:
@@ -284,6 +287,7 @@ spec:
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
+                      privileged: false
                       readOnlyRootFilesystem: true
                     livenessProbe:
                       httpGet:

--- a/internal/operator/backrest/backup.go
+++ b/internal/operator/backrest/backup.go
@@ -104,7 +104,7 @@ func Backrest(namespace string, clientset kubeapi.Interface, task *crv1.Pgtask) 
 		JobName:         task.Spec.Parameters[config.LABEL_JOB_NAME],
 		ClusterName:     task.Spec.Parameters[config.LABEL_PG_CLUSTER],
 		PodName:         task.Spec.Parameters[config.LABEL_POD_NAME],
-		SecurityContext: "{}",
+		SecurityContext: `{"runAsNonRoot": true}`,
 		Command:         cmd,
 		CommandOpts:     task.Spec.Parameters[config.LABEL_BACKREST_OPTS],
 		PITRTarget:      "",

--- a/internal/operator/backrest/restore.go
+++ b/internal/operator/backrest/restore.go
@@ -49,27 +49,6 @@ const (
 // for pgBackRest using the '--target' option
 var restoreTargetRegex = regexp.MustCompile("--target(=| +)")
 
-type BackrestRestoreJobTemplateFields struct {
-	JobName                string
-	ClusterName            string
-	WorkflowID             string
-	ToClusterPVCName       string
-	SecurityContext        string
-	CCPImagePrefix         string
-	CCPImageTag            string
-	CommandOpts            string
-	PITRTarget             string
-	PgbackrestStanza       string
-	PgbackrestDBPath       string
-	PgbackrestRepo1Path    string
-	PgbackrestRepo1Host    string
-	PgbackrestS3EnvVars    string
-	NodeSelector           string
-	Tablespaces            string
-	TablespaceVolumes      string
-	TablespaceVolumeMounts string
-}
-
 // UpdatePGClusterSpecForRestore updates the spec for pgcluster resource provided as need to
 // perform a restore
 func UpdatePGClusterSpecForRestore(clientset kubeapi.Interface, cluster *crv1.Pgcluster,

--- a/internal/operator/common.go
+++ b/internal/operator/common.go
@@ -72,6 +72,9 @@ var ContainerImageOverrides = map[string]string{}
 // for detailed explanations of each mode available.
 var namespaceOperatingMode ns.NamespaceOperatingMode
 
+// runAsNonRoot forces the Pod to run as a non-root Pod
+var runAsNonRoot = true
+
 type containerResourcesTemplateFields struct {
 	// LimitsMemory and LimitsCPU detemrine the memory/CPU limits
 	LimitsMemory, LimitsCPU string
@@ -166,6 +169,8 @@ func Initialize(clientset kubernetes.Interface) {
 func GetPodSecurityContext(supplementalGroups []int64) string {
 	// set up the security context struct
 	securityContext := v1.PodSecurityContext{
+		// we don't want to run the pods as root, so explicitly disallow this
+		RunAsNonRoot: &runAsNonRoot,
 		// add any supplemental groups that the user passed in
 		SupplementalGroups: supplementalGroups,
 	}


### PR DESCRIPTION
This adds some explicit additions to the security contexts to the containers within the PostgreSQL Operator ecosystem, including:

- Ensuring the containers are run as non-root users.
- Disallow privilege escalation, since it's not needed.
- Disallow writing to the root container filesystem.
- Ensure the containers run in unprivileged mode, though this is the environmental default.

Issue: [ch7571]
Issue: [ch10570]