### PR TITLE
Fixes ReplicaSet & Pod Logs Permissions in OLM ClusterServiceVersion Spec

### DIFF
--- a/installers/olm/postgresoperator.csv.yaml
+++ b/installers/olm/postgresoperator.csv.yaml
@@ -107,8 +107,6 @@ spec:
                 - endpoints
                 - pods
                 - pods/exec
-                - pods/log
-                - replicasets
                 - secrets
                 - services
                 - persistentvolumeclaims
@@ -122,9 +120,18 @@ spec:
                 - delete
                 - deletecollection
             - apiGroups:
+                - ''
+              resources:
+                - pods/log
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
                 - apps
               resources:
                 - deployments
+                - replicasets
               verbs:
                 - get
                 - list


### PR DESCRIPTION
Fixes the ReplicaSet and pods/logs permissions defined in the PostgreSQL Operator ClusterServiceVersion spec.  This aligns the `clusterPermissions` defined in the CSV with the RBAC generated via other supported installation methods.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

ReplicaSet permissions are missing in the ClusterServiceVersion spec for OLM.

**What is the new behavior (if this is a feature change)?**

ReplicaSet permissions are included in the ClusterServiceVersion spec for OLM.

**Other information**:

Issue: [ch10871]
fixes #2334