### PR TITLE
Update related images for RedHat OLM build

### DIFF
--- a/installers/olm/config/redhat/related-images.yaml
+++ b/installers/olm/config/redhat/related-images.yaml
@@ -17,15 +17,9 @@ spec:
             - { name: RELATED_IMAGE_PGBOUNCER,  value: 'registry.connect.redhat.com/crunchydata/crunchy-pgbouncer:ubi8-1.15-2' }
             - { name: RELATED_IMAGE_PGEXPORTER, value: 'registry.connect.redhat.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.2-0' }
 
-            - { name: RELATED_IMAGE_POSTGRES_10, value: 'registry.connect.redhat.com/crunchydata/crunchy-postgres-ha:ubi8-10.18-0' }
-            - { name: RELATED_IMAGE_POSTGRES_11, value: 'registry.connect.redhat.com/crunchydata/crunchy-postgres-ha:ubi8-11.13-0' }
             - { name: RELATED_IMAGE_POSTGRES_12, value: 'registry.connect.redhat.com/crunchydata/crunchy-postgres-ha:ubi8-12.8-0' }
             - { name: RELATED_IMAGE_POSTGRES_13, value: 'registry.connect.redhat.com/crunchydata/crunchy-postgres-ha:ubi8-13.4-0' }
 
-            - { name: RELATED_IMAGE_POSTGRES_10_GIS_2.3, value: 'registry.connect.redhat.com/crunchydata/crunchy-postgres-gis-ha:ubi8-10.18-2.3-0' }
-            - { name: RELATED_IMAGE_POSTGRES_10_GIS_2.4, value: 'registry.connect.redhat.com/crunchydata/crunchy-postgres-gis-ha:ubi8-10.18-2.4-0' }
-            - { name: RELATED_IMAGE_POSTGRES_11_GIS_2.4, value: 'registry.connect.redhat.com/crunchydata/crunchy-postgres-gis-ha:ubi8-11.13-2.4-0' }
-            - { name: RELATED_IMAGE_POSTGRES_11_GIS_2.5, value: 'registry.connect.redhat.com/crunchydata/crunchy-postgres-gis-ha:ubi8-11.13-2.5-0' }
             - { name: RELATED_IMAGE_POSTGRES_12_GIS_2.5, value: 'registry.connect.redhat.com/crunchydata/crunchy-postgres-gis-ha:ubi8-12.8-2.5-0' }
             - { name: RELATED_IMAGE_POSTGRES_12_GIS_3.0, value: 'registry.connect.redhat.com/crunchydata/crunchy-postgres-gis-ha:ubi8-12.8-3.0-0' }
             - { name: RELATED_IMAGE_POSTGRES_13_GIS_3.0, value: 'registry.connect.redhat.com/crunchydata/crunchy-postgres-gis-ha:ubi8-13.4-3.0-0' }


### PR DESCRIPTION
When building a redhat OLM bundle for v5, be currently populate related images in the CSV for all PG versions supported by Crunchy. We should only support the latest PG version (13) along with PG 12.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable? Generated the bundle locally and ran `make validate-bundles`



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
[ch12436]