### PR TITLE
corrected namespace to use values.namespace

### DIFF
--- a/examples/helm/postgres/templates/NOTES.txt
+++ b/examples/helm/postgres/templates/NOTES.txt
@@ -47,7 +47,7 @@ And use the following connection string to connect to your cluster:
 
 If you need to log in as the PostgreSQL superuser, you can do so with the following command:
 
-    PGPASSWORD=$(kubectl -n jkatz get secrets {{ .Values.name }}-postgres-secret -o jsonpath='{.data.password}' | base64 -d) psql -h localhost -U postgres {{ .Values.name }}
+    PGPASSWORD=$(kubectl -n {{ .Values.namespace }} get secrets {{ .Values.name }}-postgres-secret -o jsonpath='{.data.password}' | base64 -d) psql -h localhost -U postgres {{ .Values.name }}
 
 More information about the custom resource workflow the docs can be found here:
 


### PR DESCRIPTION
Changed namespace "jkatz" to use the values.namespace

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

The print out after helm install, has 
"PGPASSWORD=$(kubectl -n **jkatz** get secrets ....)

**What is the new behavior (if this is a feature change)?**

This has been corrected to use the namespace value provided in the values.yaml
"PGPASSWORD=$(kubectl -n **<.Values.namespace>** get secrets ....)


**Other information**:
