### PR TITLE
Include additional dependencies into minimal image

### DIFF
--- a/build/pgo-base/Dockerfile
+++ b/build/pgo-base/Dockerfile
@@ -53,6 +53,10 @@ RUN if  [ "$BASEOS" = "ubi8" ]; then \
     ${PACKAGER} -y update \
     && ${PACKAGER} -y install \
         glibc-langpack-en \
+        procps-ng \
+        less \
+        vim-minimal \
+    && ${PACKAGER} reinstall tzdata -y \
     && ${PACKAGER} -y clean all ; \
 fi
 


### PR DESCRIPTION
This includes some of the process debugging utils, vi, less,
and ensuring tzdata is present[1]

[1] https://access.redhat.com/solutions/5616681

Issue: [ch11367]