### PR TITLE
Allow for a S3 bucket name to be edited after cluster creation

### DIFF
--- a/docs/content/architecture/high-availability/_index.md
+++ b/docs/content/architecture/high-availability/_index.md
@@ -443,5 +443,6 @@ modification to the custom resource:
 - Custom annotation changes
 - Enabling/disabling the monitoring sidecar on a PostgreSQL cluster (`--metrics`)
 - Enabling/disabling the pgBadger sidecar on a PostgreSQL cluster (`--pgbadger`)
+- S3 bucket name updates
 - Tablespace additions
 - Toleration modifications

--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -726,7 +726,7 @@ make changes, as described below.
 | backrestLimits | `create`, `update` | Specify the container resource limits that the pgBackRest repository should use. Follows the [Kubernetes definitions of resource limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container). |
 | backrestRepoPath | `create` | Optional reference to the location of the pgBackRest repository. |
 | BackrestResources | `create`, `update` | Specify the container resource requests that the pgBackRest repository should use. Follows the [Kubernetes definitions of resource requests](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container). |
-| backrestS3Bucket | `create` | An optional parameter that specifies a S3 bucket that pgBackRest should use. |
+| backrestS3Bucket | `create`, `update` | An optional parameter that specifies a S3 bucket that pgBackRest should use. If the name is updated, the Postgres Operator will create a new stanza and take an initial backup in the new bucket. |
 | backrestS3Endpoint | `create` | An optional parameter that specifies the S3 endpoint pgBackRest should use. |
 | backrestS3Region | `create` | An optional parameter that specifies a cloud region that pgBackRest should use. |
 | backrestS3URIStyle | `create` | An optional parameter that specifies if pgBackRest should use the `path` or `host` S3 URI style. |

--- a/internal/apiserver/backrestservice/backrestimpl.go
+++ b/internal/apiserver/backrestservice/backrestimpl.go
@@ -424,21 +424,19 @@ func ShowBackrest(name, selector, ns string) msgs.ShowBackrestResponse {
 
 			// get the pgBackRest info using this legacy function
 			info, err := getInfo(storageType, podname, ns, verifyTLS)
+
 			// see if the function returned successfully, and if so, unmarshal the JSON
+			// if there was an error getting the info, log that the error occurred in
+			// the API server logs and have the response added to the list.
 			if err != nil {
 				log.Error(err)
-				response.Status.Code = msgs.Error
-				response.Status.Msg = err.Error()
-
-				return response
-			}
-
-			if err := json.Unmarshal([]byte(info), &detail.Info); err != nil {
-				log.Error(err)
-				response.Status.Code = msgs.Error
-				response.Status.Msg = err.Error()
-
-				return response
+			} else {
+				if err := json.Unmarshal([]byte(info), &detail.Info); err != nil {
+					log.Error(err)
+					response.Status.Code = msgs.Error
+					response.Status.Msg = err.Error()
+					return response
+				}
 			}
 
 			// append the details to the list of items


### PR DESCRIPTION
This allows for the name of a S3 bucket to be edited after a
cluster is created, i.e. through the custom resource. Should this
action be taken, the following occurs:

- The pgBackRest report Pod is redeployed
- The PostgreSQL cluster is redeployed using a rolling update
- Once the above two actions complete, a new stanza is created and
an initial backup in that stanza is created.

A create stanza must be attempted as the new bucket may be
entirely empty.

Issue: [ch11061]