### PR TITLE
Ensure superfluous label is removed from user labels on upgrade

### DIFF
--- a/internal/operator/cluster/upgrade.go
+++ b/internal/operator/cluster/upgrade.go
@@ -561,6 +561,11 @@ func preparePgclusterForUpgrade(pgcluster *crv1.Pgcluster, parameters map[string
 	}
 	delete(pgcluster.Spec.UserLabels, "service-type")
 
+	// 4.6.0 removed the "pg-pod-anti-affinity" label from user labels, as this is
+	// superfluous and handled through other processes. We can explicitly
+	// eliminate it
+	delete(pgcluster.Spec.UserLabels, "pg-pod-anti-affinity")
+
 	// 4.6.0 moved the "autofail" label to the DisableAutofail attribute. Given
 	// by default we need to start in an autofailover state, we just delete the
 	// legacy attribute


### PR DESCRIPTION
This removes the "pg-pod-anti-affinity" label from the "userlabels"
section of the pgclusters custom resource during the upgrade process.
This has long been managed through the custom resource itself and
should not be present within the custom labels.

Issue: [ch11573]