### PR TITLE
update owner ref to controller ref 

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -1537,7 +1537,7 @@ func (r *Reconciler) copyRestoreConfiguration(ctx context.Context,
 		Data:       sourceSSHConfig.Data,
 	}
 	// set ownership refs according to PostgresCluster being created (not the source cluster)
-	if err := r.setOwnerReference(cluster, restoreSSHConfig); err != nil {
+	if err := r.setControllerReference(cluster, restoreSSHConfig); err != nil {
 		return errors.WithStack(err)
 	}
 	restoreSSHConfig.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))


### PR DESCRIPTION
updated method to setControllerReference instead of setOwnerReference

the setOwnerReferece wasn't adding controller: true to the image section

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
currently controller: true is not set in the image block


**What is the new behavior (if this is a feature change)?**
updated to setControllerrefference in pgbackrest.go enable when a restore is run
the controller is set to true.


**Other information**:
[sc-12734]