### PR TITLE
Enhance default TLS settings for pgo-apiserver

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -156,7 +156,22 @@ func main() {
 			ClientAuth:         tls.VerifyClientCertIfGiven,
 			InsecureSkipVerify: tlsNoVerify,
 			ClientCAs:          tlsTrustedCAs,
-			MinVersion:         tls.VersionTLS11,
+			MinVersion:         tls.VersionTLS12, // TLS versions < 1.2 are deprecated since NIST SP 800-52 Rev. 2, Aug 2019
+			// Suites based on the intersection of OpenSSL's FIPS TLSv1.2 cipher suties [1],
+			// SSL Lab's Best Practices [2] plus their additional discouragement of CBC [3],
+			// and what's available for selection within Go TLS's library [4].
+			// [1] https://wiki.openssl.org/index.php/FIPS_mode_and_TLS#TLS_1.2
+			// [2] https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices
+			// [3] https://blog.qualys.com/product-tech/2019/04/22/zombie-poodle-and-goldendoodle-vulnerabilities
+			// [4] https://golang.org/pkg/crypto/tls/#pkg-constants
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+			},
 		}
 
 		srv = &http.Server{


### PR DESCRIPTION
The default minimum TLS was 1.1, which is deprecated. Switching the minimum to 1.2 should have no adverse affects on clients, which will be using 1.2/1.3 already.

Additionally, in this commit the ciphersuites used for TLS 1.2 are restricted to a known good subset, based around the following resources:

- https://wiki.openssl.org/index.php/FIPS_mode_and_TLS#TLS_1.2
- https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices
- https://blog.qualys.com/product-tech/2019/04/22/zombie-poodle-and-goldendoodle-vulnerabilities

This enhances the baseline TLS configuration of pgo-apiserver, with a view to making it possible to configure this during PGO installation or via configmap in the future.

Signed-off-by: Steve Kerrison <steve@usec.io>

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

TLSv1.1 will be offered when connecting to the API server, along with a set of cipher suites in TLSv1.1/1.2 that contains some which are no longer recommended. https://github.com/CrunchyData/postgres-operator/issues/1978

**What is the new behavior (if this is a feature change)?**

TLSv1.2 is the minimum offered version, and the cipher suites are limited to a smaller, recommended set.


**Other information**:

Although the bundled PGO client is not likely to have an issue with this change, if anybody is using their own client application to interact with the API, and for some reason is still unwisely using TLSv1.1 as a maximum version, or an undesirable list of ciphersuites, then they may have issues. As such it's _arguably_ a breaking change, as it introduces a requirement that wasn't previously there.