### PR TITLE
Update psql connection string in quickstart

### DIFF
--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -116,7 +116,7 @@ PG_CLUSTER_USER_SECRET_NAME=hippo-pguser-hippo
 
 PGPASSWORD=$(kubectl get secrets -n postgres-operator "${PG_CLUSTER_USER_SECRET_NAME}" -o go-template='{{.data.password | base64decode}}') \
 PGUSER=$(kubectl get secrets -n postgres-operator "${PG_CLUSTER_USER_SECRET_NAME}" -o go-template='{{.data.user | base64decode}}') \
-PGDBNAME=$(kubectl get secrets -n postgres-operator "${PG_CLUSTER_USER_SECRET_NAME}" -o go-template='{{.data.dbname | base64decode}}') \
+PGDATABASE=$(kubectl get secrets -n postgres-operator "${PG_CLUSTER_USER_SECRET_NAME}" -o go-template='{{.data.dbname | base64decode}}') \
 psql -h localhost
 ```
 


### PR DESCRIPTION
The quickstart should use the libpq envar `PGDATABASE` instead of
`PGDBNAME` from pgjdbc.

libpq-env: https://www.postgresql.org/docs/current/libpq-envars.html

