### PR TITLE
Update minor typo in Documentation v4.7.0

### DIFF
--- a/docs/content/installation/metrics/metrics-configuration.md
+++ b/docs/content/installation/metrics/metrics-configuration.md
@@ -36,7 +36,7 @@ These variables affect the general configuration of PostgreSQL Operator Monitori
 | `grafana_volume_size` | 1Gi | **Required** | Set to the size of persistent volume to create for Grafana. |
 | `metrics_image_pull_secret` |  |  | Name of a Secret containing credentials for container image registries. |
 | `metrics_image_pull_secret_manifest` |  |  | Provide a path to the image Secret manifest to be installed in the metrics namespace. |
-| `metrics_namespace` | 1G | **Required** | The namespace that should be created (if it doesn't already exist) and utilized for installation of the Matrics infrastructure. |
+| `metrics_namespace` | 1G | **Required** | The namespace that should be created (if it doesn't already exist) and utilized for installation of the Metrics infrastructure. |
 | `pgbadgerport` | 10000 | **Required** | Set to configure the port used by pgbadger in any PostgreSQL clusters. |
 | `prometheus_install` | false | **Required** | Set to true to install Promotheus in order to capture metrics exported from PostgreSQL clusters. |
 | `prometheus_service_type` | true | **Required** | How to [expose][k8s-service-type] the Prometheus service. |


### PR DESCRIPTION
**Checklist:**

 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**

A minor typo appears in the current documentation of **v.4.7.0** ([Visit Documentation v.4.7.0](https://access.crunchydata.com/documentation/postgres-operator/4.7.0/installation/metrics/other/ansible/metrics-prerequisites/))

**What is the new behavior (if this is a feature change)?**

Fix minor typo in `metrics-configuration` documentation

- `Matrics` should be `Metrics` on line 39 of `metrics-configuration.md ` (Path: `docs/content/installation/metrics/metrics-configuration.md`)

