### PR TITLE
Allow supplemental groups to be specified per cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ generate-crd:
 		paths='./pkg/apis/postgres-operator.crunchydata.com/...' \
 		output:dir='config/crd/bases' # config/crd/bases/{group}_{plural}.yaml
 
+# TODO(cbandy): Run config/crd through Kustomize to pickup any patches there.
 generate-crd-docs:
 	GOBIN='$(CURDIR)/hack/tools' go install fybrik.io/crdoc@v0.4.0
 	$(CURDIR)/hack/tools/crdoc \

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -5639,6 +5639,14 @@ spec:
                 required:
                 - repoName
                 type: object
+              supplementalGroups:
+                description: 'A list of group IDs applied to the process of a container.
+                  These can be useful when accessing shared file systems with constrained
+                  permissions. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context'
+                items:
+                  format: int64
+                  type: integer
+                type: array
               users:
                 description: Users to create inside PostgreSQL and the databases they
                   should access. The default creates one user that can access one

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,2 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+
+patchesJson6902:
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: postgresclusters.postgres-operator.crunchydata.com
+  path: validation.yaml

--- a/config/crd/validation.yaml
+++ b/config/crd/validation.yaml
@@ -1,0 +1,14 @@
+# PostgresCluster "v1beta1" is in "/spec/versions/0"
+
+# Containers should not run with a root GID.
+# - https://kubernetes.io/docs/concepts/security/pod-security-standards/
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/supplementalGroups/items/minimum
+  value: 1
+
+# Supplementary GIDs must fit within int32.
+# - https://releases.k8s.io/v1.18.0/pkg/apis/core/validation/validation.go#L3659-L3663
+# - https://releases.k8s.io/v1.22.0/pkg/apis/core/validation/validation.go#L3923-L3927
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/supplementalGroups/items/maximum
+  value: 2147483647 # math.MaxInt32

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -155,6 +155,11 @@ PostgresClusterSpec defines the desired state of PostgresCluster
         <td>Run this cluster as a read-only copy of an existing cluster or archive.</td>
         <td>false</td>
       </tr><tr>
+        <td><b>supplementalGroups</b></td>
+        <td>[]integer</td>
+        <td>A list of group IDs applied to the process of a container. These can be useful when accessing shared file systems with constrained permissions. More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context</td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#postgresclusterspecusersindex">users</a></b></td>
         <td>[]object</td>
         <td>Users to create inside PostgreSQL and the databases they should access. The default creates one user that can access one database matching the PostgresCluster name. An empty list creates no users. Removing a user from this list does NOT drop the user nor revoke their access.</td>

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1180,13 +1180,7 @@ func generateInstanceStatefulSetIntent(_ context.Context,
 
 	sts.Spec.Template.Spec.ServiceAccountName = instanceServiceAccountName
 
-	podSecurityContext := initialize.RestrictedPodSecurityContext()
-	podSecurityContext.SupplementalGroups = []int64{65534}
-	// set fsGroups if not OpenShift
-	if cluster.Spec.OpenShift == nil || !*cluster.Spec.OpenShift {
-		podSecurityContext.FSGroup = initialize.Int64(26)
-	}
-	sts.Spec.Template.Spec.SecurityContext = podSecurityContext
+	sts.Spec.Template.Spec.SecurityContext = postgres.PodSecurityContext(cluster)
 
 	// Set the image pull secrets, if any exist.
 	// This is set here rather than using the service account due to the lack

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -143,6 +143,12 @@ type PostgresClusterSpec struct {
 	// +optional
 	Standby *PostgresStandbySpec `json:"standby,omitempty"`
 
+	// A list of group IDs applied to the process of a container. These can be
+	// useful when accessing shared file systems with constrained permissions.
+	// More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context
+	// +optional
+	SupplementalGroups []int64 `json:"supplementalGroups,omitempty"`
+
 	// Users to create inside PostgreSQL and the databases they should access.
 	// The default creates one user that can access one database matching the
 	// PostgresCluster name. An empty list creates no users. Removing a user

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
@@ -802,6 +802,11 @@ func (in *PostgresClusterSpec) DeepCopyInto(out *PostgresClusterSpec) {
 		*out = new(PostgresStandbySpec)
 		**out = **in
 	}
+	if in.SupplementalGroups != nil {
+		in, out := &in.SupplementalGroups, &out.SupplementalGroups
+		*out = make([]int64, len(*in))
+		copy(*out, *in)
+	}
 	if in.Users != nil {
 		in, out := &in.Users, &out.Users
 		*out = make([]PostgresUserSpec, len(*in))


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**

Supplemental groups are hard-coded to what some systems call `nfsnobody`.


**What is the new behavior (if this is a feature change)?**

Supplemental groups are an optional field in `PostgresCluster.spec`. When omitted, Pods run without any supplemental groups. The root GID (0) is disallowed.


**Other information**:

Issue: [ch11761]