### PR TITLE
Ensure label correctness when creating clusters with API

### DIFF
--- a/internal/apiserver/clusterservice/clusterimpl.go
+++ b/internal/apiserver/clusterservice/clusterimpl.go
@@ -868,6 +868,7 @@ func CreateCluster(request *msgs.CreateClusterRequest, ns, pgouser string) msgs.
 
 	// Create an instance of our CRD
 	newInstance := getClusterParams(request, clusterName, ns)
+	newInstance.ObjectMeta.Labels[config.LABEL_PG_CLUSTER] = clusterName
 	newInstance.ObjectMeta.Labels[config.LABEL_PGOUSER] = pgouser
 	newInstance.Spec.BackrestStorageTypes = backrestStorageTypes
 


### PR DESCRIPTION
This ensures an expected label on the pgcluster CR is present when
created with API, as it is queried in other parts of the system.