### PR TITLE
Docs for Deleting Repo Host STS Following Upgrade from 5.0.0-5.0.2

### DIFF
--- a/docs/content/installation/upgrade.md
+++ b/docs/content/installation/upgrade.md
@@ -17,17 +17,17 @@ However, when upgrading to or from certain versions of PGO, extra steps may be r
 to ensure a clean and successful upgrade.  This page will therefore document any additional
 steps that must be completed when upgrading PGO.
 
-## Upgrading from PGO 5.0.0 Using Kustomize
+## Upgrading from PGO v5.0.0 Using Kustomize
 
-Starting with PGO 5.0.1, both the Deployment and ServiceAccount created when installing PGO via
+Starting with PGO v5.0.1, both the Deployment and ServiceAccount created when installing PGO via
 the installers in the
 [Postgres Operator examples repository](https://github.com/CrunchyData/postgres-operator-examples)
 have been renamed from `postgres-operator` to `pgo`.  As a result of this change, if using
-Kustomize to install PGO and upgrading from PGO 5.0.0, the following step must be completed prior
+Kustomize to install PGO and upgrading from PGO v5.0.0, the following step must be completed prior
 to upgrading.  This will ensure multiple versions of PGO are not installed and running concurrently
 within your Kubernetes environment.
 
-Prior to upgrading PGO, first manually delete the PGO 5.0.0 `postgres-operator` Deployment and
+Prior to upgrading PGO, first manually delete the PGO v5.0.0 `postgres-operator` Deployment and
 ServiceAccount:
 
 ```bash
@@ -40,3 +40,25 @@ by applying the new version of the Kustomize installer:
 ```bash
 kubectl apply -k kustomize/install/bases
 ```
+
+## Upgrading from PGO v5.0.2 and Below
+
+As a result of changes to pgBackRest dedicated repository host deployments in PGO v5.0.3
+(please see the [PGO v5.0.3 release notes]({{< relref "../releases/5.0.3.md" >}}) for more details),
+reconciliation of a pgBackRest dedicated repository host might become stuck with the following
+error (as shown in the PGO logs) following an upgrade from PGO versions v5.0.0 through v5.0.2:
+
+```bash
+StatefulSet.apps \"hippo-repo-host\" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy' and 'minReadySeconds' are forbidden
+```
+
+If this is the case, proceed with deleting the pgBackRest dedicated repository host StatefulSet,
+and PGO will then proceed with recreating and reconciling the dedicated repository host normally:
+
+```bash
+kubectl delete sts hippo-repo-host
+```
+
+Additionally, please be sure to update and apply all PostgresCluster custom resources in accordance
+with any applicable spec changes described in the 
+[PGO v5.0.3 release notes]({{< relref "../releases/5.0.3.md" >}}).


### PR DESCRIPTION
Adds upgrade documentation that instructs users to delete the dedicated repository StatefulSet following an upgrade from `v5.0.0-5.0.2` if a certain error is seen in the PGO logs that prevents reconciliation.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
N/A

[sc-13164]

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

N/A


**Other Information**:
N/A