### PR TITLE
Add Release Date for v4.7.1 Release

### DIFF
--- a/docs/content/releases/4.7.1.md
+++ b/docs/content/releases/4.7.1.md
@@ -5,7 +5,7 @@ draft: false
 weight: 49
 ---
 
-Crunchy Data announces the release of PGO, the Postgres Operator 4.7.1 on July DD, 2021.
+Crunchy Data announces the release of PGO, the Postgres Operator 4.7.1 on July 29, 2021.
 
 The PostgreSQL Operator is released in conjunction with the [Crunchy Container Suite](https://github.com/CrunchyData/crunchy-containers/).
 


### PR DESCRIPTION
Adds a release date for the `v4.7.1` release to the `v4.7.1` release notes.