### PR TITLE
Consistently name startup instance when restoring from a different cluster

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -879,7 +879,9 @@ func (r *Reconciler) prepareForRestore(ctx context.Context,
 			cluster.Status.StartupInstanceSet =
 				runners[0].GetLabels()[naming.LabelInstanceSet]
 		} else if len(cluster.Spec.InstanceSets) > 0 {
-			cluster.Status.StartupInstance = naming.GenerateInstance(cluster,
+			// Generate a hash that will be used make sure that the startup
+			// instance is named consistently
+			cluster.Status.StartupInstance = naming.GenerateStartupInstance(cluster,
 				&cluster.Spec.InstanceSets[0]).Name
 			cluster.Status.StartupInstanceSet = cluster.Spec.InstanceSets[0].Name
 		} else {

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -2703,7 +2703,11 @@ func TestPrepareForRestore(t *testing.T) {
 		}}
 
 		for i, tc := range testCases {
-			t.Run(tc.desc, func(t *testing.T) {
+			name := tc.desc
+			if !dedicated {
+				name = tc.desc + "-no-repo"
+			}
+			t.Run(name, func(t *testing.T) {
 
 				clusterName := "prepare-for-restore-" + strconv.Itoa(i)
 				if !dedicated {
@@ -2742,6 +2746,9 @@ func TestPrepareForRestore(t *testing.T) {
 
 				if primaryInstance != nil {
 					assert.Assert(t, cluster.Status.StartupInstance == primaryInstanceName)
+				} else {
+					assert.Equal(t, cluster.Status.StartupInstance,
+						naming.GenerateStartupInstance(cluster, &cluster.Spec.InstanceSets[0]).Name)
 				}
 
 				leaderEP, dcsEP, failoverEP := v1.Endpoints{}, v1.Endpoints{}, v1.Endpoints{}

--- a/internal/naming/names_test.go
+++ b/internal/naming/names_test.go
@@ -239,3 +239,24 @@ func TestGenerateInstance(t *testing.T) {
 	assert.Equal(t, cluster.Namespace, instance.Namespace)
 	assert.Assert(t, strings.HasPrefix(instance.Name, cluster.Name+"-"+set.Name+"-"))
 }
+
+// TestGenerateStartupInstance ensures that a consistent ObjectMeta will be
+// provided assuming the same cluster name and instance set name is passed
+// into GenerateStartupInstance
+func TestGenerateStartupInstance(t *testing.T) {
+	cluster := &v1beta1.PostgresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns1", Name: "pg0",
+		},
+	}
+	set := &v1beta1.PostgresInstanceSetSpec{Name: "hippos"}
+
+	instanceOne := GenerateStartupInstance(cluster, set)
+
+	assert.Equal(t, cluster.Namespace, instanceOne.Namespace)
+	assert.Assert(t, strings.HasPrefix(instanceOne.Name, cluster.Name+"-"+set.Name+"-"))
+
+	instanceTwo := GenerateStartupInstance(cluster, set)
+	assert.DeepEqual(t, instanceOne, instanceTwo)
+
+}


### PR DESCRIPTION
In some environments, caching issues when GETing a cluster from the client, lead to errors when applying changes to the restore job. Using a hash of `cluster.Name` and `instanceSet.Name` to generate the startup instance name ensures that the `StartupInstance` status is set consistently and the `prepareForRestore` function is idempotent. This logic is used when using a `dataSource` to restore from another cluster.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable? NA
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
[ch12088]