### PR TITLE
Add support for S3 EKS service authentication

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -1158,9 +1158,12 @@ func (r *Reconciler) generateRestoreJobIntent(cluster *v1beta1.PostgresCluster,
 					Resources:       dataSource.Resources,
 				}},
 				RestartPolicy: corev1.RestartPolicyNever,
-				Volumes:       volumes,
-				Affinity:      dataSource.Affinity,
-				Tolerations:   dataSource.Tolerations,
+				// Assign the instance serviceaccount to the job pod to allow AWS IAM integration
+				// - https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html
+				ServiceAccountName: naming.ClusterInstanceRBAC(cluster).Name,
+				Volumes:            volumes,
+				Affinity:           dataSource.Affinity,
+				Tolerations:        dataSource.Tolerations,
 			},
 		},
 	}

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -2405,6 +2405,9 @@ func TestGenerateRestoreJobIntent(t *testing.T) {
 		PriorityClassName: initialize.String("some-priority-class"),
 	}
 	cluster := &v1beta1.PostgresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
 		Spec: v1beta1.PostgresClusterSpec{
 			Metadata: &v1beta1.Metadata{
 				Labels:      map[string]string{"Global": "test"},
@@ -2539,10 +2542,7 @@ func TestGenerateRestoreJobIntent(t *testing.T) {
 							assert.Assert(t, job.Spec.Template.Spec.SecurityContext != nil)
 						})
 						t.Run("ServiceAccount", func(t *testing.T) {
-							assert.Equal(t, job.Spec.Template.Spec.ServiceAccountName, "")
-							if assert.Check(t, job.Spec.Template.Spec.AutomountServiceAccountToken != nil) {
-								assert.Equal(t, *job.Spec.Template.Spec.AutomountServiceAccountToken, false)
-							}
+							assert.Equal(t, job.Spec.Template.Spec.ServiceAccountName, "test-instance")
 						})
 					})
 				})


### PR DESCRIPTION
pgBackRest allows integrating with AWS EKS to assume an IAM role.
This integration was previously tested with manual changes; this PR adds
documentation on how to use this integration without making manual
changes to ServiceAccounts; and also updates the ServiceAccount used by
the restore job that was previously using the default SA.

**Checklist:**
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**
Currently users who want to take advantage of the pgBackRest/AWS IAM integration have no direction and have to make manual changes if they want to restore (as the restore job uses the the default ServiceAccount).

**What is the new behavior (if this is a feature change)?**
This adds documentation on how users can easily take advantage of pgBackRest/AWS IAM integration through the postgrescluster's spec.metadata.annotations field; and updates the restore job to use the shared instance serviceaccount.

**Other information**:
Issue [sc-12968]