### PR TITLE
Change pgAdmin Deployment to StatefulSet

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -209,7 +209,7 @@ func (r *Reconciler) getPGBackRestResources(ctx context.Context,
 	for _, gvk := range gvks {
 		uList := &unstructured.UnstructuredList{}
 		uList.SetGroupVersionKind(gvk)
-		if err := r.Client.List(context.Background(), uList,
+		if err := r.Client.List(ctx, uList,
 			client.InNamespace(postgresCluster.GetNamespace()),
 			client.MatchingLabelsSelector{Selector: selector}); err != nil {
 			return nil, errors.WithStack(err)

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -555,8 +555,7 @@ func TestReconcilePGBackRest(t *testing.T) {
 				Type: condition, Reason: "testing", Status: status})
 		}
 
-		requeue := r.reconcileScheduledBackups(context.Background(),
-			postgresCluster, serviceAccount)
+		requeue := r.reconcileScheduledBackups(ctx, postgresCluster, serviceAccount)
 		assert.Assert(t, !requeue)
 
 		returnedCronJob := &batchv1beta1.CronJob{}


### PR DESCRIPTION
Certain properties of a pgAdmin deployment make it better suited to be deployed via a StatefulSet rather than a Deployment (e.g. it includes its own embedded database, and we also want to ensure only a single replica is running at any given time).  This change therefore updates the intent generated by PGO for deploying pgAdmin to use a StatefulSet rather than a Deployment.  The StatefulSet uses the default `RollingUpdate` update strategy, and is also configured with a proper `ServiceName` as required for a stable network ID.

[sc-12915]