### PR TITLE
Cleans pgBackRest Repo on In-Place Restore

### DIFF
--- a/internal/controller/job/bootstraphandler.go
+++ b/internal/controller/job/bootstraphandler.go
@@ -143,6 +143,7 @@ func (c *Controller) cleanupBootstrapResources(job *apiv1.Job, cluster *crv1.Pgc
 	if restore {
 		restoreClusterName = job.GetLabels()[config.LABEL_PG_CLUSTER]
 		repoName = fmt.Sprintf(util.BackrestRepoDeploymentName, restoreClusterName)
+		cleanRepo = true
 	} else {
 		restoreClusterName = cluster.Spec.PGDataSource.RestoreFrom
 		repoName = fmt.Sprintf(util.BackrestRepoDeploymentName, restoreClusterName)


### PR DESCRIPTION
The pgBackRest repository is now cleaned up following an in-place restore and then recreated during cluster initialization.  This
ensures the proper initialization logic is executed when the pgBackRest repository is scaled up to one during initialization. Specifically, this triggers the deployment and initialization of the Primary Pod for the cluster.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The pgBackRest repository is not deleted on a in-place restore.  This prevents the primary Pod from scaling properly following the restore.

**What is the new behavior (if this is a feature change)?**

The pgBackRest repository is deleted on a in-place restore, ensuring the primary Pod scales properly following the restore.

**Other information**:

This change does not require any backpatches.