### PR TITLE
Reconcile PVCs Using Labels

### DIFF
--- a/internal/controller/postgrescluster/cluster.go
+++ b/internal/controller/postgrescluster/cluster.go
@@ -194,7 +194,8 @@ func (r *Reconciler) reconcileClusterPrimaryService(
 // prior to bootstrapping the cluster, specifically according to any data source configured in the
 // PostgresCluster spec.
 func (r *Reconciler) reconcileDataSource(ctx context.Context,
-	cluster *v1beta1.PostgresCluster, observed *observedInstances) (bool, error) {
+	cluster *v1beta1.PostgresCluster, observed *observedInstances,
+	clusterVolumes []v1.PersistentVolumeClaim) (bool, error) {
 
 	// a hash func to hash the pgBackRest restore options
 	hashFunc := func(jobConfigs []string) (string, error) {
@@ -303,7 +304,7 @@ func (r *Reconciler) reconcileDataSource(ctx context.Context,
 
 	// proceed with initializing the PG data directory if not already initialized
 	if err := r.reconcilePostgresClusterDataSource(ctx, cluster, dataSource,
-		configHash); err != nil {
+		configHash, clusterVolumes); err != nil {
 		return true, err
 	}
 	// return early until the PG data directory is initialized

--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -207,7 +207,7 @@ func (r *Reconciler) Reconcile(
 		// which it will indicate that an early return is no longer needed, and reconciliation
 		// can proceed normally.
 		var returnEarly bool
-		returnEarly, err = r.reconcileDataSource(ctx, cluster, instances)
+		returnEarly, err = r.reconcileDataSource(ctx, cluster, instances, clusterVolumes)
 		if err != nil || returnEarly {
 			return patchClusterStatus()
 		}

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1028,7 +1028,7 @@ func (r *Reconciler) reconcileInstance(
 
 	// Add pgBackRest containers, volumes, etc. to the instance Pod spec
 	if err == nil {
-		err = addPGBackRestToInstancePodSpec(cluster, &instance.Spec.Template, instance)
+		err = addPGBackRestToInstancePodSpec(cluster, &instance.Spec.Template, instance, r.getRepoPVCNames(ctx, cluster))
 	}
 
 	// Add pgMonitor resources to the instance Pod spec
@@ -1182,7 +1182,7 @@ func generateInstanceStatefulSetIntent(_ context.Context,
 // configured, and then mounting the proper pgBackRest configuration resources (ConfigMaps
 // and Secrets)
 func addPGBackRestToInstancePodSpec(cluster *v1beta1.PostgresCluster,
-	template *v1.PodTemplateSpec, instance *appsv1.StatefulSet) error {
+	template *v1.PodTemplateSpec, instance *appsv1.StatefulSet, repoPVCNames map[string]string) error {
 
 	addSSH := pgbackrest.RepoHostEnabled(cluster)
 	dedicatedRepoEnabled := pgbackrest.DedicatedRepoHostEnabled(cluster)
@@ -1197,7 +1197,7 @@ func addPGBackRestToInstancePodSpec(cluster *v1beta1.PostgresCluster,
 		}
 	}
 	if !dedicatedRepoEnabled {
-		if err := pgbackrest.AddRepoVolumesToPod(cluster, template,
+		if err := pgbackrest.AddRepoVolumesToPod(cluster, template, repoPVCNames,
 			pgBackRestConfigContainers...); err != nil {
 			return err
 		}

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1026,9 +1026,14 @@ func (r *Reconciler) reconcileInstance(
 			spec, instanceCertificates, instanceConfigMap, &instance.Spec.Template)
 	}
 
+	// Get the pgBackRest repo PVC names
+	var repoPVCNames map[string]string
+	if err == nil {
+		repoPVCNames, err = r.getRepoPVCNames(ctx, cluster)
+	}
 	// Add pgBackRest containers, volumes, etc. to the instance Pod spec
 	if err == nil {
-		err = addPGBackRestToInstancePodSpec(cluster, &instance.Spec.Template, instance, r.getRepoPVCNames(ctx, cluster))
+		err = addPGBackRestToInstancePodSpec(cluster, &instance.Spec.Template, instance, repoPVCNames)
 	}
 
 	// Add pgMonitor resources to the instance Pod spec

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -317,28 +317,34 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
 		repoHost  *v1beta1.PGBackRestRepoHost
 		sshConfig *v1.ConfigMapProjection
 		sshSecret *v1.SecretProjection
+		testMap   map[string]string
 	}{{
 		repoHost: nil,
+		testMap:  map[string]string{},
 	}, {
 		repoHost: &v1beta1.PGBackRestRepoHost{},
+		testMap:  map[string]string{},
 	}, {
 		repoHost: &v1beta1.PGBackRestRepoHost{
 			Dedicated: &v1beta1.DedicatedRepo{
 				Resources: v1.ResourceRequirements{},
 			},
 		},
+		testMap: map[string]string{},
 	}, {
 		repoHost: nil,
 		sshConfig: &v1.ConfigMapProjection{
 			LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-config.conf"}},
 		sshSecret: &v1.SecretProjection{
 			LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-secret.conf"}},
+		testMap: map[string]string{},
 	}, {
 		repoHost: &v1beta1.PGBackRestRepoHost{},
 		sshConfig: &v1.ConfigMapProjection{
 			LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-config.conf"}},
 		sshSecret: &v1.SecretProjection{
 			LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-secret.conf"}},
+		testMap: map[string]string{},
 	}, {
 		repoHost: &v1beta1.PGBackRestRepoHost{
 			Dedicated: &v1beta1.DedicatedRepo{
@@ -349,7 +355,60 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
 			LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-config.conf"}},
 		sshSecret: &v1.SecretProjection{
 			LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-secret.conf"}},
-	}}
+		testMap: map[string]string{},
+	},
+		// rerun the same tests, but this time simulate an existing PVC
+		{
+			repoHost: nil,
+			testMap: map[string]string{
+				"repo1": "hippo-repo1",
+			},
+		}, {
+			repoHost: &v1beta1.PGBackRestRepoHost{},
+			testMap: map[string]string{
+				"repo1": "hippo-repo1",
+			},
+		}, {
+			repoHost: &v1beta1.PGBackRestRepoHost{
+				Dedicated: &v1beta1.DedicatedRepo{
+					Resources: v1.ResourceRequirements{},
+				},
+			},
+			testMap: map[string]string{
+				"repo1": "hippo-repo1",
+			},
+		}, {
+			repoHost: nil,
+			sshConfig: &v1.ConfigMapProjection{
+				LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-config.conf"}},
+			sshSecret: &v1.SecretProjection{
+				LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-secret.conf"}},
+			testMap: map[string]string{
+				"repo1": "hippo-repo1",
+			},
+		}, {
+			repoHost: &v1beta1.PGBackRestRepoHost{},
+			sshConfig: &v1.ConfigMapProjection{
+				LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-config.conf"}},
+			sshSecret: &v1.SecretProjection{
+				LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-secret.conf"}},
+			testMap: map[string]string{
+				"repo1": "hippo-repo1",
+			},
+		}, {
+			repoHost: &v1beta1.PGBackRestRepoHost{
+				Dedicated: &v1beta1.DedicatedRepo{
+					Resources: v1.ResourceRequirements{},
+				},
+			},
+			sshConfig: &v1.ConfigMapProjection{
+				LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-config.conf"}},
+			sshSecret: &v1.SecretProjection{
+				LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-secret.conf"}},
+			testMap: map[string]string{
+				"repo1": "hippo-repo1",
+			},
+		}}
 
 	for _, tc := range testCases {
 		repoHost := (tc.repoHost != nil)
@@ -374,7 +433,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
 				}
 			}
 
-			err := addPGBackRestToInstancePodSpec(postgresCluster, template, instance)
+			err := addPGBackRestToInstancePodSpec(postgresCluster, template, instance, tc.testMap)
 			assert.NilError(t, err)
 
 			// if there is no dedicated repo host configured, verfiy pgBackRest repos are mounted to the

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -219,20 +219,7 @@ func (r *Reconciler) getPGBackRestResources(ctx context.Context,
 			continue
 		}
 
-		// store objects owned directly by the PostgreSQL cluster
-		owned := []unstructured.Unstructured{}
-		// store objects that are not directly owned by the postgrescluster,
-		// which will include the Jobs created by the scheduled backup CronJobs
-		other := []unstructured.Unstructured{}
-		for i, u := range uList.Items {
-			if metav1.IsControlledBy(&uList.Items[i], postgresCluster) {
-				owned = append(owned, u)
-			} else {
-				other = append(other, u)
-			}
-		}
-
-		owned, err := r.cleanupRepoResources(ctx, postgresCluster, owned)
+		owned, err := r.cleanupRepoResources(ctx, postgresCluster, uList.Items)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -245,7 +232,7 @@ func (r *Reconciler) getPGBackRestResources(ctx context.Context,
 		// if the current objects are Jobs, update the status for the Jobs
 		// created by the pgBackRest scheduled backup CronJobs
 		if gvk.Kind == "JobList" {
-			r.setScheduledJobStatus(ctx, postgresCluster, other)
+			r.setScheduledJobStatus(ctx, postgresCluster, uList.Items)
 		}
 
 	}

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -1303,7 +1303,7 @@ func (r *Reconciler) reconcilePGBackRest(ctx context.Context,
 // for the PostgresCluster being reconciled using the backups of another PostgresCluster.
 func (r *Reconciler) reconcilePostgresClusterDataSource(ctx context.Context,
 	cluster *v1beta1.PostgresCluster, dataSource *v1beta1.PostgresClusterDataSource,
-	configHash string) error {
+	configHash string, clusterVolumes []corev1.PersistentVolumeClaim) error {
 
 	// grab cluster, namespaces and repo name information from the data source
 	sourceClusterName := dataSource.ClusterName
@@ -1464,10 +1464,6 @@ func (r *Reconciler) reconcilePostgresClusterDataSource(ctx context.Context,
 		Name:      instanceName,
 		Namespace: cluster.GetNamespace(),
 	}}
-	clusterVolumes, err := r.observePersistentVolumeClaims(ctx, cluster)
-	if err != nil {
-		return errors.WithStack(err)
-	}
 	// Reconcile the PGDATA and WAL volumes for the restore
 	pgdata, err := r.reconcilePostgresDataVolume(ctx, cluster, instanceSet, fakeSTS, clusterVolumes)
 	if err != nil {

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -2256,7 +2256,7 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 					pgclusterDataSource = tc.dataSource.PostgresCluster
 				}
 				err := r.reconcilePostgresClusterDataSource(ctx, cluster, pgclusterDataSource,
-					"testhash")
+					"testhash", nil)
 				assert.NilError(t, err)
 
 				restoreJobs := &batchv1.JobList{}

--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -463,7 +463,11 @@ func (r *Reconciler) reconcilePostgresDataVolume(
 	}
 
 	var pvc *v1.PersistentVolumeClaim
-	if existingPVCName := r.getPGPVCNames(ctx, cluster, labelMap); existingPVCName != "" {
+	existingPVCName, err := r.getPGPVCNames(ctx, cluster, labelMap)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if existingPVCName != "" {
 		pvc = &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
 			Namespace: cluster.GetNamespace(),
 			Name:      existingPVCName,
@@ -474,7 +478,7 @@ func (r *Reconciler) reconcilePostgresDataVolume(
 
 	pvc.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PersistentVolumeClaim"))
 
-	err := errors.WithStack(r.setControllerReference(cluster, pvc))
+	err = errors.WithStack(r.setControllerReference(cluster, pvc))
 
 	pvc.Annotations = naming.Merge(
 		cluster.Spec.Metadata.GetAnnotationsOrNil(),
@@ -515,7 +519,11 @@ func (r *Reconciler) reconcilePostgresWALVolume(
 	}
 
 	var pvc *v1.PersistentVolumeClaim
-	if existingPVCName := r.getPGPVCNames(ctx, cluster, labelMap); existingPVCName != "" {
+	existingPVCName, err := r.getPGPVCNames(ctx, cluster, labelMap)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if existingPVCName != "" {
 		pvc = &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
 			Namespace: cluster.GetNamespace(),
 			Name:      existingPVCName,
@@ -572,7 +580,7 @@ func (r *Reconciler) reconcilePostgresWALVolume(
 		return pvc, err
 	}
 
-	err := errors.WithStack(r.setControllerReference(cluster, pvc))
+	err = errors.WithStack(r.setControllerReference(cluster, pvc))
 
 	pvc.Annotations = naming.Merge(
 		cluster.Spec.Metadata.GetAnnotationsOrNil(),

--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -453,6 +453,7 @@ func (r *Reconciler) reconcilePostgresUsersInPostgreSQL(
 func (r *Reconciler) reconcilePostgresDataVolume(
 	ctx context.Context, cluster *v1beta1.PostgresCluster,
 	instanceSpec *v1beta1.PostgresInstanceSetSpec, instance *appsv1.StatefulSet,
+	clusterVolumes []corev1.PersistentVolumeClaim,
 ) (*corev1.PersistentVolumeClaim, error) {
 
 	labelMap := map[string]string{
@@ -463,7 +464,7 @@ func (r *Reconciler) reconcilePostgresDataVolume(
 	}
 
 	var pvc *v1.PersistentVolumeClaim
-	existingPVCName, err := r.getPGPVCNames(ctx, cluster, labelMap)
+	existingPVCName, err := getPGPVCName(labelMap, clusterVolumes)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -508,7 +509,7 @@ func (r *Reconciler) reconcilePostgresDataVolume(
 func (r *Reconciler) reconcilePostgresWALVolume(
 	ctx context.Context, cluster *v1beta1.PostgresCluster,
 	instanceSpec *v1beta1.PostgresInstanceSetSpec, instance *appsv1.StatefulSet,
-	observed *Instance,
+	observed *Instance, clusterVolumes []corev1.PersistentVolumeClaim,
 ) (*corev1.PersistentVolumeClaim, error) {
 
 	labelMap := map[string]string{
@@ -519,7 +520,7 @@ func (r *Reconciler) reconcilePostgresWALVolume(
 	}
 
 	var pvc *v1.PersistentVolumeClaim
-	existingPVCName, err := r.getPGPVCNames(ctx, cluster, labelMap)
+	existingPVCName, err := getPGPVCName(labelMap, clusterVolumes)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/internal/controller/postgrescluster/postgres_test.go
+++ b/internal/controller/postgrescluster/postgres_test.go
@@ -210,7 +210,7 @@ func TestReconcilePostgresVolumes(t *testing.T) {
 	instance := &appsv1.StatefulSet{ObjectMeta: naming.GenerateInstance(cluster, spec)}
 
 	t.Run("DataVolume", func(t *testing.T) {
-		pvc, err := reconciler.reconcilePostgresDataVolume(ctx, cluster, spec, instance)
+		pvc, err := reconciler.reconcilePostgresDataVolume(ctx, cluster, spec, instance, nil)
 		assert.NilError(t, err)
 
 		assert.Assert(t, metav1.IsControlledBy(pvc, cluster))
@@ -235,7 +235,7 @@ volumeMode: Filesystem
 		observed := &Instance{}
 
 		t.Run("None", func(t *testing.T) {
-			pvc, err := reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed)
+			pvc, err := reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed, nil)
 			assert.NilError(t, err)
 			assert.Assert(t, pvc == nil)
 		})
@@ -250,7 +250,7 @@ volumeMode: Filesystem
 				},
 			}`), spec))
 
-			pvc, err := reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed)
+			pvc, err := reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed, nil)
 			assert.NilError(t, err)
 
 			assert.Assert(t, metav1.IsControlledBy(pvc, cluster))
@@ -278,14 +278,14 @@ volumeMode: Filesystem
 
 				t.Run("FilesAreNotSafe", func(t *testing.T) {
 					// No pods; expect no changes to the PVC.
-					returned, err := reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed)
+					returned, err := reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed, nil)
 					assert.NilError(t, err)
 					assert.DeepEqual(t, returned, pvc, ignoreTypeMeta)
 
 					// Not running; expect no changes to the PVC.
 					observed.Pods = []*corev1.Pod{{}}
 
-					returned, err = reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed)
+					returned, err = reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed, nil)
 					assert.NilError(t, err)
 					assert.DeepEqual(t, returned, pvc, ignoreTypeMeta)
 
@@ -310,7 +310,7 @@ volumeMode: Filesystem
 						return expected
 					}
 
-					returned, err = reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed)
+					returned, err = reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed, nil)
 					assert.Equal(t, expected, errors.Unwrap(err), "expected pod exec")
 					assert.DeepEqual(t, returned, pvc, ignoreTypeMeta)
 
@@ -324,7 +324,7 @@ volumeMode: Filesystem
 						return nil
 					}
 
-					returned, err = reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed)
+					returned, err = reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed, nil)
 					assert.NilError(t, err)
 					assert.DeepEqual(t, returned, pvc, ignoreTypeMeta)
 				})
@@ -347,7 +347,7 @@ volumeMode: Filesystem
 						return nil
 					}
 
-					returned, err := reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed)
+					returned, err := reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed, nil)
 					assert.NilError(t, err)
 					assert.Assert(t, returned == nil)
 
@@ -357,7 +357,7 @@ volumeMode: Filesystem
 
 					// Pods will redeploy while the PVC is scheduled for deletion.
 					observed.Pods = nil
-					returned, err = reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed)
+					returned, err = reconciler.reconcilePostgresWALVolume(ctx, cluster, spec, instance, observed, nil)
 					assert.NilError(t, err)
 					assert.Assert(t, returned == nil)
 				})

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -574,35 +574,49 @@ func TestGetPVCNameMethods(t *testing.T) {
 		})
 
 		assert.NilError(t, err)
-		assert.Assert(t, reconciler.getPVCName(ctx, cluster, selector) == "testpgdatavol")
+
+		pvcName, err := reconciler.getPVCName(ctx, cluster, selector)
+		assert.NilError(t, err)
+
+		assert.Assert(t, pvcName == "testpgdatavol")
 
 	})
 
 	t.Run("get pgdata PVC", func(t *testing.T) {
 
-		assert.Assert(t, reconciler.getPGPVCNames(ctx, cluster, map[string]string{
+		pvcNames, err := reconciler.getPGPVCNames(ctx, cluster, map[string]string{
 			naming.LabelCluster:     cluster.Name,
 			naming.LabelInstanceSet: "testinstance1",
 			naming.LabelInstance:    "testinstance1-abcd",
 			naming.LabelRole:        naming.RolePostgresData,
-		}) == "testpgdatavol")
+		})
+		assert.NilError(t, err)
+
+		assert.Assert(t, pvcNames == "testpgdatavol")
 	})
 
 	t.Run("get wal PVC", func(t *testing.T) {
 
-		assert.Assert(t, reconciler.getPGPVCNames(ctx, cluster, map[string]string{
+		pvcNames, err := reconciler.getPGPVCNames(ctx, cluster, map[string]string{
 			naming.LabelCluster:     cluster.Name,
 			naming.LabelInstanceSet: "testinstance1",
 			naming.LabelInstance:    "testinstance1-abcd",
 			naming.LabelRole:        naming.RolePostgresWAL,
-		}) == "testwalvol")
+		})
+		assert.NilError(t, err)
+
+		assert.Assert(t, pvcNames == "testwalvol")
 	})
 
 	t.Run("get one repo PVC", func(t *testing.T) {
 		expectedMap := map[string]string{
 			"testrepo1": "testrepovol1",
 		}
-		assert.DeepEqual(t, reconciler.getRepoPVCNames(ctx, cluster), expectedMap)
+
+		repoPVCNames, err := reconciler.getRepoPVCNames(ctx, cluster)
+		assert.NilError(t, err)
+
+		assert.DeepEqual(t, repoPVCNames, expectedMap)
 	})
 
 	t.Run("get two repo PVCs", func(t *testing.T) {
@@ -620,6 +634,10 @@ func TestGetPVCNameMethods(t *testing.T) {
 			"testrepo1": "testrepovol1",
 			"testrepo2": "testrepovol2",
 		}
-		assert.DeepEqual(t, reconciler.getRepoPVCNames(ctx, cluster), expectedMap)
+
+		repoPVCNames, err := reconciler.getRepoPVCNames(ctx, cluster)
+		assert.NilError(t, err)
+
+		assert.DeepEqual(t, repoPVCNames, expectedMap)
 	})
 }


### PR DESCRIPTION

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Currently, when reconciling the various PVCs for a PostgresCluster,
 a specific naming convention is used. Specifically, each PVC is
reconciled as follows:

PostgreSQL Data: <clusterName>-<instanceName>-pgdata
  e.g., hippo-instance1-abcd-pgdata
pgBackRest Repository: <clusterName>-<repoName>
  e.g., hippo-repo1


**What is the new behavior (if this is a feature change)?**
While this approach simplifies reconciliation logic, it does mean that
existing PVC's that do not follow this convention cannot be used.

To allow for more versatility, this commit updates all PVC reconciliation
logic to reconcile PVC's based on their labels. This is done by first
identifying the PVC by their labels, then using the names of the PVCs
during reconciliation. This means any existing PVC in the environment
should be detected and reconciled, while a new PVC will be generated if
no existing PVC is found.


**Other information**:
[ch11966]