### PR TITLE
Maintain YAML & JSON Ordering for DCS Config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
 	github.com/fatih/color v1.9.0
 	github.com/gorilla/mux v1.7.4
+	github.com/iancoleman/orderedmap v0.2.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/nsqio/go-nsq v1.0.8
@@ -20,6 +21,7 @@ require (
 	go.opentelemetry.io/otel/exporters/trace/jaeger v0.13.0
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.20.1
 	k8s.io/apimachinery v0.20.1
 	k8s.io/client-go v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -274,6 +274,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/orderedmap v0.2.0 h1:sq1N/TFpYH++aViPcaKjys3bDClUEU7s5B+z6jq8pNA=
+github.com/iancoleman/orderedmap v0.2.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=

--- a/internal/operator/config/dcs.go
+++ b/internal/operator/config/dcs.go
@@ -27,12 +27,16 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/util"
 	"github.com/iancoleman/orderedmap"
 	log "github.com/sirupsen/logrus"
-	goyaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
+
+	// This yaml package is needed for a specific requirement within this package for maintaining
+	// the order of YAML keys when encoding/decoding.  Outside of this specific use-case, the
+	// 'sigs.k8s.io/yaml' should be leveraged for all other required YAML functionality.
+	goyaml "gopkg.in/yaml.v2"
 )
 
 const (

--- a/internal/operator/config/dcs.go
+++ b/internal/operator/config/dcs.go
@@ -25,7 +25,9 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/config"
 	"github.com/crunchydata/postgres-operator/internal/kubeapi"
 	"github.com/crunchydata/postgres-operator/internal/util"
+	"github.com/iancoleman/orderedmap"
 	log "github.com/sirupsen/logrus"
+	goyaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -170,13 +172,13 @@ func (d *DCS) apply() error {
 		namespace)
 
 	// first grab the DCS config from the PGHA config map
-	dcsConfig, rawDCS, err := d.GetDCSConfig()
+	dcsConfig, dcsConfigJSONOrdered, err := d.GetDCSConfig()
 	if err != nil {
 		return err
 	}
 
 	// next grab the current/live DCS from the "config" annotation of the Patroni configMap
-	clusterDCS, rawClusterDCS, err := d.getClusterDCSConfig()
+	clusterDCS, clusterDCSYAMLOrdered, err := d.getClusterDCSConfig()
 	if err != nil {
 		return err
 	}
@@ -189,17 +191,26 @@ func (d *DCS) apply() error {
 	}
 
 	// ensure the current "pause" setting is not overridden if currently set for the cluster
-	if _, ok := rawClusterDCS["pause"]; ok {
-		rawDCS["pause"] = rawClusterDCS["pause"]
+	var pauseExists bool
+	var pauseVal interface{}
+	for _, v := range clusterDCSYAMLOrdered {
+		if v.Key == "pause" {
+			pauseExists = true
+			pauseVal = v.Value
+			break
+		}
+	}
+	if pauseExists {
+		dcsConfigJSONOrdered.Set("pause", pauseVal)
 	}
 
 	// proceed with updating the DCS with the contents of the configMap
-	dcsConfigJSON, err := json.Marshal(rawDCS)
+	orderedDCSConfigPatch, err := json.Marshal(dcsConfigJSONOrdered)
 	if err != nil {
 		return err
 	}
 
-	if err := d.patchDCSAnnotation(string(dcsConfigJSON)); err != nil {
+	if err := d.patchDCSAnnotation(string(orderedDCSConfigPatch)); err != nil {
 		return err
 	}
 
@@ -212,7 +223,7 @@ func (d *DCS) apply() error {
 // getClusterDCSConfig obtains the configuration that is currently stored in the cluster's DCS.
 // Specifically, it obtains the configuration stored in the "config" annotation of the
 // "<clustername>-config" configMap.
-func (d *DCS) getClusterDCSConfig() (*DCSConfig, map[string]json.RawMessage, error) {
+func (d *DCS) getClusterDCSConfig() (*DCSConfig, goyaml.MapSlice, error) {
 	ctx := context.TODO()
 	clusterDCS := &DCSConfig{}
 
@@ -233,18 +244,18 @@ func (d *DCS) getClusterDCSConfig() (*DCSConfig, map[string]json.RawMessage, err
 		return nil, nil, err
 	}
 
-	var rawJSON map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(config), &rawJSON); err != nil {
+	orderedYAML := goyaml.MapSlice{}
+	if err := goyaml.Unmarshal([]byte(config), &orderedYAML); err != nil {
 		return nil, nil, err
 	}
 
-	return clusterDCS, rawJSON, nil
+	return clusterDCS, orderedYAML, nil
 }
 
 // GetDCSConfig returns the current DCS configuration included in the ClusterConfig's
 // configMap, i.e. the contents of the "<clustername-dcs-config>" configuration unmarshalled
 // into a DCSConfig struct.
-func (d *DCS) GetDCSConfig() (*DCSConfig, map[string]json.RawMessage, error) {
+func (d *DCS) GetDCSConfig() (*DCSConfig, *orderedmap.OrderedMap, error) {
 	dcsYAML, ok := d.configMap.Data[d.configName]
 	if !ok {
 		return nil, nil, ErrMissingClusterConfig
@@ -256,12 +267,13 @@ func (d *DCS) GetDCSConfig() (*DCSConfig, map[string]json.RawMessage, error) {
 		return nil, nil, err
 	}
 
-	var rawJSON map[string]json.RawMessage
-	if err := yaml.Unmarshal([]byte(dcsYAML), &rawJSON); err != nil {
+	orderedJSON := orderedmap.New()
+	orderedJSON.SetEscapeHTML(false)
+	if err := yaml.Unmarshal([]byte(dcsYAML), &orderedJSON); err != nil {
 		return nil, nil, err
 	}
 
-	return dcsConfig, rawJSON, nil
+	return dcsConfig, orderedJSON, nil
 }
 
 // patchDCSAnnotation patches the "config" annotation within the DCS configMap with the
@@ -291,12 +303,12 @@ func (d *DCS) refresh() error {
 	log.Debugf("Cluster Config: refreshing DCS config for cluster %s (namespace %s)", clusterName,
 		namespace)
 
-	clusterDCS, _, err := d.getClusterDCSConfig()
+	_, clusterDCSYAMLOrdered, err := d.getClusterDCSConfig()
 	if err != nil {
 		return err
 	}
 
-	clusterDCSBytes, err := yaml.Marshal(clusterDCS)
+	clusterDCSBytes, err := goyaml.Marshal(clusterDCSYAMLOrdered)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Testing has shown that with versions of PostgreSQL earlier than v13, changes to the ordering of the various Patroni and PostgreSQL settings stored within a cluster's DCS (as stored in the `config` annotation of the `<cluster-name>-config` ConfigMap) can cause a replica to automatically restart.  And being that the go standard library does not guarantee ordering when encoding/decoding JSON, the DCS configuration can be re-ordered when the `<cluser-name>-pgha-config` ConfigMap is updated, and the operator subsequently syncs its contents with the `<cluster-name>-config` ConfigMap.  This, in turn, can lead to the automatic restart of a replica following a configuration change in the `<cluser-name>-pgha-config`, since the settings might be patched in a different order than initially stored.

While in general order for JSON typically should not matter, this commit ensures order is maintained when marshalling and unmarshalling the DCS configuration found within both the `<cluster-name>-config` and `<cluster-name>-pgha-config` ConfigMaps into both YAML and JSON.  With this change,a replica will no longer automatically following a configuration change, but will rather show a pending restart as expected.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

When using PG v12 or less, after cluster creation replicas are sometimes automatically restarted following configuration changes that require a PG restart.

[ch10876]

**What is the new behavior (if this is a feature change)?**

When using any supported PG version, any change to a PG setting requiring a PG restart results in a pending restart for all instances (including replicas).

**Other information**:

N/A