### PR TITLE
Update CRD  Docs

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -3061,7 +3061,7 @@ spec:
                 type: object
               openshift:
                 description: Whether or not the PostgreSQL cluster is being deployed
-                  to an OpenShift envioronment
+                  to an OpenShift environment
                 type: boolean
               patroni:
                 properties:

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -6419,7 +6419,7 @@ Condition contains details for one aspect of the current state of this API Resou
       </tr><tr>
         <td><b>status</b></td>
         <td>enum</td>
-        <td>status of the condition, one of True, False, Unknown. [True False Unknown]</td>
+        <td>status of the condition, one of True, False, Unknown.</td>
         <td>true</td>
       </tr><tr>
         <td><b>type</b></td>

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -89,7 +89,7 @@ type PostgresClusterSpec struct {
 	// +listMapKey=name
 	InstanceSets []PostgresInstanceSetSpec `json:"instances"`
 
-	// Whether or not the PostgreSQL cluster is being deployed to an OpenShift envioronment
+	// Whether or not the PostgreSQL cluster is being deployed to an OpenShift environment
 	// +optional
 	OpenShift *bool `json:"openshift,omitempty"`
 


### PR DESCRIPTION
Changes were made to the crd docs without updating the associated comments in the code. This change also covers a change in the tool that generates the doc. `v0.3.0` of this tool exposes more properties to the template and no longer puts enum validation into the docstring.

[ch12044]