### PR TITLE
Restart PostgreSQL when changing postmaster parameters

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -4855,18 +4855,24 @@ spec:
               patroni:
                 properties:
                   dynamicConfiguration:
+                    description: 'Patroni dynamic configuration settings. Changes
+                      to this value will be automatically reloaded without validation.
+                      Changes to certain PostgreSQL parameters cause PostgreSQL to
+                      restart. More info: https://patroni.readthedocs.io/en/latest/SETTINGS.html'
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   leaderLeaseDurationSeconds:
                     default: 30
                     description: TTL of the cluster leader lock. "Think of it as the
                       length of time before initiation of the automatic failover process."
+                      Changing this value causes PostgreSQL to restart.
                     format: int32
                     minimum: 3
                     type: integer
                   port:
                     default: 8008
-                    description: The port on which Patroni should listen.
+                    description: The port on which Patroni should listen. Changing
+                      this value causes PostgreSQL to restart.
                     format: int32
                     minimum: 1024
                     type: integer
@@ -4874,6 +4880,7 @@ spec:
                     default: 10
                     description: The interval for refreshing the leader lock and applying
                       dynamicConfiguration. Must be less than leaderLeaseDurationSeconds.
+                      Changing this value causes PostgreSQL to restart.
                     format: int32
                     minimum: 1
                     type: integer

--- a/docs/content/architecture/high-availability.md
+++ b/docs/content/architecture/high-availability.md
@@ -204,7 +204,8 @@ the [high availability tutorial]({{< relref "tutorial/high-availability.md" >}}#
 During the lifecycle of a PostgreSQL cluster, there are certain events that may
 require a planned restart, such as an update to a "restart required" PostgreSQL
 configuration setting (e.g. [`shared_buffers`](https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-SHARED-BUFFERS))
-or a change to a Kubernetes Deployment template (e.g. [changing the memory request]({{< relref "tutorial/resize-cluster.md">}}#customize-cpu-memory)). Restarts can be disruptive in a high availability deployment, which is
+or a change to a Kubernetes Pod template (e.g. [changing the memory request]({{< relref "tutorial/resize-cluster.md">}}#customize-cpu-memory)).
+Restarts can be disruptive in a high availability deployment, which is
 why many setups employ a ["rolling update" strategy](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/)
 (aka a "rolling restart") to minimize or eliminate downtime during a planned
 restart.
@@ -222,8 +223,7 @@ process:
   1. The replica is explicitly shut down to ensure any outstanding changes are
   flushed to disk.
 
-  2. If requested, the PostgreSQL Operator will apply any changes to the
-  Deployment.
+  2. If requested, the PostgreSQL Operator will apply any changes to the Pod.
 
   3. The replica is brought back online. The PostgreSQL Operator waits for the
   replica to become available before it proceeds to the next replica.

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -7226,22 +7226,22 @@ Changing this value causes PostgreSQL and the exporter to restart. More info: ht
     <tbody><tr>
         <td><b>dynamicConfiguration</b></td>
         <td>object</td>
-        <td></td>
+        <td>Patroni dynamic configuration settings. Changes to this value will be automatically reloaded without validation. Changes to certain PostgreSQL parameters cause PostgreSQL to restart. More info: https://patroni.readthedocs.io/en/latest/SETTINGS.html</td>
         <td>false</td>
       </tr><tr>
         <td><b>leaderLeaseDurationSeconds</b></td>
         <td>integer</td>
-        <td>TTL of the cluster leader lock. "Think of it as the length of time before initiation of the automatic failover process."</td>
+        <td>TTL of the cluster leader lock. "Think of it as the length of time before initiation of the automatic failover process." Changing this value causes PostgreSQL to restart.</td>
         <td>false</td>
       </tr><tr>
         <td><b>port</b></td>
         <td>integer</td>
-        <td>The port on which Patroni should listen.</td>
+        <td>The port on which Patroni should listen. Changing this value causes PostgreSQL to restart.</td>
         <td>false</td>
       </tr><tr>
         <td><b>syncPeriodSeconds</b></td>
         <td>integer</td>
-        <td>The interval for refreshing the leader lock and applying dynamicConfiguration. Must be less than leaderLeaseDurationSeconds.</td>
+        <td>The interval for refreshing the leader lock and applying dynamicConfiguration. Must be less than leaderLeaseDurationSeconds. Changing this value causes PostgreSQL to restart.</td>
         <td>false</td>
       </tr></tbody>
 </table>

--- a/docs/content/tutorial/customize-cluster.md
+++ b/docs/content/tutorial/customize-cluster.md
@@ -9,7 +9,9 @@ Postgres is known for its ease of customization; PGO helps you to roll out chang
 
 ## Custom Postgres Configuration
 
-Part of the trick of managing multiple instances in a Postgres cluster is ensuring all of the configuration changes are propagated to each of them. This is where PGO helps: when you make a Postgres configuration change for a cluster, PGO will apply the changes to all of the managed instances.
+Part of the trick of managing multiple instances in a Postgres cluster is ensuring all of the configuration
+changes are propagated to each of them. This is where PGO helps: when you make a Postgres configuration
+change for a cluster, PGO will apply it to all of the Postgres instances.
 
 For example, in our previous step we added CPU and memory limits of `2.0` and `4Gi` respectively. Let's tweak some of the Postgres settings to better use our new resources. We can do this in the `spec.patroni.dynamicConfiguration` section. Here is an example updated manifest that tweaks several settings:
 
@@ -69,13 +71,13 @@ patroni:
         work_mem: 2MB
 ```
 
-Apply these updates to your Kubernetes cluster with the following command:
+Apply these updates to your Postgres cluster with the following command:
 
 ```
 kubectl apply -k kustomize/postgres
 ```
 
-PGO will go and apply these settings to all of the Postgres clusters. You can verify that the changes are present using the Postgres `SHOW` command, e.g.
+PGO will go and apply these settings, restarting each Postgres instance when necessary. You can verify that the changes are present using the Postgres `SHOW` command, e.g.
 
 ```
 SHOW work_mem;
@@ -299,9 +301,8 @@ create table t_random as select s, md5(random()::text) from generate_Series(1,5)
 
 ### Changes Not Applied
 
-If your Postgres configuration settings are not present, you may need to check a few things. First, ensure that you are using the syntax that Postgres expects. You can see this in the [Postgres configuration documentation](https://www.postgresql.org/docs/current/runtime-config.html).
-
-Some settings, such as `shared_buffers`, require for Postgres to restart. Patroni only performs a reload when parameter changes are identified.  Therefore, for parameters that require a restart, the restart can be performed manually by  executing into a Postgres instance and running `patronictl restart --force <clusterName>-ha`.
+If your Postgres configuration settings are not present, ensure that you are using the syntax that Postgres expects.
+You can see this in the [Postgres configuration documentation](https://www.postgresql.org/docs/current/runtime-config.html).
 
 ## Next Steps
 

--- a/docs/content/tutorial/high-availability.md
+++ b/docs/content/tutorial/high-availability.md
@@ -58,7 +58,7 @@ spec:
                 storage: 1Gi
 ```
 
-Apply these updates to your Kubernetes cluster with the following command:
+Apply these updates to your Postgres cluster with the following command:
 
 ```
 kubectl apply -k kustomize/postgres

--- a/docs/content/tutorial/resize-cluster.md
+++ b/docs/content/tutorial/resize-cluster.md
@@ -76,7 +76,7 @@ resources:
     memory: 4Gi
 ```
 
-Apply these updates to your Kubernetes cluster with the following command:
+Apply these updates to your Postgres cluster with the following command:
 
 ```
 kubectl apply -k kustomize/postgres
@@ -166,7 +166,7 @@ volumeClaimSpec:
       storage: 20Gi
 ```
 
-Apply these updates to your Kubernetes cluster with the following command:
+Apply these updates to your Postgres cluster with the following command:
 
 ```
 kubectl apply -k kustomize/postgres

--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -292,6 +292,11 @@ func (r *Reconciler) Reconcile(
 	if err == nil {
 		err = r.reconcilePGAdmin(ctx, cluster)
 	}
+	if err == nil {
+		// This is after [Reconciler.rolloutInstances] to ensure that recreating
+		// Pods takes precedence.
+		err = r.handlePatroniRestarts(ctx, cluster, instances)
+	}
 
 	// at this point everything reconciled successfully, and we can update the
 	// observedGeneration

--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -196,10 +196,8 @@ func (r *Reconciler) reconcilePostgresDatabases(
 			// but early versions of PGO do not load it automatically. Assume
 			// that an error here is because the cluster started during one of
 			// those versions and has not been restarted.
-			// TODO(cbandy): After we have a more general way of handling or
-			// reporting pending restarts, consider returning this error instead.
 			r.Recorder.Event(cluster, corev1.EventTypeWarning, "pgAuditDisabled",
-				"Unable to install pgAudit; try restarting PostgreSQL")
+				"Unable to install pgAudit")
 		}
 
 		// Enabling PostGIS extensions is a one-way operation

--- a/internal/controller/postgrescluster/watches.go
+++ b/internal/controller/postgrescluster/watches.go
@@ -43,6 +43,19 @@ func (*Reconciler) watchPods() handler.Funcs {
 					Namespace: e.ObjectNew.GetNamespace(),
 					Name:      cluster,
 				}})
+				return
+			}
+
+			// Queue an event when a Patroni pod indicates it needs to restart
+			// or finished restarting.
+			if len(cluster) != 0 &&
+				(patroni.PodRequiresRestart(e.ObjectOld) ||
+					patroni.PodRequiresRestart(e.ObjectNew)) {
+				q.Add(reconcile.Request{NamespacedName: client.ObjectKey{
+					Namespace: e.ObjectNew.GetNamespace(),
+					Name:      cluster,
+				}})
+				return
 			}
 		},
 	}

--- a/internal/patroni/reconcile.go
+++ b/internal/patroni/reconcile.go
@@ -187,9 +187,27 @@ func PodIsStandbyLeader(pod metav1.Object) bool {
 		return false
 	}
 
+	// TODO(cbandy): This works only when using Kubernetes for DCS.
+
 	// - https://github.com/zalando/patroni/blob/v2.0.2/patroni/ha.py#L190
 	// - https://github.com/zalando/patroni/blob/v2.0.2/patroni/ha.py#L294
 	// - https://github.com/zalando/patroni/blob/v2.0.2/patroni/ha.py#L353
 	status := pod.GetAnnotations()["status"]
 	return strings.Contains(status, `"role":"standby_leader"`)
+}
+
+// PodRequiresRestart returns whether or not PostgreSQL inside pod has (pending)
+// parameter changes that require a PostgreSQL restart.
+func PodRequiresRestart(pod metav1.Object) bool {
+	if pod == nil {
+		return false
+	}
+
+	// TODO(cbandy): This works only when using Kubernetes for DCS.
+
+	// - https://github.com/zalando/patroni/blob/v2.1.1/patroni/ha.py#L198
+	// - https://github.com/zalando/patroni/blob/v2.1.1/patroni/postgresql/config.py#L977
+	// - https://github.com/zalando/patroni/blob/v2.1.1/patroni/postgresql/config.py#L1007
+	status := pod.GetAnnotations()["status"]
+	return strings.Contains(status, `"pending_restart":true`)
 }

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/patroni_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/patroni_types.go
@@ -22,33 +22,33 @@ import (
 type PatroniSpec struct {
 	// TODO(cbandy): Find a better way to have a map[string]interface{} here.
 	// See: https://github.com/kubernetes-sigs/controller-tools/commit/557da250b8
-	// TODO(cbandy): Describe this field.
 
+	// Patroni dynamic configuration settings. Changes to this value will be
+	// automatically reloaded without validation. Changes to certain PostgreSQL
+	// parameters cause PostgreSQL to restart.
+	// More info: https://patroni.readthedocs.io/en/latest/SETTINGS.html
 	// +optional
 	// +kubebuilder:validation:XPreserveUnknownFields
 	DynamicConfiguration runtime.RawExtension `json:"dynamicConfiguration,omitempty"`
 
-	// TODO(cbandy): Describe the downtime involved with changing.
-
 	// TTL of the cluster leader lock. "Think of it as the
 	// length of time before initiation of the automatic failover process."
+	// Changing this value causes PostgreSQL to restart.
 	// +optional
 	// +kubebuilder:default=30
 	// +kubebuilder:validation:Minimum=3
 	LeaderLeaseDurationSeconds *int32 `json:"leaderLeaseDurationSeconds,omitempty"`
 
-	// TODO(cbandy): Describe the downtime involved with changing.
-
 	// The port on which Patroni should listen.
+	// Changing this value causes PostgreSQL to restart.
 	// +optional
 	// +kubebuilder:default=8008
 	// +kubebuilder:validation:Minimum=1024
 	Port *int32 `json:"port,omitempty"`
 
-	// TODO(cbandy): Describe the downtime involved with changing.
-
 	// The interval for refreshing the leader lock and applying
 	// dynamicConfiguration. Must be less than leaderLeaseDurationSeconds.
+	// Changing this value causes PostgreSQL to restart.
 	// +optional
 	// +kubebuilder:default=10
 	// +kubebuilder:validation:Minimum=1


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature (non-breaking change which adds functionality)

**What is the current behavior? (link to any open issues here)**

One must manually restart PostgreSQL when changing a parameter that can only be set at server start.

**What is the new behavior (if this is a feature change)?**

PGO rolls out such changes while considering whether the primary or replica must apply it first.

**Other information**:

Issue: [sc-11430]