### PR TITLE
Make Upgrade Check URL Configurable

### DIFF
--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 
@@ -88,10 +89,17 @@ func main() {
 	done := make(chan bool, 1)
 	if upgradeCheckingEnabled {
 		log.Info("upgrade checking enabled")
-		go upgradecheck.CheckForUpgradesScheduler(done, versionString,
-			mgr.GetClient(), mgr.GetConfig(), isOpenshift(ctx, mgr.GetConfig()),
-			mgr.GetCache(),
-		)
+		// set the URL for the check for upgrades endpoint
+		upgradeCheckURL := os.Getenv("CHECK_FOR_UPGRADES_URL")
+		if upgradeCheckURL == "" {
+			log.Error(errors.New("check for upgrades URL is not set"),
+				"unable to check for upgrades")
+		} else {
+			go upgradecheck.CheckForUpgradesScheduler(done, versionString, upgradeCheckURL,
+				mgr.GetClient(), mgr.GetConfig(), isOpenshift(ctx, mgr.GetConfig()),
+				mgr.GetCache(),
+			)
+		}
 	} else {
 		log.Info("upgrade checking disabled")
 	}

--- a/internal/upgradecheck/http.go
+++ b/internal/upgradecheck/http.go
@@ -46,8 +46,8 @@ var (
 		Steps:    4,
 	}
 
-	// TODO(benjaminjb): Make configurable
-	upgradeCheckURL    = "http://localhost:8080"
+	// upgradeCheckURL is set using the CHECK_FOR_UPGRADES_URL env var
+	upgradeCheckURL    string
 	upgradeCheckPeriod = 24 * time.Hour
 )
 
@@ -144,7 +144,7 @@ func checkForUpgrades(log logr.Logger, versionString string, backoff wait.Backof
 // CheckForUpgradesScheduler invokes the check func when the operator starts
 // and then on the given period schedule
 func CheckForUpgradesScheduler(channel chan bool,
-	versionString string, crclient crclient.Client,
+	versionString, url string, crclient crclient.Client,
 	cfg *rest.Config, isOpenShift bool,
 	cacheClient CacheWithWait,
 ) {
@@ -158,6 +158,9 @@ func CheckForUpgradesScheduler(channel chan bool,
 			)
 		}
 	}()
+
+	// set the URL for the check for upgrades endpoint
+	upgradeCheckURL = url
 
 	// Since we pass the client to this function before we start the manager
 	// in cmd/postgres-operator/main.go, we want to make sure cache is synced

--- a/internal/upgradecheck/http_test.go
+++ b/internal/upgradecheck/http_test.go
@@ -171,6 +171,7 @@ func TestCheckForUpgradesScheduler(t *testing.T) {
 	_, server := setupVersionServer(t, true)
 	defer server.Close()
 	cfg := &rest.Config{Host: server.URL}
+	const testUpgradeCheckURL = "http://localhost:8080"
 
 	t.Run("panic from checkForUpgrades doesn't bubble up", func(t *testing.T) {
 		done := make(chan bool, 1)
@@ -185,7 +186,8 @@ func TestCheckForUpgradesScheduler(t *testing.T) {
 			panic(fmt.Errorf("oh no!"))
 		}
 
-		go CheckForUpgradesScheduler(done, "4.7.3", fakeClient, cfg, false, &MockCacheClient{works: true})
+		go CheckForUpgradesScheduler(done, "4.7.3", testUpgradeCheckURL, fakeClient, cfg, false,
+			&MockCacheClient{works: true})
 		time.Sleep(1 * time.Second)
 		done <- true
 
@@ -206,7 +208,8 @@ func TestCheckForUpgradesScheduler(t *testing.T) {
 		// Set loop time to 1s and sleep for 2s before sending the done signal -- though the cache sync
 		// failure will exit the func before the sleep ends
 		upgradeCheckPeriod = 1 * time.Second
-		go CheckForUpgradesScheduler(done, "4.7.3", fakeClient, cfg, false, &MockCacheClient{works: false})
+		go CheckForUpgradesScheduler(done, "4.7.3", testUpgradeCheckURL, fakeClient, cfg, false,
+			&MockCacheClient{works: false})
 		time.Sleep(2 * time.Second)
 		done <- true
 
@@ -234,7 +237,8 @@ func TestCheckForUpgradesScheduler(t *testing.T) {
 
 		// Set loop time to 1s and sleep for 2s before sending the done signal
 		upgradeCheckPeriod = 1 * time.Second
-		go CheckForUpgradesScheduler(done, "4.7.3", fakeClient, cfg, false, &MockCacheClient{works: true})
+		go CheckForUpgradesScheduler(done, "4.7.3", testUpgradeCheckURL, fakeClient, cfg, false,
+			&MockCacheClient{works: true})
 		time.Sleep(2 * time.Second)
 		done <- true
 


### PR DESCRIPTION
Makes it possible to configure the URL for the endpoint used to check for PGO upgrades.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

The upgrade check URL is not configurable.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

The upgrade check URL is configurable.

[sc-13171]

**Other Information**:

N/A