### PR TITLE
OpenShift Auto-detection

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -3066,7 +3066,8 @@ spec:
                 type: object
               openshift:
                 description: Whether or not the PostgreSQL cluster is being deployed
-                  to an OpenShift environment
+                  to an OpenShift environment. If the field is unset, the operator
+                  will automatically detect the environment.
                 type: boolean
               patroni:
                 properties:

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -62,12 +62,6 @@ Let's create a simple Postgres cluster. You can do this by executing the followi
 kubectl apply -k kustomize/postgres
 ```
 
-If you are on OpenShift, use the following command instead:
-
-```
-kubectl apply -k kustomize/openshift
-```
-
 This will create a Postgres cluster named `hippo` in the `postgres-operator` namespace. You can track the progress of your cluster using the following command:
 
 ```

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -122,7 +122,7 @@ PostgresClusterSpec defines the desired state of PostgresCluster
       </tr><tr>
         <td><b>openshift</b></td>
         <td>boolean</td>
-        <td>Whether or not the PostgreSQL cluster is being deployed to an OpenShift environment</td>
+        <td>Whether or not the PostgreSQL cluster is being deployed to an OpenShift environment. If the field is unset, the operator will automatically detect the environment.</td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#postgresclusterspecpatroni">patroni</a></b></td>

--- a/docs/content/tutorial/backups.md
+++ b/docs/content/tutorial/backups.md
@@ -106,7 +106,7 @@ s3:
   region: "<YOUR_AWS_S3_REGION>"
 ```
 
-Again, replace these values with the values that match your S3 configuration. If you are deploying to OpenShift, ensure to set `spec.openshift` to `true`.
+Again, replace these values with the values that match your S3 configuration.
 
 When your configuration is saved, you can deploy your cluster:
 
@@ -124,7 +124,7 @@ There is an example for creating a Postgres cluster that uses GCS for backups in
 
 First, copy your GCS key secret (which is a JSON file) into `kustomize/gcs/gcs-key.json`. Note that a `.gitignore` directive prevents you from committing this file.
 
-Next, open the `postgres.yaml` file and edit `spec.backups.pgbackrest.repos.gcs.bucket` to the name of the GCS bucket that you want to back up to. If you are deploying to OpenShift, ensure to set `spec.openshift` to `true`.
+Next, open the `postgres.yaml` file and edit `spec.backups.pgbackrest.repos.gcs.bucket` to the name of the GCS bucket that you want to back up to.
 
 Save this file, and then run:
 
@@ -163,7 +163,7 @@ azure:
   container: "<YOUR_AZURE_CONTAINER>"
 ```
 
-Again, replace these values with the values that match your Azure configuration. If you are deploying to OpenShift, ensure to set `spec.openshift` to `true`.
+Again, replace these values with the values that match your Azure configuration.
 
 When your configuration is saved, you can deploy your cluster:
 

--- a/docs/content/tutorial/create-cluster.md
+++ b/docs/content/tutorial/create-cluster.md
@@ -15,13 +15,7 @@ Creating a Postgres cluster is pretty simple. Using the example in the `kustomiz
 kubectl apply -k kustomize/postgres
 ```
 
-and PGO will create a simple Postgres cluster named `hippo` in the `postgres-operator` namespace. Note that if you are on OpenShift, you will need to set `spec.openshift` to `true`. You can also run the example from the `kustomize/openshift` directory:
-
-```
-kubectl apply -k kustomize/openshift
-```
-
-You can track the status of your Postgres cluster using `kubectl describe` on the `postgresclusters.postgres-operator.crunchydata.com` custom resource:
+and PGO will create a simple Postgres cluster named `hippo` in the `postgres-operator` namespace. You can track the status of your Postgres cluster using `kubectl describe` on the `postgresclusters.postgres-operator.crunchydata.com` custom resource:
 
 ```
 kubectl -n postgres-operator describe postgresclusters.postgres-operator.crunchydata.com hippo

--- a/docs/content/tutorial/customize-cluster.md
+++ b/docs/content/tutorial/customize-cluster.md
@@ -58,8 +58,6 @@ spec:
           work_mem: 2MB
 ```
 
-(If you are on OpenShift, ensure that `spec.openshift` is set to `true`).
-
 In particular, we added the following to `spec`:
 
 ```

--- a/docs/content/tutorial/getting-started.md
+++ b/docs/content/tutorial/getting-started.md
@@ -12,7 +12,7 @@ As part of the installation, please be sure that you have done the following:
 1. [Forked the Postgres Operator examples repository](https://github.com/CrunchyData/postgres-operator-examples/fork) and cloned it to your host machine.
 1. Installed PGO to the `postgres-operator` namespace. If you are inside your `postgres-operator-examples` directory, you can run the `kubectl apply -k kustomize/install` command.
 
-Throughout this tutorial, we will be building on the example provided in the `kustomize/postgres`. If you are using OpenShift, you will want to use the example in the `kustomize/openshift` directory, but in this tutorial, treat references to `kustomize/postgres` as the equivalent of taking action on files in `kustomize/openshift`.
+Throughout this tutorial, we will be building on the example provided in the `kustomize/postgres`.
 
 When referring to a nested object within a YAML manifest, we will be using the `.` format similar to `kubectl explain`. For example, if we want to refer to the deepest element in this yaml file:
 

--- a/docs/content/tutorial/high-availability.md
+++ b/docs/content/tutorial/high-availability.md
@@ -60,8 +60,6 @@ spec:
                 storage: 1Gi
 ```
 
-(If you are on OpenShift, ensure that `spec.openshift` is set to `true`).
-
 Apply these updates to your Kubernetes cluster with the following command:
 
 ```
@@ -274,8 +272,6 @@ spec:
                 storage: 1Gi
 ```
 
-(If you are on OpenShift, ensure that `spec.openshift` is set to `true`).
-
 Apply those changes in your Kubernetes cluster.
 
 Let's take a closer look at this section:
@@ -343,8 +339,6 @@ spec:
               requests:
                 storage: 1Gi
 ```
-
-(If you are on OpenShift, ensure that `spec.openshift` is set to `true`).
 
 Apply those changes in your Kubernetes cluster.
 

--- a/docs/content/tutorial/resize-cluster.md
+++ b/docs/content/tutorial/resize-cluster.md
@@ -56,8 +56,6 @@ spec:
                 storage: 1Gi
 ```
 
-(If you are on OpenShift, ensure that `spec.openshift` is set to `true`).
-
 In particular, we added the following to `spec.instances`:
 
 ```
@@ -138,8 +136,6 @@ spec:
               requests:
                 storage: 20Gi
 ```
-
-(If you are on OpenShift, ensure that `spec.openshift` is set to `true`).
 
 In particular, we added the following to `spec.instances`:
 

--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -57,10 +57,11 @@ const (
 
 // Reconciler holds resources for the PostgresCluster reconciler
 type Reconciler struct {
-	Client   client.Client
-	Owner    client.FieldOwner
-	Recorder record.EventRecorder
-	Tracer   trace.Tracer
+	Client      client.Client
+	Owner       client.FieldOwner
+	Recorder    record.EventRecorder
+	Tracer      trace.Tracer
+	IsOpenShift bool
 
 	PodExec func(
 		namespace, pod, container string,
@@ -106,6 +107,10 @@ func (r *Reconciler) Reconcile(
 	// is necessary because controller-runtime makes a copy before returning
 	// from its cache.
 	cluster.Default()
+
+	if cluster.Spec.OpenShift == nil {
+		cluster.Spec.OpenShift = &r.IsOpenShift
+	}
 
 	// Keep a copy of cluster prior to any manipulations.
 	before := cluster.DeepCopy()

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -95,7 +95,9 @@ type PostgresClusterSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	InstanceSets []PostgresInstanceSetSpec `json:"instances"`
 
-	// Whether or not the PostgreSQL cluster is being deployed to an OpenShift environment
+	// Whether or not the PostgreSQL cluster is being deployed to an OpenShift
+	// environment. If the field is unset, the operator will automatically
+	// detect the environment.
 	// +optional
 	OpenShift *bool `json:"openshift,omitempty"`
 


### PR DESCRIPTION
Update the operator to automatically detect if it is running in an
OpenShift environment. When the postgres-operator binary starts, it will
check if its being run in an OpenShift environment and pass a value into
the reconciler. When a postgrescluster is reconciled, this value will be
used to set `cluster.Spec.Openshift` if the field is not set by the user
in the spec.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
[ch11680]