### PR TITLE
Delete Previous Bootstrap Secret on Restore

### DIFF
--- a/internal/controller/job/bootstraphandler.go
+++ b/internal/controller/job/bootstraphandler.go
@@ -24,7 +24,6 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/config"
 	"github.com/crunchydata/postgres-operator/internal/operator"
 	backrestoperator "github.com/crunchydata/postgres-operator/internal/operator/backrest"
-	cl "github.com/crunchydata/postgres-operator/internal/operator/cluster"
 	"github.com/crunchydata/postgres-operator/internal/util"
 	crv1 "github.com/crunchydata/postgres-operator/pkg/apis/crunchydata.com/v1"
 
@@ -175,7 +174,7 @@ func (c *Controller) cleanupBootstrapResources(job *apiv1.Job, cluster *crv1.Pgc
 
 	// delete the "bootstrap" version of pgBackRest repo Secret
 	if err := c.Client.CoreV1().Secrets(job.GetNamespace()).Delete(ctx,
-		fmt.Sprintf(cl.BoostrapConfigPrefix, cluster.GetName(), config.LABEL_BACKREST_REPO_SECRET),
+		fmt.Sprintf(util.BootstrapConfigPrefix, cluster.GetName(), config.LABEL_BACKREST_REPO_SECRET),
 		metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}

--- a/internal/operator/backrest/restore.go
+++ b/internal/operator/backrest/restore.go
@@ -265,6 +265,14 @@ func PrepareClusterForRestore(clientset kubeapi.Interface, cluster *crv1.Pgclust
 	log.Debugf("restore workflow: set 'init' flag to 'true' for cluster %s",
 		clusterName)
 
+	// delete the "bootstrap" pgBackRest repo Secret if it exists, e.g. from a previous restore
+	// attempt
+	if err := clientset.CoreV1().Secrets(namespace).Delete(ctx,
+		fmt.Sprintf(util.BootstrapConfigPrefix, cluster.GetName(), config.LABEL_BACKREST_REPO_SECRET),
+		metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+		return nil, err
+	}
+
 	return patchedCluster, nil
 }
 

--- a/internal/operator/cluster/cluster.go
+++ b/internal/operator/cluster/cluster.go
@@ -69,10 +69,6 @@ const (
 
 	// pgBadgerContainerName is the name of the pgBadger container
 	pgBadgerContainerName = "pgbadger"
-
-	// BoostrapConfigPrefix is the format of the prefix used for the Secret containing the
-	// pgBackRest configuration required to bootstrap a new cluster using a pgBackRest backup
-	BoostrapConfigPrefix = "%s-bootstrap-%s"
 )
 
 // a group of constants that are used as part of the TLS support
@@ -960,7 +956,7 @@ func createBootstrapBackRestSecret(clientset kubernetes.Interface,
 
 	// Create a copy of the secret for the cluster being recreated.  This ensures a copy of the
 	// required pgBackRest Secret is always present is the namespace of the cluster being created.
-	secretCopyName := fmt.Sprintf(BoostrapConfigPrefix, cluster.GetName(),
+	secretCopyName := fmt.Sprintf(util.BootstrapConfigPrefix, cluster.GetName(),
 		config.LABEL_BACKREST_REPO_SECRET)
 	secretCopy := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/util/cluster.go
+++ b/internal/util/cluster.go
@@ -97,6 +97,10 @@ const (
 	backRestRepoSecretKeySSHHostPrivateKey = "ssh_host_ed25519_key"
 )
 
+// BootstrapConfigPrefix is the format of the prefix used for the Secret containing the
+// pgBackRest configuration required to bootstrap a new cluster using a pgBackRest backup
+const BootstrapConfigPrefix = "%s-bootstrap-%s"
+
 const (
 	// SQLValidUntilAlways uses a special PostgreSQL value to ensure a password
 	// is always valid


### PR DESCRIPTION
When performing an in-place restore (e.g. using `pgo restore`), any existing "bootstrap" Secrets are now deleted.  This facilitates retry attempts, e.g. after a restore attempt fails, by ensuring all resources can be properly recreated in order to re-attempt the restore.

Additionally, fixes the spelling of variable `BootstrapConfigPrefix`, and moves it to a location where it can be utilized by both the
`cluster` and `pgbackrest` packages.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The "bootstrap" Secret (if exists) **_is not_** deleted before performing an in-place restore.

**What is the new behavior (if this is a feature change)?**

The "bootstrap" Secret (if exists) **_is_** not deleted before performing an in-place restore.

**Other information**:

N/A