### PR TITLE
Validate number of instances that can be defined

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -2542,7 +2542,7 @@ spec:
                     replicas:
                       default: 1
                       format: int32
-                      minimum: 0
+                      minimum: 1
                       type: integer
                     resources:
                       description: Compute resources of a PostgreSQL container.
@@ -2743,6 +2743,7 @@ spec:
                   required:
                   - dataVolumeClaimSpec
                   type: object
+                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/internal/controller/postgrescluster/controller_test.go
+++ b/internal/controller/postgrescluster/controller_test.go
@@ -61,7 +61,9 @@ func TestDeleteControlled(t *testing.T) {
 	assert.NilError(t, yaml.Unmarshal([]byte(`{
 		spec: {
 			postgresVersion: 13,
-			instances: [],
+			instances: [{
+				name: instance,
+			}],
 		},
 	}`), cluster))
 
@@ -173,13 +175,20 @@ var _ = Describe("PostgresCluster Reconciler", func() {
 	}
 
 	Specify(`"postgres" cluster not allowed`, func() {
-		cluster := create(`{
-metadata: { name: postgres },
-spec: {
-	postgresVersion: 13,
-	instances: [],
-},
-		}`)
+		cluster := create(`
+metadata:
+    name: postgres
+spec:
+    postgresVersion: 13
+    instances:
+    - name: samba
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteMany"
+        resources:
+        requests:
+            storage: 1Gi
+`)
 		Expect(reconcile(cluster)).To(BeZero())
 
 		Expect(test.Recorder.Events).To(Not(BeEmpty()))
@@ -201,13 +210,20 @@ spec: {
 		var cluster *v1beta1.PostgresCluster
 
 		BeforeEach(func() {
-			cluster = create(`{
-metadata: { name: carlos },
-spec: {
-	postgresVersion: 13,
-	instances: [],
-},
-			}`)
+			cluster = create(`
+metadata:
+  name: carlos
+spec:
+  postgresVersion: 13
+  instances:
+  - name: samba
+    dataVolumeClaimSpec:
+      accessModes:
+      - "ReadWriteMany"
+      resources:
+        requests:
+          storage: 1Gi
+`)
 			Expect(reconcile(cluster)).To(BeZero())
 		})
 

--- a/internal/controller/postgrescluster/pki_test.go
+++ b/internal/controller/postgrescluster/pki_test.go
@@ -77,7 +77,9 @@ func TestReconcileCerts(t *testing.T) {
 		},
 		Spec: v1beta1.PostgresClusterSpec{
 			PostgresVersion: 12,
-			InstanceSets:    []v1beta1.PostgresInstanceSetSpec{},
+			InstanceSets: []v1beta1.PostgresInstanceSetSpec{{
+				Name: "instance",
+			}},
 		},
 	}
 	cluster1.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("postgrescluster"))
@@ -95,7 +97,9 @@ func TestReconcileCerts(t *testing.T) {
 		},
 		Spec: v1beta1.PostgresClusterSpec{
 			PostgresVersion: 12,
-			InstanceSets:    []v1beta1.PostgresInstanceSetSpec{},
+			InstanceSets: []v1beta1.PostgresInstanceSetSpec{{
+				Name: "instance",
+			}},
 		},
 	}
 	cluster2.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("postgrescluster"))

--- a/internal/controller/postgrescluster/scale_test.go
+++ b/internal/controller/postgrescluster/scale_test.go
@@ -179,24 +179,6 @@ func TestScaleDown(t *testing.T) {
 				DataVolumeClaimSpec: volumeClaimSpec,
 			}},
 			updateRunningInstances: 2,
-		}, {
-			name: "OneSetToZero",
-			// Remove all replicas and ensure that the primary has been deleted
-			createSet: []v1beta1.PostgresInstanceSetSpec{{
-				Name:                "daisy",
-				Replicas:            Int32(3),
-				DataVolumeClaimSpec: volumeClaimSpec,
-			}},
-			createRunningInstances: 3,
-			updateSet: []v1beta1.PostgresInstanceSetSpec{{
-				Name:                "daisy",
-				Replicas:            Int32(0),
-				DataVolumeClaimSpec: volumeClaimSpec,
-			}},
-			updateRunningInstances: 0,
-			primaryTest: func(t *testing.T, old, new string) {
-				assert.Equal(t, new, "", "There should not be a primary instance")
-			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -87,6 +87,7 @@ type PostgresClusterSpec struct {
 
 	// +listType=map
 	// +listMapKey=name
+	// +kubebuilder:validation:MinItems=1
 	InstanceSets []PostgresInstanceSetSpec `json:"instances"`
 
 	// Whether or not the PostgreSQL cluster is being deployed to an OpenShift envioronment
@@ -269,7 +270,7 @@ type PostgresInstanceSetSpec struct {
 
 	// +optional
 	// +kubebuilder:default=1
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=1
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Compute resources of a PostgreSQL container.


### PR DESCRIPTION
The cluster can get into a bad state by scaling down to have zero instances. This change adds validation to the CRD ensuring that a user can never reach this bad state. A cluster must have at least one `instance` defined in `spec.instances` and each `instance` must have at least one replica (defaulting to 1 if unset). 

After the CRD is updated with the validation change, clusters that do not pass validation will run into issues. The operator will no longer be able to make changes to the invalid spec meaning fields like `status` and `finalizers` won't be updated. Clusters that do not pass validation cannot be deleted.

It is recommended that you update any clusters to pass this validation check before updating the CRD. 

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)


**Other information**:
[ch11227]