### PR TITLE
Ignore Data Source When Upgrading

### DIFF
--- a/internal/controller/pgcluster/pgclustercontroller.go
+++ b/internal/controller/pgcluster/pgclustercontroller.go
@@ -121,7 +121,11 @@ func (c *Controller) processNextItem() bool {
 	// If bootstrapping from an existing data source then attempt to create the pgBackRest repository.
 	// If a repo already exists (e.g. because it is associated with a currently running cluster) then
 	// proceed with bootstrapping.
-	if cluster.Spec.PGDataSource.RestoreFrom != "" {
+	// Also, if the "upgrading" annotation is present on the pgcluster, assume the cluster has
+	// already been bootstrapped and is being recreated as part of the upgrade process.  More
+	// specifically, ignore the data source and proceed with adding cluster deployments.
+	_, upgrading := cluster.Annotations[config.ANNOTATION_UPGRADE_IN_PROGRESS]
+	if cluster.Spec.PGDataSource.RestoreFrom != "" && !upgrading {
 		repoCreated, err := clusteroperator.AddBootstrapRepo(c.Client, cluster)
 		if err != nil {
 			log.Error(err)


### PR DESCRIPTION
A bootstrap Job will now no longer be run if a `pgDataSource` is present in the `pgcluster` when it is recreated as part of the' `pgo upgrade` process.  Specifically, if the `upgrade-in-progress` annotation is present on the pgcluster, then it is assumed the cluster is being recreated a part of a PGO upgrade, and any data source logic is ignored.

[ch12469]