### PR TITLE
Return Early If Error During pgBackRest Reconcile

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -1181,6 +1181,7 @@ func (r *Reconciler) reconcilePGBackRest(ctx context.Context,
 		if err != nil {
 			log.Error(err, "unable to reconcile pgBackRest repo host")
 			result = updateReconcileResult(result, reconcile.Result{Requeue: true})
+			return result, nil
 		}
 		repoHostName = repoHost.GetName()
 	} else if len(postgresCluster.Status.Conditions) > 0 {
@@ -1196,6 +1197,7 @@ func (r *Reconciler) reconcilePGBackRest(ctx context.Context,
 	if err != nil {
 		log.Error(err, "unable to calculate config hashes")
 		result = updateReconcileResult(result, reconcile.Result{Requeue: true})
+		return result, nil
 	}
 
 	// reconcile all pgbackrest repository repos
@@ -1203,6 +1205,7 @@ func (r *Reconciler) reconcilePGBackRest(ctx context.Context,
 	if err != nil {
 		log.Error(err, "unable to reconcile pgBackRest repo host")
 		result = updateReconcileResult(result, reconcile.Result{Requeue: true})
+		return result, nil
 	}
 
 	// gather instance names and reconcile all pgbackrest configuration and secrets
@@ -1224,6 +1227,7 @@ func (r *Reconciler) reconcilePGBackRest(ctx context.Context,
 	if err != nil {
 		log.Error(err, "unable to create replica creation backup")
 		result = updateReconcileResult(result, reconcile.Result{Requeue: true})
+		return result, nil
 	}
 
 	// reconcile the pgBackRest stanza for all configuration pgBackRest repos


### PR DESCRIPTION
When reconciling certain pgBackRest resources (more specifically the pgBackRest dedicated repo host, repositories, configuration and RBAC), the `reconcilePGBackRest()` function will now return early if an error is detected.

Since the return values for these various reconcile functions will only ever be their zero values (e.g. `nil` for a pointer) if an error occurred, this will ensure a subsequent reconcile function never attempts to use an invalid return value from these functions (e.g. a `nil` pointer).

[sc-12660]