### PR TITLE
added disable_fsgroup var

### DIFF
--- a/installers/kubectl/postgres-operator-ocp311.yml
+++ b/installers/kubectl/postgres-operator-ocp311.yml
@@ -63,6 +63,7 @@ data:
     delete_operator_namespace: "false"
     delete_watched_namespaces: "false"
     disable_auto_failover: "false"
+    disable_fsgroup: "true"
     reconcile_rbac: "true"
     exporterport: "9187"
     metrics: "false"


### PR DESCRIPTION
Added var disable_fsgroup and set it to true for ocp 3.11 where you do not want to have the 
default PostgreSQL fsGroup (26) set.


**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
currently without this var when you try to create postgresql clusters they are not created properly



**What is the new behavior (if this is a feature change)?**
with this var added and set to true all clusters create successfully 


**Other information**:
