### PR TITLE
Properly identify pgAdmin Service from `pgo test`

### DIFF
--- a/internal/apiserver/clusterservice/clusterimpl.go
+++ b/internal/apiserver/clusterservice/clusterimpl.go
@@ -300,11 +300,14 @@ func getServices(cluster *crv1.Pgcluster, ns string) ([]msgs.ShowClusterService,
 	for _, p := range services.Items {
 		d := msgs.ShowClusterService{}
 		d.Name = p.Name
-		if strings.Contains(p.Name, "-backrest-repo") {
+		if strings.HasSuffix(p.Name, "-backrest-repo") {
 			d.BackrestRepo = true
 			d.ClusterName = cluster.Name
-		} else if strings.Contains(p.Name, "-pgbouncer") {
+		} else if strings.HasSuffix(p.Name, "-pgbouncer") {
 			d.Pgbouncer = true
+			d.ClusterName = cluster.Name
+		} else if strings.HasSuffix(p.Name, "-pgadmin") {
+			d.PGAdmin = true
 			d.ClusterName = cluster.Name
 		}
 		d.ClusterIP = p.Spec.ClusterIP
@@ -486,6 +489,8 @@ func TestCluster(name, selector, ns, pgouser string, allFlag bool) msgs.ClusterT
 				endpoint.InstanceType = msgs.ClusterTestInstanceTypePrimary
 			case (strings.HasSuffix(service.Name, "-"+msgs.PodTypeReplica) && strings.Count(service.Name, "-"+msgs.PodTypeReplica) == 1):
 				endpoint.InstanceType = msgs.ClusterTestInstanceTypeReplica
+			case service.PGAdmin:
+				endpoint.InstanceType = msgs.ClusterTestInstanceTypePGAdmin
 			case service.Pgbouncer:
 				endpoint.InstanceType = msgs.ClusterTestInstanceTypePGBouncer
 			case service.BackrestRepo:

--- a/pkg/apiservermsgs/clustermsgs.go
+++ b/pkg/apiservermsgs/clustermsgs.go
@@ -269,6 +269,7 @@ type ShowClusterService struct {
 	ClusterName  string
 	Pgbouncer    bool
 	BackrestRepo bool
+	PGAdmin      bool
 }
 
 const (
@@ -512,6 +513,7 @@ type ClusterTestRequest struct {
 const (
 	ClusterTestInstanceTypePrimary   = "primary"
 	ClusterTestInstanceTypeReplica   = "replica"
+	ClusterTestInstanceTypePGAdmin   = "pgadmin"
 	ClusterTestInstanceTypePGBouncer = "pgbouncer"
 	ClusterTestInstanceTypeBackups   = "backups"
 	ClusterTestInstanceTypeUnknown   = "unknown"


### PR DESCRIPTION
This was previously showing up as a "primary", which it certainly
isn't. Now it is properly identified as its own thing, i.e. pgAdmin.

Issue: [ch11100]