### PR TITLE
Set Default Archive Timeout

### DIFF
--- a/internal/pgbackrest/postgres.go
+++ b/internal/pgbackrest/postgres.go
@@ -30,6 +30,9 @@ func PostgreSQL(
 	if outParameters.Mandatory == nil {
 		outParameters.Mandatory = postgres.NewParameterSet()
 	}
+	if outParameters.Default == nil {
+		outParameters.Default = postgres.NewParameterSet()
+	}
 
 	// Send WAL files to all configured repositories when not in recovery.
 	// - https://pgbackrest.org/user-guide.html#quickstart/configure-archiving
@@ -38,6 +41,21 @@ func PostgreSQL(
 	archive := `pgbackrest --stanza=` + DefaultStanzaName + ` archive-push "%p"`
 	outParameters.Mandatory.Add("archive_mode", "on")
 	outParameters.Mandatory.Add("archive_command", archive)
+
+	// archive_timeout is used to determine at what point a WAL file is switched,
+	// if the WAL archive has not reached its full size in # of transactions
+	// (16MB). This has ramifications for log shipping, i.e. it ensures a WAL file
+	// is shipped to an archive every X seconds to help reduce the risk of data
+	// loss in a disaster recovery scenario. For standby servers that are not
+	// connected using streaming replication, this also ensures that new data is
+	// available at least once a minute.
+	//
+	// PostgreSQL documentation considers an archive_timeout of 60 seconds to be
+	// reasonable. There are cases where you may want to set archive_timeout to 0,
+	// for example, when the remote archive (pgBackRest repo) is unavailable; this
+	// is to prevent WAL accumulation on your primary.
+	// - https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-ARCHIVE-TIMEOUT
+	outParameters.Default.Add("archive_timeout", "60s")
 
 	// Fetch WAL files from any configured repository during recovery.
 	// - https://pgbackrest.org/command.html#command-archive-get

--- a/internal/pgbackrest/postgres_test.go
+++ b/internal/pgbackrest/postgres_test.go
@@ -35,6 +35,10 @@ func TestPostgreSQLParameters(t *testing.T) {
 		"restore_command": `pgbackrest --stanza=db archive-get %f "%p"`,
 	})
 
+	assert.DeepEqual(t, parameters.Default.AsMap(), map[string]string{
+		"archive_timeout": "60s",
+	})
+
 	cluster.Spec.Standby = &v1beta1.PostgresStandbySpec{
 		Enabled:  true,
 		RepoName: "repo99",


### PR DESCRIPTION
When archiving is enabled by PGO, an archive_timeout setting should also
be configured by default. More specifically, we should default to 60
seconds, as recommended by the PostgreSQL documentation as a
"reasonable" value for this setting:

https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-ARCHIVE-TIMEOUT

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
[sh-12876]