### PR TITLE
Bump pgMonitor to v4.5

### DIFF
--- a/bin/get-pgmonitor.sh
+++ b/bin/get-pgmonitor.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 echo "Getting pgMonitor..."
-PGMONITOR_COMMIT='v4.5-RC3'
+PGMONITOR_COMMIT='v4.5'
 
 # pgMonitor Setup
 if [[ -d ${PGOROOT?}/tools/pgmonitor ]]

--- a/internal/controller/postgrescluster/pgmonitor_test.go
+++ b/internal/controller/postgrescluster/pgmonitor_test.go
@@ -452,7 +452,7 @@ func TestReconcilePGMonitorExporterStatus(t *testing.T) {
 		podExecCalled:   false,
 		// Status was generated manually for this test case
 		// TODO jmckulk: add code to generate status
-		status:                      v1beta1.MonitoringStatus{ExporterConfiguration: "7dccdb969"},
+		status:                      v1beta1.MonitoringStatus{ExporterConfiguration: "8b589fd65"},
 		statusChangedAfterReconcile: false,
 	}} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature (non-breaking change which adds functionality)

**What is the new behavior (if this is a feature change)?**

The exporter image is built with [pgMonitor v4.5](https://github.com/CrunchyData/pgmonitor/releases/tag/v4.5). Fewer messages are logged when applying the SQL so that errors are more obvious.

**Other Information**:

Issue: [sc-12625]