### PR TITLE
Allow Restores Across Namespaces

### DIFF
--- a/cmd/pgo/cmd/cluster.go
+++ b/cmd/pgo/cmd/cluster.go
@@ -332,6 +332,7 @@ func createCluster(args []string, ns string, createClusterCmd *cobra.Command) {
 	r.WALStorageConfig = WALStorageConfig
 	r.WALPVCSize = WALPVCSize
 	r.PGDataSource.RestoreFrom = RestoreFrom
+	r.PGDataSource.Namespace = RestoreFromNamespace
 	r.PGDataSource.RestoreOpts = BackupOpts
 	// set any annotations
 	r.Annotations = getClusterAnnotations(Annotations, AnnotationsPostgres, AnnotationsBackrest,

--- a/cmd/pgo/cmd/create.go
+++ b/cmd/pgo/cmd/create.go
@@ -71,6 +71,7 @@ var (
 	WALStorageConfig                                                                             string
 	WALPVCSize                                                                                   string
 	RestoreFrom                                                                                  string
+	RestoreFromNamespace                                                                         string
 )
 
 // group the annotation requests
@@ -486,6 +487,9 @@ func init() {
 		"the TLS keypair to use for enabling certificate-based authentication between PostgreSQL instances, "+
 		"particularly for the purpose of replication. Must be used with \"server-tls-secret\" and \"server-ca-secret\".")
 	createClusterCmd.Flags().StringVarP(&RestoreFrom, "restore-from", "", "", "The name of cluster to restore from when bootstrapping a new cluster")
+	createClusterCmd.Flags().StringVarP(&RestoreFromNamespace, "restore-from-namespace", "", "",
+		"The namespace for the cluster specified using --restore-from.  Defaults to the "+
+			"namespace of the cluster being created if not provided.")
 	createClusterCmd.Flags().StringVarP(&BackupOpts, "restore-opts", "", "",
 		"The options to pass into pgbackrest where performing a restore to bootrap the cluster. "+
 			"Only applicable when a \"restore-from\" value is specified")

--- a/docs/content/architecture/disaster-recovery.md
+++ b/docs/content/architecture/disaster-recovery.md
@@ -121,6 +121,9 @@ command with several flags:
 - `--restore-from`: specifies the name of a PostgreSQL cluster (either one that
 is active, or a former cluster whose pgBackRest repository still exists) to
 restore from.
+- `--restore-from-namespace` (optional): the namespace of the PostgreSQL cluster specified
+using `--restore-from` (the namespace of the cluster being created is utilized if a namespace
+is not specified using this option)
 - `--restore-opts`: used to specify additional options, similar to the ones that
 are passed into [`pgbackrest restore`](https://pgbackrest.org/command.html#command-restore).
 
@@ -143,7 +146,10 @@ pgo create cluster newcluster \
 
 Note that when using this method, the PostgreSQL Operator can only restore one
 cluster from each pgBackRest repository at a time. Using the above example, one
-can only perform one restore from `oldcluster` at a given time.
+can only perform one restore from `oldcluster` at a given time.  Additionally,
+if the cluster being utilized for restore is in another namespace than the
+cluster being created, the proper namespace can be specified using the
+`--restore-from-namespace` option.
 
 When using the restore to a new cluster method, the PostgreSQL Operator takes
 the following actions:

--- a/docs/content/architecture/provisioning.md
+++ b/docs/content/architecture/provisioning.md
@@ -173,7 +173,9 @@ the existing pgBackRest repository host for that cluster in order to perform the
 restore.  If restoring from a former cluster that has since been deleted, a new pgBackRest
 repository host will be deployed for the sole purpose of bootstrapping the new cluster, and will
 then be destroyed once the restore is complete.  Also, please note that it is only possible for
-one cluster to bootstrap from another cluster (whether running or not) at any given time.
+one cluster to bootstrap from another cluster (whether running or not) at any given time.  And
+finally, if the cluster being utilized for restore is in another namespace than the cluster being
+created, the proper namespace can be specified using the `--restore-from-namespace` option.
 
 ## Deprovisioning
 

--- a/docs/content/pgo-client/common-tasks.md
+++ b/docs/content/pgo-client/common-tasks.md
@@ -645,6 +645,15 @@ execute the following command:
 pgo create cluster newcluster --restore-from=oldcluster
 ```
 
+##### Full Restore Across Namespaces
+
+To create a new PostgreSQL cluster from a backup in another namespace and restore it
+fully, you can execute the following command:
+
+```
+pgo create cluster newcluster --restore-from=oldcluster --restore-from-namespace=oldnamespace
+```
+
 ##### Point-in-time-Recovery (PITR)
 
 To create a new PostgreSQL cluster and restore it to specific point-in-time

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
@@ -176,7 +176,7 @@
                 }, {
                     "name": "sshd",
                     "secret": {
-                        "secretName": "{{.RestoreFrom}}-backrest-repo-config"
+                        "secretName": "{{.ClusterName}}-bootstrap-backrest-repo-config"
                     }
                 },
                 {

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-repo-template.json
@@ -6,6 +6,7 @@
         "labels": {
             {{if .BootstrapCluster}}
             "pgha-bootstrap": "{{.BootstrapCluster}}",
+            "pgha-bootstrap-namespace": "{{.BootstrapNamespace}}",
             {{ end }}
             "name": "{{.Name}}",
             "pg-cluster": "{{.ClusterName}}",
@@ -34,6 +35,7 @@
                 "labels": {
                     {{if .BootstrapCluster}}
                     "pgha-bootstrap": "{{.BootstrapCluster}}",
+                    "pgha-bootstrap-namespace": "{{.BootstrapNamespace}}",
                     {{ end }}
                     "name": "{{.Name}}",
                     "pg-cluster": "{{.ClusterName}}",

--- a/internal/config/labels.go
+++ b/internal/config/labels.go
@@ -177,11 +177,12 @@ const (
 const GLOBAL_CUSTOM_CONFIGMAP = "pgo-custom-pg-config"
 
 const (
-	LABEL_PGHA_SCOPE        = "crunchy-pgha-scope"
-	LABEL_PGHA_CONFIGMAP    = "pgha-config"
-	LABEL_PGHA_BACKUP_TYPE  = "pgha-backup-type"
-	LABEL_PGHA_ROLE         = "role"
-	LABEL_PGHA_ROLE_PRIMARY = "master"
-	LABEL_PGHA_ROLE_REPLICA = "replica"
-	LABEL_PGHA_BOOTSTRAP    = "pgha-bootstrap"
+	LABEL_PGHA_SCOPE               = "crunchy-pgha-scope"
+	LABEL_PGHA_CONFIGMAP           = "pgha-config"
+	LABEL_PGHA_BACKUP_TYPE         = "pgha-backup-type"
+	LABEL_PGHA_ROLE                = "role"
+	LABEL_PGHA_ROLE_PRIMARY        = "master"
+	LABEL_PGHA_ROLE_REPLICA        = "replica"
+	LABEL_PGHA_BOOTSTRAP           = "pgha-bootstrap"
+	LABEL_PGHA_BOOTSTRAP_NAMESPACE = "pgha-bootstrap-namespace"
 )

--- a/internal/operator/cluster/cluster.go
+++ b/internal/operator/cluster/cluster.go
@@ -65,6 +65,10 @@ const (
 
 	// pgBadgerContainerName is the name of the pgBadger container
 	pgBadgerContainerName = "pgbadger"
+
+	// BoostrapConfigPrefix is the format of the prefix used for the Secret containing the
+	// pgBackRest configuration required to bootstrap a new cluster using a pgBackRest backup
+	BoostrapConfigPrefix = "%s-bootstrap-%s"
 )
 
 func AddClusterBase(clientset kubeapi.Interface, cl *crv1.Pgcluster, namespace string) {
@@ -285,8 +289,15 @@ func AddClusterBootstrap(clientset kubeapi.Interface, cluster *crv1.Pgcluster) e
 		return err
 	}
 
-	if err := addClusterBootstrapJob(clientset, cluster, namespace, dataVolume,
-		walVolume, tablespaceVolumes); err != nil && !kerrors.IsAlreadyExists(err) {
+	// create a copy of the pgBackRest secret for the cluster being restored from
+	bootstrapSecret, err := createBootstrapBackRestSecret(clientset, cluster)
+	if err != nil {
+		publishClusterCreateFailure(cluster, err.Error())
+		return err
+	}
+
+	if err := addClusterBootstrapJob(clientset, cluster, dataVolume,
+		walVolume, tablespaceVolumes, bootstrapSecret); err != nil && !kerrors.IsAlreadyExists(err) {
 		publishClusterCreateFailure(cluster, err.Error())
 		return err
 	}
@@ -321,8 +332,11 @@ func AddBootstrapRepo(clientset kubernetes.Interface, cluster *crv1.Pgcluster) (
 	restoreClusterName := cluster.Spec.PGDataSource.RestoreFrom
 	repoName := fmt.Sprintf(util.BackrestRepoServiceName, restoreClusterName)
 
+	// get the namespace for the cluster we're restoring from
+	restoreClusterNamespace := operator.GetBootstrapNamespace(cluster)
+
 	found := true
-	repoDeployment, err := clientset.AppsV1().Deployments(cluster.GetNamespace()).
+	repoDeployment, err := clientset.AppsV1().Deployments(restoreClusterNamespace).
 		Get(ctx, repoName, metav1.GetOptions{})
 	if err != nil {
 		if !kerrors.IsNotFound(err) {
@@ -332,12 +346,13 @@ func AddBootstrapRepo(clientset kubernetes.Interface, cluster *crv1.Pgcluster) (
 	}
 
 	if !found {
-		if err = backrest.CreateRepoDeployment(clientset, cluster, false, true, 1); err != nil {
+		if err = backrest.CreateRepoDeployment(clientset, cluster, false, true, 1,
+			restoreClusterNamespace); err != nil {
 			return
 		}
 		repoCreated = true
 	} else if _, ok := repoDeployment.GetLabels()[config.LABEL_PGHA_BOOTSTRAP]; ok {
-		err = fmt.Errorf("Unable to create bootstrap repo %s to bootstrap cluster %s "+
+		err = fmt.Errorf("unable to create bootstrap repo %s to bootstrap cluster %s "+
 			"(namespace %s) because it is already running to bootstrap another cluster",
 			repoName, cluster.GetName(), cluster.GetNamespace())
 		return
@@ -678,6 +693,54 @@ func annotateBackrestSecret(clientset kubernetes.Interface, cluster *crv1.Pgclus
 			Patch(ctx, secretName, types.MergePatchType, patch, metav1.PatchOptions{})
 	}
 	return err
+}
+
+// createBootstrapBackRestSecret creates a copy of the pgBackRest secret from the source cluster
+// being utilized to bootstrap a new cluster.  This ensures the required Secret (and therefore the
+// required pgBackRest cofiguration) as needed to bootstrap a new cluster via a 'pgbackrest
+// restore' is always present in the namespace of the cluster being created (e.g. when
+// bootstrapping from the pgBackRest backups of a cluster in another namespace)
+func createBootstrapBackRestSecret(clientset kubernetes.Interface,
+	cluster *crv1.Pgcluster) (*v1.Secret, error) {
+	ctx := context.TODO()
+
+	restoreFromCluster := cluster.Spec.PGDataSource.RestoreFrom
+
+	// Get the proper namespace depending on where we're restoring from.  If no namespace is
+	// specified in the PGDataSource then assume the same namespace as the pgcluster.
+	restoreFromNamespace := operator.GetBootstrapNamespace(cluster)
+
+	// get a copy of the pgBackRest repo secret for the cluster we're restoring from
+	restoreFromSecretName := fmt.Sprintf("%s-%s", restoreFromCluster,
+		config.LABEL_BACKREST_REPO_SECRET)
+	restoreFromSecret, err := clientset.CoreV1().Secrets(restoreFromNamespace).Get(ctx,
+		restoreFromSecretName, metav1.GetOptions{})
+	if err != nil {
+		publishClusterCreateFailure(cluster, err.Error())
+		return nil, err
+	}
+
+	// Create a copy of the secret for the cluster being recreated.  This ensures a copy of the
+	// required pgBackRest Secret is always present is the namespace of the cluster being created.
+	secretCopyName := fmt.Sprintf(BoostrapConfigPrefix, cluster.GetName(),
+		config.LABEL_BACKREST_REPO_SECRET)
+	secretCopy := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: restoreFromSecret.GetAnnotations(),
+			Labels: map[string]string{
+				config.LABEL_VENDOR:            config.LABEL_CRUNCHY,
+				config.LABEL_PG_CLUSTER:        cluster.GetName(),
+				config.LABEL_PGO_BACKREST_REPO: "true",
+				config.LABEL_PGHA_BOOTSTRAP:    cluster.GetName(),
+			},
+			Name:      secretCopyName,
+			Namespace: cluster.GetNamespace(),
+		},
+		Data: restoreFromSecret.Data,
+	}
+
+	return clientset.CoreV1().Secrets(cluster.GetNamespace()).Create(ctx, secretCopy,
+		metav1.CreateOptions{})
 }
 
 // createMissingUserSecret is the heart of trying to determine if a user secret

--- a/pkg/apis/crunchydata.com/v1/cluster.go
+++ b/pkg/apis/crunchydata.com/v1/cluster.go
@@ -224,6 +224,7 @@ const (
 // directory when bootstrapping a new PostgreSQL cluster
 // swagger:ignore
 type PGDataSourceSpec struct {
+	Namespace   string `json:"namespace"`
 	RestoreFrom string `json:"restoreFrom"`
 	RestoreOpts string `json:"restoreOpts"`
 }


### PR DESCRIPTION
When creating a new PostgreSQL cluster via `pgbackrest restore` using the pgBackRest backups from another current or former PostgreSQL cluster, it is now possible restore from the backups of a cluster in different namespace (i.e. different than the cluster being created).

In support of this functionality, a copy of the pgBackRest Secret corresponding to the repository containing the backups being utilized to bootstrap the cluster is now made specifically for the bootstrap Job (and then removed when bootstrapping is complete).  This ensures the new cluster always has the information required to connect to the repository being utilized to bootstrap the cluster, regardless of what namespace it is in.  Additionally, DNS for the pgBackRest repository service is now always used when performing the restore to ensure proper connectivity across namespaces if/when needed.

And finally, a  `--restore-from-namespace` option has been added to the pgo client, which corresponds to a `spec.pgdatasource.namespace` field in the Pgcluster spec, and allows users to specify the namespace of the cluster specified for bootstrapping the new cluster.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

It is only possible to restore from clusters in the same namespace when creating a new cluster.

**What is the new behavior (if this is a feature change)?**

It is possible to restore from clusters in any namespace managed by the Operator when creating a new cluster.

[ch9969]

**Other information**:

closes #2062