### PR TITLE
Install pgAudit in every PostgresCluster

### DIFF
--- a/docs/content/guides/data-migration.md
+++ b/docs/content/guides/data-migration.md
@@ -34,17 +34,6 @@ spec:
         directory: oldhippo-backrest-shared-repo
 ```
 
-Specifically for those migrating from PGO v4 to v5, at this time, a custom “pg_hba” configuration section to preload the “pg_audit” extension is required, as this extension was enabled by default in PGO v4.x. It can be added as follows:
-
-```
-spec:
-  patroni:
-    dynamicConfiguration:
-      postgresql:
-        parameters:
-          shared_preload_libraries: pgaudit.so
-```
-
 Lastly, it is very important that the PostgreSQL version and storage configuration in your PostgresCluster match *exactly* the existing volumes being used.
 
 If the volumes were used with PostgreSQL 13, the `spec.postgresVersion` value should be `13` and the associated `spec.image` value should refer to a PostgreSQL 13 image.
@@ -84,11 +73,6 @@ metadata:
 spec:
   image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-ha:centos8-13.4-0
   postgresVersion: 13
-  patroni:
-    dynamicConfiguration:
-      postgresql:
-        parameters:
-          shared_preload_libraries: pgaudit.so
   dataSource:
     volumes:
       pgDataVolume:

--- a/docs/content/guides/v4tov5.md
+++ b/docs/content/guides/v4tov5.md
@@ -118,17 +118,7 @@ spec:
 
 Please see the [Data Migration]({{< relref "guides/data-migration.md" >}}) section of the [tutorial]({{< relref "tutorial/_index.md" >}}) for more details on how to properly populate this section of the spec when migrating from a PGO v4 cluster.
 
-2\. If you are using the default setup in your PGO v4 cluster, you will need to provide custom setup parameters to include the [`pgAudit`](https://github.com/pgaudit/pgaudit) extension extension. This looks similar to the following:
-
-```
-patroni:
-  dynamicConfiguration:
-    postgresql:
-      parameters:
-        shared_preload_libraries: pgaudit.so
-```
-
-If you customized other Postgres parameters, you will need to ensure they match in the PGO v5 cluster. For more information, please review the tutorial on [customizing a Postgres cluster]({{< relref "tutorial/customize-cluster.md" >}}).
+2\. If you customized Postgres parameters, you will need to ensure they match in the PGO v5 cluster. For more information, please review the tutorial on [customizing a Postgres cluster]({{< relref "tutorial/customize-cluster.md" >}}).
 
 3\. Once the `PostgresCluster` spec is populated according to these guidelines, you can create the `PostgresCluster` custom resource.  For example, if the `PostgresCluster` you're creating is a modified version of the [`postgres` example](https://github.com/CrunchyData/postgres-operator-examples/tree/main/kustomize/postgres) in the [PGO examples repo](https://github.com/CrunchyData/postgres-operator-examples), you can run the following command:
 
@@ -297,18 +287,7 @@ spec:
 ```
 
 
-4\. If you are using the default setup in your PGO v4 cluster, you will need to provide custom setup parameters to include the pgAudit extension. This looks similar to the following: v4):
-
-```
-spec:
-  patroni:
-    dynamicConfiguration:
-      postgresql:
-        parameters:
-          shared_preload_libraries: pgaudit.so
-```
-
-If you customized other Postgres parameters, you will need to ensure they match in the PGO v5 cluster. For more information, please review the tutorial on [customizing a Postgres cluster]({{< relref "tutorial/customize-cluster.md" >}}).
+4\. If you customized other Postgres parameters, you will need to ensure they match in the PGO v5 cluster. For more information, please review the tutorial on [customizing a Postgres cluster]({{< relref "tutorial/customize-cluster.md" >}}).
 
 5\. Once the `PostgresCluster` spec is populated according to these guidelines, you can create the `PostgresCluster` custom resource.  For example, if the `PostgresCluster` you're creating is a modified version of the [`postgres` example](https://github.com/CrunchyData/postgres-operator-examples/tree/main/kustomize/postgres) in the [PGO examples repo](https://github.com/CrunchyData/postgres-operator-examples), you can run the following command:
 
@@ -404,18 +383,7 @@ spec:
     repoName: repo1
 ```
 
-3\. If you are using the default setup in your PGO v4 cluster, you will need to provide custom setup parameters to include the pgAudit extension. This looks similar to the following: v4):
-
-```
-spec:
-  patroni:
-    dynamicConfiguration:
-      postgresql:
-        parameters:
-          shared_preload_libraries: pgaudit.so
-```
-
-If you customized other Postgres parameters, you will need to ensure they match in the PGO v5 cluster. For more information, please review the tutorial on [customizing a Postgres cluster]({{< relref "tutorial/customize-cluster.md" >}}).
+3\. If you customized other Postgres parameters, you will need to ensure they match in the PGO v5 cluster. For more information, please review the tutorial on [customizing a Postgres cluster]({{< relref "tutorial/customize-cluster.md" >}}).
 
 4\. Once the `PostgresCluster` spec is populated according to these guidelines, you can create the `PostgresCluster` custom resource.  For example, if the `PostgresCluster` you're creating is a modified version of the [`postgres` example](https://github.com/CrunchyData/postgres-operator-examples/tree/main/kustomize/postgres) in the [PGO examples repo](https://github.com/CrunchyData/postgres-operator-examples), you can run the following command:
 

--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/crunchydata/postgres-operator/internal/logging"
+	"github.com/crunchydata/postgres-operator/internal/pgaudit"
 	"github.com/crunchydata/postgres-operator/internal/pgbackrest"
 	"github.com/crunchydata/postgres-operator/internal/pgbouncer"
 	"github.com/crunchydata/postgres-operator/internal/pgmonitor"
@@ -176,8 +177,8 @@ func (r *Reconciler) Reconcile(
 	pgbouncer.PostgreSQL(cluster, &pgHBAs)
 
 	pgParameters := postgres.NewParameters()
+	pgaudit.PostgreSQLParameters(&pgParameters)
 	pgbackrest.PostgreSQL(cluster, &pgParameters)
-
 	pgmonitor.PostgreSQLParameters(cluster, &pgParameters)
 
 	if err == nil {

--- a/internal/controller/postgrescluster/pgmonitor_test.go
+++ b/internal/controller/postgrescluster/pgmonitor_test.go
@@ -447,7 +447,7 @@ func TestReconcilePGMonitorExporterStatus(t *testing.T) {
 		podExecCalled:   false,
 		// Status was generated manually for this test case
 		// TODO jmckulk: add code to generate status
-		status:                      v1beta1.MonitoringStatus{ExporterConfiguration: "6465cb4855"},
+		status:                      v1beta1.MonitoringStatus{ExporterConfiguration: "7dccdb969"},
 		statusChangedAfterReconcile: false,
 	}} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/pgaudit/postgres.go
+++ b/internal/pgaudit/postgres.go
@@ -1,0 +1,80 @@
+/*
+ Copyright 2021 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pgaudit
+
+import (
+	"context"
+	"strings"
+
+	"github.com/crunchydata/postgres-operator/internal/logging"
+	"github.com/crunchydata/postgres-operator/internal/postgres"
+)
+
+const (
+	sqlCurrentAndFutureDatabases = "" +
+		`SELECT datname FROM pg_catalog.pg_database` +
+		` WHERE datallowconn AND datname NOT IN ('template0')`
+)
+
+// When the pgAudit shared library is not loaded, the extension cannot be
+// installed. The "CREATE EXTENSION" command fails with an error, "pgaudit must
+// be loaded…".
+//
+// When the pgAudit shared library is loaded but the extension is not installed,
+// AUDIT messages are logged according to the various levels and settings
+// (including both SESSION and OBJECT events) but the messages contain fewer
+// details than normal. DDL messages, for example, lack the affected object name
+// and type.
+//
+// When the pgAudit extension is installed but the shared library is not loaded,
+//  1. No AUDIT messages are logged.
+//  2. DDL commands fail with error "pgaudit must be loaded…".
+//  3. DML commands and SELECT queries succeed and return results.
+//  4. Databases can be created and dropped.
+//  5. Roles and privileges can be created, dropped, granted, and revoked, but
+//     the "DROP OWNED" command fails.
+
+// EnableInPostgreSQL installs pgAudit triggers into every database.
+func EnableInPostgreSQL(ctx context.Context, exec postgres.Executor) error {
+	log := logging.FromContext(ctx)
+
+	stdout, stderr, err := exec.ExecInDatabasesFromQuery(ctx,
+		sqlCurrentAndFutureDatabases,
+		// Quiet the NOTICE from IF EXISTS, and install the pgAudit event triggers.
+		// - https://www.postgresql.org/docs/current/runtime-config-client.html
+		// - https://github.com/pgaudit/pgaudit#settings
+		`SET client_min_messages = WARNING; CREATE EXTENSION IF NOT EXISTS pgaudit;`,
+		map[string]string{
+			"ON_ERROR_STOP": "on", // Abort when any one command fails.
+			"QUIET":         "on", // Do not print successful commands to stdout.
+		})
+
+	log.V(1).Info("enabled pgAudit", "stdout", stdout, "stderr", stderr)
+
+	return err
+}
+
+// PostgreSQLParameters sets the parameters required by pgAudit.
+func PostgreSQLParameters(outParameters *postgres.Parameters) {
+
+	// Load the shared library when PostgreSQL starts.
+	// PostgreSQL must be restarted when changing this value.
+	// - https://github.com/pgaudit/pgaudit#settings
+	// - https://www.postgresql.org/docs/current/runtime-config-client.html
+	shared := outParameters.Mandatory.Value("shared_preload_libraries")
+	outParameters.Mandatory.Add("shared_preload_libraries",
+		strings.TrimPrefix(shared+",pgaudit", ","))
+}

--- a/internal/pgaudit/postgres.go
+++ b/internal/pgaudit/postgres.go
@@ -23,12 +23,6 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/postgres"
 )
 
-const (
-	sqlCurrentAndFutureDatabases = "" +
-		`SELECT datname FROM pg_catalog.pg_database` +
-		` WHERE datallowconn AND datname NOT IN ('template0')`
-)
-
 // When the pgAudit shared library is not loaded, the extension cannot be
 // installed. The "CREATE EXTENSION" command fails with an error, "pgaudit must
 // be loaded…".
@@ -51,8 +45,7 @@ const (
 func EnableInPostgreSQL(ctx context.Context, exec postgres.Executor) error {
 	log := logging.FromContext(ctx)
 
-	stdout, stderr, err := exec.ExecInDatabasesFromQuery(ctx,
-		sqlCurrentAndFutureDatabases,
+	stdout, stderr, err := exec.ExecInAllDatabases(ctx,
 		// Quiet the NOTICE from IF EXISTS, and install the pgAudit event triggers.
 		// - https://www.postgresql.org/docs/current/runtime-config-client.html
 		// - https://github.com/pgaudit/pgaudit#settings

--- a/internal/pgaudit/postgres_test.go
+++ b/internal/pgaudit/postgres_test.go
@@ -1,0 +1,77 @@
+/*
+ Copyright 2021 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pgaudit
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/crunchydata/postgres-operator/internal/postgres"
+)
+
+func TestEnableInPostgreSQL(t *testing.T) {
+	expected := errors.New("whoops")
+	exec := func(
+		_ context.Context, stdin io.Reader, stdout, stderr io.Writer, command ...string,
+	) error {
+		assert.Assert(t, stdout != nil, "should capture stdout")
+		assert.Assert(t, stderr != nil, "should capture stderr")
+
+		assert.Assert(t, strings.Contains(strings.Join(command, "\n"),
+			`SELECT datname FROM pg_catalog.pg_database`,
+		), "expected all databases and templates")
+
+		b, err := ioutil.ReadAll(stdin)
+		assert.NilError(t, err)
+		assert.Equal(t, string(b), strings.Trim(`
+SET client_min_messages = WARNING; CREATE EXTENSION IF NOT EXISTS pgaudit;
+		`, "\t\n"))
+
+		return expected
+	}
+
+	ctx := context.Background()
+	assert.Equal(t, expected, EnableInPostgreSQL(ctx, exec))
+}
+
+func TestPostgreSQLParameters(t *testing.T) {
+	parameters := postgres.Parameters{
+		Mandatory: postgres.NewParameterSet(),
+	}
+
+	// No comma when empty.
+	PostgreSQLParameters(&parameters)
+
+	assert.Assert(t, parameters.Default == nil)
+	assert.DeepEqual(t, parameters.Mandatory.AsMap(), map[string]string{
+		"shared_preload_libraries": "pgaudit",
+	})
+
+	// Appended when not empty.
+	parameters.Mandatory.Add("shared_preload_libraries", "some,existing")
+	PostgreSQLParameters(&parameters)
+
+	assert.Assert(t, parameters.Default == nil)
+	assert.DeepEqual(t, parameters.Mandatory.AsMap(), map[string]string{
+		"shared_preload_libraries": "some,existing,pgaudit",
+	})
+}

--- a/internal/pgbouncer/postgres_test.go
+++ b/internal/pgbouncer/postgres_test.go
@@ -53,8 +53,8 @@ func TestDisableInPostgreSQL(t *testing.T) {
 		) error {
 			assert.Assert(t, stdout != nil, "should capture stdout")
 			assert.Assert(t, stderr != nil, "should capture stderr")
-			gomega.NewWithT(t).Expect(command).To(gomega.ContainElement(
-				`SELECT datname FROM pg_catalog.pg_database WHERE datallowconn AND datname NOT IN ('template0')`,
+			assert.Assert(t, strings.Contains(strings.Join(command, "\n"),
+				`SELECT datname FROM pg_catalog.pg_database`,
 			), "expected all databases and templates")
 
 			b, err := ioutil.ReadAll(stdin)
@@ -139,8 +139,8 @@ func TestEnableInPostgreSQL(t *testing.T) {
 	) error {
 		assert.Assert(t, stdout != nil, "should capture stdout")
 		assert.Assert(t, stderr != nil, "should capture stderr")
-		gomega.NewWithT(t).Expect(command).To(gomega.ContainElement(
-			`SELECT datname FROM pg_catalog.pg_database WHERE datallowconn AND datname NOT IN ('template0')`,
+		assert.Assert(t, strings.Contains(strings.Join(command, "\n"),
+			`SELECT datname FROM pg_catalog.pg_database`,
 		), "expected all databases and templates")
 
 		b, err := ioutil.ReadAll(stdin)


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature (non-breaking change which adds functionality)

**What is the current behavior? (link to any open issues here)**

One must load pgAudit before migrating a data directory from 4.x.

**What is the new behavior (if this is a feature change)?**

pgAudit is loaded (though not configured) in every PostgresCluster and hooks are enabled in every database.

**Other information**:

Issue: [sc-12040]