### PR TITLE
Use SCRAM-SHA-256 to authenticate PgBouncer

### DIFF
--- a/internal/pgbouncer/config.go
+++ b/internal/pgbouncer/config.go
@@ -38,7 +38,8 @@ const (
 	iniFileProjectionPath   = "~postgres-operator.ini"
 
 	authFileSecretKey   = "pgbouncer-users.txt" // #nosec G101 this is a name, not a credential
-	credentialSecretKey = "pgbouncer-verifier"  // #nosec G101 this is a name, not a credential
+	passwordSecretKey   = "pgbouncer-password"  // #nosec G101 this is a name, not a credential
+	verifierSecretKey   = "pgbouncer-verifier"  // #nosec G101 this is a name, not a credential
 	emptyConfigMapKey   = "pgbouncer-empty"
 	iniFileConfigMapKey = "pgbouncer.ini"
 )
@@ -71,7 +72,7 @@ func (vs iniValueSet) String() string {
 }
 
 // authFileContents returns a PgBouncer user database.
-func authFileContents(password []byte) []byte {
+func authFileContents(password string) []byte {
 	// > There should be at least 2 fields, surrounded by double quotes.
 	// > Double quotes in a field value can be escaped by writing two double quotes.
 	// - https://www.pgbouncer.org/config.html#authentication-file-format
@@ -79,7 +80,7 @@ func authFileContents(password []byte) []byte {
 		return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
 	}
 
-	user1 := quote(postgresqlUser) + " " + quote(string(password)) + "\n"
+	user1 := quote(postgresqlUser) + " " + quote(password) + "\n"
 
 	return []byte(user1)
 }

--- a/internal/pgbouncer/config_test.go
+++ b/internal/pgbouncer/config_test.go
@@ -44,7 +44,7 @@ func TestAuthFileContents(t *testing.T) {
 	t.Parallel()
 
 	password := `very"random`
-	data := authFileContents([]byte(password))
+	data := authFileContents(password)
 	assert.Equal(t, string(data), `"_crunchypgbouncer" "very""random"`+"\n")
 }
 

--- a/internal/pgbouncer/postgres_test.go
+++ b/internal/pgbouncer/postgres_test.go
@@ -193,6 +193,9 @@ COMMIT;`))
 	assert.Equal(t, expected, EnableInPostgreSQL(ctx, exec, secret))
 }
 
-func TestPostgreSQLHBA(t *testing.T) {
-	assert.Equal(t, postgresqlHBA().String(), `hostssl all "_crunchypgbouncer" all md5`)
+func TestPostgreSQLHBAs(t *testing.T) {
+	rules := postgresqlHBAs()
+	assert.Equal(t, len(rules), 2)
+	assert.Equal(t, rules[0].String(), `hostssl all "_crunchypgbouncer" all scram-sha-256`)
+	assert.Equal(t, rules[1].String(), `host all "_crunchypgbouncer" all reject`)
 }

--- a/internal/pgbouncer/reconcile_test.go
+++ b/internal/pgbouncer/reconcile_test.go
@@ -87,6 +87,7 @@ func TestSecret(t *testing.T) {
 	assert.DeepEqual(t, constant, existing)
 
 	// A password should be generated.
+	assert.Assert(t, len(intent.Data["pgbouncer-password"]) != 0)
 	assert.Assert(t, len(intent.Data["pgbouncer-verifier"]) != 0)
 
 	// The output of authFileContents should go into intent.
@@ -350,7 +351,7 @@ func TestPostgreSQL(t *testing.T) {
 
 		assert.DeepEqual(t, hbas,
 			&postgres.HBAs{
-				Mandatory: []postgres.HostBasedAuthentication{postgresqlHBA()},
+				Mandatory: postgresqlHBAs(),
 			},
 			// postgres.HostBasedAuthentication has unexported fields. Call String() to compare.
 			cmp.Transformer("", postgres.HostBasedAuthentication.String))


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)

**What is the current behavior? (link to any open issues here)**

PgBouncer uses MD5 authentication when looking up verifiers.

**What is the new behavior (if this is a feature change)?**

PgBouncer uses SCRAM authentication when looking up verifiers.

**Other Information**:

Verified that clients are able to connect with MD5 or SCRAM. That is, users are unaffected by this change.

Issue: [ch11210]