### PR TITLE
Fix incorrect labeling command in installation path

### DIFF
--- a/installers/ansible/roles/pgo-operator/tasks/main.yml
+++ b/installers/ansible/roles/pgo-operator/tasks/main.yml
@@ -273,7 +273,7 @@
 
         - name: Label PGO BackRest Repo Secret
           command: |
-            {{ kubectl_or_oc }} label secret generic -n {{ pgo_operator_namespace }} \
+            {{ kubectl_or_oc }} label secret -n {{ pgo_operator_namespace }} \
               pgo-backrest-repo-config vendor=crunchydata
           when:
             - pgo_backrest_repo_config_result.rc == 1


### PR DESCRIPTION
This mistakenly includes the term "generic" in the kubectl
command when labeling a Secret. We only need the Secret name.
Applies on an existing pgo-backrest-repo-config Secret.

fixes #2650