### PR TITLE
Ensure shared memory is fully available to containers

### DIFF
--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1064,6 +1064,11 @@ func (r *Reconciler) reconcileInstance(
 		addTMPEmptyDir(&instance.Spec.Template)
 	}
 
+	// mount shared memory to the Postgres instance
+	if err == nil {
+		addDevSHM(&instance.Spec.Template)
+	}
+
 	if err == nil {
 		err = errors.WithStack(r.apply(ctx, instance))
 	}


### PR DESCRIPTION
7e0c1e5b6 introduced the ability to have full access to
POSIX shared memory within a Postgres instance, which is
fundamental to how Postgres works. This commit ensures that
this configuration is carried forward into v5.

Issue: [ch11872]
fixes #2640