### PR TITLE
Update golangci-lint 

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,5 +10,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.32
+          version: v1.42.0
           args: --timeout=5m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,8 @@ linters:
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
+  goimports:
+    local-prefixes: github.com/crunchydata/postgres-operator
   gomodguard:
     blocked:
       modules:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
   enable:
     - gomodguard
     - gosimple
+    - importas
     - misspell
   presets:
     - bugs
@@ -28,6 +29,15 @@ linters-settings:
             reason: >
               k8s.io/kubernetes is for managing dependencies of the Kubernetes
               project, i.e. building kubelet and kubeadm.
+  importas:
+    alias:
+      - pkg: k8s.io/api/(\w+)/(v[\w\w]+)
+        alias: $1$2
+      - pkg: k8s.io/apimachinery/pkg/apis/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: k8s.io/apimachinery/pkg/api/errors
+        alias: apierrors
+    no-unaliased: true
 
 run:
   build-tags:

--- a/internal/controller/postgrescluster/apply_test.go
+++ b/internal/controller/postgrescluster/apply_test.go
@@ -29,7 +29,6 @@ import (
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +53,7 @@ func TestServerSideApply(t *testing.T) {
 	cc, err := client.New(config, client.Options{})
 	assert.NilError(t, err)
 
-	ns := &v1.Namespace{}
+	ns := &corev1.Namespace{}
 	ns.GenerateName = "postgres-operator-test-"
 	assert.NilError(t, cc.Create(ctx, ns))
 	t.Cleanup(func() { assert.Check(t, cc.Delete(ctx, ns)) })
@@ -70,9 +69,9 @@ func TestServerSideApply(t *testing.T) {
 
 	t.Run("ObjectMeta", func(t *testing.T) {
 		reconciler := Reconciler{Client: cc, Owner: client.FieldOwner(t.Name())}
-		constructor := func() *v1.ConfigMap {
-			var cm v1.ConfigMap
-			cm.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("ConfigMap"))
+		constructor := func() *corev1.ConfigMap {
+			var cm corev1.ConfigMap
+			cm.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
 			cm.Namespace, cm.Name = ns.Name, "object-meta"
 			cm.Data = map[string]string{"key": "value"}
 			return &cm
@@ -105,16 +104,16 @@ func TestServerSideApply(t *testing.T) {
 		reconciler := Reconciler{Client: cc, Owner: client.FieldOwner(t.Name())}
 
 		// Setup two possible controllers.
-		controller1 := new(v1.ConfigMap)
+		controller1 := new(corev1.ConfigMap)
 		controller1.Namespace, controller1.Name = ns.Name, "controller1"
 		assert.NilError(t, cc.Create(ctx, controller1))
 
-		controller2 := new(v1.ConfigMap)
+		controller2 := new(corev1.ConfigMap)
 		controller2.Namespace, controller2.Name = ns.Name, "controller2"
 		assert.NilError(t, cc.Create(ctx, controller2))
 
 		// Create an object that is controlled.
-		controlled := new(v1.ConfigMap)
+		controlled := new(corev1.ConfigMap)
 		controlled.Namespace, controlled.Name = ns.Name, "controlled"
 		assert.NilError(t,
 			controllerutil.SetControllerReference(controller1, controlled, cc.Scheme()))
@@ -124,8 +123,8 @@ func TestServerSideApply(t *testing.T) {
 		assert.Assert(t, original != nil)
 
 		// Try to change the controller using client.Apply.
-		applied := new(v1.ConfigMap)
-		applied.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("ConfigMap"))
+		applied := new(corev1.ConfigMap)
+		applied.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
 		applied.Namespace, applied.Name = controlled.Namespace, controlled.Name
 		assert.NilError(t,
 			controllerutil.SetControllerReference(controller2, applied, cc.Scheme()))
@@ -215,12 +214,12 @@ func TestServerSideApply(t *testing.T) {
 	})
 
 	t.Run("ServiceSelector", func(t *testing.T) {
-		constructor := func(name string) *v1.Service {
-			var service v1.Service
-			service.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("Service"))
+		constructor := func(name string) *corev1.Service {
+			var service corev1.Service
+			service.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
 			service.Namespace, service.Name = ns.Name, name
-			service.Spec.Ports = []v1.ServicePort{{
-				Port: 9999, Protocol: v1.ProtocolTCP,
+			service.Spec.Ports = []corev1.ServicePort{{
+				Port: 9999, Protocol: corev1.ProtocolTCP,
 			}}
 			return &service
 		}

--- a/internal/controller/postgrescluster/cluster.go
+++ b/internal/controller/postgrescluster/cluster.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -39,9 +38,9 @@ import (
 func (r *Reconciler) reconcileClusterConfigMap(
 	ctx context.Context, cluster *v1beta1.PostgresCluster,
 	pgHBAs postgres.HBAs, pgParameters postgres.Parameters,
-) (*v1.ConfigMap, error) {
-	clusterConfigMap := &v1.ConfigMap{ObjectMeta: naming.ClusterConfigMap(cluster)}
-	clusterConfigMap.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("ConfigMap"))
+) (*corev1.ConfigMap, error) {
+	clusterConfigMap := &corev1.ConfigMap{ObjectMeta: naming.ClusterConfigMap(cluster)}
+	clusterConfigMap.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
 
 	err := errors.WithStack(r.setControllerReference(cluster, clusterConfigMap))
 
@@ -68,9 +67,9 @@ func (r *Reconciler) reconcileClusterConfigMap(
 // names to Pods related to cluster.
 func (r *Reconciler) reconcileClusterPodService(
 	ctx context.Context, cluster *v1beta1.PostgresCluster,
-) (*v1.Service, error) {
-	clusterPodService := &v1.Service{ObjectMeta: naming.ClusterPodService(cluster)}
-	clusterPodService.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("Service"))
+) (*corev1.Service, error) {
+	clusterPodService := &corev1.Service{ObjectMeta: naming.ClusterPodService(cluster)}
+	clusterPodService.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
 
 	err := errors.WithStack(r.setControllerReference(cluster, clusterPodService))
 
@@ -85,7 +84,7 @@ func (r *Reconciler) reconcileClusterPodService(
 	// this allows a properly configured Pod to get a DNS record based on its name.
 	// - https://docs.k8s.io/concepts/services-networking/service/#headless-services
 	// - https://docs.k8s.io/concepts/services-networking/dns-pod-service/#pods
-	clusterPodService.Spec.ClusterIP = v1.ClusterIPNone
+	clusterPodService.Spec.ClusterIP = corev1.ClusterIPNone
 	clusterPodService.Spec.PublishNotReadyAddresses = true
 	clusterPodService.Spec.Selector = map[string]string{
 		naming.LabelCluster: cluster.Name,
@@ -267,7 +266,7 @@ func (r *Reconciler) reconcileClusterReplicaService(
 // PostgresCluster spec.
 func (r *Reconciler) reconcileDataSource(ctx context.Context,
 	cluster *v1beta1.PostgresCluster, observed *observedInstances,
-	clusterVolumes []v1.PersistentVolumeClaim) (bool, error) {
+	clusterVolumes []corev1.PersistentVolumeClaim) (bool, error) {
 
 	// a hash func to hash the pgBackRest restore options
 	hashFunc := func(jobConfigs []string) (string, error) {

--- a/internal/controller/postgrescluster/cluster_test.go
+++ b/internal/controller/postgrescluster/cluster_test.go
@@ -33,7 +33,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -47,12 +46,12 @@ import (
 )
 
 var gvks = []schema.GroupVersionKind{{
-	Group:   v1.SchemeGroupVersion.Group,
-	Version: v1.SchemeGroupVersion.Version,
+	Group:   corev1.SchemeGroupVersion.Group,
+	Version: corev1.SchemeGroupVersion.Version,
 	Kind:    "ConfigMapList",
 }, {
-	Group:   v1.SchemeGroupVersion.Group,
-	Version: v1.SchemeGroupVersion.Version,
+	Group:   corev1.SchemeGroupVersion.Group,
+	Version: corev1.SchemeGroupVersion.Version,
 	Kind:    "SecretList",
 }, {
 	Group:   appsv1.SchemeGroupVersion.Group,
@@ -67,20 +66,20 @@ var gvks = []schema.GroupVersionKind{{
 	Version: batchv1beta1.SchemeGroupVersion.Version,
 	Kind:    "CronJobList",
 }, {
-	Group:   v1.SchemeGroupVersion.Group,
-	Version: v1.SchemeGroupVersion.Version,
+	Group:   corev1.SchemeGroupVersion.Group,
+	Version: corev1.SchemeGroupVersion.Version,
 	Kind:    "PersistentVolumeClaimList",
 }, {
-	Group:   v1.SchemeGroupVersion.Group,
-	Version: v1.SchemeGroupVersion.Version,
+	Group:   corev1.SchemeGroupVersion.Group,
+	Version: corev1.SchemeGroupVersion.Version,
 	Kind:    "ServiceList",
 }, {
-	Group:   v1.SchemeGroupVersion.Group,
-	Version: v1.SchemeGroupVersion.Version,
+	Group:   corev1.SchemeGroupVersion.Group,
+	Version: corev1.SchemeGroupVersion.Version,
 	Kind:    "EndpointsList",
 }, {
-	Group:   v1.SchemeGroupVersion.Group,
-	Version: v1.SchemeGroupVersion.Version,
+	Group:   corev1.SchemeGroupVersion.Group,
+	Version: corev1.SchemeGroupVersion.Version,
 	Kind:    "ServiceAccountList",
 }, {
 	Group:   rbacv1.SchemeGroupVersion.Group,
@@ -109,7 +108,7 @@ func TestCustomLabels(t *testing.T) {
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
 
-	ns := &v1.Namespace{}
+	ns := &corev1.Namespace{}
 	ns.GenerateName = "postgres-operator-test-"
 	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
 	assert.NilError(t, cc.Create(ctx, ns))
@@ -371,7 +370,7 @@ func TestCustomAnnotations(t *testing.T) {
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
 
-	ns := &v1.Namespace{}
+	ns := &corev1.Namespace{}
 	ns.GenerateName = "postgres-operator-test-"
 	ns.Labels = labels.Set{"postgres-operator-test": ""}
 	assert.NilError(t, cc.Create(ctx, ns))
@@ -641,7 +640,7 @@ func TestContainerSecurityContext(t *testing.T) {
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
 
-	ns := &v1.Namespace{}
+	ns := &corev1.Namespace{}
 	ns.GenerateName = "postgres-operator-test-"
 	ns.Labels = labels.Set{"postgres-operator-test": ""}
 	assert.NilError(t, cc.Create(ctx, ns))

--- a/internal/controller/postgrescluster/cluster_test.go
+++ b/internal/controller/postgrescluster/cluster_test.go
@@ -24,9 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crunchydata/postgres-operator/internal/initialize"
-	"github.com/crunchydata/postgres-operator/internal/naming"
-	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
@@ -43,6 +40,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crunchydata/postgres-operator/internal/initialize"
+	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 var gvks = []schema.GroupVersionKind{{

--- a/internal/controller/postgrescluster/controller_ref_manager.go
+++ b/internal/controller/postgrescluster/controller_ref_manager.go
@@ -18,7 +18,7 @@ limitations under the License.
 import (
 	"context"
 
-	kerr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -109,7 +109,7 @@ func (r *Reconciler) claimObject(ctx context.Context, postgresCluster *v1beta1.P
 	if err := r.adoptObject(ctx, postgresCluster, obj); err != nil {
 		// If adopt attempt failed because the resource no longer exists, then simply
 		// ignore.  Otherwise return the error.
-		if kerr.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return err
@@ -143,7 +143,7 @@ func (r *Reconciler) getPostgresClusterForObject(ctx context.Context,
 		Name:      clusterName,
 		Namespace: obj.GetNamespace(),
 	}, postgresCluster); err != nil {
-		if kerr.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return false, nil, nil
 		}
 		return false, nil, err

--- a/internal/controller/postgrescluster/controller_ref_manager_test.go
+++ b/internal/controller/postgrescluster/controller_ref_manager_test.go
@@ -22,7 +22,6 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/postgrescluster/controller_test.go
+++ b/internal/controller/postgrescluster/controller_test.go
@@ -30,7 +30,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -51,7 +51,7 @@ func TestDeleteControlled(t *testing.T) {
 
 	reconciler := Reconciler{Client: cc}
 
-	ns := &v1.Namespace{}
+	ns := &corev1.Namespace{}
 	ns.GenerateName = "postgres-operator-test-"
 	ns.Labels = map[string]string{"postgres-operator-test": t.Name()}
 	assert.NilError(t, cc.Create(ctx, ns))
@@ -63,7 +63,7 @@ func TestDeleteControlled(t *testing.T) {
 	assert.NilError(t, cc.Create(ctx, cluster))
 
 	t.Run("NoOwnership", func(t *testing.T) {
-		secret := &v1.Secret{}
+		secret := &corev1.Secret{}
 		secret.Namespace = ns.Name
 		secret.Name = "solo"
 
@@ -75,7 +75,7 @@ func TestDeleteControlled(t *testing.T) {
 	})
 
 	t.Run("Owned", func(t *testing.T) {
-		secret := &v1.Secret{}
+		secret := &corev1.Secret{}
 		secret.Namespace = ns.Name
 		secret.Name = "owned"
 
@@ -88,7 +88,7 @@ func TestDeleteControlled(t *testing.T) {
 	})
 
 	t.Run("Controlled", func(t *testing.T) {
-		secret := &v1.Secret{}
+		secret := &corev1.Secret{}
 		secret.Namespace = ns.Name
 		secret.Name = "controlled"
 
@@ -105,7 +105,7 @@ func TestDeleteControlled(t *testing.T) {
 
 var _ = Describe("PostgresCluster Reconciler", func() {
 	var test struct {
-		Namespace  *v1.Namespace
+		Namespace  *corev1.Namespace
 		Reconciler Reconciler
 		Recorder   *record.FakeRecorder
 	}
@@ -113,7 +113,7 @@ var _ = Describe("PostgresCluster Reconciler", func() {
 	BeforeEach(func() {
 		ctx := context.Background()
 
-		test.Namespace = &v1.Namespace{}
+		test.Namespace = &corev1.Namespace{}
 		test.Namespace.Name = "postgres-operator-test-" + rand.String(6)
 		Expect(suite.Client.Create(ctx, test.Namespace)).To(Succeed())
 
@@ -212,7 +212,7 @@ spec:
 		})
 
 		Specify("Cluster ConfigMap", func() {
-			ccm := &v1.ConfigMap{}
+			ccm := &corev1.ConfigMap{}
 			Expect(suite.Client.Get(context.Background(), client.ObjectKey{
 				Namespace: test.Namespace.Name, Name: "carlos-config",
 			}, ccm)).To(Succeed())
@@ -236,7 +236,7 @@ spec:
 		})
 
 		Specify("Cluster Pod Service", func() {
-			cps := &v1.Service{}
+			cps := &corev1.Service{}
 			Expect(suite.Client.Get(context.Background(), client.ObjectKey{
 				Namespace: test.Namespace.Name, Name: "carlos-pods",
 			}, cps)).To(Succeed())
@@ -336,7 +336,7 @@ spec:
 		})
 
 		Specify("Patroni Distributed Configuration", func() {
-			ds := &v1.Service{}
+			ds := &corev1.Service{}
 			Expect(suite.Client.Get(context.Background(), client.ObjectKey{
 				Namespace: test.Namespace.Name, Name: "carlos-ha-config",
 			}, ds)).To(Succeed())
@@ -426,7 +426,7 @@ spec:
 		})
 
 		Specify("Instance ConfigMap", func() {
-			icm := &v1.ConfigMap{}
+			icm := &corev1.ConfigMap{}
 			Expect(suite.Client.Get(context.Background(), client.ObjectKey{
 				Namespace: test.Namespace.Name, Name: instance.Name + "-config",
 			}, icm)).To(Succeed())

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -29,7 +29,6 @@ import (
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -429,11 +428,11 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
 					Repos: []v1beta1.PGBackRestRepo{{
 						Name: "repo1",
 						Volume: &v1beta1.RepoPVC{
-							VolumeClaimSpec: v1.PersistentVolumeClaimSpec{
-								AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
-								Resources: v1.ResourceRequirements{
-									Requests: map[v1.ResourceName]resource.Quantity{
-										v1.ResourceStorage: resource.MustParse("1Gi"),
+							VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+								Resources: corev1.ResourceRequirements{
+									Requests: map[corev1.ResourceName]resource.Quantity{
+										corev1.ResourceStorage: resource.MustParse("1Gi"),
 									},
 								},
 							},
@@ -441,11 +440,11 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
 					}, {
 						Name: "repo2",
 						Volume: &v1beta1.RepoPVC{
-							VolumeClaimSpec: v1.PersistentVolumeClaimSpec{
-								AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
-								Resources: v1.ResourceRequirements{
-									Requests: map[v1.ResourceName]resource.Quantity{
-										v1.ResourceStorage: resource.MustParse("2Gi"),
+							VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+								Resources: corev1.ResourceRequirements{
+									Requests: map[corev1.ResourceName]resource.Quantity{
+										corev1.ResourceStorage: resource.MustParse("2Gi"),
 									},
 								},
 							},
@@ -458,22 +457,22 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
 
 	testCases := []struct {
 		dedicatedRepoHostEnabled bool
-		sshConfig                *v1.ConfigMapProjection
-		sshSecret                *v1.SecretProjection
+		sshConfig                *corev1.ConfigMapProjection
+		sshSecret                *corev1.SecretProjection
 	}{{
 		dedicatedRepoHostEnabled: false,
 	}, {
 		dedicatedRepoHostEnabled: true,
-		sshConfig: &v1.ConfigMapProjection{
-			LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-config.conf"}},
-		sshSecret: &v1.SecretProjection{
-			LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-secret.conf"}},
+		sshConfig: &corev1.ConfigMapProjection{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "cust-ssh-config.conf"}},
+		sshSecret: &corev1.SecretProjection{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "cust-ssh-secret.conf"}},
 	}, {
 		dedicatedRepoHostEnabled: true,
-		sshConfig: &v1.ConfigMapProjection{
-			LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-config.conf"}},
-		sshSecret: &v1.SecretProjection{
-			LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-secret.conf"}},
+		sshConfig: &corev1.ConfigMapProjection{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "cust-ssh-config.conf"}},
+		sshSecret: &corev1.SecretProjection{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "cust-ssh-secret.conf"}},
 	}}
 
 	for _, tc := range testCases {
@@ -482,9 +481,9 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
 		customSecret := (tc.sshSecret != nil)
 		t.Run(fmt.Sprintf("dedicated:%t", dedicated), func(t *testing.T) {
 
-			template := &v1.PodTemplateSpec{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{{Name: naming.ContainerDatabase}},
+			template := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: naming.ContainerDatabase}},
 				},
 			}
 
@@ -509,7 +508,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
 
 				// verify the ssh volume
 				var foundSSHVolume bool
-				var sshVolume v1.Volume
+				var sshVolume corev1.Volume
 				for _, v := range template.Spec.Volumes {
 					if v.Name == naming.PGBackRestSSHVolume {
 						foundSSHVolume = true
@@ -560,7 +559,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
 			}
 
 			var foundConfigVolume bool
-			var configVolume v1.Volume
+			var configVolume corev1.Volume
 			for _, v := range template.Spec.Volumes {
 				if v.Name == pgbackrest.ConfigVol {
 					foundConfigVolume = true
@@ -605,13 +604,13 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
 func TestPodsToKeep(t *testing.T) {
 	for _, test := range []struct {
 		name      string
-		instances []v1.Pod
+		instances []corev1.Pod
 		want      map[string]int
-		checks    func(*testing.T, []v1.Pod)
+		checks    func(*testing.T, []corev1.Pod)
 	}{
 		{
 			name: "RemoveSetWithMasterOnly",
-			instances: []v1.Pod{
+			instances: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "daisy-asdf",
@@ -623,12 +622,12 @@ func TestPodsToKeep(t *testing.T) {
 				},
 			},
 			want: map[string]int{},
-			checks: func(t *testing.T, p []v1.Pod) {
+			checks: func(t *testing.T, p []corev1.Pod) {
 				assert.Equal(t, len(p), 0)
 			},
 		}, {
 			name: "RemoveSetWithReplicaOnly",
-			instances: []v1.Pod{
+			instances: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "daisy-asdf",
@@ -640,12 +639,12 @@ func TestPodsToKeep(t *testing.T) {
 				},
 			},
 			want: map[string]int{},
-			checks: func(t *testing.T, p []v1.Pod) {
+			checks: func(t *testing.T, p []corev1.Pod) {
 				assert.Equal(t, len(p), 0)
 			},
 		}, {
 			name: "KeepMasterOnly",
-			instances: []v1.Pod{
+			instances: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "daisy-asdf",
@@ -659,12 +658,12 @@ func TestPodsToKeep(t *testing.T) {
 			want: map[string]int{
 				"daisy": 1,
 			},
-			checks: func(t *testing.T, p []v1.Pod) {
+			checks: func(t *testing.T, p []corev1.Pod) {
 				assert.Equal(t, len(p), 1)
 			},
 		}, {
 			name: "KeepNoRoleLabels",
-			instances: []v1.Pod{
+			instances: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "daisy-asdf",
@@ -677,12 +676,12 @@ func TestPodsToKeep(t *testing.T) {
 			want: map[string]int{
 				"daisy": 1,
 			},
-			checks: func(t *testing.T, p []v1.Pod) {
+			checks: func(t *testing.T, p []corev1.Pod) {
 				assert.Equal(t, len(p), 1)
 			},
 		}, {
 			name: "RemoveSetWithNoRoleLabels",
-			instances: []v1.Pod{
+			instances: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "daisy-asdf",
@@ -693,12 +692,12 @@ func TestPodsToKeep(t *testing.T) {
 				},
 			},
 			want: map[string]int{},
-			checks: func(t *testing.T, p []v1.Pod) {
+			checks: func(t *testing.T, p []corev1.Pod) {
 				assert.Equal(t, len(p), 0)
 			},
 		}, {
 			name: "KeepUnknownRoleLabel",
-			instances: []v1.Pod{
+			instances: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "daisy-asdf",
@@ -712,12 +711,12 @@ func TestPodsToKeep(t *testing.T) {
 			want: map[string]int{
 				"daisy": 1,
 			},
-			checks: func(t *testing.T, p []v1.Pod) {
+			checks: func(t *testing.T, p []corev1.Pod) {
 				assert.Equal(t, len(p), 1)
 			},
 		}, {
 			name: "RemoveSetWithUnknownRoleLabel",
-			instances: []v1.Pod{
+			instances: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "daisy-asdf",
@@ -729,12 +728,12 @@ func TestPodsToKeep(t *testing.T) {
 				},
 			},
 			want: map[string]int{},
-			checks: func(t *testing.T, p []v1.Pod) {
+			checks: func(t *testing.T, p []corev1.Pod) {
 				assert.Equal(t, len(p), 0)
 			},
 		}, {
 			name: "MasterLastInSet",
-			instances: []v1.Pod{
+			instances: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "daisy-asdf",
@@ -757,13 +756,13 @@ func TestPodsToKeep(t *testing.T) {
 			want: map[string]int{
 				"daisy": 1,
 			},
-			checks: func(t *testing.T, p []v1.Pod) {
+			checks: func(t *testing.T, p []corev1.Pod) {
 				assert.Equal(t, len(p), 1)
 				assert.Equal(t, p[0].Labels[naming.LabelRole], "master")
 			},
 		}, {
 			name: "ScaleDownSetWithMaster",
-			instances: []v1.Pod{
+			instances: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "max-asdf",
@@ -805,7 +804,7 @@ func TestPodsToKeep(t *testing.T) {
 				"max":   1,
 				"daisy": 1,
 			},
-			checks: func(t *testing.T, p []v1.Pod) {
+			checks: func(t *testing.T, p []corev1.Pod) {
 				assert.Equal(t, len(p), 2)
 				assert.Equal(t, p[0].Labels[naming.LabelRole], "master")
 				assert.Equal(t, p[0].Labels[naming.LabelInstanceSet], "daisy")
@@ -814,7 +813,7 @@ func TestPodsToKeep(t *testing.T) {
 			},
 		}, {
 			name: "ScaleDownSetWithoutMaster",
-			instances: []v1.Pod{
+			instances: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "max-asdf",
@@ -856,7 +855,7 @@ func TestPodsToKeep(t *testing.T) {
 				"max":   1,
 				"daisy": 2,
 			},
-			checks: func(t *testing.T, p []v1.Pod) {
+			checks: func(t *testing.T, p []corev1.Pod) {
 				assert.Equal(t, len(p), 3)
 				assert.Equal(t, p[0].Labels[naming.LabelRole], "master")
 				assert.Equal(t, p[0].Labels[naming.LabelInstanceSet], "max")
@@ -867,7 +866,7 @@ func TestPodsToKeep(t *testing.T) {
 			},
 		}, {
 			name: "ScaleMasterSetToZero",
-			instances: []v1.Pod{
+			instances: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "max-asdf",
@@ -900,7 +899,7 @@ func TestPodsToKeep(t *testing.T) {
 				"max":   0,
 				"daisy": 2,
 			},
-			checks: func(t *testing.T, p []v1.Pod) {
+			checks: func(t *testing.T, p []corev1.Pod) {
 				assert.Equal(t, len(p), 2)
 				assert.Equal(t, p[0].Labels[naming.LabelRole], "replica")
 				assert.Equal(t, p[0].Labels[naming.LabelInstanceSet], "daisy")
@@ -909,7 +908,7 @@ func TestPodsToKeep(t *testing.T) {
 			},
 		}, {
 			name: "RemoveMasterInstanceSet",
-			instances: []v1.Pod{
+			instances: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "max-asdf",
@@ -950,7 +949,7 @@ func TestPodsToKeep(t *testing.T) {
 			want: map[string]int{
 				"daisy": 3,
 			},
-			checks: func(t *testing.T, p []v1.Pod) {
+			checks: func(t *testing.T, p []corev1.Pod) {
 				assert.Equal(t, len(p), 3)
 				assert.Equal(t, p[0].Labels[naming.LabelRole], "replica")
 				assert.Equal(t, p[0].Labels[naming.LabelInstanceSet], "daisy")
@@ -986,7 +985,7 @@ func TestDeleteInstance(t *testing.T) {
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
 
-	ns := &v1.Namespace{}
+	ns := &corev1.Namespace{}
 	ns.GenerateName = "postgres-operator-test-"
 	ns.Labels = map[string]string{"postgres-operator-test": t.Name()}
 	assert.NilError(t, reconciler.Client.Create(ctx, ns))
@@ -1118,7 +1117,7 @@ func TestGenerateInstanceStatefulSetIntent(t *testing.T) {
 		name: "custom tolerations",
 		ip: intentParams{
 			spec: &v1beta1.PostgresInstanceSetSpec{
-				Tolerations: []v1.Toleration{},
+				Tolerations: []corev1.Toleration{},
 			},
 		},
 		run: func(t *testing.T, ss *appsv1.StatefulSet) {
@@ -1128,7 +1127,7 @@ func TestGenerateInstanceStatefulSetIntent(t *testing.T) {
 		name: "custom topology spread constraints",
 		ip: intentParams{
 			spec: &v1beta1.PostgresInstanceSetSpec{
-				TopologySpreadConstraints: []v1.TopologySpreadConstraint{},
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{},
 			},
 		},
 		run: func(t *testing.T, ss *appsv1.StatefulSet) {
@@ -1410,7 +1409,7 @@ func TestFindAvailableInstanceNames(t *testing.T) {
 	testCases := []struct {
 		set                   v1beta1.PostgresInstanceSetSpec
 		fakeObservedInstances *observedInstances
-		fakeClusterVolumes    []v1.PersistentVolumeClaim
+		fakeClusterVolumes    []corev1.PersistentVolumeClaim
 		expectedInstanceNames []string
 	}{{
 		set: v1beta1.PostgresInstanceSetSpec{Name: "instance1"},
@@ -1419,9 +1418,9 @@ func TestFindAvailableInstanceNames(t *testing.T) {
 				InstanceSets: []v1beta1.PostgresInstanceSetSpec{{}},
 			}},
 			[]appsv1.StatefulSet{{}},
-			[]v1.Pod{},
+			[]corev1.Pod{},
 		),
-		fakeClusterVolumes:    []v1.PersistentVolumeClaim{{}},
+		fakeClusterVolumes:    []corev1.PersistentVolumeClaim{{}},
 		expectedInstanceNames: []string{},
 	}, {
 		set: v1beta1.PostgresInstanceSetSpec{Name: "instance1"},
@@ -1433,9 +1432,9 @@ func TestFindAvailableInstanceNames(t *testing.T) {
 				Name: "instance1-abc",
 				Labels: map[string]string{
 					naming.LabelInstanceSet: "instance1"}}}},
-			[]v1.Pod{},
+			[]corev1.Pod{},
 		),
-		fakeClusterVolumes: []v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{
+		fakeClusterVolumes: []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{
 			Name: "instance1-abc-def",
 			Labels: map[string]string{
 				naming.LabelRole:        naming.RolePostgresData,
@@ -1452,9 +1451,9 @@ func TestFindAvailableInstanceNames(t *testing.T) {
 				Name: "instance1-abc",
 				Labels: map[string]string{
 					naming.LabelInstanceSet: "instance1"}}}},
-			[]v1.Pod{},
+			[]corev1.Pod{},
 		),
-		fakeClusterVolumes:    []v1.PersistentVolumeClaim{},
+		fakeClusterVolumes:    []corev1.PersistentVolumeClaim{},
 		expectedInstanceNames: []string{},
 	}, {
 		set: v1beta1.PostgresInstanceSetSpec{Name: "instance1"},
@@ -1466,9 +1465,9 @@ func TestFindAvailableInstanceNames(t *testing.T) {
 				Name: "instance1-abc",
 				Labels: map[string]string{
 					naming.LabelInstanceSet: "instance1"}}}},
-			[]v1.Pod{},
+			[]corev1.Pod{},
 		),
-		fakeClusterVolumes: []v1.PersistentVolumeClaim{
+		fakeClusterVolumes: []corev1.PersistentVolumeClaim{
 			{ObjectMeta: metav1.ObjectMeta{
 				Name: "instance1-abc-def",
 				Labels: map[string]string{
@@ -1493,9 +1492,9 @@ func TestFindAvailableInstanceNames(t *testing.T) {
 				Name: "instance1-abc",
 				Labels: map[string]string{
 					naming.LabelInstanceSet: "instance1"}}}},
-			[]v1.Pod{},
+			[]corev1.Pod{},
 		),
-		fakeClusterVolumes: []v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{
+		fakeClusterVolumes: []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{
 			Name: "instance1-abc-def",
 			Labels: map[string]string{
 				naming.LabelRole:        naming.RolePostgresData,
@@ -1504,7 +1503,7 @@ func TestFindAvailableInstanceNames(t *testing.T) {
 		expectedInstanceNames: []string{"instance1-def"},
 	}, {
 		set: v1beta1.PostgresInstanceSetSpec{Name: "instance1",
-			WALVolumeClaimSpec: &v1.PersistentVolumeClaimSpec{}},
+			WALVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{}},
 		fakeObservedInstances: newObservedInstances(
 			&v1beta1.PostgresCluster{Spec: v1beta1.PostgresClusterSpec{
 				InstanceSets: []v1beta1.PostgresInstanceSetSpec{{Name: "instance1"}},
@@ -1513,9 +1512,9 @@ func TestFindAvailableInstanceNames(t *testing.T) {
 				Name: "instance1-abc",
 				Labels: map[string]string{
 					naming.LabelInstanceSet: "instance1"}}}},
-			[]v1.Pod{},
+			[]corev1.Pod{},
 		),
-		fakeClusterVolumes: []v1.PersistentVolumeClaim{
+		fakeClusterVolumes: []corev1.PersistentVolumeClaim{
 			{ObjectMeta: metav1.ObjectMeta{
 				Name: "instance1-abc-def",
 				Labels: map[string]string{
@@ -1531,15 +1530,15 @@ func TestFindAvailableInstanceNames(t *testing.T) {
 		expectedInstanceNames: []string{},
 	}, {
 		set: v1beta1.PostgresInstanceSetSpec{Name: "instance1",
-			WALVolumeClaimSpec: &v1.PersistentVolumeClaimSpec{}},
+			WALVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{}},
 		fakeObservedInstances: newObservedInstances(
 			&v1beta1.PostgresCluster{Spec: v1beta1.PostgresClusterSpec{
 				InstanceSets: []v1beta1.PostgresInstanceSetSpec{{Name: "instance1"}},
 			}},
 			[]appsv1.StatefulSet{},
-			[]v1.Pod{},
+			[]corev1.Pod{},
 		),
-		fakeClusterVolumes: []v1.PersistentVolumeClaim{
+		fakeClusterVolumes: []corev1.PersistentVolumeClaim{
 			{ObjectMeta: metav1.ObjectMeta{
 				Name: "instance1-def-ghi",
 				Labels: map[string]string{
@@ -1555,15 +1554,15 @@ func TestFindAvailableInstanceNames(t *testing.T) {
 		expectedInstanceNames: []string{"instance1-def"},
 	}, {
 		set: v1beta1.PostgresInstanceSetSpec{Name: "instance1",
-			WALVolumeClaimSpec: &v1.PersistentVolumeClaimSpec{}},
+			WALVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{}},
 		fakeObservedInstances: newObservedInstances(
 			&v1beta1.PostgresCluster{Spec: v1beta1.PostgresClusterSpec{
 				InstanceSets: []v1beta1.PostgresInstanceSetSpec{{Name: "instance1"}},
 			}},
 			[]appsv1.StatefulSet{},
-			[]v1.Pod{},
+			[]corev1.Pod{},
 		),
-		fakeClusterVolumes: []v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{
+		fakeClusterVolumes: []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{
 			Name: "instance1-def-ghi",
 			Labels: map[string]string{
 				naming.LabelRole:        naming.RolePostgresData,

--- a/internal/controller/postgrescluster/patroni.go
+++ b/internal/controller/postgrescluster/patroni.go
@@ -270,10 +270,7 @@ func (r *Reconciler) reconcileReplicationSecret(
 		}}
 		err := errors.WithStack(r.Client.Get(ctx,
 			client.ObjectKeyFromObject(custom), custom))
-		if err == nil {
-			return custom, err
-		}
-		return nil, err
+		return custom, err
 	}
 
 	existing := &corev1.Secret{ObjectMeta: naming.ReplicationClientCertSecret(cluster)}
@@ -330,10 +327,7 @@ func (r *Reconciler) reconcileReplicationSecret(
 	if err == nil {
 		err = errors.WithStack(r.apply(ctx, intent))
 	}
-	if err == nil {
-		return intent, err
-	}
-	return nil, err
+	return intent, err
 }
 
 // replicationCertSecretProjection returns a secret projection of the postgrescluster's

--- a/internal/controller/postgrescluster/patroni_test.go
+++ b/internal/controller/postgrescluster/patroni_test.go
@@ -342,8 +342,6 @@ func TestPatroniReplicationSecret(t *testing.T) {
 }
 
 func TestReconcilePatroniStatus(t *testing.T) {
-	ctx := context.Background()
-
 	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
 	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 	r := &Reconciler{}

--- a/internal/controller/postgrescluster/patroni_test.go
+++ b/internal/controller/postgrescluster/patroni_test.go
@@ -30,7 +30,6 @@ import (
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -307,11 +306,11 @@ func TestPatroniReplicationSecret(t *testing.T) {
 
 	t.Run("check replication certificate secret projection", func(t *testing.T) {
 		// example auto-generated secret projection
-		testSecretProjection := &v1.SecretProjection{
-			LocalObjectReference: v1.LocalObjectReference{
+		testSecretProjection := &corev1.SecretProjection{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: naming.ReplicationClientCertSecret(postgresCluster).Name,
 			},
-			Items: []v1.KeyToPath{
+			Items: []corev1.KeyToPath{
 				{
 					Key:  naming.ReplicationCert,
 					Path: naming.ReplicationCertPath,
@@ -412,9 +411,9 @@ func TestReconcilePatroniStatus(t *testing.T) {
 			Name: instanceName, Runner: runner,
 		}
 		for i := 0; i < readyReplicas; i++ {
-			instance.Pods = append(instance.Pods, &v1.Pod{
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{{
+			instance.Pods = append(instance.Pods, &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{{
 						Type:    corev1.PodReady,
 						Status:  corev1.ConditionTrue,
 						Reason:  "test",

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -35,7 +35,7 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	kerr "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1497,7 +1497,7 @@ func TestReconcileManualBackup(t *testing.T) {
 					// if a deletion is expected, then an error is expected.  otherwise an error is
 					// not expected.
 					if tc.expectCurrentJobDeletion {
-						assert.Assert(t, kerr.IsNotFound(err))
+						assert.Assert(t, apierrors.IsNotFound(err))
 						assert.ErrorContains(t, err,
 							fmt.Sprintf(`"%s" not found`, currentJobs[0].GetName()))
 					} else {

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -25,7 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
@@ -267,7 +267,7 @@ func TestReconcilePGBouncerDeployment(t *testing.T) {
 	reconciler := &Reconciler{Client: cc, Owner: client.FieldOwner(t.Name())}
 
 	cluster := &v1beta1.PostgresCluster{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
 			Namespace: ns.Name,
 		},
@@ -310,12 +310,12 @@ func TestReconcilePGBouncerDeployment(t *testing.T) {
 			},
 		}
 		cm := &corev1.ConfigMap{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-configmap",
 			},
 		}
 		s := &corev1.Secret{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-secret",
 			},
 		}

--- a/internal/controller/postgrescluster/pgmonitor.go
+++ b/internal/controller/postgrescluster/pgmonitor.go
@@ -20,6 +20,11 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/crunchydata/postgres-operator/internal/config"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/logging"
@@ -29,10 +34,6 @@ import (
 	pgpassword "github.com/crunchydata/postgres-operator/internal/postgres/password"
 	"github.com/crunchydata/postgres-operator/internal/util"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
-	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (

--- a/internal/controller/postgrescluster/pgmonitor_test.go
+++ b/internal/controller/postgrescluster/pgmonitor_test.go
@@ -26,10 +26,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/crunchydata/postgres-operator/internal/initialize"
-	"github.com/crunchydata/postgres-operator/internal/naming"
-	"github.com/crunchydata/postgres-operator/internal/pgmonitor"
-	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -40,6 +36,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/crunchydata/postgres-operator/internal/initialize"
+	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/internal/pgmonitor"
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func TestAddPGMonitorExporterToInstancePodSpec(t *testing.T) {

--- a/internal/controller/postgrescluster/pki_test.go
+++ b/internal/controller/postgrescluster/pki_test.go
@@ -250,6 +250,7 @@ func TestReconcileCerts(t *testing.T) {
 		}
 
 		intent, existing, err := createInstanceSecrets(ctx, tClient, instance, initialRoot)
+		assert.NilError(t, err)
 
 		// apply the secret changes
 		err = errors.WithStack(r.apply(ctx, existing))

--- a/internal/controller/postgrescluster/pki_test.go
+++ b/internal/controller/postgrescluster/pki_test.go
@@ -27,14 +27,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crunchydata/postgres-operator/internal/naming"

--- a/internal/controller/postgrescluster/pod_client.go
+++ b/internal/controller/postgrescluster/pod_client.go
@@ -18,7 +18,7 @@ package postgrescluster
 import (
 	"io"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -35,7 +35,7 @@ type podExecutor func(
 
 func newPodClient(config *rest.Config) (rest.Interface, error) {
 	codecs := serializer.NewCodecFactory(scheme.Scheme)
-	gvk, _ := apiutil.GVKForObject(&v1.Pod{}, scheme.Scheme)
+	gvk, _ := apiutil.GVKForObject(&corev1.Pod{}, scheme.Scheme)
 	return apiutil.RESTClientForGVK(gvk, false, config, codecs)
 }
 
@@ -51,7 +51,7 @@ func newPodExecutor(config *rest.Config) (podExecutor, error) {
 		request := client.Post().
 			Resource("pods").SubResource("exec").
 			Namespace(namespace).Name(pod).
-			VersionedParams(&v1.PodExecOptions{
+			VersionedParams(&corev1.PodExecOptions{
 				Container: container,
 				Command:   command,
 				Stdin:     stdin != nil,

--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -464,7 +463,7 @@ func (r *Reconciler) reconcilePostgresDataVolume(
 		naming.LabelData:        naming.DataPostgres,
 	}
 
-	var pvc *v1.PersistentVolumeClaim
+	var pvc *corev1.PersistentVolumeClaim
 	existingPVCName, err := getPGPVCName(labelMap, clusterVolumes)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -521,7 +520,7 @@ func (r *Reconciler) reconcilePostgresWALVolume(
 		naming.LabelData:        naming.DataPostgres,
 	}
 
-	var pvc *v1.PersistentVolumeClaim
+	var pvc *corev1.PersistentVolumeClaim
 	existingPVCName, err := getPGPVCName(labelMap, clusterVolumes)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/internal/controller/postgrescluster/scale_test.go
+++ b/internal/controller/postgrescluster/scale_test.go
@@ -27,7 +27,6 @@ import (
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -67,7 +66,7 @@ func TestScaleDown(t *testing.T) {
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
 
-	ns := &v1.Namespace{}
+	ns := &corev1.Namespace{}
 	ns.GenerateName = "postgres-operator-test-"
 	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
 	assert.NilError(t, cc.Create(ctx, ns))
@@ -83,11 +82,11 @@ func TestScaleDown(t *testing.T) {
 	}
 
 	// Defines a volume claim spec that can be used to create instances
-	volumeClaimSpec := v1.PersistentVolumeClaimSpec{
-		AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-		Resources: v1.ResourceRequirements{
-			Requests: map[v1.ResourceName]resource.Quantity{
-				v1.ResourceStorage: resource.MustParse("1Gi"),
+	volumeClaimSpec := corev1.PersistentVolumeClaimSpec{
+		AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		Resources: corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceStorage: resource.MustParse("1Gi"),
 			},
 		},
 	}
@@ -227,7 +226,7 @@ func TestScaleDown(t *testing.T) {
 
 			if test.primaryTest != nil {
 				// Grab the old primary name to use later
-				primaryPod := v1.PodList{}
+				primaryPod := corev1.PodList{}
 				assert.NilError(t, wait.Poll(time.Second, Scale(15*time.Second), func() (bool, error) {
 					primarySelector, err := naming.AsSelector(metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -283,7 +282,7 @@ func TestScaleDown(t *testing.T) {
 			// In the update case we need to ensure that the pods have deleted
 			var pods []corev1.Pod
 			assert.NilError(t, wait.Poll(time.Second, Scale(time.Minute/2), func() (bool, error) {
-				list := v1.PodList{}
+				list := corev1.PodList{}
 				selector, err := labels.Parse(strings.Join([]string{
 					"postgres-operator.crunchydata.com/cluster=" + cluster.Name,
 					"postgres-operator.crunchydata.com/instance",
@@ -300,7 +299,7 @@ func TestScaleDown(t *testing.T) {
 
 			if test.primaryTest != nil {
 				// If this is a primary test grab the updated primary
-				primaryPod := v1.PodList{}
+				primaryPod := corev1.PodList{}
 				primarySelector, err := naming.AsSelector(metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						naming.LabelCluster: cluster.Name,

--- a/internal/controller/postgrescluster/suite_test.go
+++ b/internal/controller/postgrescluster/suite_test.go
@@ -28,15 +28,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes/scheme"
+
+	// Google Kubernetes Engine / Google Cloud Platform authentication provider
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	// Google Kubernetes Engine / Google Cloud Platform authentication provider
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"github.com/crunchydata/postgres-operator/internal/logging"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"

--- a/internal/controller/postgrescluster/util_test.go
+++ b/internal/controller/postgrescluster/util_test.go
@@ -25,7 +25,6 @@ import (
 	"gotest.tools/v3/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -229,7 +228,7 @@ func TestAddDevSHM(t *testing.T) {
 
 			// check there is an empty dir mounted under the dshm volume
 			for _, v := range template.Spec.Volumes {
-				if v.Name == "dshm" && v.VolumeSource.EmptyDir != nil && v.VolumeSource.EmptyDir.Medium == v1.StorageMediumMemory {
+				if v.Name == "dshm" && v.VolumeSource.EmptyDir != nil && v.VolumeSource.EmptyDir.Medium == corev1.StorageMediumMemory {
 					found = true
 					break
 				}

--- a/internal/controller/postgrescluster/volumes.go
+++ b/internal/controller/postgrescluster/volumes.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -453,22 +452,22 @@ func (r *Reconciler) reconcileMovePGDataDir(ctx context.Context,
 	}
 
 	jobSpec := &batchv1.JobSpec{
-		Template: v1.PodTemplateSpec{
+		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: labels},
-			Spec: v1.PodSpec{
-				Containers:      []v1.Container{container},
+			Spec: corev1.PodSpec{
+				Containers:      []corev1.Container{container},
 				SecurityContext: postgres.PodSecurityContext(cluster),
 				// Set RestartPolicy to "Never" since we want a new Pod to be
 				// created by the Job controller when there is a failure
 				// (instead of the container simply restarting).
-				RestartPolicy: v1.RestartPolicyNever,
+				RestartPolicy: corev1.RestartPolicyNever,
 				// Since these Jobs don't make Kubernetes API calls, we can just
 				// use the default ServiceAccount and mount the credentials.
 				AutomountServiceAccountToken: initialize.Bool(false),
-				Volumes: []v1.Volume{{
+				Volumes: []corev1.Volume{{
 					Name: "postgres-data",
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 							ClaimName: cluster.Spec.DataSource.Volumes.
 								PGDataVolume.PVCName,
 						},
@@ -564,22 +563,22 @@ func (r *Reconciler) reconcileMoveWALDir(ctx context.Context,
 	}
 
 	jobSpec := &batchv1.JobSpec{
-		Template: v1.PodTemplateSpec{
+		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: labels},
-			Spec: v1.PodSpec{
-				Containers:      []v1.Container{container},
+			Spec: corev1.PodSpec{
+				Containers:      []corev1.Container{container},
 				SecurityContext: postgres.PodSecurityContext(cluster),
 				// Set RestartPolicy to "Never" since we want a new Pod to be
 				// created by the Job controller when there is a failure
 				// (instead of the container simply restarting).
-				RestartPolicy: v1.RestartPolicyNever,
+				RestartPolicy: corev1.RestartPolicyNever,
 				// Since these Jobs don't make Kubernetes API calls, we can just
 				// use the default ServiceAccount and mount the credentials.
 				AutomountServiceAccountToken: initialize.Bool(false),
-				Volumes: []v1.Volume{{
+				Volumes: []corev1.Volume{{
 					Name: "postgres-wal",
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 							ClaimName: cluster.Spec.DataSource.Volumes.
 								PGWALVolume.PVCName,
 						},
@@ -680,21 +679,21 @@ func (r *Reconciler) reconcileMoveRepoDir(ctx context.Context,
 	}
 
 	jobSpec := &batchv1.JobSpec{
-		Template: v1.PodTemplateSpec{
+		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: labels},
-			Spec: v1.PodSpec{
-				Containers:      []v1.Container{container},
+			Spec: corev1.PodSpec{
+				Containers:      []corev1.Container{container},
 				SecurityContext: postgres.PodSecurityContext(cluster),
 				// Set RestartPolicy to "Never" since we want a new Pod to be created by the Job
 				// controller when there is a failure (instead of the container simply restarting).
-				RestartPolicy: v1.RestartPolicyNever,
+				RestartPolicy: corev1.RestartPolicyNever,
 				// Since these Jobs don't make Kubernetes API calls, we can just
 				// use the default ServiceAccount and mount the credentials.
 				AutomountServiceAccountToken: initialize.Bool(false),
-				Volumes: []v1.Volume{{
+				Volumes: []corev1.Volume{{
 					Name: "pgbackrest-repo",
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 							ClaimName: cluster.Spec.DataSource.Volumes.
 								PGBackRestVolume.PVCName,
 						},

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -29,7 +29,6 @@ import (
 	"gotest.tools/v3/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -501,8 +500,8 @@ func TestGetPVCNameMethods(t *testing.T) {
 				naming.LabelCluster: cluster.Name,
 			},
 		},
-		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes: []v1.PersistentVolumeAccessMode{
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
 				"ReadWriteMany",
 			},
 			Resources: corev1.ResourceRequirements{
@@ -530,7 +529,7 @@ func TestGetPVCNameMethods(t *testing.T) {
 		naming.LabelInstance:    "testinstance1-abcd",
 		naming.LabelRole:        naming.RolePostgresWAL,
 	}
-	clusterVolumes := []v1.PersistentVolumeClaim{*pgDataPVC, *walPVC}
+	clusterVolumes := []corev1.PersistentVolumeClaim{*pgDataPVC, *walPVC}
 
 	repoPVC1 := pvc.DeepCopy()
 	repoPVC1.Name = "testrepovol1"
@@ -540,7 +539,7 @@ func TestGetPVCNameMethods(t *testing.T) {
 		naming.LabelPGBackRestRepo:       "testrepo1",
 		naming.LabelPGBackRestRepoVolume: "",
 	}
-	repoPVCs := []*v1.PersistentVolumeClaim{repoPVC1}
+	repoPVCs := []*corev1.PersistentVolumeClaim{repoPVC1}
 
 	repoPVC2 := pvc.DeepCopy()
 	repoPVC2.Name = "testrepovol2"
@@ -622,7 +621,7 @@ func TestReconcileConfigureExistingPVCs(t *testing.T) {
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
 
-	ns := &v1.Namespace{}
+	ns := &corev1.Namespace{}
 	ns.GenerateName = "postgres-operator-test-"
 	assert.NilError(t, tClient.Create(ctx, ns))
 	t.Cleanup(func() { assert.Check(t, tClient.Delete(ctx, ns)) })
@@ -640,8 +639,8 @@ func TestReconcileConfigureExistingPVCs(t *testing.T) {
 			},
 			InstanceSets: []v1beta1.PostgresInstanceSetSpec{{
 				Name: "instance1",
-				DataVolumeClaimSpec: v1.PersistentVolumeClaimSpec{
-					AccessModes: []v1.PersistentVolumeAccessMode{
+				DataVolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
 						corev1.ReadWriteMany},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -656,13 +655,13 @@ func TestReconcileConfigureExistingPVCs(t *testing.T) {
 					Repos: []v1beta1.PGBackRestRepo{{
 						Name: "repo1",
 						Volume: &v1beta1.RepoPVC{
-							VolumeClaimSpec: v1.PersistentVolumeClaimSpec{
-								AccessModes: []v1.PersistentVolumeAccessMode{
-									v1.ReadWriteMany},
-								Resources: v1.ResourceRequirements{
-									Requests: map[v1.ResourceName]resource.
+							VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteMany},
+								Resources: corev1.ResourceRequirements{
+									Requests: map[corev1.ResourceName]resource.
 										Quantity{
-										v1.ResourceStorage: resource.
+										corev1.ResourceStorage: resource.
 											MustParse("1Gi"),
 									},
 								},
@@ -893,7 +892,7 @@ func TestReconcileMoveDirectories(t *testing.T) {
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
 
-	ns := &v1.Namespace{}
+	ns := &corev1.Namespace{}
 	ns.GenerateName = "postgres-operator-test-"
 	assert.NilError(t, tClient.Create(ctx, ns))
 	t.Cleanup(func() { assert.Check(t, tClient.Delete(ctx, ns)) })
@@ -931,8 +930,8 @@ func TestReconcileMoveDirectories(t *testing.T) {
 					},
 				},
 				PriorityClassName: initialize.String("some-priority-class"),
-				DataVolumeClaimSpec: v1.PersistentVolumeClaimSpec{
-					AccessModes: []v1.PersistentVolumeAccessMode{
+				DataVolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
 						corev1.ReadWriteMany},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -955,13 +954,13 @@ func TestReconcileMoveDirectories(t *testing.T) {
 					Repos: []v1beta1.PGBackRestRepo{{
 						Name: "repo1",
 						Volume: &v1beta1.RepoPVC{
-							VolumeClaimSpec: v1.PersistentVolumeClaimSpec{
-								AccessModes: []v1.PersistentVolumeAccessMode{
-									v1.ReadWriteMany},
-								Resources: v1.ResourceRequirements{
-									Requests: map[v1.ResourceName]resource.
+							VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteMany},
+								Resources: corev1.ResourceRequirements{
+									Requests: map[corev1.ResourceName]resource.
 										Quantity{
-										v1.ResourceStorage: resource.
+										corev1.ResourceStorage: resource.
 											MustParse("1Gi"),
 									},
 								},

--- a/internal/patroni/certificates.go
+++ b/internal/patroni/certificates.go
@@ -16,7 +16,7 @@
 package patroni
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/crunchydata/postgres-operator/internal/pki"
 )
@@ -66,13 +66,13 @@ func certFile(key *pki.PrivateKey, cert *pki.Certificate) ([]byte, error) {
 
 // instanceCertificates returns projections of Patroni's CAs, keys, and
 // certificates to include in the instance configuration volume.
-func instanceCertificates(certificates *v1.Secret) []v1.VolumeProjection {
-	return []v1.VolumeProjection{{
-		Secret: &v1.SecretProjection{
-			LocalObjectReference: v1.LocalObjectReference{
+func instanceCertificates(certificates *corev1.Secret) []corev1.VolumeProjection {
+	return []corev1.VolumeProjection{{
+		Secret: &corev1.SecretProjection{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: certificates.Name,
 			},
-			Items: []v1.KeyToPath{
+			Items: []corev1.KeyToPath{
 				{
 					Key:  certAuthorityFileKey,
 					Path: certAuthorityConfigPath,

--- a/internal/patroni/certificates_test.go
+++ b/internal/patroni/certificates_test.go
@@ -21,7 +21,7 @@ import (
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/crunchydata/postgres-operator/internal/pki"
 )
@@ -76,7 +76,7 @@ func TestCertFile(t *testing.T) {
 }
 
 func TestInstanceCertificates(t *testing.T) {
-	certs := new(v1.Secret)
+	certs := new(corev1.Secret)
 	certs.Name = "some-name"
 
 	projections := instanceCertificates(certs)

--- a/internal/patroni/config.go
+++ b/internal/patroni/config.go
@@ -246,9 +246,9 @@ func DynamicConfiguration(
 	postgresql["parameters"] = parameters
 
 	// Copy the "postgresql.pg_hba" section after any mandatory values.
-	hba := make([]string, len(pgHBAs.Mandatory))
+	hba := make([]string, 0, len(pgHBAs.Mandatory))
 	for i := range pgHBAs.Mandatory {
-		hba[i] = pgHBAs.Mandatory[i].String()
+		hba = append(hba, pgHBAs.Mandatory[i].String())
 	}
 	if section, ok := postgresql["pg_hba"].([]interface{}); ok {
 		for i := range section {

--- a/internal/patroni/helpers.go
+++ b/internal/patroni/helpers.go
@@ -16,30 +16,30 @@
 package patroni
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func findOrAppendContainer(containers *[]v1.Container, name string) *v1.Container {
+func findOrAppendContainer(containers *[]corev1.Container, name string) *corev1.Container {
 	for i := range *containers {
 		if (*containers)[i].Name == name {
 			return &(*containers)[i]
 		}
 	}
 
-	*containers = append(*containers, v1.Container{Name: name})
+	*containers = append(*containers, corev1.Container{Name: name})
 	return &(*containers)[len(*containers)-1]
 }
 
-func mergeEnvVars(from []v1.EnvVar, vars ...v1.EnvVar) []v1.EnvVar {
+func mergeEnvVars(from []corev1.EnvVar, vars ...corev1.EnvVar) []corev1.EnvVar {
 	names := sets.NewString()
 	for i := range vars {
 		names.Insert(vars[i].Name)
 	}
 
 	// Partition original slice by whether or not the name was passed in.
-	var existing, others []v1.EnvVar
+	var existing, others []corev1.EnvVar
 	for i := range from {
 		if names.Has(from[i].Name) {
 			existing = append(existing, from[i])
@@ -56,14 +56,14 @@ func mergeEnvVars(from []v1.EnvVar, vars ...v1.EnvVar) []v1.EnvVar {
 	return from
 }
 
-func mergeVolumes(from []v1.Volume, vols ...v1.Volume) []v1.Volume {
+func mergeVolumes(from []corev1.Volume, vols ...corev1.Volume) []corev1.Volume {
 	names := sets.NewString()
 	for i := range vols {
 		names.Insert(vols[i].Name)
 	}
 
 	// Partition original slice by whether or not the name was passed in.
-	var existing, others []v1.Volume
+	var existing, others []corev1.Volume
 	for i := range from {
 		if names.Has(from[i].Name) {
 			existing = append(existing, from[i])
@@ -80,14 +80,14 @@ func mergeVolumes(from []v1.Volume, vols ...v1.Volume) []v1.Volume {
 	return from
 }
 
-func mergeVolumeMounts(from []v1.VolumeMount, mounts ...v1.VolumeMount) []v1.VolumeMount {
+func mergeVolumeMounts(from []corev1.VolumeMount, mounts ...corev1.VolumeMount) []corev1.VolumeMount {
 	names := sets.NewString()
 	for i := range mounts {
 		names.Insert(mounts[i].Name)
 	}
 
 	// Partition original slice by whether or not the name was passed in.
-	var existing, others []v1.VolumeMount
+	var existing, others []corev1.VolumeMount
 	for i := range from {
 		if names.Has(from[i].Name) {
 			existing = append(existing, from[i])

--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -85,11 +85,11 @@ func TestPGBackRestConfiguration(t *testing.T) {
 	}
 
 	// the initially created configmap
-	var cmInitial *v1.ConfigMap
+	var cmInitial *corev1.ConfigMap
 	// the returned configmap
-	var cmReturned v1.ConfigMap
+	var cmReturned corev1.ConfigMap
 	// pod spec for testing projected volumes and volume mounts
-	pod := &v1.PodSpec{}
+	pod := &corev1.PodSpec{}
 
 	testInstanceName := "test-instance-abc"
 	testRepoName := "repo-host"
@@ -120,7 +120,7 @@ func TestPGBackRestConfiguration(t *testing.T) {
 
 		t.Run("create pgbackrest configmap", func(t *testing.T) {
 
-			ns := &v1.Namespace{}
+			ns := &corev1.Namespace{}
 			ns.Name = naming.PGBackRestConfig(postgresCluster).Namespace
 			assert.NilError(t, testClient.Create(context.Background(), ns))
 			t.Cleanup(func() { assert.Check(t, testClient.Delete(context.Background(), ns)) })

--- a/internal/pgbackrest/helpers.go
+++ b/internal/pgbackrest/helpers.go
@@ -16,35 +16,35 @@
 package pgbackrest
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // findOrAppendContainer goes through a pod's container list and returns
 // the container, if found, or appends the named container to the list
-func findOrAppendContainer(containers *[]v1.Container, name string) *v1.Container {
+func findOrAppendContainer(containers *[]corev1.Container, name string) *corev1.Container {
 	for i := range *containers {
 		if (*containers)[i].Name == name {
 			return &(*containers)[i]
 		}
 	}
 
-	*containers = append(*containers, v1.Container{Name: name})
+	*containers = append(*containers, corev1.Container{Name: name})
 	return &(*containers)[len(*containers)-1]
 }
 
 // mergeVolumes adds the given volumes to a pod's existing volume
 // list. If a volume with the same name already exists, the new
 // volume replaces it.
-func mergeVolumes(from []v1.Volume, vols ...v1.Volume) []v1.Volume {
+func mergeVolumes(from []corev1.Volume, vols ...corev1.Volume) []corev1.Volume {
 	names := sets.NewString()
 	for i := range vols {
 		names.Insert(vols[i].Name)
 	}
 
 	// Partition original slice by whether or not the name was passed in.
-	var existing, others []v1.Volume
+	var existing, others []corev1.Volume
 	for i := range from {
 		if names.Has(from[i].Name) {
 			existing = append(existing, from[i])
@@ -64,14 +64,14 @@ func mergeVolumes(from []v1.Volume, vols ...v1.Volume) []v1.Volume {
 // mergeVolumeMounts adds the given volumes to a pod's existing volume mount
 // list. If a volume mount with the same name already exists, the new
 // volume mount replaces it.
-func mergeVolumeMounts(from []v1.VolumeMount, mounts ...v1.VolumeMount) []v1.VolumeMount {
+func mergeVolumeMounts(from []corev1.VolumeMount, mounts ...corev1.VolumeMount) []corev1.VolumeMount {
 	names := sets.NewString()
 	for i := range mounts {
 		names.Insert(mounts[i].Name)
 	}
 
 	// Partition original slice by whether or not the name was passed in.
-	var existing, others []v1.VolumeMount
+	var existing, others []corev1.VolumeMount
 	for i := range from {
 		if names.Has(from[i].Name) {
 			existing = append(existing, from[i])

--- a/internal/pgbackrest/helpers_test.go
+++ b/internal/pgbackrest/helpers_test.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	// Google Kubernetes Engine / Google Cloud Platform authentication provider
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -40,7 +40,7 @@ const (
 )
 
 // getCMData returns the 'Data' content from the specified configmap
-func getCMData(cm v1.ConfigMap, key string) string {
+func getCMData(cm corev1.ConfigMap, key string) string {
 
 	return cm.Data[key]
 }

--- a/internal/pgbackrest/helpers_test.go
+++ b/internal/pgbackrest/helpers_test.go
@@ -25,7 +25,6 @@ import (
 
 	// Google Kubernetes Engine / Google Cloud Platform authentication provider
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/yaml"

--- a/internal/pgbackrest/rbac_test.go
+++ b/internal/pgbackrest/rbac_test.go
@@ -19,8 +19,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 	"gotest.tools/v3/assert"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func isUniqueAndSorted(slice []string) bool {

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 	"gotest.tools/v3/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,29 +34,29 @@ func TestAddRepoVolumesToPod(t *testing.T) {
 
 	testsCases := []struct {
 		repos      []v1beta1.PGBackRestRepo
-		containers []v1.Container
+		containers []corev1.Container
 		testMap    map[string]string
 	}{{
 		repos: []v1beta1.PGBackRestRepo{
 			{Name: "repo1", Volume: &v1beta1.RepoPVC{}},
 			{Name: "repo2", Volume: &v1beta1.RepoPVC{}},
 		},
-		containers: []v1.Container{{Name: "database"}, {Name: "pgbackrest"}},
+		containers: []corev1.Container{{Name: "database"}, {Name: "pgbackrest"}},
 		testMap:    map[string]string{},
 	}, {
 		repos: []v1beta1.PGBackRestRepo{
 			{Name: "repo1", Volume: &v1beta1.RepoPVC{}},
 			{Name: "repo2", Volume: &v1beta1.RepoPVC{}},
 		},
-		containers: []v1.Container{{Name: "database"}},
+		containers: []corev1.Container{{Name: "database"}},
 		testMap:    map[string]string{},
 	}, {
 		repos:      []v1beta1.PGBackRestRepo{{Name: "repo1", Volume: &v1beta1.RepoPVC{}}},
-		containers: []v1.Container{{Name: "database"}, {Name: "pgbackrest"}},
+		containers: []corev1.Container{{Name: "database"}, {Name: "pgbackrest"}},
 		testMap:    map[string]string{},
 	}, {
 		repos:      []v1beta1.PGBackRestRepo{{Name: "repo1", Volume: &v1beta1.RepoPVC{}}},
-		containers: []v1.Container{{Name: "database"}},
+		containers: []corev1.Container{{Name: "database"}},
 		testMap:    map[string]string{},
 	},
 		// rerun the same tests, but this time simulate an existing PVC
@@ -65,7 +65,7 @@ func TestAddRepoVolumesToPod(t *testing.T) {
 				{Name: "repo1", Volume: &v1beta1.RepoPVC{}},
 				{Name: "repo2", Volume: &v1beta1.RepoPVC{}},
 			},
-			containers: []v1.Container{{Name: "database"}, {Name: "pgbackrest"}},
+			containers: []corev1.Container{{Name: "database"}, {Name: "pgbackrest"}},
 			testMap: map[string]string{
 				"repo1": "hippo-repo1",
 			},
@@ -74,19 +74,19 @@ func TestAddRepoVolumesToPod(t *testing.T) {
 				{Name: "repo1", Volume: &v1beta1.RepoPVC{}},
 				{Name: "repo2", Volume: &v1beta1.RepoPVC{}},
 			},
-			containers: []v1.Container{{Name: "database"}},
+			containers: []corev1.Container{{Name: "database"}},
 			testMap: map[string]string{
 				"repo1": "hippo-repo1",
 			},
 		}, {
 			repos:      []v1beta1.PGBackRestRepo{{Name: "repo1", Volume: &v1beta1.RepoPVC{}}},
-			containers: []v1.Container{{Name: "database"}, {Name: "pgbackrest"}},
+			containers: []corev1.Container{{Name: "database"}, {Name: "pgbackrest"}},
 			testMap: map[string]string{
 				"repo1": "hippo-repo1",
 			},
 		}, {
 			repos:      []v1beta1.PGBackRestRepo{{Name: "repo1", Volume: &v1beta1.RepoPVC{}}},
-			containers: []v1.Container{{Name: "database"}},
+			containers: []corev1.Container{{Name: "database"}},
 			testMap: map[string]string{
 				"repo1": "hippo-repo1",
 			},
@@ -95,8 +95,8 @@ func TestAddRepoVolumesToPod(t *testing.T) {
 	for _, tc := range testsCases {
 		t.Run(fmt.Sprintf("repos=%d, containers=%d", len(tc.repos), len(tc.containers)), func(t *testing.T) {
 			postgresCluster.Spec.Backups.PGBackRest.Repos = tc.repos
-			template := &v1.PodTemplateSpec{
-				Spec: v1.PodSpec{
+			template := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
 					Containers: tc.containers,
 				},
 			}
@@ -140,35 +140,35 @@ func TestAddConfigsToPod(t *testing.T) {
 	postgresCluster := &v1beta1.PostgresCluster{ObjectMeta: metav1.ObjectMeta{Name: "hippo"}}
 
 	testCases := []struct {
-		configs    []v1.VolumeProjection
-		containers []v1.Container
+		configs    []corev1.VolumeProjection
+		containers []corev1.Container
 	}{{
-		configs: []v1.VolumeProjection{
-			{ConfigMap: &v1.ConfigMapProjection{
-				LocalObjectReference: v1.LocalObjectReference{Name: "cust-config.conf"}}},
-			{Secret: &v1.SecretProjection{
-				LocalObjectReference: v1.LocalObjectReference{Name: "cust-secret.conf"}}}},
-		containers: []v1.Container{{Name: "database"}, {Name: "pgbackrest"}},
+		configs: []corev1.VolumeProjection{
+			{ConfigMap: &corev1.ConfigMapProjection{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "cust-config.conf"}}},
+			{Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "cust-secret.conf"}}}},
+		containers: []corev1.Container{{Name: "database"}, {Name: "pgbackrest"}},
 	}, {
-		configs: []v1.VolumeProjection{
-			{ConfigMap: &v1.ConfigMapProjection{
-				LocalObjectReference: v1.LocalObjectReference{Name: "cust-config.conf"}}},
-			{Secret: &v1.SecretProjection{
-				LocalObjectReference: v1.LocalObjectReference{Name: "cust-secret.conf"}}}},
-		containers: []v1.Container{{Name: "pgbackrest"}},
+		configs: []corev1.VolumeProjection{
+			{ConfigMap: &corev1.ConfigMapProjection{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "cust-config.conf"}}},
+			{Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "cust-secret.conf"}}}},
+		containers: []corev1.Container{{Name: "pgbackrest"}},
 	}, {
-		configs:    []v1.VolumeProjection{},
-		containers: []v1.Container{{Name: "database"}, {Name: "pgbackrest"}},
+		configs:    []corev1.VolumeProjection{},
+		containers: []corev1.Container{{Name: "database"}, {Name: "pgbackrest"}},
 	}, {
-		configs:    []v1.VolumeProjection{},
-		containers: []v1.Container{{Name: "pgbackrest"}},
+		configs:    []corev1.VolumeProjection{},
+		containers: []corev1.Container{{Name: "pgbackrest"}},
 	}}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("configs=%d, containers=%d", len(tc.configs), len(tc.containers)), func(t *testing.T) {
 			postgresCluster.Spec.Backups.PGBackRest.Configuration = tc.configs
-			template := &v1.PodTemplateSpec{
-				Spec: v1.PodSpec{
+			template := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
 					Containers: tc.containers,
 				},
 			}
@@ -178,7 +178,7 @@ func TestAddConfigsToPod(t *testing.T) {
 			assert.NilError(t, err)
 
 			// check that the backrest config volume exists
-			var configVol *v1.Volume
+			var configVol *corev1.Volume
 			var foundConfigVol bool
 			for i, v := range template.Spec.Volumes {
 				if v.Name == ConfigVol {
@@ -238,32 +238,32 @@ func TestAddSSHToPod(t *testing.T) {
 			Name: "hippo",
 		},
 		Spec: v1beta1.PostgresClusterSpec{
-			ImagePullPolicy: v1.PullAlways,
+			ImagePullPolicy: corev1.PullAlways,
 			Backups: v1beta1.Backups{
 				PGBackRest: v1beta1.PGBackRestArchive{},
 			},
 		},
 	}
 
-	resources := v1.ResourceRequirements{
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("250m"),
-			v1.ResourceMemory: resource.MustParse("128Mi"),
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
 		},
 	}
 
 	testCases := []struct {
-		sshConfig               *v1.ConfigMapProjection
-		sshSecret               *v1.SecretProjection
-		additionalSSHContainers []v1.Container
+		sshConfig               *corev1.ConfigMapProjection
+		sshSecret               *corev1.SecretProjection
+		additionalSSHContainers []corev1.Container
 	}{{
-		sshConfig: &v1.ConfigMapProjection{
-			LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-config.conf"}},
-		sshSecret: &v1.SecretProjection{
-			LocalObjectReference: v1.LocalObjectReference{Name: "cust-ssh-secret.conf"}},
-		additionalSSHContainers: []v1.Container{{Name: "database"}},
+		sshConfig: &corev1.ConfigMapProjection{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "cust-ssh-config.conf"}},
+		sshSecret: &corev1.SecretProjection{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "cust-ssh-secret.conf"}},
+		additionalSSHContainers: []corev1.Container{{Name: "database"}},
 	}, {
-		additionalSSHContainers: []v1.Container{{Name: "database"}},
+		additionalSSHContainers: []corev1.Container{{Name: "database"}},
 	}}
 
 	for _, tc := range testCases {
@@ -285,8 +285,8 @@ func TestAddSSHToPod(t *testing.T) {
 
 		t.Run(testRunStr, func(t *testing.T) {
 
-			template := &v1.PodTemplateSpec{
-				Spec: v1.PodSpec{
+			template := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
 					Containers: tc.additionalSSHContainers,
 				},
 			}
@@ -297,7 +297,7 @@ func TestAddSSHToPod(t *testing.T) {
 
 			// verify the ssh volume
 			var foundSSHVolume bool
-			var sshVolume v1.Volume
+			var sshVolume corev1.Volume
 			for _, v := range template.Spec.Volumes {
 				if v.Name == naming.PGBackRestSSHVolume {
 					foundSSHVolume = true
@@ -335,7 +335,7 @@ func TestAddSSHToPod(t *testing.T) {
 					foundSSHContainer = true
 					// verify proper resources are present and correct
 					assert.DeepEqual(t, c.Resources, resources)
-					assert.Equal(t, c.ImagePullPolicy, v1.PullAlways)
+					assert.Equal(t, c.ImagePullPolicy, corev1.PullAlways)
 				}
 				var foundVolumeMount bool
 				for _, vm := range c.VolumeMounts {
@@ -352,7 +352,7 @@ func TestAddSSHToPod(t *testing.T) {
 	}
 }
 
-func getContainerNames(containers []v1.Container) []string {
+func getContainerNames(containers []corev1.Container) []string {
 	names := make([]string, len(containers))
 	for i, c := range containers {
 		names[i] = c.Name

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -19,13 +19,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/crunchydata/postgres-operator/internal/naming"
-	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func TestAddRepoVolumesToPod(t *testing.T) {

--- a/internal/pgbackrest/ssh_config.go
+++ b/internal/pgbackrest/ssh_config.go
@@ -22,13 +22,14 @@ import (
 	"crypto/rand"
 	"fmt"
 
+	"golang.org/x/crypto/ssh"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/pki"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
-	"golang.org/x/crypto/ssh"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/internal/pgbackrest/ssh_config_test.go
+++ b/internal/pgbackrest/ssh_config_test.go
@@ -29,7 +29,7 @@ import (
 
 	"golang.org/x/crypto/ssh"
 	"gotest.tools/v3/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,15 +83,15 @@ func TestSSHDConfiguration(t *testing.T) {
 	}
 
 	// the initially created configmap
-	var sshCMInitial v1.ConfigMap
+	var sshCMInitial corev1.ConfigMap
 	// the returned configmap
-	var sshCMReturned v1.ConfigMap
+	var sshCMReturned corev1.ConfigMap
 	// pod spec for testing projected volumes and volume mounts
-	pod := &v1.PodSpec{}
+	pod := &corev1.PodSpec{}
 	// initially created secret
-	var secretInitial v1.Secret
+	var secretInitial corev1.Secret
 	// returned secret
-	var secretReturned v1.Secret
+	var secretReturned corev1.Secret
 
 	t.Run("ssh configmap and secret checks", func(t *testing.T) {
 
@@ -103,7 +103,7 @@ func TestSSHDConfiguration(t *testing.T) {
 			teardownTestEnv(t, testEnv)
 		})
 
-		ns := &v1.Namespace{}
+		ns := &corev1.Namespace{}
 		ns.Name = naming.PGBackRestConfig(postgresCluster).Namespace
 		assert.NilError(t, testClient.Create(context.Background(), ns))
 		t.Cleanup(func() { assert.Check(t, testClient.Delete(context.Background(), ns)) })

--- a/internal/pgbackrest/ssh_config_test.go
+++ b/internal/pgbackrest/ssh_config_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-
 	"reflect"
 	"strings"
 	"testing"

--- a/internal/pgbackrest/util.go
+++ b/internal/pgbackrest/util.go
@@ -20,9 +20,10 @@ import (
 	"hash/fnv"
 	"io"
 
-	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 // maxPGBackrestRepos is the maximum number of repositories that can be configured according to the

--- a/internal/pgbackrest/util_test.go
+++ b/internal/pgbackrest/util_test.go
@@ -21,9 +21,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func TestCalculateConfigHashes(t *testing.T) {

--- a/internal/pgmonitor/postgres_test.go
+++ b/internal/pgmonitor/postgres_test.go
@@ -19,9 +19,10 @@ import (
 	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/crunchydata/postgres-operator/internal/postgres"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
-	"gotest.tools/v3/assert"
 )
 
 func TestPostgreSQLHBA(t *testing.T) {

--- a/internal/pgmonitor/util_test.go
+++ b/internal/pgmonitor/util_test.go
@@ -18,8 +18,9 @@ package pgmonitor
 import (
 	"testing"
 
-	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 	"gotest.tools/v3/assert"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func TestExporterEnabled(t *testing.T) {

--- a/internal/postgres/password/md5.go
+++ b/internal/postgres/password/md5.go
@@ -16,6 +16,7 @@ package password
 */
 
 import (
+
 	// #nosec G501
 	"crypto/md5"
 	"errors"


### PR DESCRIPTION
The following changes fix linter errors and warnings that appear for golangci-lint version v1.42.1.

**Other information**:
