### PR TITLE
PVC Resizing

### DIFF
--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -561,7 +561,7 @@ To resize the PVC that stores the PostgreSQL data directory across the entire
 cluster, you will need to edit the `size` attribute of the `PrimaryStorage`
 portion of the `pgclusters.crunchydata.com` custom resource.
 
-The PVC process for a cluster uses a [rolling update]({{< relref "/architecture/high-availability/_index.md">}}#rolling-updates)
+The PVC resize process for a cluster uses a [rolling update]({{< relref "/architecture/high-availability/_index.md">}}#rolling-updates)
 to apply the size changes. During the process, each Deployment is scaled down
 and back to allow for the PVC resize to take effect.
 
@@ -573,6 +573,16 @@ edit the `size` attribute of the `BackrestStorage` portion of the
 
 The Postgres Operator will apply the PVC size change and scale the pgBackRest
 Deployment down and back up.
+
+#### Resize a WAL PVC
+
+To resize the optional PVC that can be used to store WAL archives, you can edit
+the `size` attribute of the `WALStorage` portion of the
+`pgclusters.crunchydata.com` custom resource.
+
+The PVC resize process for a cluster uses a [rolling update]({{< relref "/architecture/high-availability/_index.md">}}#rolling-updates)
+to apply the size changes. During the process, each Deployment is scaled down
+and back to allow for the PVC resize to take effect.
 
 ### Monitoring
 

--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -565,6 +565,15 @@ The PVC process for a cluster uses a [rolling update]({{< relref "/architecture/
 to apply the size changes. During the process, each Deployment is scaled down
 and back to allow for the PVC resize to take effect.
 
+#### Resize the pgBackRest PVC
+
+To resize the PVC that stores the backups managed by pgBackRest, you will need to
+edit the `size` attribute of the `BackrestStorage` portion of the
+`pgclusters.crunchydata.com` custom resource.
+
+The Postgres Operator will apply the PVC size change and scale the pgBackRest
+Deployment down and back up.
+
 ### Monitoring
 
 To enable the [monitoring]({{< relref "/architecture/monitoring.md">}})

--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -559,7 +559,7 @@ and how you can resize the PVCs.
 
 To resize the PVC that stores the PostgreSQL data directory across the entire
 cluster, you will need to edit the `size` attribute of the `PrimaryStorage`
-portion of the `pgclusters.crunchydata.com` custom resource.
+section of the `pgclusters.crunchydata.com` custom resource.
 
 The PVC resize process for a cluster uses a [rolling update]({{< relref "/architecture/high-availability/_index.md">}}#rolling-updates)
 to apply the size changes. During the process, each Deployment is scaled down
@@ -568,7 +568,7 @@ and back to allow for the PVC resize to take effect.
 #### Resize the pgBackRest PVC
 
 To resize the PVC that stores the backups managed by pgBackRest, you will need to
-edit the `size` attribute of the `BackrestStorage` portion of the
+edit the `size` attribute of the `BackrestStorage` section of the
 `pgclusters.crunchydata.com` custom resource.
 
 The Postgres Operator will apply the PVC size change and scale the pgBackRest
@@ -577,12 +577,22 @@ Deployment down and back up.
 #### Resize a WAL PVC
 
 To resize the optional PVC that can be used to store WAL archives, you can edit
-the `size` attribute of the `WALStorage` portion of the
+the `size` attribute of the `WALStorage` section of the
 `pgclusters.crunchydata.com` custom resource.
 
 The PVC resize process for a cluster uses a [rolling update]({{< relref "/architecture/high-availability/_index.md">}}#rolling-updates)
 to apply the size changes. During the process, each Deployment is scaled down
-and back to allow for the PVC resize to take effect.
+and back up to allow for the PVC resize to take effect.
+
+#### Resize the pgAdmin 4 PVC
+
+If you have deployed [pgAdmin 4]({{< relref "/architecture/pgadmin4.md" >}}) and
+need to resize its PVC, you can edit the `size` attribute of the `PGAdmin`
+section of the `pgclusters.crunchydata.com` custom resource.
+
+The PVC resize process for a cluster uses a [rolling update]({{< relref "/architecture/high-availability/_index.md">}}#rolling-updates)
+to apply the size changes. During the process, the pgAdmin 4 Deployment is
+scaled down and back up to allow for the PVC resize to take effect.
 
 ### Monitoring
 

--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -574,6 +574,19 @@ edit the `size` attribute of the `BackrestStorage` section of the
 The Postgres Operator will apply the PVC size change and scale the pgBackRest
 Deployment down and back up.
 
+#### Resize a single PostgreSQL instance / read-only replica
+
+To resize the PVC for a read-only replica, you can edit the `size` attribute
+of the `ReplicaStorage` portion of the `pgreplicas.crunchydata.com` custom
+resource.
+
+Note that if a subsequent action resizes the PVCs for all of the instances in a
+Postgres cluster and that new PVC size is larger than the specific instance
+size that is set, then the instance PVC is also resized.
+
+The Postgres Operator will apply the PVC size change and scale the instance
+Deployment down and back up.
+
 #### Resize a WAL PVC
 
 To resize the optional PVC that can be used to store WAL archives, you can edit

--- a/docs/content/custom-resources/_index.md
+++ b/docs/content/custom-resources/_index.md
@@ -542,6 +542,29 @@ kubectl apply -f "${pgo_cluster_name}-${pgo_cluster_replica_suffix}-pgreplica.ya
 
 Add this time, removing a replica must be handled through the [`pgo` client]({{< relref "/pgo-client/common-tasks.md#high-availability-scaling-up-down">}}).
 
+### Resize PVC
+
+PGO lets you resize the PVCs that the Operator manages, e.g. the Postgres data
+directory, pgBackRest, the WAL volume, etc. The PVC can be resized so long as
+the following conditions are met:
+
+1. The [Storage Class](https://kubernetes.io/docs/concepts/storage/storage-classes/)
+supports resizing.
+2. The new size of the PVC is larger than the old size.
+
+The following sections explain how the different PVC resizing operations work
+and how you can resize the PVCs.
+
+#### Resize the PostgreSQL Cluster PVC
+
+To resize the PVC that stores the PostgreSQL data directory across the entire
+cluster, you will need to edit the `size` attribute of the `PrimaryStorage`
+portion of the `pgclusters.crunchydata.com` custom resource.
+
+The PVC process for a cluster uses a [rolling update]({{< relref "/architecture/high-availability/_index.md">}}#rolling-updates)
+to apply the size changes. During the process, each Deployment is scaled down
+and back to allow for the PVC resize to take effect.
+
 ### Monitoring
 
 To enable the [monitoring]({{< relref "/architecture/monitoring.md">}})
@@ -781,7 +804,7 @@ attribute and how it works.
 | accessmode | `create` | The name of the Kubernetes Persistent Volume [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) to use. |
 | matchLabels | `create` | Only used with `StorageType` of `create`, used to match a particular subset of provisioned Persistent Volumes. |
 | name | `create` | Only needed for `PrimaryStorage` in `pgclusters.crunchydata.com`.Used to identify the name of the PostgreSQL cluster. Should match `ClusterName`. |
-| size | `create` | The size of the [Persistent Volume Claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) (PVC). Must use a Kubernetes resource value, e.g. `20Gi`. |
+| size | `create`, `update` | The size of the [Persistent Volume Claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) (PVC). Must use a Kubernetes resource value, e.g. `20Gi`. |
 | storageclass | `create` | The name of the Kubernetes [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) to use. |
 | storagetype | `create` | Set to `create` if storage is provisioned (e.g. using `hostpath`). Set to `dynamic` if using a dynamic storage provisioner, e.g. via a `StorageClass`. |
 | supplementalgroups | `create` | If provided, a comma-separated list of group IDs to use in case it is needed to interface with a particular storage system. Typically used with NFS or hostpath storage. |

--- a/internal/config/annotations.go
+++ b/internal/config/annotations.go
@@ -21,6 +21,9 @@ const (
 	ANNOTATION_BACKREST_RESTORE       = "pgo-backrest-restore"
 	ANNOTATION_PGHA_BOOTSTRAP_REPLICA = "pgo-pgha-bootstrap-replica"
 	ANNOTATION_PRIMARY_DEPLOYMENT     = "primary-deployment"
+	// ANNOTATION_CLUSTER_DO_NOT_RESIZE indicates on a custom resource update that
+	// a specific instance should not be resized
+	ANNOTATION_CLUSTER_DO_NOT_RESIZE = "do-not-resize"
 	// ANNOTATION_CLUSTER_KEEP_BACKUPS indicates that if a custom resource is
 	// deleted, ensure the backups are kept
 	ANNOTATION_CLUSTER_KEEP_BACKUPS = "keep-backups"

--- a/internal/controller/pgcluster/pgclustercontroller.go
+++ b/internal/controller/pgcluster/pgclustercontroller.go
@@ -301,6 +301,18 @@ func (c *Controller) onUpdate(oldObj, newObj interface{}) {
 		}
 	}
 
+	// see if the pgBackRest PVC size value changed.
+	if oldcluster.Spec.BackrestStorage.Size != newcluster.Spec.BackrestStorage.Size {
+		// validate that this resize can occur
+		if err := validatePVCResize(oldcluster.Spec.BackrestStorage.Size, newcluster.Spec.BackrestStorage.Size); err != nil {
+			log.Error(err)
+		} else {
+			if err := backrestoperator.ResizePVC(c.Client, newcluster); err != nil {
+				log.Error(err)
+			}
+		}
+	}
+
 	// see if any of the pgBouncer values have changed, and if so, update the
 	// pgBouncer deployment
 	if !reflect.DeepEqual(oldcluster.Spec.PgBouncer, newcluster.Spec.PgBouncer) {

--- a/internal/controller/pgtask/pgtaskcontroller.go
+++ b/internal/controller/pgtask/pgtaskcontroller.go
@@ -129,7 +129,7 @@ func (c *Controller) processNextItem() bool {
 
 		if cluster, err := c.Client.CrunchydataV1().Pgclusters(tmpTask.Namespace).
 			Get(ctx, clusterName, metav1.GetOptions{}); err == nil {
-			if err := clusteroperator.RollingUpdate(c.Client, c.Client.Config, cluster,
+			if err := clusteroperator.RollingUpdate(c.Client, c.Client.Config, cluster, false,
 				func(kubeapi.Interface, *crv1.Pgcluster, *appsv1.Deployment) error { return nil }); err != nil {
 				log.Errorf("rolling update failed: %q", err.Error())
 			}

--- a/internal/operator/cluster/cluster.go
+++ b/internal/operator/cluster/cluster.go
@@ -1014,7 +1014,7 @@ func publishClusterShutdown(cluster crv1.Pgcluster) error {
 // StopPostgreSQLInstance function, as it preps a Deployment to have its
 // PostgreSQL instance shut down. This helps to ensure that a PostgreSQL
 // instance will launch and not be in crash recovery mode
-func stopPostgreSQLInstance(clientset kubernetes.Interface, restConfig *rest.Config, deployment apps_v1.Deployment) error {
+func StopPostgreSQLInstance(clientset kubernetes.Interface, restConfig *rest.Config, deployment apps_v1.Deployment) error {
 	ctx := context.TODO()
 
 	// First, attempt to get the PostgreSQL instance Pod attachd to this

--- a/internal/operator/cluster/rolling.go
+++ b/internal/operator/cluster/rolling.go
@@ -170,7 +170,7 @@ func applyUpdateToPostgresInstance(clientset kubeapi.Interface, restConfig *rest
 	// recovery mode.
 	//
 	// If an error is returned, warn, but proceed with the function
-	if err := stopPostgreSQLInstance(clientset, restConfig, *deployment); err != nil {
+	if err := StopPostgreSQLInstance(clientset, restConfig, *deployment); err != nil {
 		log.Warn(err)
 	}
 


### PR DESCRIPTION
This patchset introduces the ability for PVCs that are managed by the Operator to be resized. This includes:

1. The data directory PVC
2. The pgBackRest PVC
3. The PVC for a specific Postgres instance
4. The optional WAL directory PVC
5. The pgAdmin 4 PVC

This does require for the underlying storage class of the PVC to be able to support resizing, and the requested PVC size must be larger than the old PVC size (i.e. you can't shrink the PVC). Both of these are Kubernetes requiremenets.

Allow of these change are available through editing the `pgclusters.crunchydata.com` custom resource (and in the case of the specific instance, the `pgreplicas.crunchydata.com` CR). A future patch will add the functionality into the `pgo` client.

More details about how PGO rolls out the changes for each of these resize operations are available in the documentation.

Issue: [ch8477]
closes #1626
closes #2332