### PR TITLE
Small cleanups to PKI tests

### DIFF
--- a/internal/controller/postgrescluster/pki_test.go
+++ b/internal/controller/postgrescluster/pki_test.go
@@ -18,7 +18,6 @@
 package postgrescluster
 
 import (
-	"bytes"
 	"context"
 	"crypto/x509"
 	"fmt"
@@ -185,7 +184,7 @@ func TestReconcileCerts(t *testing.T) {
 			assert.NilError(t, err)
 
 			// assert returned certificate matches the one created earlier
-			assert.Assert(t, bytes.Equal(fromSecret.Certificate, initialRoot.Certificate.Certificate))
+			assert.DeepEqual(t, fromSecret, initialRoot.Certificate)
 		})
 
 		t.Run("root certificate changes", func(t *testing.T) {
@@ -206,10 +205,10 @@ func TestReconcileCerts(t *testing.T) {
 			assert.NilError(t, err)
 
 			// check that the cert from the secret does not equal the initial certificate
-			assert.Assert(t, !bytes.Equal(fromSecret.Certificate, initialRoot.Certificate.Certificate))
+			assert.Assert(t, !fromSecret.Equal(*initialRoot.Certificate))
 
 			// check that the returned cert matches the cert from the secret
-			assert.Assert(t, bytes.Equal(fromSecret.Certificate, returnedRoot.Certificate.Certificate))
+			assert.DeepEqual(t, fromSecret, returnedRoot.Certificate)
 		})
 
 		t.Run("root CA secret is deleted after final cluster is deleted", func(t *testing.T) {
@@ -272,7 +271,7 @@ func TestReconcileCerts(t *testing.T) {
 			assert.NilError(t, err)
 
 			// assert returned certificate matches the one created earlier
-			assert.Assert(t, bytes.Equal(fromSecret.Certificate, initialLeafCert.Certificate.Certificate))
+			assert.DeepEqual(t, fromSecret, initialLeafCert.Certificate)
 		})
 
 		t.Run("check that the leaf certs update when root changes", func(t *testing.T) {
@@ -311,14 +310,14 @@ func TestReconcileCerts(t *testing.T) {
 			assert.NilError(t, err)
 
 			// assert old leaf cert does not match the newly reconciled one
-			assert.Assert(t, !bytes.Equal(oldLeafFromSecret.Certificate, newLeaf.Certificate.Certificate))
+			assert.Assert(t, !oldLeafFromSecret.Equal(*newLeaf.Certificate))
 
 			// 'reconcile' the certificate when the secret does not change. The returned leaf certificate should not change
 			newLeaf2, err := r.instanceCertificate(ctx, instance, instanceIntentSecret, instanceIntentSecret, newRootCert)
 			assert.NilError(t, err)
 
 			// check that the leaf cert did not change after another reconciliation
-			assert.Assert(t, bytes.Equal(newLeaf2.Certificate.Certificate, newLeaf.Certificate.Certificate))
+			assert.DeepEqual(t, newLeaf2.Certificate, newLeaf.Certificate)
 
 		})
 

--- a/internal/pki/pki.go
+++ b/internal/pki/pki.go
@@ -1,0 +1,31 @@
+/*
+ Copyright 2021 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pki
+
+import "bytes"
+
+// Equal reports whether c and other have the same value.
+func (c Certificate) Equal(other Certificate) bool {
+	return bytes.Equal(c.Certificate, other.Certificate)
+}
+
+// Equal reports whether k and other have the same value.
+func (k PrivateKey) Equal(other PrivateKey) bool {
+	if k.PrivateKey == nil || other.PrivateKey == nil {
+		return k.PrivateKey == other.PrivateKey
+	}
+	return k.PrivateKey.Equal(other.PrivateKey)
+}

--- a/internal/pki/pki_test.go
+++ b/internal/pki/pki_test.go
@@ -27,6 +27,46 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func TestCertificateEqual(t *testing.T) {
+	zero := Certificate{}
+	assert.Assert(t, zero.Equal(zero))
+
+	root := NewRootCertificateAuthority()
+	assert.NilError(t, root.Generate())
+	assert.Assert(t, root.Certificate.Equal(*root.Certificate))
+
+	assert.Assert(t, !root.Certificate.Equal(zero))
+	assert.Assert(t, !zero.Equal(*root.Certificate))
+
+	other := NewRootCertificateAuthority()
+	assert.NilError(t, other.Generate())
+	assert.Assert(t, !root.Certificate.Equal(*other.Certificate))
+
+	// DeepEqual calls the Equal method, so no cmp.Option are necessary.
+	assert.DeepEqual(t, zero, zero)
+	assert.DeepEqual(t, root.Certificate, root.Certificate)
+}
+
+func TestPrivateKeyEqual(t *testing.T) {
+	zero := PrivateKey{}
+	assert.Assert(t, zero.Equal(zero))
+
+	root := NewRootCertificateAuthority()
+	assert.NilError(t, root.Generate())
+	assert.Assert(t, root.PrivateKey.Equal(*root.PrivateKey))
+
+	assert.Assert(t, !root.PrivateKey.Equal(zero))
+	assert.Assert(t, !zero.Equal(*root.PrivateKey))
+
+	other := NewRootCertificateAuthority()
+	assert.NilError(t, other.Generate())
+	assert.Assert(t, !root.PrivateKey.Equal(*other.PrivateKey))
+
+	// DeepEqual calls the Equal method, so no cmp.Option are necessary.
+	assert.DeepEqual(t, zero, zero)
+	assert.DeepEqual(t, root.PrivateKey, root.PrivateKey)
+}
+
 // TestPKI does a full test of generating a valid certificate chain
 func TestPKI(t *testing.T) {
 	// generate the root CA


### PR DESCRIPTION
These two commits:
 - Add `Equal` methods to `pki.Certificate` and `pki.PrivateKey` so they can be used by `assert.DeepEqual` in tests.
 - Remove some Kubernetes API calls from `TestReconcileCerts`.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement