### PR TITLE
Fix restore with custom PostgreSQL parameters

### DIFF
--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -214,9 +214,11 @@ read -r max_conn <<< "${control##*max_connections setting:}"
 read -r max_lock <<< "${control##*max_locks_per_xact setting:}"
 read -r max_ptxn <<< "${control##*max_prepared_xacts setting:}"
 read -r max_work <<< "${control##*max_worker_processes setting:}"
+echo > /tmp/pg_hba.restore.conf 'local all "postgres" peer'
 cat > /tmp/postgres.restore.conf <<EOF
 archive_command = 'false'
 archive_mode = 'on'
+hba_file = '/tmp/pg_hba.restore.conf'
 max_connections = '${max_conn}'
 max_locks_per_transaction = '${max_lock}'
 max_prepared_transactions = '${max_ptxn}'

--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
@@ -320,4 +321,11 @@ func TestRestoreCommand(t *testing.T) {
 	cmd := exec.Command(shellcheck, "--enable=all", file)
 	output, err := cmd.CombinedOutput()
 	assert.NilError(t, err, "%q\n%s", cmd.Args, output)
+}
+
+func TestRestoreCommandPrettyYAML(t *testing.T) {
+	b, err := yaml.Marshal(RestoreCommand("/dir", "--options"))
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(string(b), "\n- |"),
+		"expected literal block scalar, got:\n%s", b)
 }


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)

**What is the current behavior? (link to any open issues here)**

When `max_connections` or `max_worker_processes` is configured higher than the default during backup, the restore fails because PostgreSQL refuses to start with the default values (which are now too small).

**What is the new behavior (if this is a feature change)?**

During restore, those settings (and a few others) are now configured to match exactly what PostgreSQL is expecting from the backup and WAL archive.


**Other Information**:

Issue: [ch12371]
Fixes: #2615