### PR TITLE
Allow backup config change when recreated cluster

### DIFF
--- a/internal/apiserver/clusterservice/clusterimpl.go
+++ b/internal/apiserver/clusterservice/clusterimpl.go
@@ -929,30 +929,41 @@ func CreateCluster(request *msgs.CreateClusterRequest, ns, pgouser string) msgs.
 	// the deployment template always tries to mount /sshd volume
 	secretName := fmt.Sprintf("%s-%s", clusterName, config.LABEL_BACKREST_REPO_SECRET)
 
-	if _, err := apiserver.Clientset.
-		CoreV1().Secrets(request.Namespace).
-		Get(ctx, secretName, metav1.GetOptions{}); kubeapi.IsNotFound(err) {
-		// determine if a custom CA secret should be used
-		backrestS3CACert := []byte{}
+	// determine if a custom CA secret should be used
+	backrestS3CACert := []byte{}
 
-		if request.BackrestS3CASecretName != "" {
-			backrestSecret, err := apiserver.Clientset.
-				CoreV1().Secrets(request.Namespace).
-				Get(ctx, request.BackrestS3CASecretName, metav1.GetOptions{})
-			if err != nil {
-				log.Error(err)
-				resp.Status.Code = msgs.Error
-				resp.Status.Msg = fmt.Sprintf("Error finding pgBackRest S3 CA secret \"%s\": %s",
-					request.BackrestS3CASecretName, err.Error())
-				return resp
-			}
-
-			// attempt to retrieves the custom CA, assuming it has the name
-			// "aws-s3-ca.crt"
-			backrestS3CACert = backrestSecret.Data[util.BackRestRepoSecretKeyAWSS3KeyAWSS3CACert]
+	if request.BackrestS3CASecretName != "" {
+		backrestSecret, err := apiserver.Clientset.
+			CoreV1().Secrets(request.Namespace).
+			Get(ctx, request.BackrestS3CASecretName, metav1.GetOptions{})
+		if err != nil {
+			log.Error(err)
+			resp.Status.Code = msgs.Error
+			resp.Status.Msg = fmt.Sprintf("Error finding pgBackRest S3 CA secret \"%s\": %s",
+				request.BackrestS3CASecretName, err.Error())
+			return resp
 		}
 
-		// set up the secret for the cluster that contains the pgBackRest
+		// attempt to retrieves the custom CA, assuming it has the name
+		// "aws-s3-ca.crt"
+		backrestS3CACert = backrestSecret.Data[util.BackRestRepoSecretKeyAWSS3KeyAWSS3CACert]
+	}
+
+	// save the S3 credentials in a single map so it can be used to either create a new
+	// secret or update an existing one
+	s3Credentials := map[string][]byte{
+		util.BackRestRepoSecretKeyAWSS3KeyAWSS3CACert:    backrestS3CACert,
+		util.BackRestRepoSecretKeyAWSS3KeyAWSS3Key:       []byte(request.BackrestS3Key),
+		util.BackRestRepoSecretKeyAWSS3KeyAWSS3KeySecret: []byte(request.BackrestS3KeySecret),
+	}
+
+	_, err = apiserver.Clientset.CoreV1().Secrets(request.Namespace).
+		Get(ctx, secretName, metav1.GetOptions{})
+
+	switch {
+	case kubeapi.IsNotFound(err):
+		// The pgBackRest repo config secret was not found, create it.
+		// Set up the secret for the cluster that contains the pgBackRest
 		// information
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -963,11 +974,7 @@ func CreateCluster(request *msgs.CreateClusterRequest, ns, pgouser string) msgs.
 					config.LABEL_PGO_BACKREST_REPO: "true",
 				},
 			},
-			Data: map[string][]byte{
-				util.BackRestRepoSecretKeyAWSS3KeyAWSS3CACert:    backrestS3CACert,
-				util.BackRestRepoSecretKeyAWSS3KeyAWSS3Key:       []byte(request.BackrestS3Key),
-				util.BackRestRepoSecretKeyAWSS3KeyAWSS3KeySecret: []byte(request.BackrestS3KeySecret),
-			},
+			Data: s3Credentials,
 		}
 
 		if _, err := apiserver.Clientset.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{}); err != nil && !kubeapi.IsAlreadyExists(err) {
@@ -975,10 +982,22 @@ func CreateCluster(request *msgs.CreateClusterRequest, ns, pgouser string) msgs.
 			resp.Status.Msg = fmt.Sprintf("could not create backrest repo secret: %s", err)
 			return resp
 		}
-	} else if err != nil {
+
+	case err != nil:
+		// An error occurred other than 'not found'. Log the error received when
+		// attempting to get the pgBackRest repo config secret, then return.
 		resp.Status.Code = msgs.Error
 		resp.Status.Msg = fmt.Sprintf("could not query if backrest repo secret exits: %s", err)
 		return resp
+	default:
+		// the pgBackRest repo config secret already exists, update any provided
+		// S3 credential information
+		err = updateRepoSecret(apiserver.Clientset, secretName, request.Namespace, s3Credentials)
+		if err != nil {
+			resp.Status.Code = msgs.Error
+			resp.Status.Msg = fmt.Sprintf("could not update backrest repo secret: %s", err)
+			return resp
+		}
 	}
 
 	// create a workflow for this new cluster
@@ -1009,6 +1028,30 @@ func CreateCluster(request *msgs.CreateClusterRequest, ns, pgouser string) msgs.
 
 	// and return!
 	return resp
+}
+
+// updateRepoSecret updates the existing pgBackRest repo config secret with any
+// provided S3/GCS connection information.
+func updateRepoSecret(clientset kubernetes.Interface, secretName,
+	namespace string, connectionInfo map[string][]byte) error {
+	ctx := context.TODO()
+
+	// Get the secret
+	secret, err := clientset.CoreV1().Secrets(namespace).
+		Get(ctx, secretName, metav1.GetOptions{})
+	// The secret should already exist at this point. If there is any error,
+	// return.
+	if err != nil {
+		return err
+	}
+
+	// update the secret data
+	for k, v := range connectionInfo {
+		secret.Data[k] = v
+	}
+	_, err = clientset.CoreV1().Secrets(secret.Namespace).Update(ctx, secret,
+		metav1.UpdateOptions{})
+	return err
 }
 
 func validateConfigPolicies(clusterName, PoliciesFlag, ns string) error {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Previously, when attempting to change the backup configuration
on an existing cluster, stanza-create job will error out due to
missing S3 configuration parameters despite being provided as
part of the pgo create cluster command.

**What is the new behavior (if this is a feature change)?**
This update corrects that issue by ensuring the existing pgBackRest
repo config secret is updated to include the necessary configuration
values.


**Other information**:
back-patch of [2530](https://github.com/CrunchyData/postgres-operator/pull/2530)