### PR TITLE
Custom shared preload libraries

### DIFF
--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -26,7 +26,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,20 +140,20 @@ func (r *Reconciler) Reconcile(
 	if cluster.Name == "postgres" {
 		log.Info("cluster name not allowed")
 		r.Recorder.Eventf(cluster,
-			v1.EventTypeWarning, "InvalidName", "%q is not allowed", cluster.Name)
+			corev1.EventTypeWarning, "InvalidName", "%q is not allowed", cluster.Name)
 		return result, nil
 	}
 
 	var (
-		clusterConfigMap         *v1.ConfigMap
-		clusterReplicationSecret *v1.Secret
-		clusterPodService        *v1.Service
-		clusterVolumes           []v1.PersistentVolumeClaim
-		instanceServiceAccount   *v1.ServiceAccount
+		clusterConfigMap         *corev1.ConfigMap
+		clusterReplicationSecret *corev1.Secret
+		clusterPodService        *corev1.Service
+		clusterVolumes           []corev1.PersistentVolumeClaim
+		instanceServiceAccount   *corev1.ServiceAccount
 		instances                *observedInstances
-		patroniLeaderService     *v1.Service
-		primaryCertificate       *v1.SecretProjection
-		pgUser                   *v1.Secret
+		patroniLeaderService     *corev1.Service
+		primaryCertificate       *corev1.SecretProjection
+		pgUser                   *corev1.Secret
 		rootCA                   *pki.RootCertificateAuthority
 		monitoringSecret         *corev1.Secret
 		err                      error
@@ -358,19 +357,19 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: workerCount,
 		}).
-		Owns(&v1.ConfigMap{}).
-		Owns(&v1.Endpoints{}).
-		Owns(&v1.PersistentVolumeClaim{}).
-		Owns(&v1.Secret{}).
-		Owns(&v1.Service{}).
-		Owns(&v1.ServiceAccount{}).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Endpoints{}).
+		Owns(&corev1.PersistentVolumeClaim{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ServiceAccount{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&batchv1.Job{}).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&batchv1beta1.CronJob{}).
-		Watches(&source.Kind{Type: &v1.Pod{}}, r.watchPods()).
+		Watches(&source.Kind{Type: &corev1.Pod{}}, r.watchPods()).
 		Watches(&source.Kind{Type: &appsv1.StatefulSet{}},
 			r.controllerRefHandlerFuncs()). // watch all StatefulSets
 		Complete(r)

--- a/internal/controller/postgrescluster/util_test.go
+++ b/internal/controller/postgrescluster/util_test.go
@@ -25,7 +25,6 @@ import (
 	"gotest.tools/v3/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crunchydata/postgres-operator/internal/naming"
@@ -190,7 +189,7 @@ func TestUpdateReconcileResult(t *testing.T) {
 
 func TestAddNSSWrapper(t *testing.T) {
 
-	databaseBackrestContainerCount := func(template *v1.PodTemplateSpec) int {
+	databaseBackrestContainerCount := func(template *corev1.PodTemplateSpec) int {
 		var count int
 		for _, c := range template.Spec.Containers {
 			switch c.Name {
@@ -205,7 +204,7 @@ func TestAddNSSWrapper(t *testing.T) {
 
 	image := "test-image"
 
-	expectedEnv := []v1.EnvVar{
+	expectedEnv := []corev1.EnvVar{
 		{Name: "LD_PRELOAD", Value: "/usr/lib64/libnss_wrapper.so"},
 		{Name: "NSS_WRAPPER_PASSWD", Value: "/tmp/nss_wrapper/postgres/passwd"},
 		{Name: "NSS_WRAPPER_GROUP", Value: "/tmp/nss_wrapper/postgres/group"},
@@ -216,25 +215,25 @@ func TestAddNSSWrapper(t *testing.T) {
 
 	testCases := []struct {
 		tcName      string
-		podTemplate *v1.PodTemplateSpec
+		podTemplate *corev1.PodTemplateSpec
 	}{{
 		tcName: "database and pgbackrest containers",
-		podTemplate: &v1.PodTemplateSpec{Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		podTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{Name: "database"}, {Name: "pgbackrest"}, {Name: "dontmodify"},
 			}}},
 	}, {
 		tcName: "database container only",
-		podTemplate: &v1.PodTemplateSpec{Spec: v1.PodSpec{
-			Containers: []v1.Container{{Name: "database"}, {Name: "dontmodify"}}}},
+		podTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "database"}, {Name: "dontmodify"}}}},
 	}, {
 		tcName: "pgbackest container only",
-		podTemplate: &v1.PodTemplateSpec{Spec: v1.PodSpec{
-			Containers: []v1.Container{{Name: "dontmodify"}, {Name: "pgbackrest"}}}},
+		podTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "dontmodify"}, {Name: "pgbackrest"}}}},
 	}, {
 		tcName: "other containers",
-		podTemplate: &v1.PodTemplateSpec{Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		podTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{Name: "dontmodify1"}, {Name: "dontmodify2"}}}},
 	}}
 
@@ -290,7 +289,7 @@ func TestJobCompleted(t *testing.T) {
 			Status: batchv1.JobStatus{
 				Conditions: []batchv1.JobCondition{{
 					Type:   batchv1.JobComplete,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 				}},
 			},
 		},
@@ -301,7 +300,7 @@ func TestJobCompleted(t *testing.T) {
 			Status: batchv1.JobStatus{
 				Conditions: []batchv1.JobCondition{{
 					Type:   batchv1.JobComplete,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 				}},
 			},
 		},
@@ -312,7 +311,7 @@ func TestJobCompleted(t *testing.T) {
 			Status: batchv1.JobStatus{
 				Conditions: []batchv1.JobCondition{{
 					Type:   batchv1.JobComplete,
-					Status: v1.ConditionUnknown,
+					Status: corev1.ConditionUnknown,
 				}},
 			},
 		},
@@ -344,7 +343,7 @@ func TestJobFailed(t *testing.T) {
 			Status: batchv1.JobStatus{
 				Conditions: []batchv1.JobCondition{{
 					Type:   batchv1.JobFailed,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 				}},
 			},
 		},
@@ -355,7 +354,7 @@ func TestJobFailed(t *testing.T) {
 			Status: batchv1.JobStatus{
 				Conditions: []batchv1.JobCondition{{
 					Type:   batchv1.JobFailed,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 				}},
 			},
 		},
@@ -366,7 +365,7 @@ func TestJobFailed(t *testing.T) {
 			Status: batchv1.JobStatus{
 				Conditions: []batchv1.JobCondition{{
 					Type:   batchv1.JobFailed,
-					Status: v1.ConditionUnknown,
+					Status: corev1.ConditionUnknown,
 				}},
 			},
 		},

--- a/internal/patroni/config.go
+++ b/internal/patroni/config.go
@@ -260,7 +260,17 @@ func DynamicConfiguration(
 	// Override the above with mandatory parameters.
 	if pgParameters.Mandatory != nil {
 		for k, v := range pgParameters.Mandatory.AsMap() {
-			parameters[k] = v
+			// Unlike other PostgreSQL parameters that have mandatory values,
+			// shared_preload_libraries is a comma separated list that can have
+			// other values appended in addition to the mandatory values. Below,
+			// any values provided in the CRD are appended after the mandatory
+			// values.
+			s, ok := parameters[k].(string)
+			if k == "shared_preload_libraries" && ok {
+				parameters[k] = v + "," + s
+			} else {
+				parameters[k] = v
+			}
 		}
 	}
 	postgresql["parameters"] = parameters

--- a/internal/patroni/config_test.go
+++ b/internal/patroni/config_test.go
@@ -319,6 +319,60 @@ func TestDynamicConfiguration(t *testing.T) {
 			},
 		},
 		{
+			name: "postgresql.parameters: mandatory shared_preload_libraries",
+			input: map[string]interface{}{
+				"postgresql": map[string]interface{}{
+					"parameters": map[string]interface{}{
+						"shared_preload_libraries": "given",
+					},
+				},
+			},
+			params: postgres.Parameters{
+				Mandatory: parameters(map[string]string{
+					"shared_preload_libraries": "mandatory",
+				}),
+			},
+			expected: map[string]interface{}{
+				"loop_wait": int32(10),
+				"ttl":       int32(30),
+				"postgresql": map[string]interface{}{
+					"parameters": map[string]interface{}{
+						"shared_preload_libraries": "mandatory,given",
+					},
+					"pg_hba":        []string{},
+					"use_pg_rewind": true,
+					"use_slots":     false,
+				},
+			},
+		},
+		{
+			name: "postgresql.parameters: mandatory shared_preload_libraries bad type",
+			input: map[string]interface{}{
+				"postgresql": map[string]interface{}{
+					"parameters": map[string]interface{}{
+						"shared_preload_libraries": 1,
+					},
+				},
+			},
+			params: postgres.Parameters{
+				Mandatory: parameters(map[string]string{
+					"shared_preload_libraries": "mandatory",
+				}),
+			},
+			expected: map[string]interface{}{
+				"loop_wait": int32(10),
+				"ttl":       int32(30),
+				"postgresql": map[string]interface{}{
+					"parameters": map[string]interface{}{
+						"shared_preload_libraries": "mandatory",
+					},
+					"pg_hba":        []string{},
+					"use_pg_rewind": true,
+					"use_slots":     false,
+				},
+			},
+		},
+		{
 			name: "postgresql.pg_hba: wrong-type is ignored",
 			input: map[string]interface{}{
 				"postgresql": map[string]interface{}{


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently, when monitoring is turned on, the shared_preload_libraries
get hard coded to 'pg_stat_statements,pgnodemx' because of how the
mandatory parameters are being set by the Operator.


**What is the new behavior (if this is a feature change)?**
This updates the behavior so that user defined shared_preload_libraries
are appended to the existing list, leaving the mandatory libraries in place
while keeping any user defined libraries as well.

Additionally, (separate commit) the "k8s.io/api/core/v1" package was imported as both
"corev1" and "v1" in certain files. This standardizes on the earlier usage of "v1".

**Other information**:
[ch11921]
fixes #2526