### PR TITLE
Implement Related Images for OLM Installer

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -286,7 +286,9 @@ spec:
                         type: object
                       image:
                         description: The image name to use for pgBackRest containers.  Utilized
-                          to run pgBackRest repository hosts and backups.
+                          to run pgBackRest repository hosts and backups. The image
+                          may also be set using the RELATED_IMAGE_PGBACKREST environment
+                          variable
                         type: string
                       manual:
                         description: Defines details for manual pgBackRest backup
@@ -1572,8 +1574,6 @@ spec:
                         - enabled
                         - repoName
                         type: object
-                    required:
-                    - image
                     type: object
                 required:
                 - pgbackrest
@@ -1752,7 +1752,12 @@ spec:
                     type: object
                 type: object
               image:
-                description: The image name to use for PostgreSQL containers
+                description: The image name to use for PostgreSQL containers. When
+                  omitted, the value comes from an operator environment variable.
+                  For standard PostgreSQL images, the format is RELATED_IMAGE_POSTGRES_{postgresVersion},
+                  e.g. RELATED_IMAGE_POSTGRES_13. For PostGIS enabled PostgreSQL images,
+                  the format is RELATED_IMAGE_POSTGRES_{postgresVersion}_GIS_{postGISVersion},
+                  e.g. RELATED_IMAGE_POSTGRES_13_GIS_3.1.
                 type: string
               imagePullSecrets:
                 description: The image pull secrets used to pull from a private registry
@@ -3025,7 +3030,8 @@ spec:
                             type: array
                           image:
                             description: The image name to use for crunchy-postgres-exporter
-                              containers
+                              containers. The image may also be set using the RELATED_IMAGE_PGEXPORTER
+                              environment variable.
                             type: string
                           resources:
                             description: 'Changing this value causes PostgreSQL and
@@ -3055,8 +3061,6 @@ spec:
                                   value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
-                        required:
-                        - image
                         type: object
                     type: object
                 type: object
@@ -3096,9 +3100,14 @@ spec:
                 format: int32
                 minimum: 1024
                 type: integer
+              postGISVersion:
+                description: The PostGIS extension version installed in the PostgreSQL
+                  image. When image is not set, indicates a PostGIS enabled image
+                  will be used.
+                type: string
               postgresVersion:
                 description: The major version of PostgreSQL installed in the PostgreSQL
-                  container
+                  image
                 maximum: 13
                 minimum: 10
                 type: integer
@@ -4088,7 +4097,8 @@ spec:
                       image:
                         description: 'Name of a container image that can run PgBouncer
                           1.15 or newer. Changing this value causes PgBouncer to restart.
-                          More info: https://kubernetes.io/docs/concepts/containers/images'
+                          The image may also be set using the RELATED_IMAGE_PGBOUNCER
+                          environment variable. More info: https://kubernetes.io/docs/concepts/containers/images'
                         type: string
                       metadata:
                         description: Metadata contains metadata for PostgresCluster
@@ -4188,8 +4198,6 @@ spec:
                               type: string
                           type: object
                         type: array
-                    required:
-                    - image
                     type: object
                 required:
                 - pgBouncer
@@ -4220,7 +4228,6 @@ spec:
                 type: object
             required:
             - backups
-            - image
             - instances
             - postgresVersion
             type: object

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -13,6 +13,16 @@ spec:
         env:
         - name: CRUNCHY_DEBUG
           value: "true"
+        - name: RELATED_IMAGE_POSTGRES_13
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-ha:centos8-13.3-0"
+        - name: RELATED_IMAGE_POSTGRES_13_GIS_3.1
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis-ha:centos8-13.3-3.1-0"
+        - name: RELATED_IMAGE_PGBACKREST
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.33-0"
+        - name: RELATED_IMAGE_PGBOUNCER
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-0"
+        - name: RELATED_IMAGE_PGEXPORTER
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.0-0"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -100,6 +100,11 @@ PostgresClusterSpec defines the desired state of PostgresCluster
         <td>Specifies a data source for bootstrapping the PostgreSQL cluster.</td>
         <td>false</td>
       </tr><tr>
+        <td><b>image</b></td>
+        <td>string</td>
+        <td>The image name to use for PostgreSQL containers. When omitted, the value comes from an operator environment variable. For standard PostgreSQL images, the format is RELATED_IMAGE_POSTGRES_{postgresVersion}, e.g. RELATED_IMAGE_POSTGRES_13. For PostGIS enabled PostgreSQL images, the format is RELATED_IMAGE_POSTGRES_{postgresVersion}_GIS_{postGISVersion}, e.g. RELATED_IMAGE_POSTGRES_13_GIS_3.1.</td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#postgresclusterspecimagepullsecretsindex">imagePullSecrets</a></b></td>
         <td>[]object</td>
         <td>The image pull secrets used to pull from a private registry Changing this value causes all running pods to restart. https://k8s.io/docs/tasks/configure-pod-container/pull-image-private-registry/</td>
@@ -130,6 +135,11 @@ PostgresClusterSpec defines the desired state of PostgresCluster
         <td>The port on which PostgreSQL should listen.</td>
         <td>false</td>
       </tr><tr>
+        <td><b>postGISVersion</b></td>
+        <td>string</td>
+        <td>The PostGIS extension version installed in the PostgreSQL image. When image is not set, indicates a PostGIS enabled image will be used.</td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#postgresclusterspecproxy">proxy</a></b></td>
         <td>object</td>
         <td>The specification of a proxy that connects to PostgreSQL.</td>
@@ -150,11 +160,6 @@ PostgresClusterSpec defines the desired state of PostgresCluster
         <td>PostgreSQL backup configuration</td>
         <td>true</td>
       </tr><tr>
-        <td><b>image</b></td>
-        <td>string</td>
-        <td>The image name to use for PostgreSQL containers</td>
-        <td>true</td>
-      </tr><tr>
         <td><b><a href="#postgresclusterspecinstancesindex">instances</a></b></td>
         <td>[]object</td>
         <td></td>
@@ -162,7 +167,7 @@ PostgresClusterSpec defines the desired state of PostgresCluster
       </tr><tr>
         <td><b>postgresVersion</b></td>
         <td>integer</td>
-        <td>The major version of PostgreSQL installed in the PostgreSQL container</td>
+        <td>The major version of PostgreSQL installed in the PostgreSQL image</td>
         <td>true</td>
       </tr></tbody>
 </table>
@@ -559,15 +564,15 @@ PGMonitorSpec defines the desired state of the pgMonitor tool suite
         <td>Projected volumes containing custom PostgreSQL Exporter configuration.  Currently supports the customization of PostgreSQL Exporter queries. If a "queries.yaml" file is detected in any volume projected using this field, it will be loaded using the "extend.query-path" flag: https://github.com/prometheus-community/postgres_exporter#flags Changing the values of field causes PostgreSQL and the exporter to restart.</td>
         <td>false</td>
       </tr><tr>
+        <td><b>image</b></td>
+        <td>string</td>
+        <td>The image name to use for crunchy-postgres-exporter containers. The image may also be set using the RELATED_IMAGE_PGEXPORTER environment variable.</td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#postgresclusterspecmonitoringpgmonitorexporterresources">resources</a></b></td>
         <td>object</td>
         <td>Changing this value causes PostgreSQL and the exporter to restart. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers</td>
         <td>false</td>
-      </tr><tr>
-        <td><b>image</b></td>
-        <td>string</td>
-        <td>The image name to use for crunchy-postgres-exporter containers</td>
-        <td>true</td>
       </tr></tbody>
 </table>
 
@@ -1072,6 +1077,11 @@ Defines a PgBouncer proxy and connection pooler.
         <td>A secret projection containing a certificate and key with which to encrypt connections to PgBouncer. The "tls.crt", "tls.key", and "ca.crt" paths must be PEM-encoded certificates and keys. Changing this value causes PgBouncer to restart. More info: https://kubernetes.io/docs/concepts/configuration/secret/#projection-of-secret-keys-to-specific-paths</td>
         <td>false</td>
       </tr><tr>
+        <td><b>image</b></td>
+        <td>string</td>
+        <td>Name of a container image that can run PgBouncer 1.15 or newer. Changing this value causes PgBouncer to restart. The image may also be set using the RELATED_IMAGE_PGBOUNCER environment variable. More info: https://kubernetes.io/docs/concepts/containers/images</td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#postgresclusterspecproxypgbouncermetadata">metadata</a></b></td>
         <td>object</td>
         <td>Metadata contains metadata for PostgresCluster resources</td>
@@ -1096,11 +1106,6 @@ Defines a PgBouncer proxy and connection pooler.
         <td>[]object</td>
         <td>Tolerations of a PgBouncer pod. Changing this value causes PgBouncer to restart. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration</td>
         <td>false</td>
-      </tr><tr>
-        <td><b>image</b></td>
-        <td>string</td>
-        <td>Name of a container image that can run PgBouncer 1.15 or newer. Changing this value causes PgBouncer to restart. More info: https://kubernetes.io/docs/concepts/containers/images</td>
-        <td>true</td>
       </tr></tbody>
 </table>
 
@@ -2677,6 +2682,11 @@ pgBackRest archive configuration
         <td>Global pgBackRest configuration settings.  These settings are included in the "global" section of the pgBackRest configuration generated by the PostgreSQL Operator, and then mounted under "/etc/pgbackrest/conf.d": https://pgbackrest.org/configuration.html</td>
         <td>false</td>
       </tr><tr>
+        <td><b>image</b></td>
+        <td>string</td>
+        <td>The image name to use for pgBackRest containers.  Utilized to run pgBackRest repository hosts and backups. The image may also be set using the RELATED_IMAGE_PGBACKREST environment variable</td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#postgresclusterspecbackupspgbackrestmanual">manual</a></b></td>
         <td>object</td>
         <td>Defines details for manual pgBackRest backup Jobs</td>
@@ -2701,11 +2711,6 @@ pgBackRest archive configuration
         <td>object</td>
         <td>Defines details for performing an in-place restore using pgBackRest</td>
         <td>false</td>
-      </tr><tr>
-        <td><b>image</b></td>
-        <td>string</td>
-        <td>The image name to use for pgBackRest containers.  Utilized to run pgBackRest repository hosts and backups.</td>
-        <td>true</td>
       </tr></tbody>
 </table>
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,115 @@
+/*
+ Copyright 2021 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+)
+
+// a list of container images that are available
+// The Red Hat Marketplace requires environment variables to be used for any
+// image except the Operator's own image (see
+//  https://redhat-connect.gitbook.io/certified-operator-guide/troubleshooting-and-resources/offline-enabled-operators#golang-operators)
+// Any container images that the Operator might require to perform its functions
+// must be made available. Because a user could potentially use any of the images
+// below, each is defined separately. (See
+//	https://docs.openshift.com/container-platform/4.7/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs)
+// This approach works with the concept of image streams and can allow for automatic
+// updates when the container image is changed (See
+//  https://docs.openshift.com/container-platform/4.7/openshift_images/images-understand.html#images-imagestream-use_images-understand)
+
+const (
+	// This is the base string for each version of Postgres.
+	// For standard PostgreSQL images, the format is
+	// RELATED_IMAGE_POSTGRES_<Version>
+	// where Version is the PostgreSQL version set in Spec.PostgresVersion.
+	// Example: RELATED_IMAGE_POSTGRES_13
+	// For PostGIS enabled PostgreSQL images, the format is
+	// RELATED_IMAGE_POSTGRES_<Version>_GIS_<GIS Version> where "Version" is the
+	// PostgreSQL version set in Spec.PostgresVersion and "GIS Version"
+	// is the PostGIS version set in Spec.PostGISVersion.
+	// Example: RELATED_IMAGE_POSTGRES_13_GIS_3.1
+	CrunchyPostgres = "RELATED_IMAGE_POSTGRES_"
+
+	// Remaining images
+	CrunchyPGBouncer  = "RELATED_IMAGE_PGBOUNCER"
+	CrunchyPGBackRest = "RELATED_IMAGE_PGBACKREST"
+	CrunchyPGExporter = "RELATED_IMAGE_PGEXPORTER"
+)
+
+// defaultFromEnv returns the value of the given environment
+// variable if the spec value given is empty
+func defaultFromEnv(value, key string) string {
+	if value == "" {
+		return os.Getenv(key)
+	}
+	return value
+}
+
+// PGBackRestContainerImage returns the container image to use for pgBackRest.
+// It takes the current image defined in the postgrescluster spec and the
+// associated related image override environment variable. If the image
+// defined on the spec is empty, the value stored in the environment variable
+// is returned.
+func PGBackRestContainerImage(cluster *v1beta1.PostgresCluster) string {
+	return defaultFromEnv(cluster.Spec.Backups.PGBackRest.Image,
+		CrunchyPGBackRest)
+}
+
+// PGBouncerContainerImage returns the container image to use for pgBouncer.
+// It takes the current image defined in the postgrescluster spec and the
+// associated related image override environment variable. If the image
+// defined on the spec is empty, the value stored in the environment variable
+// is returned.
+func PGBouncerContainerImage(cluster *v1beta1.PostgresCluster) string {
+	return defaultFromEnv(cluster.Spec.Proxy.PGBouncer.Image,
+		CrunchyPGBouncer)
+}
+
+// PGExporterContainerImage returns the container image to use for the
+// PostgreSQL Exporter. It takes the current image defined in the
+// postgrescluster spec and the associated related image override environment
+// variable. If the image defined on the spec is empty, the value stored in the
+// environment variable is returned.
+func PGExporterContainerImage(cluster *v1beta1.PostgresCluster) string {
+	return defaultFromEnv(cluster.Spec.Monitoring.PGMonitor.Exporter.Image,
+		CrunchyPGExporter)
+}
+
+// PostgresContainerImage returns the container image to use for PostgreSQL
+// based images. It takes in the postgrescluster CRD and first checks for the
+// image value on the spec. If empty, it attempts to retrieve the relevant
+// environment variable value for the required image. This is determined by
+// gathering the defined Postgres version and, if it exists, PostGIS version
+// from the spec. Depending on these configured items, the relevant value is
+// pulled from the environment variable.
+func PostgresContainerImage(cluster *v1beta1.PostgresCluster) string {
+
+	if cluster.Spec.Image != "" {
+		return cluster.Spec.Image
+	}
+
+	key := fmt.Sprintf("%s%v", CrunchyPostgres, cluster.Spec.PostgresVersion)
+
+	if version := cluster.Spec.PostGISVersion; version != "" {
+		key += "_GIS_" + version
+	}
+
+	return os.Getenv(key)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,257 @@
+/*
+ Copyright 2021 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDefaultFromEnv(t *testing.T) {
+
+	t.Run("env var set, value given", func(t *testing.T) {
+
+		// TODO(tjmoore4): The uses of os.Setenv/os.Unsetenv should be repaced
+		// once we move to Go 1.17.
+		// Go 1.17 has a testing.T.Setenv() that makes sure to
+		// undo the effect when the test ends.
+		// This should allow the use of Unsetenv to be removed below.
+		// https://tip.golang.org/doc/go1.17#testing
+		// https://github.com/golang/go/blob/3e48c0381fd1/src/testing/testing.go#L986
+		os.Setenv("TEST_ENV_VAR", "testEnvValue")
+		assert.Equal(t, defaultFromEnv("testValue", "TEST_ENV_VAR"), "testValue")
+	})
+
+	t.Run("env var set, value not given", func(t *testing.T) {
+
+		os.Setenv("TEST_ENV_VAR", "testEnvValue")
+		assert.Equal(t, defaultFromEnv("", "TEST_ENV_VAR"), "testEnvValue")
+	})
+
+	t.Run("env var not set, value given", func(t *testing.T) {
+
+		os.Unsetenv("TEST_ENV_VAR")
+		assert.Equal(t, defaultFromEnv("testValue", "TEST_ENV_VAR"), "testValue")
+	})
+
+	t.Run("env var not set, value not given", func(t *testing.T) {
+
+		os.Unsetenv("TEST_ENV_VAR")
+		assert.Equal(t, defaultFromEnv("", "TEST_ENV_VAR"), "")
+	})
+}
+
+func TestPGBackRestContainerImage(t *testing.T) {
+
+	// set up test testcluster
+	testcluster := &v1beta1.PostgresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testcluster",
+			Namespace: "testnamespace",
+		},
+		Spec: v1beta1.PostgresClusterSpec{
+			Metadata:        &v1beta1.Metadata{},
+			PostgresVersion: 12,
+			PostGISVersion:  "3.0",
+			InstanceSets:    []v1beta1.PostgresInstanceSetSpec{},
+			Backups: v1beta1.Backups{
+				PGBackRest: v1beta1.PGBackRestArchive{},
+			},
+		},
+	}
+
+	t.Run("env var not set and spec empty", func(t *testing.T) {
+
+		os.Unsetenv(CrunchyPGBackRest)
+		assert.Equal(t, PGBackRestContainerImage(testcluster), "")
+	})
+
+	t.Run("get image from env var when image missing in spec", func(t *testing.T) {
+
+		os.Setenv(CrunchyPGBackRest, "envVarPGBackRestImage")
+		assert.Equal(t, PGBackRestContainerImage(testcluster), "envVarPGBackRestImage")
+	})
+
+	t.Run("image name from spec", func(t *testing.T) {
+
+		os.Setenv(CrunchyPGBackRest, "envVarPGBackRestImage")
+		testcluster.Spec.Backups.PGBackRest.Image = "specPGBackRestImage"
+		assert.Equal(t, PGBackRestContainerImage(testcluster), "specPGBackRestImage")
+	})
+
+	t.Run("env var and spec empty", func(t *testing.T) {
+
+		os.Setenv(CrunchyPGBackRest, "")
+		testcluster.Spec.Backups.PGBackRest.Image = ""
+		assert.Equal(t, PGBackRestContainerImage(testcluster), "")
+	})
+}
+
+func TestPGBouncerContainerImage(t *testing.T) {
+
+	// set up test testcluster
+	testcluster := &v1beta1.PostgresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testcluster",
+			Namespace: "testnamespace",
+		},
+		Spec: v1beta1.PostgresClusterSpec{
+			Metadata:        &v1beta1.Metadata{},
+			PostgresVersion: 12,
+			InstanceSets:    []v1beta1.PostgresInstanceSetSpec{},
+			Proxy: &v1beta1.PostgresProxySpec{
+				PGBouncer: &v1beta1.PGBouncerPodSpec{},
+			},
+		},
+	}
+
+	t.Run("env var not set and spec empty", func(t *testing.T) {
+
+		os.Unsetenv(CrunchyPGBouncer)
+		assert.Equal(t, PGBouncerContainerImage(testcluster), "")
+	})
+
+	t.Run("get image from env var when image missing in spec", func(t *testing.T) {
+
+		os.Setenv(CrunchyPGBouncer, "envVarPGBouncerImage")
+		assert.Equal(t, PGBouncerContainerImage(testcluster), "envVarPGBouncerImage")
+	})
+
+	t.Run("image name from spec", func(t *testing.T) {
+
+		os.Setenv(CrunchyPGBouncer, "envVarPGBouncerImage")
+		testcluster.Spec.Proxy.PGBouncer.Image = "specPGBouncerImage"
+		assert.Equal(t, PGBouncerContainerImage(testcluster), "specPGBouncerImage")
+	})
+
+	t.Run("env var and spec empty", func(t *testing.T) {
+
+		os.Setenv(CrunchyPGBouncer, "")
+		testcluster.Spec.Proxy.PGBouncer.Image = ""
+		assert.Equal(t, PGBouncerContainerImage(testcluster), "")
+	})
+}
+
+func TestPGExporterContainerImage(t *testing.T) {
+
+	// set up testcluster
+	testcluster := &v1beta1.PostgresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testcluster",
+			Namespace: "testnamespace",
+		},
+		Spec: v1beta1.PostgresClusterSpec{
+			Metadata:        &v1beta1.Metadata{},
+			PostgresVersion: 12,
+			InstanceSets:    []v1beta1.PostgresInstanceSetSpec{},
+			Monitoring: &v1beta1.MonitoringSpec{
+				PGMonitor: &v1beta1.PGMonitorSpec{
+					Exporter: &v1beta1.ExporterSpec{},
+				},
+			},
+		},
+	}
+
+	t.Run("env var not set and spec empty", func(t *testing.T) {
+
+		os.Unsetenv(CrunchyPGExporter)
+		assert.Equal(t, PGExporterContainerImage(testcluster), "")
+	})
+
+	t.Run("get image from env var when image missing in spec", func(t *testing.T) {
+
+		os.Setenv(CrunchyPGExporter, "envVarPGExporterImage")
+		assert.Equal(t, PGExporterContainerImage(testcluster), "envVarPGExporterImage")
+	})
+
+	t.Run("image name from spec", func(t *testing.T) {
+
+		os.Setenv(CrunchyPGExporter, "envVarPGExporterImage")
+		testcluster.Spec.Monitoring.PGMonitor.Exporter.Image = "specPGExporterImage"
+		assert.Equal(t, PGExporterContainerImage(testcluster), "specPGExporterImage")
+	})
+
+	t.Run("env var and spec empty", func(t *testing.T) {
+
+		os.Setenv(CrunchyPGExporter, "")
+		testcluster.Spec.Monitoring.PGMonitor.Exporter.Image = ""
+		assert.Equal(t, PGExporterContainerImage(testcluster), "")
+	})
+}
+
+func TestPostgresContainerImage(t *testing.T) {
+
+	// set up testcluster
+	testcluster := &v1beta1.PostgresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testcluster",
+			Namespace: "testnamespace",
+		},
+		Spec: v1beta1.PostgresClusterSpec{
+			Metadata:        &v1beta1.Metadata{},
+			PostgresVersion: 12,
+			InstanceSets:    []v1beta1.PostgresInstanceSetSpec{},
+		},
+	}
+
+	t.Run("env var not set and spec empty", func(t *testing.T) {
+
+		assert.Equal(t, PostgresContainerImage(testcluster), "")
+	})
+
+	t.Run("env var and spec empty", func(t *testing.T) {
+
+		os.Setenv("RELATED_IMAGE_POSTGRES_12", "")
+		assert.Equal(t, PostgresContainerImage(testcluster), "")
+	})
+
+	t.Run("check env var when image missing in spec", func(t *testing.T) {
+
+		os.Setenv("RELATED_IMAGE_POSTGRES_12", "envVarImage")
+		fmt.Printf("IMAGE RETURNED: %s\n", PostgresContainerImage(testcluster))
+		assert.Equal(t, PostgresContainerImage(testcluster), "envVarImage")
+	})
+
+	t.Run("return image name from spec", func(t *testing.T) {
+
+		testcluster.Spec.Image = "specImageName"
+		os.Setenv("RELATED_IMAGE_POSTGRES_12", "envVarImage")
+		assert.Equal(t, PostgresContainerImage(testcluster), "specImageName")
+	})
+
+	t.Run("return GIS image name from env var", func(t *testing.T) {
+
+		testcluster.Spec.Image = ""
+		testcluster.Spec.PostGISVersion = "3.0"
+
+		os.Setenv("RELATED_IMAGE_POSTGRES_12_GIS_3.0", "envVarGISImage")
+		assert.Equal(t, PostgresContainerImage(testcluster), "envVarGISImage")
+	})
+
+	t.Run("return GIS image name from spec", func(t *testing.T) {
+
+		testcluster.Spec.Image = "specGISImageName"
+		testcluster.Spec.PostGISVersion = "3.0"
+		os.Setenv("RELATED_IMAGE_POSTGRES_12_GIS_3.0", "envVarGISImage")
+		assert.Equal(t, PostgresContainerImage(testcluster), "specGISImageName")
+	})
+
+}

--- a/internal/controller/postgrescluster/helpers_test.go
+++ b/internal/controller/postgrescluster/helpers_test.go
@@ -38,6 +38,8 @@ import (
 )
 
 var (
+	//TODO(tjmoore4): With the new RELATED_IMAGES defaulting behavior, tests could be refactored
+	// to reference those environment variables instead of hard coded image values
 	CrunchyPostgresHAImage = "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-ha:centos8-13.3-4.7.0"
 	CrunchyPGBackRestImage = "registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-13.3-4.7.0"
 	CrunchyPGBouncerImage  = "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-13.3-4.7.0"

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/crunchydata/postgres-operator/internal/config"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/logging"
 	"github.com/crunchydata/postgres-operator/internal/naming"
@@ -1048,7 +1049,9 @@ func (r *Reconciler) reconcileInstance(
 	// add nss_wrapper init container and add nss_wrapper env vars to the database and pgbackrest
 	// containers
 	if err == nil {
-		addNSSWrapper(cluster.Spec.Image, &instance.Spec.Template)
+		addNSSWrapper(config.PostgresContainerImage(cluster),
+			&instance.Spec.Template)
+
 	}
 	// add an emptyDir volume to the PodTemplateSpec and an associated '/tmp' volume mount to
 	// all containers included within that spec

--- a/internal/controller/postgrescluster/pgmonitor.go
+++ b/internal/controller/postgrescluster/pgmonitor.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/crunchydata/postgres-operator/internal/config"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/logging"
 	"github.com/crunchydata/postgres-operator/internal/naming"
@@ -282,7 +283,7 @@ func addPGMonitorExporterToInstancePodSpec(
 	securityContext := initialize.RestrictedSecurityContext()
 	exporterContainer := corev1.Container{
 		Name:      naming.ContainerPGMonitorExporter,
-		Image:     cluster.Spec.Monitoring.PGMonitor.Exporter.Image,
+		Image:     config.PGExporterContainerImage(cluster),
 		Resources: cluster.Spec.Monitoring.PGMonitor.Exporter.Resources,
 		Command: []string{
 			"/opt/cpm/bin/start.sh",

--- a/internal/patroni/reconcile.go
+++ b/internal/patroni/reconcile.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/crunchydata/postgres-operator/internal/config"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/pgbackrest"
@@ -169,7 +170,7 @@ func diffCopyReplicationTLS(postgresCluster *v1beta1.PostgresCluster,
 		naming.ContainerClientCertCopy)
 
 	container.Command = copyReplicationCerts(naming.PatroniScope(postgresCluster))
-	container.Image = postgresCluster.Spec.Image
+	container.Image = config.PostgresContainerImage(postgresCluster)
 
 	container.VolumeMounts = mergeVolumeMounts(container.VolumeMounts, v1.VolumeMount{
 		Name:      volumeName,

--- a/internal/pgbackrest/reconcile.go
+++ b/internal/pgbackrest/reconcile.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/crunchydata/postgres-operator/internal/config"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/postgres"
@@ -182,7 +183,7 @@ func AddSSHToPod(postgresCluster *v1beta1.PostgresCluster, template *v1.PodTempl
 	if enableSSHD {
 		container := v1.Container{
 			Command: []string{"/usr/sbin/sshd", "-D", "-e"},
-			Image:   postgresCluster.Spec.Backups.PGBackRest.Image,
+			Image:   config.PGBackRestContainerImage(postgresCluster),
 			LivenessProbe: &v1.Probe{
 				Handler: v1.Handler{
 					TCPSocket: &v1.TCPSocketAction{

--- a/internal/postgres/reconcile.go
+++ b/internal/postgres/reconcile.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/crunchydata/postgres-operator/internal/config"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
@@ -46,7 +47,7 @@ func InitCopyReplicationTLS(postgresCluster *v1beta1.PostgresCluster,
 	template.Spec.InitContainers = append(template.Spec.InitContainers,
 		v1.Container{
 			Command:         []string{"bash", "-c", cmd},
-			Image:           postgresCluster.Spec.Image,
+			Image:           config.PostgresContainerImage(postgresCluster),
 			Name:            naming.ContainerClientCertInit,
 			SecurityContext: initialize.RestrictedSecurityContext(),
 		})
@@ -168,7 +169,7 @@ func InstancePod(ctx context.Context,
 		// Patroni will set the command and probes.
 
 		Env:       Environment(inCluster),
-		Image:     inCluster.Spec.Image,
+		Image:     config.PostgresContainerImage(inCluster),
 		Resources: inInstanceSpec.Resources,
 
 		Ports: []corev1.ContainerPort{{
@@ -186,7 +187,7 @@ func InstancePod(ctx context.Context,
 
 		Command:   startupCommand(inCluster, inInstanceSpec),
 		Env:       Environment(inCluster),
-		Image:     inCluster.Spec.Image,
+		Image:     config.PostgresContainerImage(inCluster),
 		Resources: inInstanceSpec.Resources,
 
 		SecurityContext: initialize.RestrictedSecurityContext(),

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbackrest_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbackrest_types.go
@@ -113,10 +113,11 @@ type PGBackRestArchive struct {
 	// +optional
 	Global map[string]string `json:"global,omitempty"`
 
-	// The image name to use for pgBackRest containers.  Utilized to run pgBackRest repository
-	// hosts and backups.
-	// +kubebuilder:validation:Required
-	Image string `json:"image"`
+	// The image name to use for pgBackRest containers.  Utilized to run
+	// pgBackRest repository hosts and backups. The image may also be set using
+	// the RELATED_IMAGE_PGBACKREST environment variable
+	// +optional
+	Image string `json:"image,omitempty"`
 
 	// Defines a pgBackRest repository
 	// +kubebuilder:validation:Required

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbouncer_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbouncer_types.go
@@ -78,9 +78,11 @@ type PGBouncerPodSpec struct {
 	CustomTLSSecret *corev1.SecretProjection `json:"customTLSSecret,omitempty"`
 
 	// Name of a container image that can run PgBouncer 1.15 or newer. Changing
-	// this value causes PgBouncer to restart.
+	// this value causes PgBouncer to restart. The image may also be set using
+	// the RELATED_IMAGE_PGBOUNCER environment variable.
 	// More info: https://kubernetes.io/docs/concepts/containers/images
-	Image string `json:"image"`
+	// +optional
+	Image string `json:"image,omitempty"`
 
 	// Port on which PgBouncer should listen for client connections. Changing
 	// this value causes PgBouncer to restart.

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_test.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_test.go
@@ -51,9 +51,7 @@ metadata:
   creationTimestamp: null
 spec:
   backups:
-    pgbackrest:
-      image: ""
-  image: ""
+    pgbackrest: {}
   instances: null
   patroni:
     dynamicConfiguration: null
@@ -83,9 +81,7 @@ metadata:
   creationTimestamp: null
 spec:
   backups:
-    pgbackrest:
-      image: ""
-  image: ""
+    pgbackrest: {}
   instances:
   - dataVolumeClaimSpec:
       resources: {}
@@ -126,7 +122,6 @@ status:
 		assert.DeepEqual(t, string(b), strings.TrimSpace(`
 pgBouncer:
   config: {}
-  image: ""
   port: 5432
   replicas: 1
   resources: {}

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -75,9 +75,14 @@ type PostgresClusterSpec struct {
 	// +optional
 	CustomReplicationClientTLSSecret *corev1.SecretProjection `json:"customReplicationTLSSecret,omitempty"`
 
-	// The image name to use for PostgreSQL containers
-	// +kubebuilder:validation:Required
-	Image string `json:"image"`
+	// The image name to use for PostgreSQL containers. When omitted, the value
+	// comes from an operator environment variable. For standard PostgreSQL images,
+	// the format is RELATED_IMAGE_POSTGRES_{postgresVersion},
+	// e.g. RELATED_IMAGE_POSTGRES_13. For PostGIS enabled PostgreSQL images,
+	// the format is RELATED_IMAGE_POSTGRES_{postgresVersion}_GIS_{postGISVersion},
+	// e.g. RELATED_IMAGE_POSTGRES_13_GIS_3.1.
+	// +optional
+	Image string `json:"image,omitempty"`
 
 	// The image pull secrets used to pull from a private registry
 	// Changing this value causes all running pods to restart.
@@ -103,11 +108,16 @@ type PostgresClusterSpec struct {
 	// +kubebuilder:validation:Minimum=1024
 	Port *int32 `json:"port,omitempty"`
 
-	// The major version of PostgreSQL installed in the PostgreSQL container
+	// The major version of PostgreSQL installed in the PostgreSQL image
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=10
 	// +kubebuilder:validation:Maximum=13
 	PostgresVersion int `json:"postgresVersion"`
+
+	// The PostGIS extension version installed in the PostgreSQL image.
+	// When image is not set, indicates a PostGIS enabled image will be used.
+	// +optional
+	PostGISVersion string `json:"postGISVersion,omitempty"`
 
 	// The specification of a proxy that connects to PostgreSQL.
 	// +optional
@@ -441,9 +451,10 @@ type ExporterSpec struct {
 	// +optional
 	Configuration []corev1.VolumeProjection `json:"configuration,omitempty"`
 
-	// The image name to use for crunchy-postgres-exporter containers
-	// +kubebuilder:validation:Required
-	Image string `json:"image"`
+	// The image name to use for crunchy-postgres-exporter containers. The image may
+	// also be set using the RELATED_IMAGE_PGEXPORTER environment variable.
+	// +optional
+	Image string `json:"image,omitempty"`
 
 	// Changing this value causes PostgreSQL and the exporter to restart.
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)




**What is the new behavior (if this is a feature change)?**
This commit adds operator support for the "related images" concept
as defined by the Operator Lifecycle Manager (OLM). This specifically
allows PGO to run in a restricted environment (e.g. the images can be
installed "offline"). Essentially, when the image parameters are not
defined on the postgrescluster spec, the Operator attempts to retrieve
the image value from a "RELATED_IMAGE_*" environment variable for the
relevant image. For the pgBouncer, pgBackRest and Postgres Exporter
images there will be one variable each. The PostgreSQL image will have
one unique variable for each supported Postgres version, and the PostGIS
enabled PostgreSQL image will have 2 variables for each Postgres version,
one for each supported PostGIS version per PostgreSQL version.



**Other information**:
[ch11988]