### PR TITLE
Update label for policy (REL_4_5)

### DIFF
--- a/internal/apiserver/policyservice/policyimpl.go
+++ b/internal/apiserver/policyservice/policyimpl.go
@@ -203,7 +203,7 @@ func ApplyPolicy(request *msgs.ApplyPolicyRequest, ns, pgouser string) msgs.Appl
 
 	if request.DryRun {
 		for _, d := range allDeployments {
-			log.Debugf("deployment : %s", d.ObjectMeta.Name)
+			log.Debugf("deployment: %s", d.ObjectMeta.Name)
 			resp.Name = append(resp.Name, d.ObjectMeta.Name)
 		}
 		return resp
@@ -223,7 +223,7 @@ func ApplyPolicy(request *msgs.ApplyPolicyRequest, ns, pgouser string) msgs.Appl
 
 		cl, err := apiserver.Clientset.
 			CrunchydataV1().Pgclusters(ns).
-			Get(d.ObjectMeta.Labels[config.LABEL_SERVICE_NAME], metav1.GetOptions{})
+			Get(d.ObjectMeta.Labels[config.LABEL_PG_CLUSTER], metav1.GetOptions{})
 		if err != nil {
 			resp.Status.Code = msgs.Error
 			resp.Status.Msg = err.Error()
@@ -231,7 +231,7 @@ func ApplyPolicy(request *msgs.ApplyPolicyRequest, ns, pgouser string) msgs.Appl
 		}
 
 		if err := util.ExecPolicy(apiserver.Clientset, apiserver.RESTConfig,
-			ns, request.Name, d.ObjectMeta.Labels[config.LABEL_SERVICE_NAME], cl.Spec.Port); err != nil {
+			ns, request.Name, d.ObjectMeta.Labels[config.LABEL_PG_CLUSTER], cl.Spec.Port); err != nil {
 			log.Error(err)
 			resp.Status.Code = msgs.Error
 			resp.Status.Msg = err.Error()

--- a/internal/util/policy.go
+++ b/internal/util/policy.go
@@ -40,8 +40,8 @@ import (
 )
 
 // ExecPolicy execute a sql policy against a cluster
-func ExecPolicy(clientset kubeapi.Interface, restconfig *rest.Config, namespace, policyName, serviceName, port string) error {
-	//fetch the policy sql
+func ExecPolicy(clientset kubeapi.Interface, restconfig *rest.Config, namespace, policyName, clusterName, port string) error {
+	// fetch the policy sql
 	sql, err := GetPolicySQL(clientset, namespace, policyName)
 
 	if err != nil {
@@ -53,11 +53,10 @@ func ExecPolicy(clientset kubeapi.Interface, restconfig *rest.Config, namespace,
 	stdin := strings.NewReader(sql)
 
 	// now, we need to ensure we can get the Pod name of the primary PostgreSQL
-	// instance. Thname being passed in is actually the "serviceName" of the Pod
-	// We can isolate the exact Pod we want by using this (LABEL_SERVICE_NAME) and
-	// the LABEL_PGHA_ROLE labels
+	// instance. We can isolate the exact Pod we want by using the
+	// LABEL_PG_CLUSTER and LABEL_PGHA_ROLE labels
 	selector := fmt.Sprintf("%s=%s,%s=%s",
-		config.LABEL_SERVICE_NAME, serviceName,
+		config.LABEL_PG_CLUSTER, clusterName,
 		config.LABEL_PGHA_ROLE, config.LABEL_PGHA_ROLE_PRIMARY)
 
 	podList, err := clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: selector})


### PR DESCRIPTION
The policy logic uses the service name and role label to determine which
pod is the primary and where to run SQL.  This change uses the
pg-cluster label instead of the service name label.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
[ch11899]