### PR TITLE
Validate instance set names

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -3394,6 +3394,8 @@ spec:
                   type: object
                 type: array
               instances:
+                description: Specifies one or more sets of PostgreSQL pods that replicate
+                  data for this cluster.
                 items:
                   properties:
                     affinity:
@@ -4172,6 +4174,10 @@ spec:
                       type: object
                     name:
                       default: ""
+                      description: Name that associates this set of PostgreSQL pods.
+                        This field is optional when only one instance set is defined.
+                        Each instance set in a cluster must have a unique name.
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
                       type: string
                     priorityClassName:
                       description: 'Priority class name for the PostgreSQL pod. Changing
@@ -4179,6 +4185,7 @@ spec:
                       type: string
                     replicas:
                       default: 1
+                      description: Number of desired PostgreSQL pods.
                       format: int32
                       minimum: 1
                       type: integer

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -92,7 +92,7 @@ PostgresClusterSpec defines the desired state of PostgresCluster
       </tr><tr>
         <td><b><a href="#postgresclusterspecinstancesindex">instances</a></b></td>
         <td>[]object</td>
-        <td></td>
+        <td>Specifies one or more sets of PostgreSQL pods that replicate data for this cluster.</td>
         <td>true</td>
       </tr><tr>
         <td><b>postgresVersion</b></td>
@@ -3649,7 +3649,7 @@ Resource requirements for a sidecar container
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
-        <td></td>
+        <td>Name that associates this set of PostgreSQL pods. This field is optional when only one instance set is defined. Each instance set in a cluster must have a unique name.</td>
         <td>false</td>
       </tr><tr>
         <td><b>priorityClassName</b></td>
@@ -3659,7 +3659,7 @@ Resource requirements for a sidecar container
       </tr><tr>
         <td><b>replicas</b></td>
         <td>integer</td>
-        <td></td>
+        <td>Number of desired PostgreSQL pods.</td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#postgresclusterspecinstancesindexresources">resources</a></b></td>

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -91,6 +91,8 @@ type PostgresClusterSpec struct {
 	// +optional
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
+	// Specifies one or more sets of PostgreSQL pods that replicate data for
+	// this cluster.
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
@@ -374,8 +376,16 @@ type PostgresInstanceSetSpec struct {
 	// +optional
 	Metadata *Metadata `json:"metadata,omitempty"`
 
+	// This value goes into the name of an appsv1.StatefulSet and the hostname
+	// of a corev1.Pod. The pattern below is IsDNS1123Label wrapped in "()?" to
+	// accommodate the empty default.
+
+	// Name that associates this set of PostgreSQL pods. This field is optional
+	// when only one instance set is defined. Each instance set in a cluster
+	// must have a unique name.
 	// +optional
 	// +kubebuilder:default=""
+	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$`
 	Name string `json:"name"`
 
 	// Scheduling constraints of a PostgreSQL pod. Changing this value causes
@@ -395,6 +405,7 @@ type PostgresInstanceSetSpec struct {
 	// +optional
 	PriorityClassName *string `json:"priorityClassName,omitempty"`
 
+	// Number of desired PostgreSQL pods.
 	// +optional
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=1


### PR DESCRIPTION

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**

`spec.instances.name` is optional but only when there's a single instance set. Two or more instance sets without a name are rejected: `spec.instances[1]: Duplicate value: map[string]interface {}{"name":""}`.


**What is the new behavior (if this is a feature change)?**

Call out the above limitation in the field description. Values like `UPPER` and `lower.with.dots` used to be accepted but would not build a working cluster. Reject them instead.

**Other Information**:

Issue: [sc-13112]