### PR TITLE
Simplify test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ DEBUG_BUILD ?= false
 GO ?= go
 GO_BUILD = $(GO_CMD) build -trimpath
 GO_CMD = $(GO_ENV) $(GO)
+GO_TEST ?= $(GO) test
 
 # Disable optimizations if creating a debug build
 ifeq ("$(DEBUG_BUILD)", "true")
@@ -189,17 +190,17 @@ pgo-base-docker: pgo-base-build
 #======== Utility =======
 .PHONY: check
 check:
-	$(GO) test -cover ./...
+	$(GO_TEST) -cover ./...
 
 # - KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT=true
 .PHONY: check-envtest
 check-envtest: hack/tools/envtest
-	KUBEBUILDER_ASSETS="$(CURDIR)/$^/bin" $(GO) test -count=1 -cover -tags=envtest ./...
+	KUBEBUILDER_ASSETS="$(CURDIR)/$^/bin" $(GO_TEST) -count=1 -cover -tags=envtest ./...
 
 .PHONY: check-envtest-existing
 check-envtest-existing:
 	${PGO_KUBE_CLIENT} apply -k ./config/dev
-	USE_EXISTING_CLUSTER=true $(GO) test -count=1 -cover -tags=envtest ./...
+	USE_EXISTING_CLUSTER=true $(GO_TEST) -count=1 -cover -tags=envtest ./...
 	${PGO_KUBE_CLIENT} delete -k ./config/dev
 
 

--- a/Makefile
+++ b/Makefile
@@ -189,17 +189,17 @@ pgo-base-docker: pgo-base-build
 #======== Utility =======
 .PHONY: check
 check:
-	PGOROOT=$(PGOROOT) $(GO) test -cover ./...
+	$(GO) test -cover ./...
 
 # - KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT=true
 .PHONY: check-envtest
 check-envtest: hack/tools/envtest
-	KUBEBUILDER_ASSETS="$(CURDIR)/$^/bin" $(GO) test -count=1 -cover -tags=envtest ./internal/controller/... ./internal/pgbackrest/...
+	KUBEBUILDER_ASSETS="$(CURDIR)/$^/bin" $(GO) test -count=1 -cover -tags=envtest ./...
 
 .PHONY: check-envtest-existing
 check-envtest-existing:
 	${PGO_KUBE_CLIENT} apply -k ./config/dev
-	USE_EXISTING_CLUSTER=true $(GO) test -count=1 -tags=envtest ./internal/controller/... ./internal/pgbackrest/...
+	USE_EXISTING_CLUSTER=true $(GO) test -count=1 -cover -tags=envtest ./...
 	${PGO_KUBE_CLIENT} delete -k ./config/dev
 
 


### PR DESCRIPTION
I like to use `gotestsum -f testname` on the longer-running tests to see some progress before the entire package finishes.

```shell
make check-envtest GO_TEST='gotestsum -f testname --'
```