### PR TITLE
Ensure "vendor" label is present on PGO objects

### DIFF
--- a/deploy/cluster-role-bindings.yaml
+++ b/deploy/cluster-role-bindings.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pgo-cluster-role
+  labels:
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/cluster-roles-readonly.yaml
+++ b/deploy/cluster-roles-readonly.yaml
@@ -2,6 +2,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-cluster-role
+  labels:
+    vendor: crunchydata
 rules:
   - apiGroups:
       - ''

--- a/deploy/cluster-roles.yaml
+++ b/deploy/cluster-roles.yaml
@@ -3,6 +3,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-cluster-role
+  labels:
+    vendor: crunchydata
 rules:
   - apiGroups:
       - ''

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -53,6 +53,8 @@ then
 		--from-literal=aws-s3-key="${pgbackrest_aws_s3_key}" \
 		--from-literal=aws-s3-key-secret="${pgbackrest_aws_s3_key_secret}" \
 		--from-literal=gcs-key="${pgbackrest_gcs_key}"
+  $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE label secret pgo-backrest-repo-config \
+		vendor=crunchydata
 fi
 
 #
@@ -65,11 +67,12 @@ then
 fi
 
 $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create secret tls pgo.tls --key=${PGOROOT}/conf/postgres-operator/server.key --cert=${PGOROOT}/conf/postgres-operator/server.crt
+$PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE label secret pgo.tls vendor=crunchydata
 
 $PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE create configmap pgo-config \
 	--from-file=${PGOROOT}/conf/postgres-operator/pgo.yaml \
 	--from-file=${PGO_CONF_DIR}/pgo-configs
-
+$PGO_CMD --namespace=$PGO_OPERATOR_NAMESPACE label configmap pgo-config vendor=crunchydata
 
 #
 # check if custom port value is set, otherwise set default values

--- a/deploy/local-namespace-rbac.yaml
+++ b/deploy/local-namespace-rbac.yaml
@@ -3,6 +3,8 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-local-ns
+  labels:
+    vendor: crunchydata
 rules:
   - apiGroups:
       - ''
@@ -28,6 +30,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pgo-local-ns
+  labels:
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -41,6 +45,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pgo-target-role-binding
+  labels:
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/role-bindings.yaml
+++ b/deploy/role-bindings.yaml
@@ -4,6 +4,8 @@ kind: RoleBinding
 metadata:
   name: pgo-role
   namespace: "$PGO_OPERATOR_NAMESPACE"
+  labels:
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/roles.yaml
+++ b/deploy/roles.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-role
   namespace: "$PGO_OPERATOR_NAMESPACE"
+  labels:
+    vendor: crunchydata
 rules:
   - apiGroups:
       - ''

--- a/deploy/service-accounts.yaml
+++ b/deploy/service-accounts.yaml
@@ -4,3 +4,5 @@ kind: ServiceAccount
 metadata:
   name: postgres-operator
   namespace: $PGO_OPERATOR_NAMESPACE
+  labels:
+    vendor: crunchydata

--- a/deploy/service.json
+++ b/deploy/service.json
@@ -4,7 +4,8 @@
     "metadata": {
 	"name": "postgres-operator",
         "labels": {
-            "name": "postgres-operator"
+            "name": "postgres-operator",
+            "vendor": "crunchydata"
         }
     },
     "spec": {

--- a/docs/content/installation/other/operator-hub.md
+++ b/docs/content/installation/other/operator-hub.md
@@ -25,6 +25,8 @@ If you plan to use AWS S3 to store backups and would like to have the keys avail
 kubectl -n "$PGO_OPERATOR_NAMESPACE" create secret generic pgo-backrest-repo-config \
   --from-literal=aws-s3-key="<your-aws-s3-key>" \
   --from-literal=aws-s3-key-secret="<your-aws-s3-key-secret>"
+kubectl -n "$PGO_OPERATOR_NAMESPACE" label secret pgo-backrest-repo-config \
+  vendor=crunchydata
 ```
 
 ### Certificates (optional)

--- a/installers/ansible/roles/pgo-operator/files/crds/pgclusters-crd.yaml
+++ b/installers/ansible/roles/pgo-operator/files/crds/pgclusters-crd.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pgclusters.crunchydata.com
+  labels:
+    vendor: crunchydata
 spec:
   group: crunchydata.com
   names:

--- a/installers/ansible/roles/pgo-operator/files/crds/pgpolicies-crd.yaml
+++ b/installers/ansible/roles/pgo-operator/files/crds/pgpolicies-crd.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pgpolicies.crunchydata.com
+  labels:
+    vendor: crunchydata
 spec:
   group: crunchydata.com
   names:

--- a/installers/ansible/roles/pgo-operator/files/crds/pgreplicas-crd.yaml
+++ b/installers/ansible/roles/pgo-operator/files/crds/pgreplicas-crd.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pgreplicas.crunchydata.com
+  labels:
+    vendor: crunchydata
 spec:
   group: crunchydata.com
   names:

--- a/installers/ansible/roles/pgo-operator/files/crds/pgtasks-crd.yaml
+++ b/installers/ansible/roles/pgo-operator/files/crds/pgtasks-crd.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pgtasks.crunchydata.com
+  labels:
+    vendor: crunchydata
 spec:
   group: crunchydata.com
   names:

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-role-binding.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-role-binding.json
@@ -3,7 +3,10 @@
     "kind": "RoleBinding",
     "metadata": {
         "name": "pgo-backrest-role-binding",
-        "namespace": "{{.TargetNamespace}}"
+        "namespace": "{{.TargetNamespace}}",
+        "labels": {
+          "vendor": "crunchydata"
+        }
     },
     "roleRef": {
         "apiGroup": "rbac.authorization.k8s.io",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-role.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-role.json
@@ -3,7 +3,10 @@
     "kind": "Role",
     "metadata": {
         "name": "pgo-backrest-role",
-        "namespace": "{{.TargetNamespace}}"
+        "namespace": "{{.TargetNamespace}}",
+        "labels": {
+          "vendor": "crunchydata"
+        }
     },
     "rules": [
         {

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-sa.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-backrest-sa.json
@@ -3,6 +3,9 @@
     "kind": "ServiceAccount",
     "metadata": {
         "name": "pgo-backrest",
-        "namespace": "{{.TargetNamespace}}"
+        "namespace": "{{.TargetNamespace}}",
+        "labels": {
+          "vendor": "crunchydata"
+        }
     }
 }

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-default-sa.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-default-sa.json
@@ -3,7 +3,10 @@
     "kind": "ServiceAccount",
     "metadata": {
         "name": "pgo-default",
-        "namespace": "{{.TargetNamespace}}"
+        "namespace": "{{.TargetNamespace}}",
+        "labels": {
+          "vendor": "crunchydata"
+        }
     },
     "automountServiceAccountToken": false
 }

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-target-role-binding.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-target-role-binding.json
@@ -3,7 +3,10 @@
     "kind": "RoleBinding",
     "metadata": {
         "name": "pgo-target-role-binding",
-        "namespace": "{{.TargetNamespace}}"
+        "namespace": "{{.TargetNamespace}}",
+        "labels": {
+          "vendor": "crunchydata"
+        }
     },
     "roleRef": {
         "apiGroup": "rbac.authorization.k8s.io",

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-target-role.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-target-role.json
@@ -3,7 +3,10 @@
     "kind": "Role",
     "metadata": {
         "name": "pgo-target-role",
-        "namespace": "{{.TargetNamespace}}"
+        "namespace": "{{.TargetNamespace}}",
+        "labels": {
+          "vendor": "crunchydata"
+        }
     },
     "rules": [
         {

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-target-sa.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pgo-target-sa.json
@@ -3,6 +3,9 @@
     "kind": "ServiceAccount",
     "metadata": {
         "name": "pgo-target",
-        "namespace": "{{.TargetNamespace}}"
+        "namespace": "{{.TargetNamespace}}",
+        "labels": {
+          "vendor": "crunchydata"
+        }
     }
 }

--- a/installers/ansible/roles/pgo-operator/tasks/main.yml
+++ b/installers/ansible/roles/pgo-operator/tasks/main.yml
@@ -215,7 +215,8 @@
           command: |
             {{ kubectl_or_oc }} create clusterrolebinding pgo-cluster-admin \
               --clusterrole cluster-admin \
-              --serviceaccount "{{ pgo_operator_namespace }}:postgres-operator"
+              --serviceaccount "{{ pgo_operator_namespace }}:postgres-operator" && \
+            {{ kubectl_or_oc }} label clusterrolebinding pgo-cluster-admin vendor=crunchydata
           when: pgo_cluster_admin_result.rc == 1
 
 
@@ -270,6 +271,15 @@
             - (backrest_aws_s3_key | default('') != '') or
               (backrest_aws_s3_secret | default('') != '')
 
+        - name: Label PGO BackRest Repo Secret
+          command: |
+            {{ kubectl_or_oc }} label secret generic -n {{ pgo_operator_namespace }} \
+              pgo-backrest-repo-config vendor=crunchydata
+          when:
+            - pgo_backrest_repo_config_result.rc == 1
+            - (backrest_aws_s3_key | default('') != '') or
+              (backrest_aws_s3_secret | default('') != '')
+
     - name: PGO ConfigMap
       tags:
         - install
@@ -292,6 +302,12 @@
               --from-file=pgo.yaml='{{ output_dir }}/pgo.yaml' \
               --from-file='{{ role_path }}/files/pgo-configs' \
               -n {{ pgo_operator_namespace }}
+          when: pgo_config_result.rc == 1
+
+        - name: Label PGO ConfigMap
+          command: |
+            {{ kubectl_or_oc }} -n {{ pgo_operator_namespace }} label configmap \
+              pgo-config vendor=crunchydata
           when: pgo_config_result.rc == 1
 
     - name: PGO Service

--- a/installers/ansible/roles/pgo-operator/templates/cluster-rbac-readonly.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/cluster-rbac-readonly.yaml.j2
@@ -3,6 +3,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-cluster-role
+  labels:
+    vendor: crunchydata
 rules:
   - apiGroups:
       - ''
@@ -17,6 +19,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pgo-cluster-role
+  labels:
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/installers/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/cluster-rbac.yaml.j2
@@ -3,6 +3,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-cluster-role
+  labels:
+    vendor: crunchydata
 rules:
   - apiGroups:
       - ''
@@ -111,6 +113,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pgo-cluster-role
+  labels:
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/installers/ansible/roles/pgo-operator/templates/local-namespace-rbac.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/local-namespace-rbac.yaml.j2
@@ -3,6 +3,8 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-local-ns
+  labels:
+    vendor: crunchydata
 rules:
   - apiGroups:
       - ''
@@ -28,6 +30,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pgo-local-ns
+  labels:
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -41,6 +45,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pgo-target-role-binding
+  labels:
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/installers/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/pgo-role-rbac.yaml.j2
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-role
   namespace: {{ pgo_operator_namespace }}
+  labels:
+    vendor: crunchydata
 rules:
   - apiGroups:
       - ''
@@ -28,6 +30,8 @@ kind: RoleBinding
 metadata:
   name: pgo-role
   namespace: {{ pgo_operator_namespace }}
+  labels:
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/installers/ansible/roles/pgo-operator/templates/pgo-service-account.yaml.j2
+++ b/installers/ansible/roles/pgo-operator/templates/pgo-service-account.yaml.j2
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   name: postgres-operator
   namespace: {{ pgo_operator_namespace }}
+  labels:
+    vendor: crunchydata
 imagePullSecrets:
 {% if ccp_image_pull_secret %}
   - name: {{ ccp_image_pull_secret }}

--- a/installers/ansible/roles/pgo-operator/templates/service.json.j2
+++ b/installers/ansible/roles/pgo-operator/templates/service.json.j2
@@ -4,7 +4,8 @@
     "metadata": {
 	"name": "postgres-operator",
         "labels": {
-            "name": "postgres-operator"
+            "name": "postgres-operator",
+            "vendor": "crunchydata"
         }
     },
     "spec": {

--- a/installers/kubectl/postgres-operator-ocp311.yml
+++ b/installers/kubectl/postgres-operator-ocp311.yml
@@ -3,12 +3,16 @@ kind: ServiceAccount
 metadata:
   name: pgo-deployer-sa
   namespace: pgo
+  labels:
+    vendor: crunchydata
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pgo-deployer-crb
   namespace: pgo
+  labels:
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -23,6 +27,8 @@ kind: ConfigMap
 metadata:
   name: pgo-deployer-cm
   namespace: pgo
+  labels:
+    vendor: crunchydata
 data:
   values.yaml: |-
     # =====================
@@ -155,11 +161,15 @@ kind: Job
 metadata:
   name: pgo-deploy
   namespace: pgo
+  labels:
+    vendor: crunchydata
 spec:
   backoffLimit: 0
   template:
     metadata:
       name: pgo-deploy
+      labels:
+        vendor: crunchydata
     spec:
       serviceAccountName: pgo-deployer-sa
       restartPolicy: Never

--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -3,11 +3,15 @@ kind: ServiceAccount
 metadata:
   name: pgo-deployer-sa
   namespace: pgo
+  labels:
+    vendor: crunchydata
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pgo-deployer-cr
+  labels:
+    vendor: crunchydata
 rules:
   - apiGroups:
       - ''
@@ -34,6 +38,7 @@ rules:
       - get
       - create
       - delete
+      - patch
   - apiGroups:
       - ''
     resources:
@@ -45,6 +50,7 @@ rules:
       - create
       - delete
       - list
+      - patch
   - apiGroups:
       - ''
     resources:
@@ -118,6 +124,8 @@ kind: ConfigMap
 metadata:
   name: pgo-deployer-cm
   namespace: pgo
+  labels:
+    vendor: crunchydata
 data:
   values.yaml: |-
     # =====================
@@ -249,6 +257,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pgo-deployer-crb
+  labels:
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -263,11 +273,15 @@ kind: Job
 metadata:
   name: pgo-deploy
   namespace: pgo
+  labels:
+    vendor: crunchydata
 spec:
   backoffLimit: 0
   template:
     metadata:
       name: pgo-deploy
+      labels:
+        vendor: crunchydata
     spec:
       serviceAccountName: pgo-deployer-sa
       restartPolicy: Never

--- a/installers/metrics/kubectl/postgres-operator-metrics-ocp311.yml
+++ b/installers/metrics/kubectl/postgres-operator-metrics-ocp311.yml
@@ -5,6 +5,7 @@ metadata:
   namespace: pgo
   labels:
     app.kubernetes.io/name: postgres-operator-monitoring
+    vendor: crunchydata
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -13,6 +14,7 @@ metadata:
   namespace: pgo
   labels:
     app.kubernetes.io/name: postgres-operator-monitoring
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -29,6 +31,7 @@ metadata:
   namespace: pgo
   labels:
     app.kubernetes.io/name: postgres-operator-monitoring
+    vendor: crunchydata
 data:
   values.yaml: |-
     # =====================
@@ -84,6 +87,7 @@ metadata:
   namespace: pgo
   labels:
     app.kubernetes.io/name: postgres-operator-monitoring
+    vendor: crunchydata
 spec:
   backoffLimit: 0
   template:
@@ -91,6 +95,7 @@ spec:
       name: pgo-metrics-deploy
       labels:
         app.kubernetes.io/name: postgres-operator-monitoring
+        vendor: crunchydata
     spec:
       serviceAccountName: pgo-metrics-deployer-sa
       restartPolicy: Never

--- a/installers/metrics/kubectl/postgres-operator-metrics.yml
+++ b/installers/metrics/kubectl/postgres-operator-metrics.yml
@@ -5,6 +5,7 @@ metadata:
   namespace: pgo
   labels:
     app.kubernetes.io/name: postgres-operator-monitoring
+    vendor: crunchydata
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12,6 +13,7 @@ metadata:
   name: pgo-metrics-deployer-cr
   labels:
     app.kubernetes.io/name: postgres-operator-monitoring
+    vendor: crunchydata
 rules:
   - apiGroups:
       - ''
@@ -83,6 +85,7 @@ metadata:
   namespace: pgo
   labels:
     app.kubernetes.io/name: postgres-operator-monitoring
+    vendor: crunchydata
 data:
   values.yaml: |-
     # =====================
@@ -137,6 +140,7 @@ metadata:
   name: pgo-metrics-deployer-crb
   labels:
     app.kubernetes.io/name: postgres-operator-monitoring
+    vendor: crunchydata
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -153,6 +157,7 @@ metadata:
   namespace: pgo
   labels:
     app.kubernetes.io/name: postgres-operator-monitoring
+    vendor: crunchydata
 spec:
   backoffLimit: 0
   template:
@@ -160,6 +165,7 @@ spec:
       name: pgo-metrics-deploy
       labels:
         app.kubernetes.io/name: postgres-operator-monitoring
+        vendor: crunchydata
     spec:
       serviceAccountName: pgo-metrics-deployer-sa
       restartPolicy: Never

--- a/installers/olm/description.openshift.md
+++ b/installers/olm/description.openshift.md
@@ -71,6 +71,7 @@ If you plan to use AWS S3 to store backups, you can configure your environment t
 oc -n "$PGO_OPERATOR_NAMESPACE" create secret generic pgo-backrest-repo-config \
   --from-literal=aws-s3-key="<your-aws-s3-key>" \
   --from-literal=aws-s3-key-secret="<your-aws-s3-key-secret>"
+oc -n "$PGO_OPERATOR_NAMESPACE" label secret pgo-backrest-repo-config vendor=crunchydata
 ```
 
 ### Certificates (optional)

--- a/installers/olm/description.upstream.md
+++ b/installers/olm/description.upstream.md
@@ -65,6 +65,7 @@ If you plan to use AWS S3 to store backups, you can configure your environment t
 kubectl -n "$PGO_OPERATOR_NAMESPACE" create secret generic pgo-backrest-repo-config \
   --from-literal=aws-s3-key="<your-aws-s3-key>" \
   --from-literal=aws-s3-key-secret="<your-aws-s3-key-secret>"
+kubectl -n "$PGO_OPERATOR_NAMESPACE" label secret pgo-backrest-repo-config vendor=crunchydata
 ```
 
 ### Certificates (optional)

--- a/installers/olm/postgresoperator.crd.yaml
+++ b/installers/olm/postgresoperator.crd.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pgclusters.crunchydata.com
+  labels:
+    vendor: crunchydata
 spec:
   group: crunchydata.com
   names:
@@ -37,6 +39,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pgpolicies.crunchydata.com
+  labels:
+    vendor: crunchydata
 spec:
   group: crunchydata.com
   names:
@@ -58,6 +62,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pgreplicas.crunchydata.com
+  labels:
+    vendor: crunchydata
 spec:
   group: crunchydata.com
   names:
@@ -79,6 +85,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pgtasks.crunchydata.com
+  labels:
+    vendor: crunchydata
 spec:
   group: crunchydata.com
   names:

--- a/internal/config/pgoconfig.go
+++ b/internal/config/pgoconfig.go
@@ -757,6 +757,9 @@ func initialize(clientset kubernetes.Interface, namespace string) (*v1.ConfigMap
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: CustomConfigMapName,
+			Labels: map[string]string{
+				LABEL_VENDOR: LABEL_CRUNCHY,
+			},
 		},
 		Data: map[string]string{},
 	}

--- a/internal/operator/common.go
+++ b/internal/operator/common.go
@@ -514,6 +514,9 @@ func initializeOperatorBackrestSecret(clientset kubernetes.Interface, namespace 
 		secret = &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: config.SecretOperatorBackrestRepoConfig,
+				Labels: map[string]string{
+					config.LABEL_VENDOR: config.LABEL_CRUNCHY,
+				},
 			},
 			Data: map[string][]byte{},
 		}


### PR DESCRIPTION
Though PGO leverages a lot of stable naming, this label is a
helpful identifier among the objects that PGO is managing. Some
derived objects (e.g. Secrets from SAs) do not get the label, but
they are tightly coulpled to the object that does get the label.

Most objects had the "vendor" label already, but this should bring
everything inline.

fixes #2470