### PR TITLE
Installs Required Packages for pgo-scheduler

### DIFF
--- a/build/pgo-scheduler/Dockerfile
+++ b/build/pgo-scheduler/Dockerfile
@@ -3,6 +3,7 @@ ARG BASEVER
 ARG PREFIX
 FROM ${PREFIX}/pgo-base:${BASEOS}-${BASEVER}
 
+ARG BASEOS
 ARG PGVERSION
 ARG BACKREST_VERSION
 ARG PACKAGER
@@ -28,6 +29,13 @@ fi
 RUN if [ "$DFSET" = "rhel" ] ; then \
 	mkdir -p /opt/cpm/bin /opt/cpm/conf /pgo-config \
 	&& chown -R 2:2 /opt/cpm /pgo-config ; \
+fi
+
+RUN if  [ "$BASEOS" = "ubi8" ]; then \
+    ${PACKAGER} -y install \
+        findutils \
+        procps \
+    && ${PACKAGER} -y clean all ; \
 fi
 
 ADD bin/pgo-scheduler /opt/cpm/bin


### PR DESCRIPTION
When building the `pgo-scheduler` image using `ubi8-minimal`, the `findutils` and `procps` packages are now installed.  This ensures the `find` utility is present as required by the scheduler's liveness probe, while also ensuring the `pgrep` and `pidof` utilities are present as required by the scheduler's `start.sh` script.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

Liveness probe errors are seen when using `ubi8-minimal`:

```bash
  Warning  Unhealthy       5m21s (x5 over 9m21s)  kubelet, crc-nsk8x-master-0  Liveness probe failed: bash: find: command not found
  Normal   Killing         21s (x5 over 8m21s)    kubelet, crc-nsk8x-master-0  Container scheduler failed liveness probe, will be restarted
```

Additionally, missing command errors are seen when the scheduler receives a signal to terminate:

```
Signal trap triggered, beginning shutdown..
/opt/cpm/bin/start.sh: line 19: pgrep: command not found
/opt/cpm/bin/start.sh: line 21: pidof: command not found
kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]
```

**What is the new behavior (if this is a feature change)?**

Liveness probes and `start.sh` logic executes successfully.

**Other information**:

N/A