### PR TITLE
Allow Scaledown of Original Primary After Upgrade

### DIFF
--- a/cmd/pgo-rmdata/process.go
+++ b/cmd/pgo-rmdata/process.go
@@ -70,20 +70,15 @@ func Delete(request Request) error {
 			log.Error(err)
 		}
 		// delete the pgreplica CRD
-		if err := request.Clientset.
-			CrunchydataV1().Pgreplicas(request.Namespace).
+		if err := request.Clientset.CrunchydataV1().Pgreplicas(request.Namespace).
 			Delete(ctx, request.ReplicaName, metav1.DeleteOptions{}); err != nil {
-			// If the name of the replica being deleted matches the scope for the cluster, then
-			// we assume it was the original primary and the pgreplica deletion will fail with
-			// a not found error.  In this case we allow the rmdata process to continue despite
-			// the error.  This allows for the original primary to be scaled down once it is
-			// is no longer a primary, and has become a replica.
-			if !(request.ReplicaName == request.ClusterPGHAScope && kerror.IsNotFound(err)) {
+			// if the pgreplica is not found, assume we're scaling down the original primary and
+			// continue with removing the replica
+			if !kerror.IsNotFound(err) {
 				log.Error(err)
-				return nil
+			} else {
+				log.Debug("pgreplica not found, assuming scale down of original primary")
 			}
-			log.Debug("replica name matches PGHA scope, assuming scale down of original primary" +
-				"and therefore ignoring error attempting to delete nonexistent pgreplica")
 		}
 
 		err = removeReplica(request)


### PR DESCRIPTION
Updates the rmdata process to simply ignore any isNotFound errors when attempting to delete a pgreplica for a scaledown request.  Specifically, the pgreplica deletion logic is no longer concerned with the replica name matching the cluster scope when determining whether or not to ignore an isNotFound error, since the there are scenarios where we might expect this error even though the replica name does not match the scope (for instance following a upgrade, where the original primary might have a name that does not match the scope, e.g. if a failover has previously occurred prior to the upgrade).

And since the goal of running the rmdata process is to delete any/all replica resources, including the pgreplica itself, if the replica is already gone for some reason (e.g. if someone manually deletes it before rmdata has a chance to, or if the original primary is being scaled down, which will simply not have an associated pgreplica), the rmdata process can continue with 
attempting to cleanup all other replica resources to ensure the replica is fully removed.

[sc-13225]