### PR TITLE
Manage pgAdmin server connections

### DIFF
--- a/internal/controller/postgrescluster/pgadmin.go
+++ b/internal/controller/postgrescluster/pgadmin.go
@@ -349,7 +349,7 @@ func (r *Reconciler) reconcilePGAdminUsers(
 	}
 
 	write := func(ctx context.Context, exec pgadmin.Executor) error {
-		return pgadmin.WriteUsersInPGAdmin(ctx, exec, specUsers, passwords)
+		return pgadmin.WriteUsersInPGAdmin(ctx, cluster, exec, specUsers, passwords)
 	}
 
 	revision, err := safeHash32(func(hasher io.Writer) error {

--- a/internal/controller/postgrescluster/pgadmin_test.go
+++ b/internal/controller/postgrescluster/pgadmin_test.go
@@ -621,6 +621,7 @@ func TestReconcilePGAdminUsers(t *testing.T) {
 	cluster := &v1beta1.PostgresCluster{}
 	cluster.Namespace = "ns1"
 	cluster.Name = "pgc1"
+	cluster.Spec.Port = initialize.Int32(5432)
 	cluster.Spec.UserInterface =
 		&v1beta1.UserInterfaceSpec{PGAdmin: &v1beta1.PGAdminPodSpec{}}
 

--- a/internal/pgadmin/users.go
+++ b/internal/pgadmin/users.go
@@ -19,9 +19,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/crunchydata/postgres-operator/internal/logging"
+	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -34,7 +36,7 @@ type Executor func(
 // blocks that user from logging in to pgAdmin. The pgAdmin configuration
 // database must exist before calling this.
 func WriteUsersInPGAdmin(
-	ctx context.Context, exec Executor,
+	ctx context.Context, cluster *v1beta1.PostgresCluster, exec Executor,
 	users []v1beta1.PostgresUserSpec, passwords map[string]string,
 ) error {
 	// The location of pgAdmin files can vary by container image. Look for
@@ -72,11 +74,47 @@ if sys.path[0] != root:
 	//
 	// TODO(cbandy): pgAdmin v4.21 adds "auth_source" and "username" as required attributes.
 	// - https://git.postgresql.org/gitweb/?p=pgadmin4.git;f=web/pgadmin/model/__init__.py;hb=REL-4_21#l65
+
+	// When the users are created or modified, server groups and connections will
+	// also be configured, similar to the way server groups and connections are
+	// made with their respective dialog windows.
+	// - https://www.pgadmin.org/docs/pgadmin4/latest/server_group_dialog.html
+	// - https://www.pgadmin.org/docs/pgadmin4/latest/server_dialog.html
+
+	// We use a similar method to the import method when creating server connections
+	// - https://www.pgadmin.org/docs/pgadmin4/development/import_export_servers.html
+	// - https://git.postgresql.org/gitweb/?p=pgadmin4.git;f=web/setup.py;hb=REL-4_20#l256
+
+	// One server connection will be configured for each defined user.
+	// The name of the server connection will be the same as the cluster name.
+	// Note that the server connections are created when the users are created or
+	// modified. Changes to a server connection will generally persist until a
+	// change is made to the corresponding user. For custom server connections,
+	// a new server should be created with a unique name.
+
+	// The server connection password is the plaintext password encrypted with the
+	// password itself as the key.
+	// - https://git.postgresql.org/gitweb/?p=pgadmin4.git;;f=web/pgadmin/__init__.py;hb=REL-4_20#l580
+	// - https://git.postgresql.org/gitweb/?p=pgadmin4.git;f=web/pgadmin/utils/master_password.py;hb=REL-4_20#l20
+	// - https://git.postgresql.org/gitweb/?p=pgadmin4.git;;f=web/pgadmin/browser/server_groups/servers/__init__.py;hb=REL-4_20#l840
+
+	// Due to limitations on the types of updates that can be made to active server
+	// connections, when the current server connection is updated, we need to delete
+	// it and add a new server connection in its place. This will require a refresh
+	// if pgAdmin web GUI is being used when the update takes place.
+	// - https://git.postgresql.org/gitweb/?p=pgadmin4.git;f=web/pgadmin/browser/server_groups/servers/__init__.py;hb=REL-4_20#l604
+
+	// define the hostname of the primary service
+	primary := naming.ClusterPrimaryService(cluster)
+	hostname := primary.Name + "." + primary.Namespace + ".svc"
+
 	const script = `
+import copy
 import json
 import sys
 from pgadmin import create_app
-from pgadmin.model import db, Role, User
+from pgadmin.model import db, Role, User, Server, ServerGroup
+from pgadmin.utils.crypto import encrypt
 
 with create_app().app_context():
     admin = db.session.query(User).filter_by(id=1).first()
@@ -105,6 +143,54 @@ with create_app().app_context():
 
         db.session.add(user)
         db.session.commit()
+
+        # Set the cluster and host name variable.
+        (clustername, hostname, port) = sys.argv[1:]
+
+        # Get or create the group as necessary
+        group = (
+            db.session.query(ServerGroup).filter_by(
+                user_id=user.id,
+            ).order_by("id").first() or
+            ServerGroup()
+        )
+        group.name = "Crunchy PostgreSQL Operator"
+        group.user_id = user.id
+        db.session.add(group)
+        db.session.commit()
+
+        # Get or create the server connection.
+        server = (
+            db.session.query(Server).filter_by(
+                servergroup_id=group.id,
+                user_id=user.id,
+                name=clustername,
+            ).first() or
+            Server()
+        )
+
+        # Add the required values.
+        server.name = clustername
+        server.servergroup_id = group.id
+        server.user_id = user.id
+        server.ssl_mode = "prefer"
+        server.host = hostname
+        server.username = data['username']
+        # Save the encrypted server password.
+        server.password = encrypt(data['password'], data['password'])
+        server.maintenance_db = "postgres"
+        server.port = port
+
+        # If the existing server doesn't match our needed configuration, create
+        # a new one.
+        if server.id and db.session.is_modified(server):
+            old = copy.deepcopy(server)
+            db.make_transient(server)
+            server.id = None
+            db.session.delete(old)
+
+        db.session.add(server)
+        db.session.commit()
 `
 
 	var err error
@@ -125,7 +211,8 @@ with create_app().app_context():
 	}
 
 	if err == nil {
-		err = exec(ctx, &stdin, &stdout, &stderr, "python", "-c", search+script)
+		err = exec(ctx, &stdin, &stdout, &stderr, "python", "-c", search+script,
+			cluster.Name, hostname, fmt.Sprint(*cluster.Spec.Port))
 
 		log := logging.FromContext(ctx)
 		log.V(1).Info("wrote pgAdmin users",


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

This commit creates server connections based on the users defined
for the PostgresCluster. With this update, each user is able to
log in with their unique password credential and manage their
Postgres database sessions. Relevant changes, such as port or
password, are handled automatically, but in some cases may require
reloading the page.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
Issue: [sc-12538]