### PR TITLE
Track linter issues that are not yet enforced

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with: { go-version: 1.x }
+
       - uses: golangci/golangci-lint-action@v2
         with:
+          # https://github.com/golangci/golangci-lint-action/issues/365
+          skip-go-installation: true
           version: latest
           args: --timeout=5m
+
+      # Count issues reported by disabled linters. The command always
+      # exits zero to ensure it does not fail the pull request check.
+      - name: Count non-blocking issues
+        run: >
+          golangci-lint run \
+            --config .golangci.next.yaml \
+            --issues-exit-code 0 \
+            --max-issues-per-linter 0 \
+            --max-same-issues 0 \
+            --out-format json |
+          jq --color-output --sort-keys \
+            'reduce .Issues[] as $i ({}; .[$i.FromLinter] += 1)' ||
+          true

--- a/.golangci.next.yaml
+++ b/.golangci.next.yaml
@@ -1,0 +1,36 @@
+# https://golangci-lint.run/usage/configuration/
+#
+# This file is for linters that might be interesting to enforce in the future.
+# Rules that should be enforced immediately belong in [.golangci.yaml].
+#
+# Both files are used by [.github/workflows/lint.yaml].
+
+linters:
+  disable-all: true
+  enable:
+    - gocritic
+    - godot
+    - godox
+    - goerr113
+    - gofumpt
+    - gosec # exclude-use-default
+    - nilnil
+    - nolintlint
+    - predeclared
+    - revive
+    - staticcheck # exclude-use-default
+    - tenv
+    - thelper
+    - tparallel
+    - unconvert
+    - wastedassign
+
+issues:
+  # https://github.com/golangci/golangci-lint/issues/2239
+  exclude-use-default: false
+
+linters-settings:
+
+run:
+  build-tags:
+    - envtest


### PR DESCRIPTION
Some of these linters might be worthwhile to enable and enforce in the future. Provide a place to configure them and run them that does not fail pull request checks. To run them locally:

```sh
golangci-lint run --config .golangci.next.yaml
```

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
