### PR TITLE
Stop messing with PgBouncer verbosity

### DIFF
--- a/internal/pgbouncer/config_test.go
+++ b/internal/pgbouncer/config_test.go
@@ -68,12 +68,9 @@ func TestClusterINI(t *testing.T) {
 # Your changes will not be saved.
 
 [pgbouncer]
-verbose = 1
 %include /etc/pgbouncer/pgbouncer.ini
 
 [pgbouncer]
-verbose = 0
-
 auth_file = /etc/pgbouncer/~postgres-operator/users.txt
 auth_query = SELECT username, password from pgbouncer.get_auth($1)
 auth_user = _crunchypgbouncer
@@ -111,12 +108,9 @@ unix_socket_dir =
 # Your changes will not be saved.
 
 [pgbouncer]
-verbose = 1
 %include /etc/pgbouncer/pgbouncer.ini
 
 [pgbouncer]
-verbose = whomp
-
 auth_file = /etc/pgbouncer/~postgres-operator/users.txt
 auth_query = SELECT username, password from pgbouncer.get_auth($1)
 auth_user = _crunchypgbouncer
@@ -131,6 +125,7 @@ listen_port = 8888
 server_tls_ca_file = /etc/pgbouncer/~postgres-operator/backend-ca.crt
 server_tls_sslmode = verify-full
 unix_socket_dir =
+verbose = whomp
 
 [databases]
 appdb = conn=str


### PR DESCRIPTION
PgBouncer 1.16.0 fixed the underlying issue with its "%include" directives. Users can increase verbosity in their own configuration files to keep the old behavior.

See: https://github.com/libusual/libusual/commit/ab960074cb7a

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)

**What is the current behavior? (link to any open issues here)**

Users must lower verbosity in their custom configuration files if they don't want them to be logged. When there are no custom configuration files, the following messages are unnecessary:

```
2021-11-04 16:12:21.102 UTC [7] LOG stats: 0 xacts/s, 0 queries/s, in 0 B/s, out 0 B/s, xact 0 us, query 0 us, wait 0 us
2021-11-04 16:13:13.247 UTC [7] LOG got SIGHUP, re-reading config
2021-11-04 16:13:13.247 UTC [7] DEBUG parse_ini_file: 'verbose' = '1' ok:1
2021-11-04 16:13:13.247 UTC [7] DEBUG processing include: /etc/pgbouncer/pgbouncer.ini
2021-11-04 16:13:13.247 UTC [7] DEBUG returned to processing file /etc/pgbouncer/~postgres-operator.ini
2021-11-04 16:13:13.247 UTC [7] DEBUG parse_ini_file: [pgbouncer]
2021-11-04 16:13:13.247 UTC [7] DEBUG parse_ini_file: 'verbose' = '0'
2021-11-04 16:13:21.101 UTC [7] LOG stats: 0 xacts/s, 0 queries/s, in 0 B/s, out 0 B/s, xact 0 us, query 0 us, wait 0 us
```

**What is the new behavior (if this is a feature change)?**

PgBouncer runs with its default verbosity until a user configures it. They can raise or lower it wherever they want, however they want. When there are no customizations:

```
2021-11-05 14:22:21.101 UTC [7] LOG stats: 0 xacts/s, 0 queries/s, in 0 B/s, out 0 B/s, xact 0 us, query 0 us, wait 0 us
2021-11-05 14:22:48.329 UTC [7] LOG got SIGHUP, re-reading config
2021-11-05 14:23:21.101 UTC [7] LOG stats: 0 xacts/s, 0 queries/s, in 0 B/s, out 0 B/s, xact 0 us, query 0 us, wait 0 us
```

**Other Information**:

Issue: [sc-13089]