### PR TITLE
Include more SANs in the PostgreSQL TLS certificate

### DIFF
--- a/docs/content/releases/5.0.3.md
+++ b/docs/content/releases/5.0.3.md
@@ -82,6 +82,7 @@ Read more about how you can [get started]({{< relref "quickstart/_index.md" >}})
 
 - A dedicated pgBackRest repository host is now only deployed if a `volume` repository is configured.  This means that deployments that use only cloud-based (`s3`, `gcs`, `azure`) repos will no longer see a dedicated repository host, nor will `SSHD` run in within that Postgres cluster. As a result of this change, the `spec.backups.pgbackrest.repoHost.dedicated` section is removed from the `PostgresCluster` spec, and all settings within it are consolidated under the `spec.backups.pgbackrest.repoHost` section. When upgrading please update the `PostgresCluster` spec to ensure any settings from section `spec.backups.pgbackrest.repoHost.dedicated` are moved into section `spec.backups.pgbackrest.repoHost`.
 - PgBouncer now uses SCRAM when authenticating into Postgres.
+- Generated Postgres certificates include the FQDN and other local names of the primary Postgres service. To regenerate the certificate of an existing cluster, delete the `tls.key` field from its certificate secret.
 
 ## Fixes
 

--- a/internal/controller/postgrescluster/cluster.go
+++ b/internal/controller/postgrescluster/cluster.go
@@ -192,7 +192,7 @@ func (r *Reconciler) generateClusterPrimaryService(
 // to the PostgreSQL primary instance.
 func (r *Reconciler) reconcileClusterPrimaryService(
 	ctx context.Context, cluster *v1beta1.PostgresCluster, leader *corev1.Service,
-) error {
+) (*corev1.Service, error) {
 	service, endpoints, err := r.generateClusterPrimaryService(cluster, leader)
 
 	if err == nil {
@@ -201,7 +201,7 @@ func (r *Reconciler) reconcileClusterPrimaryService(
 	if err == nil {
 		err = errors.WithStack(r.apply(ctx, endpoints))
 	}
-	return err
+	return service, err
 }
 
 // generateClusterReplicaService returns a v1.Service that exposes PostgreSQL

--- a/internal/controller/postgrescluster/cluster_test.go
+++ b/internal/controller/postgrescluster/cluster_test.go
@@ -819,15 +819,15 @@ func TestReconcileClusterPrimaryService(t *testing.T) {
 	cluster.Namespace = ns.Name
 	assert.NilError(t, cc.Create(ctx, cluster))
 
-	assert.ErrorContains(t,
-		reconciler.reconcileClusterPrimaryService(ctx, cluster, nil),
-		"not implemented")
+	_, err := reconciler.reconcileClusterPrimaryService(ctx, cluster, nil)
+	assert.ErrorContains(t, err, "not implemented")
 
 	leader := &corev1.Service{}
 	leader.Spec.ClusterIP = "192.0.2.10"
 
-	assert.NilError(t,
-		reconciler.reconcileClusterPrimaryService(ctx, cluster, leader))
+	service, err := reconciler.reconcileClusterPrimaryService(ctx, cluster, leader)
+	assert.NilError(t, err)
+	assert.Assert(t, service != nil && service.UID != "", "expected created service")
 }
 
 func TestGenerateClusterReplicaServiceIntent(t *testing.T) {

--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -150,6 +150,7 @@ func (r *Reconciler) Reconcile(
 		instances                *observedInstances
 		patroniLeaderService     *corev1.Service
 		primaryCertificate       *corev1.SecretProjection
+		primaryService           *corev1.Service
 		rootCA                   *pki.RootCertificateAuthority
 		monitoringSecret         *corev1.Secret
 		err                      error
@@ -242,13 +243,13 @@ func (r *Reconciler) Reconcile(
 		patroniLeaderService, err = r.reconcilePatroniLeaderLease(ctx, cluster)
 	}
 	if err == nil {
-		err = r.reconcileClusterPrimaryService(ctx, cluster, patroniLeaderService)
+		primaryService, err = r.reconcileClusterPrimaryService(ctx, cluster, patroniLeaderService)
 	}
 	if err == nil {
 		err = r.reconcileClusterReplicaService(ctx, cluster)
 	}
 	if err == nil {
-		primaryCertificate, err = r.reconcileClusterCertificate(ctx, rootCA, cluster)
+		primaryCertificate, err = r.reconcileClusterCertificate(ctx, rootCA, cluster, primaryService)
 	}
 	if err == nil {
 		instanceServiceAccount, err = r.reconcileRBACResources(ctx, cluster)


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)

**What is the current behavior? (link to any open issues here)**

The certificate generated for the PostgreSQL primary contains only a single DNS name.

closes CrunchyData/postgres-operator#2729


**What is the new behavior (if this is a feature change)?**

The FQDN and every possible local (search domain) name is included as SANs in the certificate.


**Other information**:

Issue: [sc-12692]