### PR TITLE
Create a service to expose PostgreSQL replicas

### DIFF
--- a/docs/content/tutorial/connect-cluster.md
+++ b/docs/content/tutorial/connect-cluster.md
@@ -23,6 +23,7 @@ hippo-ha          ClusterIP   10.103.73.92   <none>        5432/TCP   3h14m
 hippo-ha-config   ClusterIP   None           <none>        <none>     3h14m
 hippo-pods        ClusterIP   None           <none>        <none>     3h14m
 hippo-primary     ClusterIP   None           <none>        5432/TCP   3h14m
+hippo-replicas    ClusterIP   10.98.110.215  <none>        5432/TCP   3h14m
 ```
 
 You do not need to worry about most of these Services, as they are used to help manage the overall health of your Postgres cluster. For the purposes of connecting to your database, the Service of interest is called `hippo-primary`. Thanks to PGO, you do not need to even worry about that, as that information is captured within a Secret!

--- a/docs/content/tutorial/high-availability.md
+++ b/docs/content/tutorial/high-availability.md
@@ -97,7 +97,8 @@ NAME              TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
 hippo-ha          ClusterIP   10.103.73.92   <none>        5432/TCP   4h8m
 hippo-ha-config   ClusterIP   None           <none>        <none>     4h8m
 hippo-pods        ClusterIP   None           <none>        <none>     4h8m
-hippo-primary     ClusterIP   None           <none>        5432/TCP   3h14m
+hippo-primary     ClusterIP   None           <none>        5432/TCP   4h8m
+hippo-replicas    ClusterIP   10.98.110.215  <none>        5432/TCP   4h8m
 ```
 
 We also mentioned that the application is connected to the `hippo-primary` Service. What happens if we were to delete this Service?
@@ -121,6 +122,7 @@ hippo-ha          ClusterIP   10.103.73.92   <none>        5432/TCP   4h8m
 hippo-ha-config   ClusterIP   None           <none>        <none>     4h8m
 hippo-pods        ClusterIP   None           <none>        <none>     4h8m
 hippo-primary     ClusterIP   None           <none>        5432/TCP   3s
+hippo-replicas    ClusterIP   10.98.110.215  <none>        5432/TCP   4h8m
 ```
 
 Wow -- PGO detected that the primary Service was deleted and it recreated it! Based on how your application connects to Postgres, it may not have even noticed that this event took place!

--- a/internal/controller/postgrescluster/cluster.go
+++ b/internal/controller/postgrescluster/cluster.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -186,6 +187,59 @@ func (r *Reconciler) reconcileClusterPrimaryService(
 		err = errors.WithStack(r.apply(ctx, endpoints))
 	}
 
+	return err
+}
+
+// generateClusterReplicaServiceIntent returns a v1.Service that exposes
+// PostgreSQL replica instances.
+func generateClusterReplicaServiceIntent(cluster *v1beta1.PostgresCluster) *corev1.Service {
+	service := &corev1.Service{ObjectMeta: naming.ClusterReplicaService(cluster)}
+	service.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
+
+	service.Annotations = naming.Merge(
+		cluster.Spec.Metadata.GetAnnotationsOrNil())
+	service.Labels = naming.Merge(
+		cluster.Spec.Metadata.GetLabelsOrNil(),
+		map[string]string{
+			naming.LabelCluster: cluster.Name,
+			naming.LabelRole:    naming.RoleReplica,
+		})
+
+	// Allocate an IP address and let Kubernetes manage the Endpoints by selecting
+	// Pods with the replica role.
+	// - https://docs.k8s.io/concepts/services-networking/service/#defining-a-service
+	service.Spec.Type = corev1.ServiceTypeClusterIP
+	service.Spec.Selector = map[string]string{
+		naming.LabelCluster: cluster.Name,
+		naming.LabelRole:    naming.RoleReplica,
+	}
+
+	// The TargetPort must be the name (not the number) of the PostgreSQL
+	// ContainerPort. This name allows the port number to differ between Pods,
+	// which can happen during a rolling update.
+	service.Spec.Ports = []corev1.ServicePort{{
+		Name:       naming.PortPostgreSQL,
+		Port:       *cluster.Spec.Port,
+		Protocol:   corev1.ProtocolTCP,
+		TargetPort: intstr.FromString(naming.PortPostgreSQL),
+	}}
+
+	return service
+}
+
+// +kubebuilder:rbac:groups="",resources="services",verbs={create,patch}
+
+// reconcileClusterReplicaService writes the Service that exposes PostgreSQL
+// replica instances.
+func (r *Reconciler) reconcileClusterReplicaService(
+	ctx context.Context, cluster *v1beta1.PostgresCluster,
+) error {
+	service := generateClusterReplicaServiceIntent(cluster)
+
+	err := errors.WithStack(r.setControllerReference(cluster, service))
+	if err == nil {
+		err = errors.WithStack(r.apply(ctx, service))
+	}
 	return err
 }
 

--- a/internal/controller/postgrescluster/cluster_test.go
+++ b/internal/controller/postgrescluster/cluster_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 	"github.com/pkg/errors"
@@ -700,4 +701,65 @@ func TestContainerSecurityContext(t *testing.T) {
 			assert.Equal(t, *initContainer.SecurityContext.AllowPrivilegeEscalation, false)
 		}
 	}
+}
+
+func TestGenerateClusterReplicaServiceIntent(t *testing.T) {
+	cluster := &v1beta1.PostgresCluster{}
+	cluster.Namespace = "ns1"
+	cluster.Name = "pg2"
+	cluster.Spec.Port = initialize.Int32(9876)
+
+	service := generateClusterReplicaServiceIntent(cluster)
+
+	assert.Assert(t, marshalMatches(service.TypeMeta, `
+apiVersion: v1
+kind: Service
+	`))
+	assert.Assert(t, marshalMatches(service.ObjectMeta, `
+creationTimestamp: null
+labels:
+  postgres-operator.crunchydata.com/cluster: pg2
+  postgres-operator.crunchydata.com/role: replica
+name: pg2-replicas
+namespace: ns1
+	`))
+	assert.Assert(t, marshalMatches(service.Spec, `
+ports:
+- name: postgres
+  port: 9876
+  protocol: TCP
+  targetPort: postgres
+selector:
+  postgres-operator.crunchydata.com/cluster: pg2
+  postgres-operator.crunchydata.com/role: replica
+type: ClusterIP
+	`))
+
+	t.Run("AnnotationsLabels", func(t *testing.T) {
+		cluster := cluster
+		cluster.Spec.Metadata = &v1beta1.Metadata{
+			Annotations: map[string]string{"some": "note"},
+			Labels:      map[string]string{"happy": "label"},
+		}
+
+		service := generateClusterReplicaServiceIntent(cluster)
+
+		// Annotations present in the metadata.
+		assert.Assert(t, marshalMatches(service.ObjectMeta.Annotations, `
+some: note
+		`))
+
+		// Labels present in the metadata.
+		assert.Assert(t, marshalMatches(service.ObjectMeta.Labels, `
+happy: label
+postgres-operator.crunchydata.com/cluster: pg2
+postgres-operator.crunchydata.com/role: replica
+		`))
+
+		// Labels not in the selector.
+		assert.Assert(t, marshalMatches(service.Spec.Selector, `
+postgres-operator.crunchydata.com/cluster: pg2
+postgres-operator.crunchydata.com/role: replica
+		`))
+	})
 }

--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -228,6 +228,9 @@ func (r *Reconciler) Reconcile(
 		err = r.reconcileClusterPrimaryService(ctx, cluster, patroniLeaderService)
 	}
 	if err == nil {
+		err = r.reconcileClusterReplicaService(ctx, cluster)
+	}
+	if err == nil {
 		primaryCertificate, err = r.reconcileClusterCertificate(ctx, rootCA, cluster)
 	}
 	if err == nil {

--- a/internal/naming/names.go
+++ b/internal/naming/names.go
@@ -200,6 +200,15 @@ func ClusterPrimaryService(cluster *v1beta1.PostgresCluster) metav1.ObjectMeta {
 	}
 }
 
+// ClusterReplicaService returns the ObjectMeta necessary to lookup the Service
+// that exposes PostgreSQL replica instances.
+func ClusterReplicaService(cluster *v1beta1.PostgresCluster) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Namespace: cluster.Namespace,
+		Name:      cluster.Name + "-replicas",
+	}
+}
+
 // GenerateInstance returns a random name for a member of cluster and set.
 func GenerateInstance(
 	cluster *v1beta1.PostgresCluster, set *v1beta1.PostgresInstanceSetSpec,

--- a/internal/naming/names_test.go
+++ b/internal/naming/names_test.go
@@ -166,6 +166,7 @@ func TestClusterNamesUniqueAndValid(t *testing.T) {
 			{"ClusterPGBouncer", ClusterPGBouncer(cluster)},
 			{"ClusterPodService", ClusterPodService(cluster)},
 			{"ClusterPrimaryService", ClusterPrimaryService(cluster)},
+			{"ClusterReplicaService", ClusterReplicaService(cluster)},
 			// Patroni can use Endpoints which relate directly to a Service.
 			{"PatroniDistributedConfiguration", PatroniDistributedConfiguration(cluster)},
 			{"PatroniLeaderEndpoints", PatroniLeaderEndpoints(cluster)},


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature (non-breaking change which adds functionality)


**What is the new behavior (if this is a feature change)?**

There is now a `{cluster}-replicas` service that points to any/all available PostgreSQL replicas.


**Other information**:

Issue: [ch12144]