### PR TITLE
Add Missing RBAC to Helm Installer

### DIFF
--- a/installers/helm/templates/rbac.yaml
+++ b/installers/helm/templates/rbac.yaml
@@ -47,6 +47,7 @@ rules:
       - get
       - create
       - delete
+      - patch
   - apiGroups:
       - ''
     resources:
@@ -58,6 +59,7 @@ rules:
       - create
       - delete
       - list
+      - patch
   - apiGroups:
       - ''
     resources:


### PR DESCRIPTION
The RBAC for the Helm installer has been updated to include missing `patch`  permissions, specifically as required to label various resources during the installation using the `kubectl label` command.

This aligns the RBAC for Helm with similar changes recently made for the `kubectl` installer:

https://github.com/CrunchyData/postgres-operator/commit/4e8a2be77c8a2e25ad1cf593c6d7f0feb86d42e3#diff-18a197032470cdb8092ba8904636067c935e0c3a07a4799946d171da1dd158dc

[ch12076]