### PR TITLE
Add go test for image pull secrets on scheduled backup jobs

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -3023,6 +3023,18 @@ func TestReconcileScheduledBackups(t *testing.T) {
 						assert.Equal(t, returnedCronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Name,
 							"pgbackrest")
 						assert.Assert(t, returnedCronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].SecurityContext != &corev1.SecurityContext{})
+
+						// verify the image pull secret
+						if returnedCronJob.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets == nil {
+							t.Error("image pull secret is missing tolerations")
+						}
+
+						if returnedCronJob.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets != nil {
+							if returnedCronJob.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets[0].Name !=
+								"myImagePullSecret" {
+								t.Error("image pull secret name is not set correctly")
+							}
+						}
 					}
 					return
 				}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Because of the overlap between the merge of the PRs for 11701 and 11739,
the go test for checking that the image pull secret is properly set for
the job created by the scheduled backup cronjob has not yet been added.


**What is the new behavior (if this is a feature change)?**
This commit adds an image pull secret test in line with the existing
tests already in place.


**Other information**:
[ch11765]