### PR TITLE
Update UsePAM in sshd_config During Operator Upgrade

### DIFF
--- a/internal/operator/backrest/repo.go
+++ b/internal/operator/backrest/repo.go
@@ -165,12 +165,13 @@ func CreateRepoDeployment(clientset kubernetes.Interface, cluster *crv1.Pgcluste
 //
 // If the Secret already exists, then missing fields will be overwritten.
 func CreateRepoSecret(clientset kubernetes.Interface, cluster *crv1.Pgcluster) error {
-	return util.CreateBackrestRepoSecrets(clientset,
+	_, err := util.CreateBackrestRepoSecrets(clientset,
 		util.BackrestRepoConfig{
 			ClusterName:       cluster.Name,
 			ClusterNamespace:  cluster.Namespace,
 			OperatorNamespace: operator.PgoNamespace,
 		})
+	return err
 }
 
 // setBootstrapRepoOverrides overrides certain fields used to populate the pgBackRest repository template

--- a/internal/operator/cluster/upgrade.go
+++ b/internal/operator/cluster/upgrade.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -50,6 +51,11 @@ const (
 	postgresGISImage   = "crunchy-postgres-gis"
 	postgresGISHAImage = "crunchy-postgres-gis-ha"
 )
+
+// nssWrapperRegex is the regular expression that is utilized to determine if the UsePAM
+// setting is set to 'yes' in the sshd_config (as it might be for versions up to v4.6.1,
+// v4.5.2 and v4.4.3)
+var usePAMRegex = regexp.MustCompile(`(?im)^UsePAM\s*yes`)
 
 // AddUpgrade implements the upgrade workflow in accordance with the received pgtask
 // the general process is outlined below:
@@ -468,9 +474,18 @@ func recreateBackrestRepoSecret(clientset kubernetes.Interface, clustername, nam
 		}
 	}
 
+	var repoSecret *v1.Secret
 	if err == nil {
-		err = util.CreateBackrestRepoSecrets(clientset, config)
+		repoSecret, err = util.CreateBackrestRepoSecrets(clientset, config)
 	}
+	if err != nil {
+		log.Errorf("error generating new backrest repo secrets during pgcluster upgrade: %v", err)
+	}
+
+	if err := updatePGBackRestSSHDConfig(clientset, repoSecret, namespace); err != nil {
+		log.Errorf("error upgrading pgBackRest sshd_config: %v", err)
+	}
+
 	if err != nil {
 		log.Errorf("error generating new backrest repo secrets during pgcluster upgrade: %v", err)
 	}
@@ -928,4 +943,29 @@ func updateClusterConfig(clientset kubeapi.Interface, pgcluster *crv1.Pgcluster,
 
 	// sync the changes to the configmap to the DCS
 	return pgoconfig.NewDCS(patchedClusterConfig, clientset, pgcluster.GetObjectMeta().GetLabels()[config.LABEL_PGHA_SCOPE]).Sync()
+}
+
+// updatePGBackRestSSHDConfig is responsible for upgrading the sshd_config file as needed across
+// operator versions to ensure proper functionality with pgBackRest
+func updatePGBackRestSSHDConfig(clientset kubernetes.Interface, repoSecret *v1.Secret,
+	namespace string) error {
+
+	ctx := context.TODO()
+	updatedRepoSecret := repoSecret.DeepCopy()
+
+	// For versions prior to v4.6.2, the UsePAM setting might be set to 'yes' as previously
+	// required to workaround a known Docker issue.  Since this issue has since been resolved,
+	// we now want to ensure this setting is set to 'no'.
+	if !usePAMRegex.MatchString(string(updatedRepoSecret.Data["sshd_config"])) {
+		return nil
+	}
+
+	updatedRepoSecret.Data["sshd_config"] =
+		[]byte(usePAMRegex.ReplaceAllString(string(updatedRepoSecret.Data["sshd_config"]),
+			"UsePAM no"))
+
+	_, err := clientset.CoreV1().Secrets(namespace).Update(ctx, updatedRepoSecret,
+		metav1.UpdateOptions{})
+
+	return err
 }


### PR DESCRIPTION
The `sshd_config` file is now properly upgraded if needed during a PostgreSQL Operator upgrade.  Specifically, the the `UsePAM` setting is set to `no` if currently set to `yes` to align with the default `sshd_config` deployed with the PostgreSQL Operator as of version 4.6.1.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

During a cluster upgrade the `UsePAM` setting in the `sshd_config` **_is not_** set to `no` if currently set to `yes`.

**What is the new behavior (if this is a feature change)?**

During a cluster upgrade the `UsePAM` setting in the `sshd_config` **_is_** set to `no` if currently set to `yes`.

**Other information**:

N/A