### PR TITLE
Fix the syntax for matching roles in pg_hba.conf

### DIFF
--- a/internal/postgres/hba.go
+++ b/internal/postgres/hba.go
@@ -129,7 +129,7 @@ func (hba *HostBasedAuthentication) Replication() *HostBasedAuthentication {
 
 // Role makes hba match connections by users that are members of a specific role.
 func (hba *HostBasedAuthentication) Role(name string) *HostBasedAuthentication {
-	hba.user = hba.quote("+" + name)
+	hba.user = "+" + hba.quote(name)
 	return hba
 }
 

--- a/internal/postgres/hba_test.go
+++ b/internal/postgres/hba_test.go
@@ -62,7 +62,7 @@ func TestHostBasedAuthentication(t *testing.T) {
 			User("KD6-3.7").Method("scram-sha-256").
 			String())
 
-	assert.Equal(t, `hostssl "data" "+admin" all md5  clientcert="verify-ca"`,
+	assert.Equal(t, `hostssl "data" +"admin" all md5  clientcert="verify-ca"`,
 		NewHBA().TLS().Database("data").Role("admin").
 			Method("md5").Options(map[string]string{"clientcert": "verify-ca"}).
 			String())


### PR DESCRIPTION
We don't match on groups so far, but the syntax came up in a recent security discussion and I noticed that we spelled it wrong in our code.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
