### PR TITLE
Allow v4.x & v5.x Operator to Run in a Single Namespace

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: postgres-operator
+  name: pgo
 spec:
   replicas: 1
   template:
@@ -17,4 +17,4 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-      serviceAccountName: postgres-operator
+      serviceAccountName: pgo

--- a/config/rbac/cluster/role_binding.yaml
+++ b/config/rbac/cluster/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
   name: postgres-operator
 subjects:
 - kind: ServiceAccount
-  name: postgres-operator
+  name: pgo

--- a/config/rbac/cluster/service_account.yaml
+++ b/config/rbac/cluster/service_account.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: postgres-operator
+  name: pgo

--- a/config/rbac/namespace/role_binding.yaml
+++ b/config/rbac/namespace/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
   name: postgres-operator
 subjects:
 - kind: ServiceAccount
-  name: postgres-operator
+  name: pgo

--- a/config/rbac/namespace/service_account.yaml
+++ b/config/rbac/namespace/service_account.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: postgres-operator
+  name: pgo

--- a/examples/helm/create-cluster/README.md
+++ b/examples/helm/create-cluster/README.md
@@ -30,9 +30,9 @@ The following commands will allow you to execute a dry run first with the debug 
 in order to verify everything is set correctly. After verifying your settings, run the install 
 command without the flags:
 ```
-helm install --dry-run --debug -n postgres-operator postgres-cluster create-cluster
+helm install --dry-run --debug -n postgres-operator pgo create-cluster
 
-helm install -n postgres-operator postgres-cluster create-cluster
+helm install -n postgres-operator pgo create-cluster
 ```
 ## Verify
 Now you can verify your Hippo cluster has deployed into the postgres-operator

--- a/examples/helm/install/Chart.yaml
+++ b/examples/helm/install/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v3
-name: postgres-operator
+name: pgo
 description: A Helm chart for Kubernetes
 type: application
 version: 0.1.0

--- a/examples/helm/install/README.md
+++ b/examples/helm/install/README.md
@@ -29,12 +29,12 @@ cd postgres-operator/examples/helm
 
 The following commands will deploy the operator into the postgres-operator namespace. The `--dry-run` flag will allow you to verify that your configuration is set correctly. 
 ```
-helm install --dry-run -n postgres-operator postgres-operator install
+helm install --dry-run -n postgres-operator pgo install
 ```
 
 Then run the install command without the flag.
 ```
-helm install -n postgres-operator postgres-operator install
+helm install -n postgres-operator pgo install
 ```
 
 ## Verify
@@ -65,5 +65,5 @@ kubectl get role -n postgres-operator
 Run the following helm command to uninstall the operator:
 
 ```
-helm uninstall -n postgres-operator postgres-operator
+helm uninstall -n postgres-operator pgo
 ```

--- a/installers/olm/postgresoperator.csv.yaml
+++ b/installers/olm/postgresoperator.csv.yaml
@@ -66,7 +66,7 @@ spec:
     strategy: deployment
     spec:
       clusterPermissions:
-        - serviceAccountName: postgres-operator
+        - serviceAccountName: pgo
           rules:
             # dynamic namespace mode
             - apiGroups:
@@ -165,7 +165,7 @@ spec:
                 - deletecollection
 
       permissions:
-        - serviceAccountName: postgres-operator
+        - serviceAccountName: pgo
           rules:
             - apiGroups:
                 - ''
@@ -199,7 +199,7 @@ spec:
                   name: postgres-operator
                   vendor: crunchydata
               spec:
-                serviceAccountName: postgres-operator
+                serviceAccountName: pgo
                 containers:
                   - name: apiserver
                     image: '${PGO_IMAGE_PREFIX}/pgo-apiserver:${PGO_IMAGE_TAG}'


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
It is not currently possible to run both the v4.x and v5.x PostgreSQL
Operator in a single namespace due to a naming conflict with the
operators' respectively deployments.


**What is the new behavior (if this is a feature change)?**
This commit updates the PostgreSQL Operator v5.x installers to name
the v5.x Operator deployment 'pgo' instead of 'postgres-operator' to
allow both versions to run in the same namespace.

Also, to facilitate independent installation and removal of the 4.x
and 5.x Operators, the default service account name has been updated
in 5.x to 'pgo' in place of the current 'postgres-cluster'.


**Other information**:
[ch11969]

For existing v5.0.0 deployments, the follow steps can be taken to update the Operator
deployment and serviceaccount:

1. `git checkout` the updated changes
2. run
```
make deploy
kubectl delete deployment postgres-operator -n <operator-namespace>
kubectl delete sa postgres-operator -n <operator-namespace>
```
