### PR TITLE
Mention WAL archiving more prominently with backups

### DIFF
--- a/docs/content/architecture/backups.md
+++ b/docs/content/architecture/backups.md
@@ -11,7 +11,7 @@ backups of your database" is automatically "yes!"
 The PostgreSQL Operator uses the open source
 [pgBackRest](https://pgbackrest.org) backup and restore utility that is designed
 for working with databases that are many terabytes in size. As described in the
-[Provisioning](/architecture/provisioning/) section, pgBackRest is enabled by
+[tutorial]({{< relref "/tutorial/backups.md" >}}), pgBackRest is enabled by
 default as it permits the PostgreSQL Operator to automate some advanced as well
 as convenient behaviors, including:
 
@@ -40,26 +40,16 @@ You can store your pgBackRest backups in up to four different locations and usin
 - Google Cloud Storage (GCS)
 - Azure Blob Storage
 
-The pgBackRest repository consists of the following Kubernetes objects:
-
-- A Deployment
-- A Secret that contains information that is specific to the PostgreSQL cluster
-that it is deployed with (e.g. SSH keys, AWS S3 keys, etc.)
-- A Service
-
-The PostgreSQL primary is automatically configured to use the
-`pgbackrest archive-push` and push the write-ahead log (WAL) archives to the
-correct repository.
+PostgreSQL is automatically configured to use the `pgbackrest archive-push` command
+to archive the write-ahead log (WAL) in all repositories.
 
 ## Backups
 
 PGO supports three types of pgBackRest backups:
 
-- Full (`full`): A full backup of all the contents of the PostgreSQL cluster
-- Differential (`diff`): A backup of only the files that have changed since the
-last full backup
-- Incremental (`incr`):  A backup of only the files that have changed since the
-last full or differential backup
+- Full: A full backup of all the contents of the PostgreSQL cluster
+- Differential: A backup of only the files that have changed since the last full backup
+- Incremental: A backup of only the files that have changed since the last full, differential, or incremental backup
 
 ## Scheduling Backups
 
@@ -68,7 +58,8 @@ backups. PGO enables this by managing a series of Kubernetes CronJobs to ensure 
 
 Note that pgBackRest presently only supports taking one backup at a time. This may change in a future release, but for the time being we suggest that you stagger your backup times.
 
-Please see the [backup configuration tutorial]({{< relref "tutorial/backups.md" >}}) for how to set up backup schedules.
+Please see the [backup management tutorial]({{< relref "/tutorial/backup-management.md" >}}) for how to set up backup schedules
+and configure retention policies.
 
 ## Restores
 
@@ -79,11 +70,7 @@ ways to restore a cluster:
 - Restore to a new cluster
 - Restore in-place
 
-For examples for this, please see the [disaster recovery tutorial]({{< relref "tutorial/disaster-recovery.md" >}})
-
-### Setting Backup Retention Policies
-
-Unless specified, pgBackRest will keep an unlimited number of backups. You can specify backup retention using the `repoN-retention-` options. Please see the [backup configuration tutorial]({{< relref "tutorial/backups.md" >}}) for examples.
+For examples of this, please see the [disaster recovery tutorial]({{< relref "/tutorial/disaster-recovery.md" >}})
 
 ## Deleting a Backup
 

--- a/docs/content/tutorial/backup-management.md
+++ b/docs/content/tutorial/backup-management.md
@@ -15,21 +15,25 @@ Now that we have backups set up, lets look at some of the various backup managem
 
 ## Managing Scheduled Backups
 
-PGO sets up your Postgres clusters so that they are continuously archiving: your data is constantly being stored in your backup repository. Effectively, this is a backup!
+PGO sets up your Postgres clusters so that they are continuously archiving the [write-ahead log](https://www.postgresql.org/docs/current/wal-intro.html):
+your data is constantly being stored in your backup repository. Effectively, this is a backup!
 
 However, in a [disaster recovery]({{< relref "./disaster-recovery.md" >}}) scenario, you likely want to get your Postgres cluster back up and running as quickly as possible (e.g. a short "[recovery time objective (RTO)](https://en.wikipedia.org/wiki/Disaster_recovery#Recovery_Time_Objective)"). What helps accomplish this is to take periodic backups. This makes it faster to restore!
 
 [pgBackRest](https://pgbackrest.org/), the backup management tool used by PGO, provides different backup types to help both from a space management and RTO optimization perspective. These backup types include:
 
-- **full** (`full`): A backup of your entire Postgres cluster. This is the largest of all of the backup types.
-- **differential** (`diff`): A backup of all of the data since the last `full` backup.
-- **incremental** (`incr`): A backup of all of the data since the last `full`, `diff`, or `incr` backup.
+- `full`: A backup of your entire Postgres cluster. This is the largest of all of the backup types.
+- `differential`: A backup of all of the data since the last `full` backup.
+- `incremental`: A backup of all of the data since the last `full`, `differential`, or `incremental` backup.
 
 Selecting the appropriate backup strategy for your Postgres cluster is outside the scope of this tutorial, but let's look at how we can set up scheduled backups.
 
-Backup schedules are stored in the `spec.backups.pgbackrest.repos.schedules` section. Each value in this section accepts a [cron-formatted](https://k8s.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax) string that dictates the backup schedule. The available keys are `full`, `differential`, and `incremental` for full, differential, and incremental backups respectively.
+Backup schedules are stored in the `spec.backups.pgbackrest.repos.schedules` section. Each value in this section
+accepts a [cron-formatted](https://docs.k8s.io/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax) string
+that dictates the backup schedule.
 
-Let's say that our backup policy is to take a full backup once a day at 1am and take incremental backups every four hours. We would want to add configuration to our spec that looks similar to:
+Let's say that our backup policy is to take a full backup once a day at 1am and take incremental backups every four hours.
+We would want to add configuration to our spec that looks similar to:
 
 ```
 spec:
@@ -42,20 +46,27 @@ spec:
           incremental: "0 */4 * * *"
 ```
 
-To manage schedule backups, PGO will create several Kubernetes [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) objects that will perform backups on the specified periods. The backups will use the [configuration that you specified]({{< relref "./backups.md" >}}).
+To manage scheduled backups, PGO will create several Kubernetes [CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)
+that will perform backups on the specified periods. The backups will use the [configuration that you specified]({{< relref "./backups.md" >}}).
 
-Ensuring you take regularly scheduled backups is important to maintaining Postgres cluster health. However, you don't need to keep all of your backups: this could cause you to run out of space! As such, it's also important to set a backup retention policy.
+Ensuring you take regularly scheduled backups is important to maintaining Postgres cluster health.
+However, you don't need to keep all of your backups: this could cause you to run out of space!
+As such, it's also important to set a backup retention policy.
 
 ## Managing Backup Retention
 
-PGO lets you set backup retention on full and differential backups. When a backup expires, either through your retention policy or through manual expiration, pgBackRest will clean up any backup associated with it. For example, if you have a full backup with four incremental backups associated with it, when the full backup expires, all of its incremental backups also expire.
+PGO lets you set backup retention on full and differential backups. When a full backup expires,
+either through your retention policy or through manual expiration, pgBackRest will clean up any
+backup and WAL files associated with it. For example, if you have a full backup with four associated
+incremental backups, when the full backup expires, all of its incremental backups also expire.
 
 There are two different types of backup retention you can set:
 
 - `count`: This is based on the number of backups you want to keep. This is the default.
-- `time`: This is based on the total number of days you would like to keep the a backup.
+- `time`: This is based on the total number of days you would like to keep a backup.
 
-Let's look at an example where we keep full backups for 14 days. The most convenient way to do this is through the `spec.backups.pgbackrest.global` section, e.g.:
+Let's look at an example where we keep full backups for 14 days. The most convenient way to do this
+is through the `spec.backups.pgbackrest.global` section:
 
 ```
 spec:
@@ -66,13 +77,16 @@ spec:
         repo1-retention-full-type: time
 ```
 
-For a full list of available configuration options, please visit the [pgBackRest configuration](https://pgbackrest.org/configuration.html) guide.
+The full list of available configuration options is in the [pgBackRest configuration](https://pgbackrest.org/configuration.html) guide.
 
 ## Taking a One-Off Backup
 
-There are times where you may want to take a one-off backup, such as before major application changes or updates. This is not your typical declarative action -- in fact a one-off backup is imperative in its nature! -- but it is possibly to take a one-off backup of your Postgres cluster with PGO.
+There are times where you may want to take a one-off backup, such as before major application changes
+or updates. This is not your typical declarative action -- in fact a one-off backup is imperative
+in its nature! -- but it is possible to take a one-off backup of your Postgres cluster with PGO.
 
-First, you need to configure your spec to be able to take a one-off backup, you will need to edit the `spec.backups.pgbackrest.manual` section of your custom resource. This will contain information about the type of backup you want to take and any other [pgBackRest configuration](https://pgbackrest.org/configuration.html) options.
+First, you need to configure the `spec.backups.pgbackrest.manual` section to be able to take a one-off backup.
+This contains information about the type of backup you want to take and any other [pgBackRest configuration](https://pgbackrest.org/configuration.html) options.
 
 Let's configure the custom resource to take a one-off full backup:
 
@@ -86,13 +100,15 @@ spec:
          - --type=full
 ```
 
-This does not trigger the one-off backup -- you have to do that by adding the `postgres-operator.crunchydata.com/pgbackrest-backup` to your custom resource. The best way to set this annotation is with a timestamp, so you know when you initialized the backup.
+This does not trigger the one-off backup -- you have to do that by adding the
+`postgres-operator.crunchydata.com/pgbackrest-backup` annotation to your custom resource.
+The best way to set this annotation is with a timestamp, so you know when you initialized the backup.
 
 For example, for our `hippo` cluster, we can run the following command to trigger the one-off backup:
 
-```
+```shell
 kubectl annotate -n postgres-operator postgrescluster hippo \
-  postgres-operator.crunchydata.com/pgbackrest-backup="$( date '+%F_%H:%M:%S' )"
+  postgres-operator.crunchydata.com/pgbackrest-backup="$(date)"
 ```
 
 PGO will detect this annotation and create a new, one-off backup Job!
@@ -101,9 +117,9 @@ If you intend to take one-off backups with similar settings in the future, you c
 
 To re-run the command above, you will need to add the `--overwrite` flag so the annotation's value can be updated, i.e.
 
-```
+```shell
 kubectl annotate -n postgres-operator postgrescluster hippo --overwrite \
-  postgres-operator.crunchydata.com/pgbackrest-backup="$( date '+%F_%H:%M:%S' )"
+  postgres-operator.crunchydata.com/pgbackrest-backup="$(date)"
 ```
 
 ## Next Steps

--- a/docs/content/tutorial/backups.md
+++ b/docs/content/tutorial/backups.md
@@ -16,15 +16,20 @@ An important part of a healthy Postgres cluster is maintaining backups. PGO opti
 
 and more.
 
-Let's explore the various disaster recovery features work in PGO by first looking at how to set up backups.
+Let's explore the various disaster recovery features in PGO by first looking at how to set up backups.
 
 ## Understanding Backup Configuration and Basic Operations
 
-The backup configuration for a PGO managed Postgres cluster resides in the `spec.backups.pgbackrest` section of a custom resource. In addition to indicate which version of pgBackRest to use, this section allows you to configure the fundamental backup settings for your Postgres cluster, including:
+The backup configuration for a PGO managed Postgres cluster resides in the
+`spec.backups.pgbackrest` section of a custom resource. In addition to indicating which
+version of pgBackRest to use, this section allows you to configure the fundamental
+backup settings for your Postgres cluster, including:
 
 - `spec.backups.pgbackrest.configuration` - allows to add additional configuration and references to Secrets that are needed for configuration your backups. For example, this may reference a Secret that contains your S3 credentials.
 - `spec.backups.pgbackrest.global` - a convenience to apply global [pgBackRest configuration](https://pgbackrest.org/configuration.html). An example of this may be setting the global pgBackRest logging level (e.g. `log-level-console: info`), or provide configuration to optimize performance.
-- `spec.backups.pgbackrest.repos` - information on each specific pgBackRest backup repository. This allows you to configure where and how your backups are stored. You can keep backups in up to four (4) different locations!
+- `spec.backups.pgbackrest.repos` - information on each specific pgBackRest backup repository.
+  This allows you to configure where and how your backups and WAL archive are stored.
+  You can keep backups in up to four (4) different locations!
 
 You can configure the `repos` section based on the backup storage system you are looking to use. Specifically, you configure your `repos` section according to the storage type you are using. There are four storage types available in `spec.backups.pgbackrest.repos`:
 


### PR DESCRIPTION
When configuring pgBackRest and scheduling backups, it is important to understand that repositories contain WAL files in addition to backups.

---

We have three different pages that focus on pgBackRest and backups.

1. Architecture: This fixes some links and adjusts the language to reflect how WAL works with multi-repo.
2. Configuration: Mention that WAL files are in the repositories.
3. Management: Link to the definition/explanation of WAL in upstream docs. Clarify that full backups determine what WAL is retained by pgBackRest. Lots of other rewording and tweaks.