### PR TITLE
Remove unused pgBackRest configuration

### DIFF
--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -90,8 +90,6 @@ func TestPGBackRestConfiguration(t *testing.T) {
 	var cmInitial *corev1.ConfigMap
 	// the returned configmap
 	var cmReturned corev1.ConfigMap
-	// pod spec for testing projected volumes and volume mounts
-	pod := &corev1.PodSpec{}
 
 	testInstanceName := "test-instance-abc"
 	testRepoName := "repo-host"
@@ -214,93 +212,6 @@ pg1-path = /pgdata/pg`+strconv.Itoa(postgresCluster.Spec.PostgresVersion)+`
 pg1-port = 2345
 pg1-socket-path = /tmp/postgres
 `)
-	})
-
-	t.Run("check primary config volume", func(t *testing.T) {
-
-		PostgreSQLConfigVolumeAndMount(&cmReturned, pod, "database")
-
-		assert.Assert(t, simpleMarshalContains(&pod.Volumes, strings.TrimSpace(`
-		- name: pgbackrest-config
-  projected:
-    sources:
-    - configMap:
-        items:
-        - key: pgbackrest_primary.conf
-          path: /etc/pgbackrest/pgbackrest.conf
-        name: `+postgresCluster.GetName()+`-pgbackrest-config
-		`)+"\n"))
-	})
-
-	t.Run("check primary config volume mount", func(t *testing.T) {
-
-		PostgreSQLConfigVolumeAndMount(&cmReturned, pod, "database")
-
-		container := findOrAppendContainer(&pod.Containers, "database")
-
-		assert.Assert(t, simpleMarshalContains(container.VolumeMounts, strings.TrimSpace(`
-		- mountPath: /etc/pgbackrest/conf.d
-  name: pgbackrest-config
-  readOnly: true
-		`)+"\n"))
-	})
-
-	t.Run("check default config volume", func(t *testing.T) {
-
-		JobConfigVolumeAndMount(&cmReturned, pod, "pgbackrest")
-
-		assert.Assert(t, simpleMarshalContains(pod.Volumes, strings.TrimSpace(`
-		- name: pgbackrest-config
-  projected:
-    sources:
-    - configMap:
-        items:
-        - key: pgbackrest_job.conf
-          path: /etc/pgbackrest/pgbackrest.conf
-        name: `+postgresCluster.GetName()+`-pgbackrest-config
-		`)+"\n"))
-	})
-
-	t.Run("check default config volume mount", func(t *testing.T) {
-
-		JobConfigVolumeAndMount(&cmReturned, pod, "pgbackrest")
-
-		container := findOrAppendContainer(&pod.Containers, "pgbackrest")
-
-		assert.Assert(t, simpleMarshalContains(container.VolumeMounts, strings.TrimSpace(`
-		- mountPath: /etc/pgbackrest/conf.d
-  name: pgbackrest-config
-  readOnly: true
-		`)+"\n"))
-	})
-
-	t.Run("check repo config volume", func(t *testing.T) {
-
-		RepositoryConfigVolumeAndMount(&cmReturned, pod, "pgbackrest")
-
-		assert.Assert(t, simpleMarshalContains(&pod.Volumes, strings.TrimSpace(`
-		- name: pgbackrest-config
-  projected:
-    sources:
-    - configMap:
-        items:
-        - key: pgbackrest_repo.conf
-          path: /etc/pgbackrest/pgbackrest.conf
-        name: `+postgresCluster.GetName()+`-pgbackrest-config
-		`)+"\n"))
-	})
-
-	t.Run("check repo config volume mount", func(t *testing.T) {
-
-		RepositoryConfigVolumeAndMount(&cmReturned, pod, "pgbackrest")
-
-		container := findOrAppendContainer(&pod.Containers, "pgbackrest")
-
-		assert.Assert(t, simpleMarshalContains(container.VolumeMounts, strings.TrimSpace(`
-		- mountPath: /etc/pgbackrest/conf.d
-  name: pgbackrest-config
-  readOnly: true
-		`)+"\n"))
 	})
 }
 


### PR DESCRIPTION
A few functions were exported from our internal pgbackrest package but they were never called. This removes them and their constants. The remaining functions in this file do not make any API calls, so remove them from the tests as well.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
