### PR TITLE
Stop writing ExternalIPs for <cluster>-primary service

### DIFF
--- a/internal/controller/postgrescluster/cluster.go
+++ b/internal/controller/postgrescluster/cluster.go
@@ -149,20 +149,6 @@ func (r *Reconciler) generateClusterPrimaryService(
 		TargetPort: intstr.FromString(naming.PortPostgreSQL),
 	}}
 
-	// Copy the LoadBalancerStatus of the leader Service into external fields.
-	// These fields are presented in the "External-IP" field of `kubectl get`.
-	// - https://releases.k8s.io/v1.18.0/pkg/printers/internalversion/printers.go#L1046
-	// - https://releases.k8s.io/v1.22.0/pkg/printers/internalversion/printers.go#L1110
-	if leader.Spec.Type == corev1.ServiceTypeLoadBalancer {
-		for _, ingress := range leader.Status.LoadBalancer.Ingress {
-			service.Spec.ExternalIPs = append(service.Spec.ExternalIPs, ingress.IP)
-
-			if service.Spec.ExternalName == "" && ingress.Hostname != "" {
-				service.Spec.ExternalName = ingress.Hostname
-			}
-		}
-	}
-
 	// Resolve to the ClusterIP for which Patroni has configured the Endpoints.
 	endpoints.Subsets = []corev1.EndpointSubset{{
 		Addresses: []corev1.EndpointAddress{{IP: leader.Spec.ClusterIP}},

--- a/internal/controller/postgrescluster/cluster_test.go
+++ b/internal/controller/postgrescluster/cluster_test.go
@@ -797,10 +797,11 @@ subsets:
 		assert.NilError(t, err)
 		alwaysExpect(t, service, endpoints)
 
-		assert.DeepEqual(t, service.Spec.ExternalIPs, []string{
-			"55.44.33.22", "99.88.77.66", "1.2.3.4",
-		})
-		assert.Equal(t, service.Spec.ExternalName, "some.host")
+		// generateClusterPrimaryService no longer sets ExternalIPs or ExternalName from
+		// LoadBalancer-type leader service
+		// - https://cloud.google.com/anthos/clusters/docs/security-bulletins#gcp-2020-015
+		assert.Equal(t, len(service.Spec.ExternalIPs), 0)
+		assert.Equal(t, service.Spec.ExternalName, "")
 	})
 }
 


### PR DESCRIPTION
For convenience, if a cluster was created with `spec.service.type` `LoadBalancer`,
we updated the <cluster>-primary Service with the ExternalIPs and ExternalName.
However, this has led to a problem in GKE auto-pilot clusters, where
ExternalIPs are not allowed due to security concerns.
(See https://cloud.google.com/anthos/clusters/docs/security-bulletins#gcp-2020-015).
This PR removes the code that added the ExternalIPs and ExternalName to the
<cluster>-primary Service.

**Checklist:**
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable? -- no documentation specifically referenced the LoadBalancer type/ExternalIP on <cluster>-primary Service
 - [x] Have you tested your changes on all related environments with successful results, as applicable? -- verified error and verified fix in auto-pilot clusters; could not replicate in non-auto-pilot
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other

**What is the current behavior (link to any open issues here)?**
Operator 5.x would fail to create cluster in GKE auto-pilot clusters

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Operator can create cluster in GKE auto-pilot clusters

**Other Information**:
Issue [sc-13257]