### PR TITLE
Ensure cluster created with sync replication has at least 1 replica

### DIFF
--- a/cmd/pgo/cmd/cluster.go
+++ b/cmd/pgo/cmd/cluster.go
@@ -349,6 +349,11 @@ func createCluster(args []string, ns string, createClusterCmd *cobra.Command) {
 	// only set SyncReplication in the request if actually provided via the CLI
 	if createClusterCmd.Flag("sync-replication").Changed {
 		r.SyncReplication = &SyncReplication
+
+		// if it is true, ensure there is at least one replica
+		if *r.SyncReplication && r.ReplicaCount < 1 {
+			r.ReplicaCount = 1
+		}
 	}
 	// only set BackrestS3VerifyTLS in the request if actually provided via the CLI
 	// if set, store provided value accordingly

--- a/internal/apiserver/clusterservice/clusterimpl.go
+++ b/internal/apiserver/clusterservice/clusterimpl.go
@@ -1424,6 +1424,12 @@ func getClusterParams(request *msgs.CreateClusterRequest, name string, ns string
 	spec.CustomConfig = request.CustomConfig
 	spec.SyncReplication = request.SyncReplication
 
+	replicas, _ := strconv.Atoi(spec.Replicas)
+	if *spec.SyncReplication && replicas < 1 {
+		spec.Replicas = "1"
+		log.Infof("sync replication set. ensuring there is at least one replica.")
+	}
+
 	if request.BackrestConfig != "" {
 		configmap := v1.ConfigMapProjection{}
 		configmap.Name = request.BackrestConfig


### PR DESCRIPTION
This enforces that a cluster created with sync replication should
have at least one replica.

Issue: [ch10889]