### PR TITLE
Fix UsePAM Setting in sshd_config File

### DIFF
--- a/installers/ansible/roles/pgo-operator/files/pgo-backrest-repo/sshd_config
+++ b/installers/ansible/roles/pgo-operator/files/pgo-backrest-repo/sshd_config
@@ -82,7 +82,7 @@ ChallengeResponseAuthentication yes
 
 # This is set explicitly to *no* as we are only using pubkey authentication and
 # because each container is isolated to only an unprivileged user.
-UsePAM No
+UsePAM no
 
 #AllowAgentForwarding yes
 #AllowTcpForwarding yes


### PR DESCRIPTION
Fixes the UsePAM setting in sshd_config by changing the value from `No` to `no`.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

`UsePAM` is set to `No` in the default `sshd_config`.

**What is the new behavior (if this is a feature change)?**

`UsePAM` is set to `no` in the default `sshd_config`.

**Other information**:

N/A