### PR TITLE
Ensure pgBouncer resource limits can be set on create

### DIFF
--- a/cmd/pgo/cmd/create.go
+++ b/cmd/pgo/cmd/create.go
@@ -556,7 +556,7 @@ func init() {
 	// pgo create pgbouncer
 	createPgbouncerCmd.Flags().StringVar(&PgBouncerCPURequest, "cpu", "", "Set the number of millicores to request for CPU "+
 		"for pgBouncer. Defaults to being unset.")
-	createPgbouncerCmd.Flags().StringVar(&PgBouncerCPULimit, "cpu-limit", "", "Set the number of millicores to request for CPU "+
+	createPgbouncerCmd.Flags().StringVar(&PgBouncerCPULimit, "cpu-limit", "", "Set the number of millicores to limit for CPU "+
 		"for pgBouncer.")
 	createPgbouncerCmd.Flags().StringVar(&PgBouncerMemoryRequest, "memory", "", "Set the amount of memory to request for "+
 		"pgBouncer. Defaults to server value (24Mi).")

--- a/internal/apiserver/pgbouncerservice/pgbouncerimpl.go
+++ b/internal/apiserver/pgbouncerservice/pgbouncerimpl.go
@@ -149,6 +149,7 @@ func CreatePgbouncer(request *msgs.CreatePgbouncerRequest, ns, pgouser string) m
 		}
 
 		cluster.Spec.PgBouncer.Resources = resources
+		cluster.Spec.PgBouncer.Limits = limits
 		cluster.Spec.PgBouncer.TLSSecret = request.TLSSecret
 
 		// update the cluster CRD with these udpates. If there is an error


### PR DESCRIPTION
This only affects the "pgo create pgbouncer" command; the resource
limits were not being set in the custom resource from the API.
However, this functionally works correctly if set directly on the
custom resource.

Issue: [sc-13146]