### PR TITLE
Default scheduling constraints for HA

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -3358,6 +3358,12 @@ spec:
                 - key
                 - name
                 type: object
+              disableDefaultPodScheduling:
+                description: Whether or not the PostgreSQL cluster should use the
+                  defined default scheduling constraints. If the field is unset or
+                  false, the default scheduling constraints will be used in addition
+                  to any custom constraints provided.
+                type: boolean
               image:
                 description: The image name to use for PostgreSQL containers. When
                   omitted, the value comes from an operator environment variable.

--- a/docs/content/architecture/scheduling.md
+++ b/docs/content/architecture/scheduling.md
@@ -1,0 +1,123 @@
+---
+title: "Scheduling"
+date:
+draft: false
+weight: 120
+---
+
+Deploying to your Kubernetes cluster may allow for greater reliability than other 
+environments, but that's only the case when it's configured correctly. Fortunately,
+PGO, the Postgres Operator from Crunchy Data, is ready to help with helpful 
+default settings to ensure you make the most out of your Kubernetes environment!
+
+## High Availability By Default
+
+As shown in the [high availability tutorial]({{< relref "tutorial/high-availability.md" >}}#pod-topology-spread-constraints),
+PGO supports the use of [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
+to customize your Pod deployment strategy, but useful defaults are already in place
+for you without any additional configuration required!
+
+PGO's default scheduling constraints for HA is implemented for the various Pods
+ comprising a PostgreSQL cluster, specifically to ensure the Operator always 
+ deploys a High-Availability cluster architecture by default.
+    
+ Using Pod Topology Spread Constraints, the general scheduling guidelines are as 
+ follows:
+    
+- Pods are only considered from the same cluster.
+- PgBouncer pods are only considered amongst other PgBouncer pods.
+- Postgres pods are considered amongst all Postgres pods and pgBackRest repo host Pods.
+- pgBackRest repo host Pods are considered amongst all Postgres pods and pgBackRest repo hosts Pods.
+- Pods are scheduled across the different `kubernetes.io/hostname` and `topology.kubernetes.io/zone` failure domains.
+- Pods are scheduled when there are fewer nodes than pods, e.g. single node.
+
+With the above configuration, your data is distributed as widely as possible 
+throughout your Kubernetes cluster to maximize safety.
+
+## Customization
+
+While the default scheduling settings are designed to meet the widest variety of
+environments, they can be customized or removed as needed. Assuming a PostgresCluster
+named 'hippo', the default Pod Topology Spread Constraints applied on Postgres
+Instance and pgBackRest Repo Host Pods are as follows:
+
+```
+    topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchExpressions:
+        - key: postgres-operator.crunchydata.com/cluster
+          operator: In
+          values:
+          - hippo
+        - key: postgres-operator.crunchydata.com/data
+          operator: In
+          values:
+          - postgres
+          - pgbackrest
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchExpressions:
+        - key: postgres-operator.crunchydata.com/cluster
+          operator: In
+          values:
+          - hippo
+        - key: postgres-operator.crunchydata.com/data
+          operator: In
+          values:
+          - postgres
+          - pgbackrest
+```
+
+Similarly, for pgBouncer Pods they will be:
+
+```
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchExpressions:
+      - key: postgres-operator.crunchydata.com/cluster
+        operator: In
+        values:
+        - hippo
+      - key: postgres-operator.crunchydata.com/role
+        operator: In
+        values:
+        - pgbouncer
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchExpressions:
+      - key: postgres-operator.crunchydata.com/cluster
+        operator: In
+        values:
+        - hippo
+      - key: postgres-operator.crunchydata.com/role
+        operator: In
+        values:
+        - pgbouncer
+```
+
+Which, as described in the [API documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods),
+means that there should be a maximum of one Pod difference within the 
+`kubernetes.io/hostname` and `topology.kubernetes.io/zone` failure domains when
+considering either `data` Pods, i.e. Postgres Instance or pgBackRest repo host Pods
+from a single PostgresCluster or when considering pgBouncer Pods from a single 
+PostgresCluster. 
+
+Any other scheduling configuration settings, such as [Affinity, Anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity),
+[Taints, Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/),
+or other [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
+will be added in addition to these defaults. Care should be taken to ensure the
+combined effect of these settings are appropriate for your Kubernetes cluster.
+
+In cases where these defaults are not desired, PGO does provide a method to disable
+the default Pod scheduling by setting the `spec.disableDefaultPodScheduling` to 
+'true'.

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -120,6 +120,11 @@ PostgresClusterSpec defines the desired state of PostgresCluster
         <td>DatabaseInitSQL defines a ConfigMap containing custom SQL that will be run after the cluster is initialized. This ConfigMap must be in the same namespace as the cluster.</td>
         <td>false</td>
       </tr><tr>
+        <td><b>disableDefaultPodScheduling</b></td>
+        <td>boolean</td>
+        <td>Whether or not the PostgreSQL cluster should use the defined default scheduling constraints. If the field is unset or false, the default scheduling constraints will be used in addition to any custom constraints provided.</td>
+        <td>false</td>
+      </tr><tr>
         <td><b>image</b></td>
         <td>string</td>
         <td>The image name to use for PostgreSQL containers. When omitted, the value comes from an operator environment variable. For standard PostgreSQL images, the format is RELATED_IMAGE_POSTGRES_{postgresVersion}, e.g. RELATED_IMAGE_POSTGRES_13. For PostGIS enabled PostgreSQL images, the format is RELATED_IMAGE_POSTGRES_{postgresVersion}_GIS_{postGISVersion}, e.g. RELATED_IMAGE_POSTGRES_13_GIS_3.1.</td>

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1143,6 +1143,7 @@ func generateInstanceStatefulSetIntent(_ context.Context,
 			naming.LabelCluster:     cluster.Name,
 			naming.LabelInstanceSet: spec.Name,
 			naming.LabelInstance:    sts.Name,
+			naming.LabelData:        naming.DataPostgres,
 		})
 
 	// Don't clutter the namespace with extra ControllerRevisions.
@@ -1166,6 +1167,36 @@ func generateInstanceStatefulSetIntent(_ context.Context,
 	sts.Spec.Template.Spec.TopologySpreadConstraints = spec.TopologySpreadConstraints
 	if spec.PriorityClassName != nil {
 		sts.Spec.Template.Spec.PriorityClassName = *spec.PriorityClassName
+	}
+
+	// if default pod scheduling is not explicitly disabled, add the default
+	// pod topology spread constraints
+	if cluster.Spec.DisableDefaultPodScheduling == nil ||
+		(cluster.Spec.DisableDefaultPodScheduling != nil &&
+			!*cluster.Spec.DisableDefaultPodScheduling) {
+		sts.Spec.Template.Spec.TopologySpreadConstraints = append(sts.Spec.Template.Spec.TopologySpreadConstraints,
+			corev1.TopologySpreadConstraint{
+				MaxSkew:           int32(1),
+				TopologyKey:       "kubernetes.io/hostname",
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: naming.LabelCluster, Operator: "In", Values: []string{cluster.Name}},
+						{Key: naming.LabelData, Operator: "In", Values: []string{naming.DataPostgres, naming.DataPGBackRest}},
+					},
+				},
+			},
+			corev1.TopologySpreadConstraint{
+				MaxSkew:           int32(1),
+				TopologyKey:       "topology.kubernetes.io/zone",
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: naming.LabelCluster, Operator: "In", Values: []string{cluster.Name}},
+						{Key: naming.LabelData, Operator: "In", Values: []string{naming.DataPostgres, naming.DataPGBackRest}},
+					},
+				},
+			})
 	}
 
 	// Though we use a StatefulSet to keep an instance running, we only ever

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -498,7 +498,9 @@ func (r *Reconciler) generateRepoHostIntent(postgresCluster *v1beta1.PostgresClu
 		postgresCluster.Spec.Metadata.GetLabelsOrNil(),
 		postgresCluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
 		naming.PGBackRestDedicatedLabels(postgresCluster.GetName()),
-	)
+		map[string]string{
+			naming.LabelData: naming.DataPGBackRest,
+		})
 
 	repo := &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
@@ -532,6 +534,36 @@ func (r *Reconciler) generateRepoHostIntent(postgresCluster *v1beta1.PostgresClu
 		if repoHost.PriorityClassName != nil {
 			repo.Spec.Template.Spec.PriorityClassName = *repoHost.PriorityClassName
 		}
+	}
+
+	// if default pod scheduling is not explicitly disabled, add the default
+	// pod topology spread constraints
+	if postgresCluster.Spec.DisableDefaultPodScheduling == nil ||
+		(postgresCluster.Spec.DisableDefaultPodScheduling != nil &&
+			!*postgresCluster.Spec.DisableDefaultPodScheduling) {
+		repo.Spec.Template.Spec.TopologySpreadConstraints = append(repo.Spec.Template.Spec.TopologySpreadConstraints,
+			corev1.TopologySpreadConstraint{
+				MaxSkew:           int32(1),
+				TopologyKey:       "kubernetes.io/hostname",
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: naming.LabelCluster, Operator: "In", Values: []string{postgresCluster.Name}},
+						{Key: naming.LabelData, Operator: "In", Values: []string{naming.DataPostgres, naming.DataPGBackRest}},
+					},
+				},
+			},
+			corev1.TopologySpreadConstraint{
+				MaxSkew:           int32(1),
+				TopologyKey:       "topology.kubernetes.io/zone",
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: naming.LabelCluster, Operator: "In", Values: []string{postgresCluster.Name}},
+						{Key: naming.LabelData, Operator: "In", Values: []string{naming.DataPostgres, naming.DataPGBackRest}},
+					},
+				},
+			})
 	}
 
 	// Set the image pull secrets, if any exist.

--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -461,6 +461,7 @@ func (r *Reconciler) reconcilePostgresDataVolume(
 		naming.LabelInstanceSet: instanceSpec.Name,
 		naming.LabelInstance:    instance.Name,
 		naming.LabelRole:        naming.RolePostgresData,
+		naming.LabelData:        naming.DataPostgres,
 	}
 
 	var pvc *v1.PersistentVolumeClaim
@@ -517,6 +518,7 @@ func (r *Reconciler) reconcilePostgresWALVolume(
 		naming.LabelInstanceSet: instanceSpec.Name,
 		naming.LabelInstance:    instance.Name,
 		naming.LabelRole:        naming.RolePostgresWAL,
+		naming.LabelData:        naming.DataPostgres,
 	}
 
 	var pvc *v1.PersistentVolumeClaim

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -857,6 +857,7 @@ func TestReconcileConfigureExistingPVCs(t *testing.T) {
 		// expected volume labels, plus the original label
 		expected := map[string]string{
 			naming.LabelCluster:              cluster.Name,
+			naming.LabelData:                 naming.DataPGBackRest,
 			naming.LabelPGBackRest:           "",
 			naming.LabelPGBackRestRepo:       "repo1",
 			naming.LabelPGBackRestRepoVolume: "",

--- a/internal/naming/labels.go
+++ b/internal/naming/labels.go
@@ -36,6 +36,9 @@ const (
 	// LabelClusterCertificate is used to identify a secret containing a cluster certificate
 	LabelClusterCertificate = labelPrefix + "cluster-certificate"
 
+	// LabelData is used to identify Pods and Volumes store Postgres data.
+	LabelData = labelPrefix + "data"
+
 	// LabelMoveJob is used to identify a directory move Job.
 	LabelMoveJob = labelPrefix + "move-job"
 
@@ -113,6 +116,14 @@ const (
 
 	// RoleMonitoring is the LabelRole applied to Monitoring resources
 	RoleMonitoring = "monitoring"
+)
+
+const (
+	// DataPostgres is a LabelData value that indicates the object has PostgreSQL data.
+	DataPostgres = "postgres"
+
+	// DataPGBackRest is a LabelData value that indicates the object has pgBackRest data.
+	DataPGBackRest = "pgbackrest"
 )
 
 // BackupJobType represents different types of backups (e.g. ad-hoc backups, scheduled backups,
@@ -259,6 +270,7 @@ func PGBackRestRepoVolumeLabels(clusterName, repoName string) labels.Set {
 	repoLabels := PGBackRestRepoLabels(clusterName, repoName)
 	repoVolLabels := map[string]string{
 		LabelPGBackRestRepoVolume: "",
+		LabelData:                 DataPGBackRest,
 	}
 	return labels.Merge(repoLabels, repoVolLabels)
 }

--- a/internal/naming/labels_test.go
+++ b/internal/naming/labels_test.go
@@ -25,6 +25,7 @@ import (
 
 func TestLabelsValid(t *testing.T) {
 	assert.Assert(t, nil == validation.IsQualifiedName(LabelCluster))
+	assert.Assert(t, nil == validation.IsQualifiedName(LabelData))
 	assert.Assert(t, nil == validation.IsQualifiedName(LabelInstance))
 	assert.Assert(t, nil == validation.IsQualifiedName(LabelInstanceSet))
 	assert.Assert(t, nil == validation.IsQualifiedName(LabelMoveJob))

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -61,6 +61,12 @@ type PostgresClusterSpec struct {
 	// namespace as the cluster.
 	// +optional
 	DatabaseInitSQL *DatabaseInitSQL `json:"databaseInitSQL,omitempty"`
+	// Whether or not the PostgreSQL cluster should use the defined default
+	// scheduling constraints. If the field is unset or false, the default
+	// scheduling constraints will be used in addition to any custom constraints
+	// provided.
+	// +optional
+	DisableDefaultPodScheduling *bool `json:"disableDefaultPodScheduling,omitempty"`
 
 	// The image name to use for PostgreSQL containers. When omitted, the value
 	// comes from an operator environment variable. For standard PostgreSQL images,

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
@@ -934,6 +934,11 @@ func (in *PostgresClusterSpec) DeepCopyInto(out *PostgresClusterSpec) {
 		*out = new(DatabaseInitSQL)
 		**out = **in
 	}
+	if in.DisableDefaultPodScheduling != nil {
+		in, out := &in.DisableDefaultPodScheduling, &out.DisableDefaultPodScheduling
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ImagePullSecrets != nil {
 		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
 		*out = make([]v1.LocalObjectReference, len(*in))


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the new behavior (if this is a feature change)?**
This commit implements default constraints for the various Pods comprising a
PostgreSQL cluster, specifically as needed to ensure the Operator always
attempts to deploy High-Availability cluster architecture by default.

Using Pod Topology Spread Constraints, the general scheduling guidelines are
as follows:

- Pods are only considered from the same cluster.
- PgBouncer pods are only considered amongst other PgBouncer pods.
- Postgres pods are considered amongst all Postgres pods and pgBackRest repo
    host Pods.
- pgBackRest repo host Pods are considered amongst all Postgres pods and
    pgBackRest repo hosts Pods.
- Pods are scheduled across the different kubernetes.io/hostname and
    topology.kubernetes.io/zone failure domains.
- Pods are scheduled when there are fewer nodes than pods, e.g. single node.

We apply default pod topology spread constraints per the rules above when the
new spec.disableDefaultPodScheduling field is not specified at all, or is set
to false. By default it will be set to false.


**Other information**:
Issue: [sc-11183]