### PR TITLE
Add Final Resource Check to rmdata

### DIFF
--- a/cmd/pgo-rmdata/main.go
+++ b/cmd/pgo-rmdata/main.go
@@ -61,8 +61,19 @@ func main() {
 
 	request.Clientset = client
 
+	// create a dynamic client using the same REST config as the typed client
+	dynamicClient, err := kubeapi.NewDynamicClientForConfig(client.Config)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	request.DynamicClient = dynamicClient
+
 	log.Infoln("pgo-rmdata starts")
 	log.Infof("request is %s", request.String())
 
-	Delete(request)
+	// if an error occurs while deleting, then exit with exit code 1
+	if err := Delete(request); err != nil {
+		log.Fatalln(err)
+	}
 }

--- a/cmd/pgo-rmdata/types.go
+++ b/cmd/pgo-rmdata/types.go
@@ -19,10 +19,12 @@ import (
 	"fmt"
 
 	"github.com/crunchydata/postgres-operator/internal/kubeapi"
+	"k8s.io/client-go/dynamic"
 )
 
 type Request struct {
 	Clientset        kubeapi.Interface
+	DynamicClient    dynamic.Interface
 	RemoveData       bool
 	RemoveBackup     bool
 	IsBackup         bool

--- a/internal/kubeapi/client_config.go
+++ b/internal/kubeapi/client_config.go
@@ -16,6 +16,7 @@ package kubeapi
 */
 
 import (
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -100,4 +101,10 @@ func NewClientForConfig(config *rest.Config) (*Client, error) {
 	}
 
 	return client, err
+}
+
+// NewDynamicClientForConfig returns a dynamic client that is created and configured using the
+// provided REST configuration.
+func NewDynamicClientForConfig(config *rest.Config) (dynamic.Interface, error) {
+	return dynamic.NewForConfig(config)
 }


### PR DESCRIPTION
Adds a final check to the `rmdata` process that verifies all resources have been deleted.  If the final check fails, an error is thrown and the Job will fail.  This allows users to monitor for the completion condition in the Job to verify that all resources have been successfully deleted.

Additionally, the `pgcluster` is now deleted last as part of the `rmdata` process (assuming the `rmdata` process has been triggered via a `pgtask`, and not by deleting a `pgcluster`).  This means the `pgcluster` will remain visible in the environment until all resources have been removed.

Please note that the `DISABLE_FINAL_CHECK` environment variable can be set to `true` to disable the new "final check" behavior, essentially reverting back to previous behavior in which the Job might complete despite all resources not being fully deleted/removed. Additionally, as of this commit wait logic has been implemented for any/all Deployments and PVCs being deleted.

[sc-13106]