### PR TITLE
Move default spread constraints into function

### DIFF
--- a/docs/content/architecture/scheduling.md
+++ b/docs/content/architecture/scheduling.md
@@ -42,35 +42,31 @@ named 'hippo', the default Pod Topology Spread Constraints applied on Postgres
 Instance and pgBackRest Repo Host Pods are as follows:
 
 ```
-    topologySpreadConstraints:
-    - maxSkew: 1
-      topologyKey: kubernetes.io/hostname
-      whenUnsatisfiable: ScheduleAnyway
-      labelSelector:
-        matchExpressions:
-        - key: postgres-operator.crunchydata.com/cluster
-          operator: In
-          values:
-          - hippo
-        - key: postgres-operator.crunchydata.com/data
-          operator: In
-          values:
-          - postgres
-          - pgbackrest
-    - maxSkew: 1
-      topologyKey: topology.kubernetes.io/zone
-      whenUnsatisfiable: ScheduleAnyway
-      labelSelector:
-        matchExpressions:
-        - key: postgres-operator.crunchydata.com/cluster
-          operator: In
-          values:
-          - hippo
-        - key: postgres-operator.crunchydata.com/data
-          operator: In
-          values:
-          - postgres
-          - pgbackrest
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        postgres-operator.crunchydata.com/cluster: hippo
+      matchExpressions:
+      - key: postgres-operator.crunchydata.com/data
+        operator: In
+        values:
+        - postgres
+        - pgbackrest
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        postgres-operator.crunchydata.com/cluster: hippo
+      matchExpressions:
+      - key: postgres-operator.crunchydata.com/data
+        operator: In
+        values:
+        - postgres
+        - pgbackrest
 ```
 
 Similarly, for pgBouncer Pods they will be:
@@ -81,28 +77,16 @@ topologySpreadConstraints:
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
     labelSelector:
-      matchExpressions:
-      - key: postgres-operator.crunchydata.com/cluster
-        operator: In
-        values:
-        - hippo
-      - key: postgres-operator.crunchydata.com/role
-        operator: In
-        values:
-        - pgbouncer
+      matchLabels:
+        postgres-operator.crunchydata.com/cluster: hippo
+        postgres-operator.crunchydata.com/role: pgbouncer
   - maxSkew: 1
     topologyKey: topology.kubernetes.io/zone
     whenUnsatisfiable: ScheduleAnyway
     labelSelector:
-      matchExpressions:
-      - key: postgres-operator.crunchydata.com/cluster
-        operator: In
-        values:
-        - hippo
-      - key: postgres-operator.crunchydata.com/role
-        operator: In
-        values:
-        - pgbouncer
+      matchLabels:
+        postgres-operator.crunchydata.com/cluster: hippo
+        postgres-operator.crunchydata.com/role: pgbouncer
 ```
 
 Which, as described in the [API documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods),

--- a/internal/controller/postgrescluster/helpers_test.go
+++ b/internal/controller/postgrescluster/helpers_test.go
@@ -1,5 +1,3 @@
-// +build envtest
-
 /*
  Copyright 2021 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +35,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/crunchydata/postgres-operator/internal/controller/runtime"
+	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -101,7 +100,7 @@ func testCluster() *v1beta1.PostgresCluster {
 			},
 			InstanceSets: []v1beta1.PostgresInstanceSetSpec{{
 				Name:                "instance1",
-				Replicas:            Int32(1),
+				Replicas:            initialize.Int32(1),
 				DataVolumeClaimSpec: testVolumeClaimSpec(),
 			}},
 			Backups: v1beta1.Backups{

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1165,29 +1165,11 @@ func generateInstanceStatefulSetIntent(_ context.Context,
 	if cluster.Spec.DisableDefaultPodScheduling == nil ||
 		(cluster.Spec.DisableDefaultPodScheduling != nil &&
 			!*cluster.Spec.DisableDefaultPodScheduling) {
-		sts.Spec.Template.Spec.TopologySpreadConstraints = append(sts.Spec.Template.Spec.TopologySpreadConstraints,
-			corev1.TopologySpreadConstraint{
-				MaxSkew:           int32(1),
-				TopologyKey:       "kubernetes.io/hostname",
-				WhenUnsatisfiable: corev1.ScheduleAnyway,
-				LabelSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{Key: naming.LabelCluster, Operator: "In", Values: []string{cluster.Name}},
-						{Key: naming.LabelData, Operator: "In", Values: []string{naming.DataPostgres, naming.DataPGBackRest}},
-					},
-				},
-			},
-			corev1.TopologySpreadConstraint{
-				MaxSkew:           int32(1),
-				TopologyKey:       "topology.kubernetes.io/zone",
-				WhenUnsatisfiable: corev1.ScheduleAnyway,
-				LabelSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{Key: naming.LabelCluster, Operator: "In", Values: []string{cluster.Name}},
-						{Key: naming.LabelData, Operator: "In", Values: []string{naming.DataPostgres, naming.DataPGBackRest}},
-					},
-				},
-			})
+		sts.Spec.Template.Spec.TopologySpreadConstraints = append(
+			sts.Spec.Template.Spec.TopologySpreadConstraints,
+			defaultTopologySpreadConstraints(
+				naming.ClusterDataForPostgresAndPGBackRest(cluster.Name),
+			)...)
 	}
 
 	// Though we use a StatefulSet to keep an instance running, we only ever

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -1212,36 +1212,32 @@ func TestGenerateInstanceStatefulSetIntent(t *testing.T) {
 		name: "check default scheduling constraints are added",
 		run: func(t *testing.T, ss *appsv1.StatefulSet) {
 			assert.Equal(t, len(ss.Spec.Template.Spec.TopologySpreadConstraints), 2)
-			assert.Assert(t, marshalMatches(ss.Spec.Template.Spec.TopologySpreadConstraints,
-				`- labelSelector:
+			assert.Assert(t, marshalMatches(ss.Spec.Template.Spec.TopologySpreadConstraints, `
+- labelSelector:
     matchExpressions:
-    - key: postgres-operator.crunchydata.com/cluster
-      operator: In
-      values:
-      - hippo
     - key: postgres-operator.crunchydata.com/data
       operator: In
       values:
       - postgres
       - pgbackrest
+    matchLabels:
+      postgres-operator.crunchydata.com/cluster: hippo
   maxSkew: 1
   topologyKey: kubernetes.io/hostname
   whenUnsatisfiable: ScheduleAnyway
 - labelSelector:
     matchExpressions:
-    - key: postgres-operator.crunchydata.com/cluster
-      operator: In
-      values:
-      - hippo
     - key: postgres-operator.crunchydata.com/data
       operator: In
       values:
       - postgres
       - pgbackrest
+    matchLabels:
+      postgres-operator.crunchydata.com/cluster: hippo
   maxSkew: 1
   topologyKey: topology.kubernetes.io/zone
   whenUnsatisfiable: ScheduleAnyway
-`))
+			`))
 		},
 	}, {
 		name: "check default scheduling constraints are appended to existing",
@@ -1263,8 +1259,8 @@ func TestGenerateInstanceStatefulSetIntent(t *testing.T) {
 		},
 		run: func(t *testing.T, ss *appsv1.StatefulSet) {
 			assert.Equal(t, len(ss.Spec.Template.Spec.TopologySpreadConstraints), 3)
-			assert.Assert(t, marshalMatches(ss.Spec.Template.Spec.TopologySpreadConstraints,
-				`- labelSelector:
+			assert.Assert(t, marshalMatches(ss.Spec.Template.Spec.TopologySpreadConstraints, `
+- labelSelector:
     matchExpressions:
     - key: postgres-operator.crunchydata.com/cluster
       operator: In
@@ -1277,33 +1273,29 @@ func TestGenerateInstanceStatefulSetIntent(t *testing.T) {
   whenUnsatisfiable: ScheduleAnyway
 - labelSelector:
     matchExpressions:
-    - key: postgres-operator.crunchydata.com/cluster
-      operator: In
-      values:
-      - hippo
     - key: postgres-operator.crunchydata.com/data
       operator: In
       values:
       - postgres
       - pgbackrest
+    matchLabels:
+      postgres-operator.crunchydata.com/cluster: hippo
   maxSkew: 1
   topologyKey: kubernetes.io/hostname
   whenUnsatisfiable: ScheduleAnyway
 - labelSelector:
     matchExpressions:
-    - key: postgres-operator.crunchydata.com/cluster
-      operator: In
-      values:
-      - hippo
     - key: postgres-operator.crunchydata.com/data
       operator: In
       values:
       - postgres
       - pgbackrest
+    matchLabels:
+      postgres-operator.crunchydata.com/cluster: hippo
   maxSkew: 1
   topologyKey: topology.kubernetes.io/zone
   whenUnsatisfiable: ScheduleAnyway
-`))
+			`))
 		},
 	}, {
 		name: "check defined constraint when defaults disabled",

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -540,29 +540,11 @@ func (r *Reconciler) generateRepoHostIntent(postgresCluster *v1beta1.PostgresClu
 	if postgresCluster.Spec.DisableDefaultPodScheduling == nil ||
 		(postgresCluster.Spec.DisableDefaultPodScheduling != nil &&
 			!*postgresCluster.Spec.DisableDefaultPodScheduling) {
-		repo.Spec.Template.Spec.TopologySpreadConstraints = append(repo.Spec.Template.Spec.TopologySpreadConstraints,
-			corev1.TopologySpreadConstraint{
-				MaxSkew:           int32(1),
-				TopologyKey:       "kubernetes.io/hostname",
-				WhenUnsatisfiable: corev1.ScheduleAnyway,
-				LabelSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{Key: naming.LabelCluster, Operator: "In", Values: []string{postgresCluster.Name}},
-						{Key: naming.LabelData, Operator: "In", Values: []string{naming.DataPostgres, naming.DataPGBackRest}},
-					},
-				},
-			},
-			corev1.TopologySpreadConstraint{
-				MaxSkew:           int32(1),
-				TopologyKey:       "topology.kubernetes.io/zone",
-				WhenUnsatisfiable: corev1.ScheduleAnyway,
-				LabelSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{Key: naming.LabelCluster, Operator: "In", Values: []string{postgresCluster.Name}},
-						{Key: naming.LabelData, Operator: "In", Values: []string{naming.DataPostgres, naming.DataPGBackRest}},
-					},
-				},
-			})
+		repo.Spec.Template.Spec.TopologySpreadConstraints = append(
+			repo.Spec.Template.Spec.TopologySpreadConstraints,
+			defaultTopologySpreadConstraints(
+				naming.ClusterDataForPostgresAndPGBackRest(postgresCluster.Name),
+			)...)
 	}
 
 	// Set the image pull secrets, if any exist.

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -323,8 +323,8 @@ func TestReconcilePGBackRest(t *testing.T) {
 		// TODO(tjmoore4): Add additional tests to test appending existing
 		// topology spread constraints and spec.disableDefaultPodScheduling being
 		// set to true (as done in instance StatefulSet tests).
-		assert.Assert(t, marshalMatches(repo.Spec.Template.Spec.TopologySpreadConstraints,
-			`- labelSelector:
+		assert.Assert(t, marshalMatches(repo.Spec.Template.Spec.TopologySpreadConstraints, `
+- labelSelector:
     matchExpressions:
     - key: postgres-operator.crunchydata.com/cluster
       operator: In
@@ -337,33 +337,29 @@ func TestReconcilePGBackRest(t *testing.T) {
   whenUnsatisfiable: ScheduleAnyway
 - labelSelector:
     matchExpressions:
-    - key: postgres-operator.crunchydata.com/cluster
-      operator: In
-      values:
-      - hippocluster
     - key: postgres-operator.crunchydata.com/data
       operator: In
       values:
       - postgres
       - pgbackrest
+    matchLabels:
+      postgres-operator.crunchydata.com/cluster: hippocluster
   maxSkew: 1
   topologyKey: kubernetes.io/hostname
   whenUnsatisfiable: ScheduleAnyway
 - labelSelector:
     matchExpressions:
-    - key: postgres-operator.crunchydata.com/cluster
-      operator: In
-      values:
-      - hippocluster
     - key: postgres-operator.crunchydata.com/data
       operator: In
       values:
       - postgres
       - pgbackrest
+    matchLabels:
+      postgres-operator.crunchydata.com/cluster: hippocluster
   maxSkew: 1
   topologyKey: topology.kubernetes.io/zone
   whenUnsatisfiable: ScheduleAnyway
-`))
+		`))
 
 		// Ensure pod priority class has been added to dedicated repo
 		if repo.Spec.Template.Spec.PriorityClassName != "some-priority-class" {

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -439,29 +439,9 @@ func (r *Reconciler) reconcilePGBouncerDeployment(
 	if cluster.Spec.DisableDefaultPodScheduling == nil ||
 		(cluster.Spec.DisableDefaultPodScheduling != nil &&
 			!*cluster.Spec.DisableDefaultPodScheduling) {
-		deploy.Spec.Template.Spec.TopologySpreadConstraints = append(deploy.Spec.Template.Spec.TopologySpreadConstraints,
-			corev1.TopologySpreadConstraint{
-				MaxSkew:           int32(1),
-				TopologyKey:       "kubernetes.io/hostname",
-				WhenUnsatisfiable: corev1.ScheduleAnyway,
-				LabelSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{Key: naming.LabelCluster, Operator: "In", Values: []string{cluster.Name}},
-						{Key: naming.LabelRole, Operator: "In", Values: []string{naming.RolePGBouncer}},
-					},
-				},
-			},
-			corev1.TopologySpreadConstraint{
-				MaxSkew:           int32(1),
-				TopologyKey:       "topology.kubernetes.io/zone",
-				WhenUnsatisfiable: corev1.ScheduleAnyway,
-				LabelSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{Key: naming.LabelCluster, Operator: "In", Values: []string{cluster.Name}},
-						{Key: naming.LabelRole, Operator: "In", Values: []string{naming.RolePGBouncer}},
-					},
-				},
-			})
+		deploy.Spec.Template.Spec.TopologySpreadConstraints = append(
+			deploy.Spec.Template.Spec.TopologySpreadConstraints,
+			defaultTopologySpreadConstraints(*deploy.Spec.Selector)...)
 	}
 
 	// Restart containers any time they stop, die, are killed, etc.

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -330,34 +330,22 @@ func TestReconcilePGBouncerDeployment(t *testing.T) {
 		// TODO(tjmoore4): Add additional tests to test appending existing
 		// topology spread constraints and spec.disableDefaultPodScheduling being
 		// set to true (as done in instance StatefulSet tests).
-		assert.Assert(t, marshalMatches(list.Items[0].Spec.Template.Spec.TopologySpreadConstraints,
-			`- labelSelector:
-    matchExpressions:
-    - key: postgres-operator.crunchydata.com/cluster
-      operator: In
-      values:
-      - test-cluster
-    - key: postgres-operator.crunchydata.com/role
-      operator: In
-      values:
-      - pgbouncer
+		assert.Assert(t, marshalMatches(list.Items[0].Spec.Template.Spec.TopologySpreadConstraints, `
+- labelSelector:
+    matchLabels:
+      postgres-operator.crunchydata.com/cluster: test-cluster
+      postgres-operator.crunchydata.com/role: pgbouncer
   maxSkew: 1
   topologyKey: kubernetes.io/hostname
   whenUnsatisfiable: ScheduleAnyway
 - labelSelector:
-    matchExpressions:
-    - key: postgres-operator.crunchydata.com/cluster
-      operator: In
-      values:
-      - test-cluster
-    - key: postgres-operator.crunchydata.com/role
-      operator: In
-      values:
-      - pgbouncer
+    matchLabels:
+      postgres-operator.crunchydata.com/cluster: test-cluster
+      postgres-operator.crunchydata.com/role: pgbouncer
   maxSkew: 1
   topologyKey: topology.kubernetes.io/zone
   whenUnsatisfiable: ScheduleAnyway
-`))
+		`))
 	})
 
 }

--- a/internal/controller/postgrescluster/topology.go
+++ b/internal/controller/postgrescluster/topology.go
@@ -1,0 +1,38 @@
+/*
+ Copyright 2021 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package postgrescluster
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// defaultTopologySpreadConstraints returns constraints that prefer to schedule
+// pods on different nodes and in different zones.
+func defaultTopologySpreadConstraints(selector metav1.LabelSelector) []corev1.TopologySpreadConstraint {
+	return []corev1.TopologySpreadConstraint{
+		{
+			TopologyKey:       corev1.LabelHostname,
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
+			LabelSelector:     &selector, MaxSkew: 1,
+		},
+		{
+			TopologyKey:       corev1.LabelTopologyZone,
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
+			LabelSelector:     &selector, MaxSkew: 1,
+		},
+	}
+}

--- a/internal/controller/postgrescluster/topology_test.go
+++ b/internal/controller/postgrescluster/topology_test.go
@@ -1,0 +1,60 @@
+/*
+ Copyright 2021 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package postgrescluster
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDefaultTopologySpreadConstraints(t *testing.T) {
+	constraints := defaultTopologySpreadConstraints(metav1.LabelSelector{
+		MatchLabels: map[string]string{"basic": "stuff"},
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: "k1", Operator: "op", Values: []string{"v1", "v2"}},
+		},
+	})
+
+	// Entire selector, hostname, zone, and ScheduleAnyway.
+	assert.Assert(t, marshalMatches(constraints, `
+- labelSelector:
+    matchExpressions:
+    - key: k1
+      operator: op
+      values:
+      - v1
+      - v2
+    matchLabels:
+      basic: stuff
+  maxSkew: 1
+  topologyKey: kubernetes.io/hostname
+  whenUnsatisfiable: ScheduleAnyway
+- labelSelector:
+    matchExpressions:
+    - key: k1
+      operator: op
+      values:
+      - v1
+      - v2
+    matchLabels:
+      basic: stuff
+  maxSkew: 1
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: ScheduleAnyway
+	`))
+}

--- a/internal/naming/selectors.go
+++ b/internal/naming/selectors.go
@@ -46,6 +46,21 @@ func Cluster(cluster string) metav1.LabelSelector {
 	}
 }
 
+// ClusterDataForPostgresAndPGBackRest selects things for PostgreSQL data and
+// things for pgBackRest data.
+func ClusterDataForPostgresAndPGBackRest(cluster string) metav1.LabelSelector {
+	return metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			LabelCluster: cluster,
+		},
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      LabelData,
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{DataPostgres, DataPGBackRest},
+		}},
+	}
+}
+
 // ClusterInstance selects things for a single instance in a cluster.
 func ClusterInstance(cluster, instance string) metav1.LabelSelector {
 	return metav1.LabelSelector{

--- a/internal/naming/selectors_test.go
+++ b/internal/naming/selectors_test.go
@@ -43,6 +43,18 @@ func TestCluster(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid")
 }
 
+func TestClusterDataForPostgresAndPGBackRest(t *testing.T) {
+	s, err := AsSelector(ClusterDataForPostgresAndPGBackRest("something"))
+	assert.NilError(t, err)
+	assert.DeepEqual(t, s.String(), strings.Join([]string{
+		"postgres-operator.crunchydata.com/cluster=something",
+		"postgres-operator.crunchydata.com/data in (pgbackrest,postgres)",
+	}, ","))
+
+	_, err = AsSelector(ClusterDataForPostgresAndPGBackRest("--whoa/yikes"))
+	assert.ErrorContains(t, err, "invalid")
+}
+
 func TestClusterInstance(t *testing.T) {
 	s, err := AsSelector(ClusterInstance("daisy", "dog"))
 	assert.NilError(t, err)


### PR DESCRIPTION
This moves the selector for postgres+pgbackrest and the zone+hostname topologies into functions to ensure Postgres and pgBackRest pods change together.

The PgBouncer deployment and topology now use the same selector (object) rather than an equivalent one.