### PR TITLE
Fix PG14 pause on restore

### DIFF
--- a/docs/content/tutorial/disaster-recovery.md
+++ b/docs/content/tutorial/disaster-recovery.md
@@ -20,7 +20,7 @@ Please review the table below to understand how each of these attributes work in
 - `spec.dataSource.postgresCluster.clusterName`: The name of the cluster that you are restoring from. This corresponds to the `metadata.name` attribute on a different `postgrescluster` custom resource.
 - `spec.dataSource.postgresCluster.clusterNamespace`: The namespace of the cluster that you are restoring from. Used when the cluster exists in a different namespace.
 - `spec.dataSource.postgresCluster.repoName`: The name of the pgBackRest repository from the `spec.dataSource.postgresCluster.clusterName` to use for the restore. Can be one of `repo1`, `repo2`, `repo3`, or `repo4`. The repository must exist in the other cluster.
-- `spec.dataSource.postgresCluster.options`: Any additional [pgBackRest restore options](https://pgbackrest.org/command.html#command-restore) or general options you would like to pass in. For example, you may want to set `--process-max` to help improve performance on larger databases.
+- `spec.dataSource.postgresCluster.options`: Any additional [pgBackRest restore options](https://pgbackrest.org/command.html#command-restore) or general options that PGO allows. For example, you may want to set `--process-max` to help improve performance on larger databases; but you will not be able to set`--target-action`, since that option is currently disallowed. (PGO always sets it to `promote` if a `--target` is present, and otherwise leaves it blank.)
 - `spec.dataSource.postgresCluster.resources`: Setting [resource limits and requests](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) of the restore job can ensure that it runs efficiently.
 - `spec.dataSource.postgresCluster.affinity`: Custom [Kubernetes affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) rules constrain the restore job so that it only runs on certain nodes.
 - `spec.dataSource.postgresCluster.tolerations`: Custom [Kubernetes tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) allow the restore job to run on [tainted](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) nodes.
@@ -143,7 +143,9 @@ spec:
     postgresCluster:
       clusterName: hippo
       repoName: repo1
-      options: --type=time --target="2021-06-09 14:15:11-04"
+      options: 
+      - --type=time 
+      - --target="2021-06-09 14:15:11-04"
 ```
 
 Notice how we put in the options to specify where to make the PITR.

--- a/internal/pgbackrest/restore.md
+++ b/internal/pgbackrest/restore.md
@@ -1,0 +1,125 @@
+<!--
+ Copyright 2021 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+## Target Action
+
+The `--target-action` option of `pgbackrest restore` almost translates to the
+PostgreSQL `recovery_target_action` parameter but not exactly. The behavior of
+that parameter also depends on the PostgreSQL version and on other parameters.
+
+For PostgreSQL 9.5 through 14,
+
+ - The PostgreSQL documentation states that for `recovery_target_action`
+   "the default is `pause`," but that is only the case when `hot_standby=on`.
+
+ - The PostgreSQL documentation states that when `hot_standby=off` "a setting
+   of `pause` will act the same as `shutdown`," but that cannot be configured
+   through pgBackRest.
+
+ - The pgBackRest documentation seems to state that `--target-action` has no
+   effect when `hot_standby=off`, but that is not the case.
+
+   See: https://github.com/pgbackrest/pgbackrest/issues/987
+
+The default value of `hot_standby` is `off` prior to PostgreSQL 10 and `on` since.
+
+### PostgreSQL 14, 13, 12
+
+[12]: https://www.postgresql.org/docs/12/runtime-config-wal.html
+[commit]: https://git.postgresql.org/gitweb/?p=postgresql.git;h=2dedf4d9a899b36d1a8ed29be5efbd1b31a8fe85
+
+| --target-action  | recovery_target_action | hot_standby=off | hot_standby=on (default) |
+|------------------|------------------------|-----------------|--------------------------|
+| _not configured_ | _not configured_       | shutdown        | pause                    |
+| `pause`          | _not configured_       | shutdown        | pause                    |
+| _not possible_   | `pause`                | shutdown        | pause                    |
+| `promote`        | `promote`              | promote         | promote                  |
+| `shutdown`       | `shutdown`             | shutdown        | shutdown                 |
+
+
+### PostgreSQL 11, 10
+
+[11]: https://www.postgresql.org/docs/11/recovery-target-settings.html
+[10]: https://www.postgresql.org/docs/10/runtime-config-replication.html
+
+| --target-action  | recovery_target_action | hot_standby=off | hot_standby=on (default) |
+|------------------|------------------------|-----------------|--------------------------|
+| _not configured_ | _not configured_       | promote         | pause                    |
+| `pause`          | _not configured_       | promote         | pause                    |
+| _not possible_   | `pause`                | shutdown        | pause                    |
+| `promote`        | `promote`              | promote         | promote                  |
+| `shutdown`       | `shutdown`             | shutdown        | shutdown                 |
+
+
+### PostgreSQL 9.6, 9.5
+
+[9.6]: https://www.postgresql.org/docs/9.6/recovery-target-settings.html
+
+| --target-action  | recovery_target_action | hot_standby=off (default) | hot_standby=on |
+|------------------|------------------------|---------------------------|----------------|
+| _not configured_ | _not configured_       | promote                   | pause          |
+| `pause`          | _not configured_       | promote                   | pause          |
+| _not possible_   | `pause`                | shutdown                  | pause          |
+| `promote`        | `promote`              | promote                   | promote        |
+| `shutdown`       | `shutdown`             | shutdown                  | shutdown       |
+
+
+### PostgreSQL 9.4, 9.3, 9.2, 9.1
+
+[9.4]: https://www.postgresql.org/docs/9.4/recovery-target-settings.html
+[9.4]: https://www.postgresql.org/docs/9.4/runtime-config-replication.html
+
+| --target-action  | pause_at_recovery_target | hot_standby=off (default) | hot_standby=on |
+|------------------|--------------------------|---------------------------|----------------|
+| _not configured_ | _not configured_         | promote                   | pause          |
+| `pause`          | _not configured_         | promote                   | pause          |
+| _not possible_   | `true`                   | promote                   | pause          |
+| `promote`        | `false`                  | promote                   | promote        |
+
+
+<!--
+
+### Setup
+
+# Change to a directory with enough space to restore and choose a data directory.
+
+cd /pgdata
+export PGDATA="$(pwd)/test"
+
+# Do a full restore then start PostgreSQL. It will run in the foreground, replay,
+# and promote. Notice the LSN in the "consistent recovery state reached" message.
+# The "selected new timeline" message indicates that it promoted.
+# Use ^C to shutdown.
+
+pgbackrest restore --pg1-path="$PGDATA" --stanza=db
+(cd "$PGDATA"; postgres -c archive_command=false -c logging_collector=off -c port=9999)
+
+
+### Test
+
+# Delete the data directory and perform a PITR.
+# Start PostgreSQL with hot_standby=on, and it will replay then pause.
+# Notice the "pausing at the end of recovery" message. Use ^C to shutdown.
+
+rm -rf "$PGDATA"
+pgbackrest restore --pg1-path="$PGDATA" --stanza=db --type=lsn --target="$LSN"
+(cd "$PGDATA"; postgres -c archive_command=false -c logging_collector=off -c port=9999 -c hot_standby=on)
+
+# Repeat the test with any pgBackRest and PostgreSQL settings you like. Look
+# in PostgreSQL conf files to see what is or is not configured.
+
+grep recovery_target_action "$PGDATA"/*.conf
+
+-->


### PR DESCRIPTION
**Checklist:**

 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**
It seems that PG 14 stops restoring from a previous repo if some of the PostgreSQL configurations are changed and pushed to WAL; under those circumstances (say, max_connections gets changed from 200 to 1000), the logs say:

```
WARNING:  hot standby is not possible because of insufficient parameter settings
DETAIL:  max_connections = 200 is a lower setting than on the primary server, where its value was 1000.
LOG:  recovery has paused
DETAIL:  If recovery is unpaused, the server will shut down.
```

This was a change to PG14; our usual behavior in this situation (in earlier versions) was to restart the server.

**What is the new behavior (if this is a feature change)?**
This checks that the server is paused and unpauses it to allow our usual behavior.

**Other information**:
Issue [sc-12979]