### PR TITLE
Fix Type Assertion for pg_hba Config

### DIFF
--- a/internal/patroni/config.go
+++ b/internal/patroni/config.go
@@ -280,8 +280,13 @@ func DynamicConfiguration(
 	for i := range pgHBAs.Mandatory {
 		hba[i] = pgHBAs.Mandatory[i].String()
 	}
-	if section, ok := postgresql["pg_hba"].([]string); ok {
-		hba = append(hba, section...)
+	if section, ok := postgresql["pg_hba"].([]interface{}); ok {
+		for i := range section {
+			// any pg_hba values that are not strings will be skipped
+			if value, ok := section[i].(string); ok {
+				hba = append(hba, value)
+			}
+		}
 	}
 	// When the section is missing or empty, include the recommended defaults.
 	if len(hba) == len(pgHBAs.Mandatory) {

--- a/internal/patroni/config_test.go
+++ b/internal/patroni/config_test.go
@@ -419,7 +419,7 @@ func TestDynamicConfiguration(t *testing.T) {
 			name: "postgresql.pg_hba: no default when input",
 			input: map[string]interface{}{
 				"postgresql": map[string]interface{}{
-					"pg_hba": []string{"custom"},
+					"pg_hba": []interface{}{"custom"},
 				},
 			},
 			hbas: postgres.HBAs{
@@ -444,7 +444,33 @@ func TestDynamicConfiguration(t *testing.T) {
 			name: "postgresql.pg_hba: mandatory before others",
 			input: map[string]interface{}{
 				"postgresql": map[string]interface{}{
-					"pg_hba": []string{"custom"},
+					"pg_hba": []interface{}{"custom"},
+				},
+			},
+			hbas: postgres.HBAs{
+				Mandatory: []postgres.HostBasedAuthentication{
+					*postgres.NewHBA().Local().Method("peer"),
+				},
+			},
+			expected: map[string]interface{}{
+				"loop_wait": int32(10),
+				"ttl":       int32(30),
+				"postgresql": map[string]interface{}{
+					"parameters": map[string]interface{}{},
+					"pg_hba": []string{
+						"local all all peer",
+						"custom",
+					},
+					"use_pg_rewind": true,
+					"use_slots":     false,
+				},
+			},
+		},
+		{
+			name: "postgresql.pg_hba: ignore non-string types",
+			input: map[string]interface{}{
+				"postgresql": map[string]interface{}{
+					"pg_hba": []interface{}{1, true, "custom", map[string]string{}, []string{}},
 				},
 			},
 			hbas: postgres.HBAs{


### PR DESCRIPTION
In accordance with the default types used when unmarshalling JSON into an interface value (https://pkg.go.dev/encoding/json#Unmarshal), the logic within the `patroni.DynamicConfiguration` function that detects
user-provided `pg_hba` configuration (as provided using the `spec.patroni.dynamicConfiguration` section of the PostgresCluster spec) now checks for an array of interface types.

This ensures user-provided `pg-hba.conf` settings are properly detected, and then added to the pg-hba section of the PostgresCluster's DCS.

closes #2534
[ch12109]