### PR TITLE
Update Secret Name In Bootstrap Job Template

### DIFF
--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/cluster-bootstrap-job.json
@@ -194,7 +194,7 @@
                 }, {
                     "name": "ssh-config",
                     "secret": {
-                        "secretName": "{{.RestoreFrom}}-backrest-repo-config",
+                        "secretName": "{{.ClusterName}}-bootstrap-backrest-repo-config",
                         "items": [
                           {
                              "key": "config",


### PR DESCRIPTION
The `secretName` in for the `ssh-config` volume in the `cluster-bootstrap-job.json` template has been updated to reference the the proper Secret as needed for restoring across namespaces.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The `secretName` in for the `ssh-config` volume in the `cluster-bootstrap-job.json` template is:

```json
"secretName": "{{.RestoreFrom}}-backrest-repo-config",
``` 

**What is the new behavior (if this is a feature change)?**

The `secretName` in for the `ssh-config` volume in the `cluster-bootstrap-job.json` template is:

```json
"secretName": "{{.ClusterName}}-bootstrap-backrest-repo-config",
``` 

**Other information**:

N/A