### PR TITLE
Remove nss_wrapper From Exporter

### DIFF
--- a/build/crunchy-postgres-exporter/Dockerfile
+++ b/build/crunchy-postgres-exporter/Dockerfile
@@ -61,11 +61,6 @@ EXPOSE 9187
 # volume permissions are applied when building the image
 VOLUME ["/conf"]
 
-# Defines a unique directory name that will be utilized by the nss_wrapper in the UID script
-ENV NSS_WRAPPER_SUBDIR="exporter"
-
-ENTRYPOINT ["/opt/cpm/bin/uid_daemon.sh"]
-
 USER 2
 
 CMD ["/opt/cpm/bin/start.sh"]


### PR DESCRIPTION
Removes the `nss_wrapper` from the `crunchy-postgres-exporter`, aligning exporter container configuration in PGO v4.x with PGO v5.x (PGO v5.xdoes not utilize the `nss_wrapper` when running the PostgrSQL exporter).

[ch12157]
fixes #2539