### PR TITLE
Removed disable_fsgroup: "false"

### DIFF
--- a/installers/kubectl/postgres-operator.yml
+++ b/installers/kubectl/postgres-operator.yml
@@ -166,7 +166,6 @@ data:
     delete_operator_namespace: "false"
     delete_watched_namespaces: "false"
     disable_auto_failover: "false"
-    disable_fsgroup: "false"
     reconcile_rbac: "true"
     exporterport: "9187"
     metrics: "false"


### PR DESCRIPTION
Removed disable_fsgroup: "false" to ensure auto-detection can occur with Openshift

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Auto-decection was not occuring when disable_fsgroup: "false" was defaulted
to false


**What is the new behavior (if this is a feature change)?**
removed disable_fsgroup: "false" and auto-detection can now occur

**Other information**:
