### PR TITLE
Remove superfluous namespace reference from spec

### DIFF
--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -113,7 +113,6 @@ spec:
   exporterport: "9187"
   limits: {}
   name: ${pgo_cluster_name}
-  namespace: ${cluster_namespace}
   pgDataSource:
     restoreFrom: ""
     restoreOpts: ""
@@ -308,7 +307,6 @@ spec:
   exporterport: "9187"
   limits: {}
   name: ${pgo_cluster_name}
-  namespace: ${cluster_namespace}
   pgDataSource:
     restoreFrom: ""
     restoreOpts: ""
@@ -428,7 +426,6 @@ spec:
   exporterport: "9187"
   limits: {}
   name: ${pgo_cluster_name}
-  namespace: ${cluster_namespace}
   pgDataSource:
     restoreFrom: ""
     restoreOpts: ""
@@ -527,7 +524,6 @@ metadata:
 spec:
   clustername: ${pgo_cluster_name}
   name: ${pgo_cluster_name}-${pgo_cluster_replica_suffix}
-  namespace: ${cluster_namespace}
   replicastorage:
     accessmode: ReadWriteMany
     matchLabels: ""
@@ -750,7 +746,6 @@ make changes, as described below.
 | exporterResources | `create`, `update` | Specify the container resource requests that the `crunchy-postgres-exporter` sidecar uses when it is deployed with a PostgreSQL instance. Follows the [Kubernetes definitions of resource requests](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container). |
 | limits | `create`, `update` | Specify the container resource limits that the PostgreSQL cluster should use. Follows the [Kubernetes definitions of resource limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container). |
 | name | `create` | The name of the PostgreSQL instance that is the primary. On creation, this should be set to be the same as `ClusterName`. |
-| namespace | `create` | The Kubernetes Namespace that the PostgreSQL cluster is deployed in. |
 | nodeAffinity | `create` | Sets the [node affinity rules](/architecture/high-availability/#node-affinity) for the PostgreSQL cluster and associated PostgreSQL instances. Can be overridden on a per-instance (`pgreplicas.crunchydata.com`) basis. Please see the `Node Affinity Specification` section below. |
 | pgBadger | `create`,`update` | If `true`, deploys the `crunchy-pgbadger` sidecar for query analysis. |
 | pgbadgerport | `create` | If the `PGBadger` label is set, then this specifies the port that the pgBadger sidecar runs on (e.g. `10000`) |
@@ -896,7 +891,6 @@ cluster. All of the attributes only affect the replica when it is created.
 |-----------|--------|-------------|
 | clustername | `create` | The name of the PostgreSQL cluster, e.g. `hippo`. This is used to group PostgreSQL instances (primary, replicas) together. |
 | name | `create` | The name of this PostgreSQL replica. It should be unique within a `ClusterName`. |
-| namespace | `create` | The Kubernetes Namespace that the PostgreSQL cluster is deployed in. |
 | nodeAffinity | `create` | Sets the [node affinity rules]({{< relref "/architecture/high-availability/_index.md#node-affinity" >}}) for this PostgreSQL instance. Follows the [Kubernetes standard format for setting node affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity). |
 | replicastorage | `create` | A specification that gives information about the storage attributes for any replicas in the PostgreSQL cluster. For details, please see the `Storage Specification` section in the `pgclusters.crunchydata.com` description. This will likely be changed in the future based on the nature of the high-availability system, but presently it is still required that you set it. It is recommended you use similar settings to that of `PrimaryStorage`. |
 | serviceType | `create`, `update` | Sets the Kubernetes [Service](https://kubernetes.io/docs/concepts/services-networking/service/) type to use for this particular instance. If not set, defaults to the value in the related `pgclusters.crunchydata.com` custom resource. |

--- a/installers/olm/description.openshift.md
+++ b/installers/olm/description.openshift.md
@@ -193,7 +193,6 @@ spec:
   exporterport: "9187"
   limits: {}
   name: ${pgo_cluster_name}
-  namespace: ${cluster_namespace}
   pgDataSource:
     restoreFrom: ""
     restoreOpts: ""

--- a/installers/olm/description.upstream.md
+++ b/installers/olm/description.upstream.md
@@ -173,7 +173,6 @@ spec:
   exporterport: "9187"
   limits: {}
   name: ${pgo_cluster_name}
-  namespace: ${cluster_namespace}
   pgDataSource:
     restoreFrom: ""
     restoreOpts: ""

--- a/internal/apiserver/backrestservice/backrestimpl.go
+++ b/internal/apiserver/backrestservice/backrestimpl.go
@@ -272,7 +272,7 @@ func DeleteBackup(request msgs.DeleteBackrestBackupRequest) msgs.DeleteBackrestB
 
 	// and execute. if there is an error, return it, otherwise we are done
 	if _, stderr, err := kubeapi.ExecToPodThroughAPI(apiserver.RESTConfig,
-		apiserver.Clientset, cmd, containername, podName, cluster.Spec.Namespace, nil); err != nil {
+		apiserver.Clientset, cmd, containername, podName, cluster.Namespace, nil); err != nil {
 		log.Error(stderr)
 		response.Code = msgs.Error
 		response.Msg = stderr
@@ -285,7 +285,6 @@ func getBackupParams(clusterName, taskName, action, podName, containerName, imag
 	var newInstance *crv1.Pgtask
 	spec := crv1.PgtaskSpec{}
 	spec.Name = taskName
-	spec.Namespace = ns
 
 	spec.TaskType = crv1.PgtaskBackrest
 	spec.Parameters = make(map[string]string)
@@ -303,7 +302,8 @@ func getBackupParams(clusterName, taskName, action, podName, containerName, imag
 
 	newInstance = &crv1.Pgtask{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: taskName,
+			Name:      taskName,
+			Namespace: ns,
 		},
 		Spec: spec,
 	}
@@ -577,7 +577,6 @@ func getRestoreParams(cluster *crv1.Pgcluster, request *msgs.RestoreRequest) (*c
 	var newInstance *crv1.Pgtask
 
 	spec := crv1.PgtaskSpec{}
-	spec.Namespace = cluster.Namespace
 	spec.Name = "backrest-restore-" + cluster.Name
 	spec.TaskType = crv1.PgtaskBackrestRestore
 	spec.Parameters = make(map[string]string)
@@ -634,7 +633,6 @@ func createRestoreWorkflowTask(cluster *crv1.Pgcluster) (string, error) {
 
 	// create pgtask CRD
 	spec := crv1.PgtaskSpec{}
-	spec.Namespace = cluster.Namespace
 	spec.Name = cluster.Name + "-" + crv1.PgtaskWorkflowBackrestRestoreType
 	spec.TaskType = crv1.PgtaskWorkflow
 

--- a/internal/apiserver/clusterservice/scaleimpl.go
+++ b/internal/apiserver/clusterservice/scaleimpl.go
@@ -123,7 +123,6 @@ func ScaleCluster(request msgs.ClusterScaleRequest, pgouser string) msgs.Cluster
 	for i := 0; i < request.ReplicaCount; i++ {
 		uniqueName := util.RandStringBytesRmndr(4)
 		labels[config.LABEL_NAME] = cluster.Spec.Name + "-" + uniqueName
-		spec.Namespace = cluster.Namespace
 		spec.Name = labels[config.LABEL_NAME]
 
 		newInstance := &crv1.Pgreplica{

--- a/internal/apiserver/dfservice/dfimpl.go
+++ b/internal/apiserver/dfservice/dfimpl.go
@@ -156,7 +156,7 @@ func getClusterDf(cluster *crv1.Pgcluster, clusterResultsChannel chan msgs.DfDet
 		LabelSelector: selector,
 	}
 
-	pods, err := apiserver.Clientset.CoreV1().Pods(cluster.Spec.Namespace).List(ctx, options)
+	pods, err := apiserver.Clientset.CoreV1().Pods(cluster.Namespace).List(ctx, options)
 	// if there is an error attempting to get the pods, just return
 	if err != nil {
 		errorChannel <- err
@@ -304,7 +304,7 @@ func getPodDf(cluster *crv1.Pgcluster, pod *v1.Pod, podResultsChannel chan msgs.
 		cmd := []string{"du", "-s", "--block-size", "1", pvcMountPoint}
 
 		stdout, stderr, err := kubeapi.ExecToPodThroughAPI(apiserver.RESTConfig,
-			apiserver.Clientset, cmd, pvcContainerName, pod.Name, cluster.Spec.Namespace, nil)
+			apiserver.Clientset, cmd, pvcContainerName, pod.Name, cluster.Namespace, nil)
 		// if the command fails, exit here
 		if err != nil {
 			err := fmt.Errorf(stderr)
@@ -321,7 +321,7 @@ func getPodDf(cluster *crv1.Pgcluster, pod *v1.Pod, podResultsChannel chan msgs.
 			return
 		}
 
-		if claimSize, err := getClaimCapacity(apiserver.Clientset, result.PVCName, cluster.Spec.Namespace); err != nil {
+		if claimSize, err := getClaimCapacity(apiserver.Clientset, result.PVCName, cluster.Namespace); err != nil {
 			errorChannel <- err
 			return
 		} else {

--- a/internal/apiserver/pgadminservice/pgadminimpl.go
+++ b/internal/apiserver/pgadminservice/pgadminimpl.go
@@ -100,7 +100,6 @@ func CreatePgAdmin(request *msgs.CreatePgAdminRequest, ns, pgouser string) msgs.
 
 		// generate the pgtask, starting with spec
 		spec := crv1.PgtaskSpec{
-			Namespace:   cluster.Namespace,
 			Name:        fmt.Sprintf("%s-%s", config.LABEL_PGADMIN_TASK_ADD, cluster.Name),
 			TaskType:    crv1.PgtaskPgAdminAdd,
 			StorageSpec: cluster.Spec.PGAdminStorage,
@@ -168,9 +167,8 @@ func DeletePgAdmin(request *msgs.DeletePgAdminRequest, ns string) msgs.DeletePgA
 
 		// generate the pgtask, starting with spec
 		spec := crv1.PgtaskSpec{
-			Namespace: cluster.Namespace,
-			Name:      config.LABEL_PGADMIN_TASK_DELETE + "-" + cluster.Name,
-			TaskType:  crv1.PgtaskPgAdminDelete,
+			Name:     config.LABEL_PGADMIN_TASK_DELETE + "-" + cluster.Name,
+			TaskType: crv1.PgtaskPgAdminDelete,
 			Parameters: map[string]string{
 				config.LABEL_PGADMIN_TASK_CLUSTER: cluster.Name,
 			},

--- a/internal/apiserver/pgbouncerservice/pgbouncerimpl.go
+++ b/internal/apiserver/pgbouncerservice/pgbouncerimpl.go
@@ -509,7 +509,7 @@ func setPgBouncerPasswordDetail(cluster crv1.Pgcluster, result *msgs.ShowPgBounc
 
 	// attempt to get the secret, but only get the password
 	password, err := util.GetPasswordFromSecret(apiserver.Clientset,
-		cluster.Spec.Namespace, pgBouncerSecretName)
+		cluster.Namespace, pgBouncerSecretName)
 	if err != nil {
 		log.Warn(err)
 	}
@@ -527,7 +527,7 @@ func setPgBouncerServiceDetail(cluster crv1.Pgcluster, result *msgs.ShowPgBounce
 
 	// have to go through a bunch of services because "current design"
 	services, err := apiserver.Clientset.
-		CoreV1().Services(cluster.Spec.Namespace).
+		CoreV1().Services(cluster.Namespace).
 		List(ctx, metav1.ListOptions{LabelSelector: selector})
 		// if there is an error, return without making any adjustments
 	if err != nil {

--- a/internal/apiserver/pgdumpservice/pgdumpimpl.go
+++ b/internal/apiserver/pgdumpservice/pgdumpimpl.go
@@ -429,7 +429,6 @@ func buildPgTaskForRestore(taskName string, action string, request *msgs.PgResto
 	spec := crv1.PgtaskSpec{}
 
 	spec.Name = taskName
-	spec.Namespace = request.Namespace
 	spec.TaskType = crv1.PgtaskpgRestore
 	spec.Parameters = make(map[string]string)
 	spec.Parameters[config.LABEL_PGRESTORE_DB] = request.PGDumpDB

--- a/internal/apiserver/policyservice/policyimpl.go
+++ b/internal/apiserver/policyservice/policyimpl.go
@@ -44,7 +44,6 @@ func CreatePolicy(client pgo.Interface, policyName, policyFile, ns, pgouser stri
 
 	// Create an instance of our CRD
 	spec := crv1.PgpolicySpec{}
-	spec.Namespace = ns
 	spec.Name = policyName
 	spec.SQL = policyFile
 

--- a/internal/apiserver/upgradeservice/upgradeimpl.go
+++ b/internal/apiserver/upgradeservice/upgradeimpl.go
@@ -121,7 +121,6 @@ func CreateUpgrade(request *msgs.CreateUpgradeRequest, ns, pgouser string) msgs.
 		spec.Parameters[config.LABEL_PGOUSER] = pgouser
 
 		spec.Name = clusterName + "-" + config.LABEL_UPGRADE
-		spec.Namespace = ns
 		labels := make(map[string]string)
 		labels[config.LABEL_PG_CLUSTER] = clusterName
 		labels[config.LABEL_PGOUSER] = pgouser

--- a/internal/apiserver/userservice/userimpl.go
+++ b/internal/apiserver/userservice/userimpl.go
@@ -654,7 +654,7 @@ func UpdateUser(request *msgs.UpdateUserRequest, pgouser string) msgs.UpdateUser
 func deleteUserSecret(cluster crv1.Pgcluster, username string) {
 	ctx := context.TODO()
 	secretName := crv1.UserSecretName(&cluster, username)
-	err := apiserver.Clientset.CoreV1().Secrets(cluster.Spec.Namespace).
+	err := apiserver.Clientset.CoreV1().Secrets(cluster.Namespace).
 		Delete(ctx, secretName, metav1.DeleteOptions{})
 	if err != nil {
 		log.Error(err)

--- a/internal/operator/backrest/backup.go
+++ b/internal/operator/backrest/backup.go
@@ -216,7 +216,6 @@ func CreateBackup(clientset pgo.Interface, namespace, clusterName, podName strin
 
 	spec := crv1.PgtaskSpec{}
 	spec.Name = taskName
-	spec.Namespace = namespace
 
 	spec.TaskType = crv1.PgtaskBackrest
 	spec.Parameters = make(map[string]string)

--- a/internal/operator/cluster/cluster.go
+++ b/internal/operator/cluster/cluster.go
@@ -693,7 +693,7 @@ func createMissingUserSecret(clientset kubernetes.Interface, cluster *crv1.Pgclu
 
 	// if the secret already exists, skip it
 	// if it returns an error other than "not found" return an error
-	if _, err := clientset.CoreV1().Secrets(cluster.Spec.Namespace).Get(
+	if _, err := clientset.CoreV1().Secrets(cluster.Namespace).Get(
 		ctx, secretName, metav1.GetOptions{}); err == nil {
 		log.Infof("user secret %q exists for user %q for cluster %q",
 			secretName, username, cluster.Spec.Name)
@@ -712,7 +712,7 @@ func createMissingUserSecret(clientset kubernetes.Interface, cluster *crv1.Pgclu
 
 	// great, now we can create the secret! if we can't, return an error
 	return util.CreateSecret(clientset, cluster.Spec.Name, secretName,
-		username, password, cluster.Spec.Namespace)
+		username, password, cluster.Namespace)
 }
 
 // createMissingUserSecrets checks to see if there are secrets for the

--- a/internal/operator/cluster/pgadmin.go
+++ b/internal/operator/cluster/pgadmin.go
@@ -129,7 +129,7 @@ func AddPgAdmin(
 func AddPgAdminFromPgTask(clientset kubeapi.Interface, restconfig *rest.Config, task *crv1.Pgtask) {
 	ctx := context.TODO()
 	clusterName := task.Spec.Parameters[config.LABEL_PGADMIN_TASK_CLUSTER]
-	namespace := task.Spec.Namespace
+	namespace := task.Namespace
 	storage := task.Spec.StorageSpec
 
 	log.Debugf("add pgAdmin from task called for cluster [%s] in namespace [%s]",
@@ -304,7 +304,7 @@ func DeletePgAdmin(clientset kubeapi.Interface, restconfig *rest.Config, cluster
 func DeletePgAdminFromPgTask(clientset kubeapi.Interface, restconfig *rest.Config, task *crv1.Pgtask) {
 	ctx := context.TODO()
 	clusterName := task.Spec.Parameters[config.LABEL_PGADMIN_TASK_CLUSTER]
-	namespace := task.Spec.Namespace
+	namespace := task.Namespace
 
 	log.Debugf("delete pgAdmin from task called for cluster [%s] in namespace [%s]",
 		clusterName, namespace)
@@ -444,7 +444,7 @@ func publishPgAdminEvent(eventType string, task *crv1.Pgtask) {
 	topics := []string{events.EventTopicPgAdmin}
 	// set up the event header
 	eventHeader := events.EventHeader{
-		Namespace: task.Spec.Namespace,
+		Namespace: task.Namespace,
 		Username:  task.ObjectMeta.Labels[config.LABEL_PGOUSER],
 		Topic:     topics,
 		Timestamp: time.Now(),

--- a/internal/operator/cluster/upgrade.go
+++ b/internal/operator/cluster/upgrade.go
@@ -703,7 +703,6 @@ func createClusterRecreateWorkflowTask(clientset pgo.Interface, clusterName, ns,
 
 	// create pgtask CRD
 	spec := crv1.PgtaskSpec{}
-	spec.Namespace = ns
 	spec.Name = clusterName + "-" + crv1.PgtaskWorkflowCreateClusterType
 	spec.TaskType = crv1.PgtaskWorkflow
 

--- a/internal/util/cluster.go
+++ b/internal/util/cluster.go
@@ -257,8 +257,7 @@ func CreateRMDataTask(clientset kubeapi.Interface, cluster *crv1.Pgcluster, repl
 			},
 		},
 		Spec: crv1.PgtaskSpec{
-			Name:      taskName,
-			Namespace: cluster.Namespace,
+			Name: taskName,
 			Parameters: map[string]string{
 				config.LABEL_DELETE_DATA:    strconv.FormatBool(deleteData),
 				config.LABEL_DELETE_BACKUPS: strconv.FormatBool(deleteBackups),
@@ -346,7 +345,7 @@ func GetPrimaryPod(clientset kubernetes.Interface, cluster *crv1.Pgcluster) (*v1
 	// set up the selector for the primary pod
 	selector := fmt.Sprintf("%s=%s,%s=%s",
 		config.LABEL_PG_CLUSTER, cluster.Spec.Name, config.LABEL_PGHA_ROLE, config.LABEL_PGHA_ROLE_PRIMARY)
-	namespace := cluster.Spec.Namespace
+	namespace := cluster.Namespace
 
 	// query the pods
 	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})

--- a/pkg/apis/crunchydata.com/v1/cluster.go
+++ b/pkg/apis/crunchydata.com/v1/cluster.go
@@ -41,7 +41,6 @@ type Pgcluster struct {
 // PgclusterSpec is the CRD that defines a Crunchy PG Cluster Spec
 // swagger:ignore
 type PgclusterSpec struct {
-	Namespace      string `json:"namespace"`
 	Name           string `json:"name"`
 	ClusterName    string `json:"clustername"`
 	Policies       string `json:"policies"`

--- a/pkg/apis/crunchydata.com/v1/policy.go
+++ b/pkg/apis/crunchydata.com/v1/policy.go
@@ -25,10 +25,9 @@ const PgpolicyResourcePlural = "pgpolicies"
 // PgpolicySpec ...
 // swagger:ignore
 type PgpolicySpec struct {
-	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
-	SQL       string `json:"sql"`
-	Status    string `json:"status"`
+	Name   string `json:"name"`
+	SQL    string `json:"sql"`
+	Status string `json:"status"`
 }
 
 // Pgpolicy ...

--- a/pkg/apis/crunchydata.com/v1/replica.go
+++ b/pkg/apis/crunchydata.com/v1/replica.go
@@ -37,7 +37,6 @@ type Pgreplica struct {
 // PgreplicaSpec ...
 // swagger:ignore
 type PgreplicaSpec struct {
-	Namespace      string        `json:"namespace"`
 	Name           string        `json:"name"`
 	ClusterName    string        `json:"clustername"`
 	ReplicaStorage PgStorageSpec `json:"replicastorage"`

--- a/pkg/apis/crunchydata.com/v1/task.go
+++ b/pkg/apis/crunchydata.com/v1/task.go
@@ -85,7 +85,6 @@ const (
 // PgtaskSpec ...
 // swagger:ignore
 type PgtaskSpec struct {
-	Namespace   string            `json:"namespace"`
 	Name        string            `json:"name"`
 	StorageSpec PgStorageSpec     `json:"storagespec"`
 	TaskType    string            `json:"tasktype"`

--- a/pkg/apis/crunchydata.com/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/crunchydata.com/v1/zz_generated.deepcopy.go
@@ -219,6 +219,7 @@ func (in *PgclusterSpec) DeepCopyInto(out *PgclusterSpec) {
 	out.WALStorage = in.WALStorage
 	out.ReplicaStorage = in.ReplicaStorage
 	out.BackrestStorage = in.BackrestStorage
+	out.PGAdminStorage = in.PGAdminStorage
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = make(corev1.ResourceList, len(*in))


### PR DESCRIPTION
This is an artifact from days of yore and not needed in modern
Operator deployments. This can remove some confusion over what
fields need to be set with regards to namespace on a custom resource.

A separate commit also includes a missing deepcopy struct.
    
Issue: [ch11028]
