### PR TITLE
Documentation Link syntax typo

### DIFF
--- a/docs/content/guides/extension-management.md
+++ b/docs/content/guides/extension-management.md
@@ -34,7 +34,7 @@ consumption) from the container itself via SQL queries.
 
 In order to do this, `pgnodemx` requires information from the Kubernetes [DownwardAPI](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/) 
 to be mounted on the PostgreSQL pods. Please see the `pgnodemx and the DownwardAPI` 
-section of the [backup architecture]]({{< relref "architecture/backups.md" >}}) page for more information on 
+section of the [backup architecture]({{< relref "architecture/backups.md" >}}) page for more information on 
 where and how the DownwardAPI is mounted.
 
 ### `pgnodemx` Configuration


### PR DESCRIPTION
Just a documentation fix: The link to the backup architecture had an extra `]`

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [X] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
