### PR TITLE
Consider 'posix,s3' & 'posix,gcs' During Upgrade

### DIFF
--- a/internal/operator/cluster/upgrade.go
+++ b/internal/operator/cluster/upgrade.go
@@ -130,17 +130,17 @@ func AddUpgrade(clientset kubeapi.Interface, upgrade *crv1.Pgtask, namespace str
 		return
 	}
 
-	// update the unix socket directories parameter so it no longer include /crunchyadm and
-	// set any path references to the /opt/crunchy... paths
-	if err = updateClusterConfig(clientset, pgcluster, namespace); err != nil {
-		log.Errorf("error updating %s-pgha-config configmap during upgrade of cluster %s, Error: %v", pgcluster.Name, pgcluster.Name, err)
-	}
-
 	// recreate new Backrest Repo secret that was just deleted
 	recreateBackrestRepoSecret(clientset, upgradeTargetClusterName, namespace, operator.PgoNamespace)
 
 	// set proper values for the pgcluster that are updated between CR versions
 	preparePgclusterForUpgrade(pgcluster, upgrade.Spec.Parameters, oldpgoversion, currentPrimary)
+
+	// update the unix socket directories parameter so it no longer include /crunchyadm and
+	// set any path references to the /opt/crunchy... paths
+	if err = updateClusterConfig(clientset, pgcluster, namespace); err != nil {
+		log.Errorf("error updating %s-pgha-config configmap during upgrade of cluster %s, Error: %v", pgcluster.Name, pgcluster.Name, err)
+	}
 
 	// create a new workflow for this recreated cluster
 	workflowid, err := createClusterRecreateWorkflowTask(clientset, pgcluster.Name, namespace, upgrade.Spec.Parameters[config.LABEL_PGOUSER])
@@ -918,7 +918,18 @@ func updateClusterConfig(clientset kubeapi.Interface, pgcluster *crv1.Pgcluster,
 	// and the /opt/cpm... directories are now set under /opt/crunchy
 	if dcsConf.PostgreSQL != nil && dcsConf.PostgreSQL.Parameters != nil {
 		dcsConf.PostgreSQL.Parameters["unix_socket_directories"] = "/tmp"
-		dcsConf.PostgreSQL.Parameters["archive_command"] = `source /opt/crunchy/bin/postgres-ha/pgbackrest/pgbackrest-set-env.sh && pgbackrest archive-push "%p"`
+
+		// ensure the proper archive_command is set according to the BackrestStorageTypes defined for
+		// the pgcluster
+		switch {
+		case operator.IsLocalAndS3Storage(pgcluster):
+			dcsConf.PostgreSQL.Parameters["archive_command"] = `source /opt/crunchy/bin/postgres-ha/pgbackrest/pgbackrest-archive-push-local-s3.sh %p`
+		case operator.IsLocalAndGCSStorage(pgcluster):
+			dcsConf.PostgreSQL.Parameters["archive_command"] = `source /opt/crunchy/bin/postgres-ha/pgbackrest/pgbackrest-archive-push-local-gcs.sh %p`
+		default:
+			dcsConf.PostgreSQL.Parameters["archive_command"] = `source /opt/crunchy/bin/postgres-ha/pgbackrest/pgbackrest-set-env.sh && pgbackrest archive-push "%p"`
+		}
+
 		dcsConf.PostgreSQL.RecoveryConf["restore_command"] = `source /opt/crunchy/bin/postgres-ha/pgbackrest/pgbackrest-set-env.sh && pgbackrest archive-get %f "%p"`
 	}
 


### PR DESCRIPTION
The Operator upgrade process now properly considers the presence of both `posix` and `s3` storage, or both `posix` and `gcs` storage, for the `backrestStorageTypes` field within the pgcluster spec. Specifically, when updating the `archive_command` during a pgcluster upgrade (specifically due to a directory change in v4.6 impacting the directory utilized for the `archive_command`), a check is now performed to determine if both `posix` and `s3` storage is enabled, or if both `posix` and `gcs` storage is enabled, and the set the proper `archive_command` is then set accordingly.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The proper `archive_command` is not set when using `posix,s3` or `posix,gcs`, resulting in failed archiving and backups 
 to `s3` or `gcs` following an upgrade.

**What is the new behavior (if this is a feature change)?**

The proper `archive_command` is set when using `posix,s3` or `posix,gcs`, ensuring proper archives pushing and backups to all repos following an upgrade.

**Other information**:

N/A