### PR TITLE
PITR doc change to correct timezone

### DIFF
--- a/docs/content/tutorial/disaster-recovery.md
+++ b/docs/content/tutorial/disaster-recovery.md
@@ -87,7 +87,7 @@ Did someone drop the user table? You may want to perform a point-in-time-recover
 You can set up a PITR using the [restore](https://pgbackrest.org/command.html#command-restore) command of [pgBackRest](https://www.pgbackrest.org), the backup management tool that powers the disaster recovery capabilities of PGO. You will need to set a few options on `spec.dataSource.postgresCluster.options` to perform a PITR. These options include:
 
 - `--type=time`: This tells pgBackRest to perform a PITR.
-- `--target`: Where to perform the PITR to. Any example recovery target is `2021-06-09 14:15:11-04`.  The timezone specified here as -04 for EDT.  See pgBackRest documentation for other timezone options.
+- `--target`: Where to perform the PITR to. Any example recovery target is `2021-06-09 14:15:11-04`.  The timezone specified here as -04 for EDT.  Please see the [pgBackRest documentation for other timezone options](https://pgbackrest.org/user-guide.html#pitr).
 - `--set` (optional): Choose which backup to start the PITR from.
 
 A few quick notes before we begin:


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ x] Have you updated or added documentation for the change, as applicable?
 - [ x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
Documentation had examples for PITR with the timezone specified as EDT.  Using this designation for timezone is not supported by pgBackRest and will result in the following error in the restore job/pod if attempted:

WARN: automatic backup set selection cannot be performed with provided time '2021-10-22 15:11:00 EDT', latest backup set will be used
      HINT: time format must be YYYY-MM-DD HH:MM:SS with optional msec and optional timezone (+/- HH or HHMM or HH:MM) - if timezone is omitted, local time is assumed (for UTC use +00)
2021-10-22 19:42:38.337 GMT [18] LOG:  invalid value for parameter "recovery_target_time": "2021-10-22 15:11:00 EDT"


**What is the new behavior (if this is a feature change)?**
Corrected the PITR documentation to specify timezone using +/- HH format.


**Other information**:
