### PR TITLE
Do not mount ServiceAccount tokens in pgBackRest

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -561,6 +561,10 @@ func (r *Reconciler) generateRepoHostIntent(postgresCluster *v1beta1.PostgresClu
 		repo.Spec.Replicas = initialize.Int32(1)
 	}
 
+	// pgBackRest does not make any Kubernetes API calls. Use the default
+	// ServiceAccount and do not mount its credentials.
+	repo.Spec.Template.Spec.AutomountServiceAccountToken = initialize.Bool(false)
+
 	repo.Spec.Template.Spec.SecurityContext = postgres.PodSecurityContext(postgresCluster)
 
 	var resources corev1.ResourceRequirements
@@ -1162,6 +1166,10 @@ func (r *Reconciler) generateRestoreJobIntent(cluster *v1beta1.PostgresCluster,
 	// of propagation to existing pods when the CRD is updated:
 	// https://github.com/kubernetes/kubernetes/issues/88456
 	job.Spec.Template.Spec.ImagePullSecrets = cluster.Spec.ImagePullSecrets
+
+	// pgBackRest does not make any Kubernetes API calls. Use the default
+	// ServiceAccount and do not mount its credentials.
+	job.Spec.Template.Spec.AutomountServiceAccountToken = initialize.Bool(false)
 
 	job.Spec.Template.Spec.SecurityContext = postgres.PodSecurityContext(cluster)
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)

**What is the current behavior? (link to any open issues here)**

Some pgBackRest pods mount a service account token even though they do not call the Kubernetes API.

**What is the new behavior (if this is a feature change)?**

These pods do not mount any service account tokens.

**Other Information**:

Issue: [sc-12749]