### PR TITLE
Update Release Notes & Doc Version Number

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -26,7 +26,7 @@ disableNavChevron = false # set true to hide next/prev chevron, default is false
 highlightClientSide = false # set true to use highlight.pack.js instead of the default hugo chroma highlighter
 menushortcutsnewtab = true # set true to open shortcuts links to a new tab/window
 enableGitInfo = true
-operatorVersion = "5.0.0"
+operatorVersion = "5.0.1"
 centosBase = "centos8"
 
 [outputs]

--- a/docs/content/releases/5.0.1.md
+++ b/docs/content/releases/5.0.1.md
@@ -1,10 +1,3 @@
----
-title: "5.0.1"
-date:
-draft: false
-weight: 899
----
-
 Crunchy Data announces the release of [Crunchy Postgres for Kubernetes](https://www.crunchydata.com/products/crunchy-postgresql-for-kubernetes/) 5.0.1.
 
 Crunchy Postgres for Kubernetes is powered by [PGO](https://github.com/CrunchyData/postgres-operator), the open source [Postgres Operator](https://github.com/CrunchyData/postgres-operator) from [Crunchy Data](https://www.crunchydata.com). [PGO](https://github.com/CrunchyData/postgres-operator) is released in conjunction with the [Crunchy Container Suite](https://github.com/CrunchyData/container-suite).
@@ -20,9 +13,15 @@ Read more about how you can [get started]({{< relref "quickstart/_index.md" >}})
 - The `replicas` value for an instance set must now be greater than `0`, and at least one instance set must now be defined for a `PostgresCluster`.  This is to prevent the cluster from being scaled down to `0` instances, since doing so results in the inability to scale the cluster back up.
 - Refreshed the PostgresCluster CRD documentation using the latest version of `crdoc` (`v0.3.0`).
 - The PGO test suite now includes a test to validate image pull secrets.
+- Related Image functionality has been implemented for the OLM installer as required to support offline deployments.
+- The name of the PGO Deployment and ServiceAccount has been changed to `pgo` for all installers, allowing both PGO v4.x and PGO v5.x to be run in the same namespace.
+- Custom affinity rules and tolerations can now be added to pgBackRest restore Jobs.
+- PGO now automatically detects whether or not it is running in an OpenShift environment.
+- OLM bundles can now be generated for PGO v5.x.
 
 ## Fixes
 
 - It is now possible to customize `shared_preload_libraries` when monitoring is enabled.
 - Fixed a typo in the description of the `openshift` field in the PostgresCluster CRD.
 - When a new cluster is created using an existing PostgresCluster as its dataSource, the original primary for that cluster will now properly initialize as a replica following a switchover. This is fixed with the upgrade to Patroni 2.1.0).
+- A consistent `startupInstance` name is now set in the PostgresCluster status when bootstrapping a new cluster using an existing PostgresCluster as its data source.


### PR DESCRIPTION
Updates the version number in PGO documentation config to "5.0.1".

[ch12164]

---

Updates the v5.0.1 release notes.

[ch12164]