### PR TITLE
Cleanup "create-by-resource" Example

### DIFF
--- a/examples/create-by-resource/fromcrd.json
+++ b/examples/create-by-resource/fromcrd.json
@@ -50,9 +50,8 @@
     "database": "userdb",
     "exporterport": "9187",
     "name": "fromcrd",
-    "namespace": "pgouser1",
     "pgbadgerport": "10000",
-    "podPodAntiAffinity": {
+    "podAntiAffinity": {
       "default": "preferred",
       "pgBackRest": "preferred",
       "pgBouncer": "preferred"


### PR DESCRIPTION
Cleans up the `create-by-resource` example, specifically removing a `namespace` field from the `fromcrd` pgcluster that is no longer supported, while also fixing the spelling of field `podAntiAffinity`.

[sc-12566]