### PR TITLE
Remove uses of io/ioutil

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,7 @@ linters:
     - gofumpt
     - scopelint
   enable:
+    - depguard
     - gomodguard
     - gosimple
     - importas
@@ -15,6 +16,12 @@ linters:
     - unused
 
 linters-settings:
+  depguard:
+    include-go-root: true
+    packages-with-error-message:
+      - io/ioutil: >
+          Use the "io" and "os" packages instead.
+          See https://go.dev/doc/go1.16#ioutil
   exhaustive:
     default-signifies-exhaustive: true
   goimports:

--- a/internal/controller/postgrescluster/instance_rollout_test.go
+++ b/internal/controller/postgrescluster/instance_rollout_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -84,7 +83,7 @@ func TestReconcilerRolloutInstance(t *testing.T) {
 			assert.Equal(t, container, "database")
 
 			// Checkpoint with timeout.
-			b, _ := ioutil.ReadAll(stdin)
+			b, _ := io.ReadAll(stdin)
 			assert.Equal(t, string(b), "SET statement_timeout = :'timeout'; CHECKPOINT;")
 			commandString := strings.Join(command, " ")
 			assert.Assert(t, cmp.Contains(commandString, "psql"))

--- a/internal/patroni/config_test.go
+++ b/internal/patroni/config_test.go
@@ -16,7 +16,7 @@
 package patroni
 
 import (
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -751,7 +751,7 @@ func TestPGBackRestCreateReplicaCommand(t *testing.T) {
 	{
 		command := parsed.PostgreSQL.PGBackRest.Command
 		file := filepath.Join(dir, "command.sh")
-		assert.NilError(t, ioutil.WriteFile(file, []byte(command), 0o600))
+		assert.NilError(t, os.WriteFile(file, []byte(command), 0o600))
 
 		cmd := exec.Command(shellcheck, "--enable=all", "--shell=sh", file)
 		output, err := cmd.CombinedOutput()
@@ -773,7 +773,7 @@ func TestPGBackRestCreateReplicaCommand(t *testing.T) {
 	// It should pass shellcheck.
 	{
 		file := filepath.Join(dir, "script.bash")
-		assert.NilError(t, ioutil.WriteFile(file, []byte(script), 0o600))
+		assert.NilError(t, os.WriteFile(file, []byte(script), 0o600))
 
 		cmd := exec.Command(shellcheck, "--enable=all", file)
 		output, err := cmd.CombinedOutput()

--- a/internal/pgadmin/users_test.go
+++ b/internal/pgadmin/users_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -210,7 +209,7 @@ with create_app().app_context():
 		) error {
 			calls++
 
-			b, err := ioutil.ReadAll(stdin)
+			b, err := io.ReadAll(stdin)
 			assert.NilError(t, err)
 			assert.Assert(t, len(b) == 0, "expected no stdin, got %q", string(b))
 			return nil
@@ -233,7 +232,7 @@ with create_app().app_context():
 		) error {
 			calls++
 
-			b, err := ioutil.ReadAll(stdin)
+			b, err := io.ReadAll(stdin)
 			assert.NilError(t, err)
 			assert.DeepEqual(t, string(b), strings.TrimLeft(`
 {"password":"","username":"user-no-options"}

--- a/internal/pgaudit/postgres_test.go
+++ b/internal/pgaudit/postgres_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -40,7 +39,7 @@ func TestEnableInPostgreSQL(t *testing.T) {
 			`SELECT datname FROM pg_catalog.pg_database`,
 		), "expected all databases and templates")
 
-		b, err := ioutil.ReadAll(stdin)
+		b, err := io.ReadAll(stdin)
 		assert.NilError(t, err)
 		assert.Equal(t, string(b), strings.Trim(`
 SET client_min_messages = WARNING; CREATE EXTENSION IF NOT EXISTS pgaudit;

--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -17,7 +17,6 @@ package pgbackrest
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -258,7 +257,7 @@ func TestRestoreCommand(t *testing.T) {
 
 	dir := t.TempDir()
 	file := filepath.Join(dir, "script.bash")
-	assert.NilError(t, ioutil.WriteFile(file, []byte(command[3]), 0o600))
+	assert.NilError(t, os.WriteFile(file, []byte(command[3]), 0o600))
 
 	cmd := exec.Command(shellcheck, "--enable=all", file)
 	output, err := cmd.CombinedOutput()

--- a/internal/pgbackrest/pgbackrest_test.go
+++ b/internal/pgbackrest/pgbackrest_test.go
@@ -18,7 +18,7 @@ package pgbackrest
 import (
 	"context"
 	"io"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -71,7 +71,7 @@ fi
 	// Write out that inline script.
 	dir := t.TempDir()
 	file := filepath.Join(dir, "script.bash")
-	assert.NilError(t, ioutil.WriteFile(file, []byte(shellCheckScript), 0o600))
+	assert.NilError(t, os.WriteFile(file, []byte(shellCheckScript), 0o600))
 
 	// Expect shellcheck to be happy.
 	cmd := exec.Command(shellcheck, "--enable=all", file)

--- a/internal/pgbouncer/config_test.go
+++ b/internal/pgbouncer/config_test.go
@@ -16,7 +16,7 @@
 package pgbouncer
 
 import (
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -228,7 +228,7 @@ func TestReloadCommand(t *testing.T) {
 	// Write out that inline script.
 	dir := t.TempDir()
 	file := filepath.Join(dir, "script.bash")
-	assert.NilError(t, ioutil.WriteFile(file, []byte(command[3]), 0o600))
+	assert.NilError(t, os.WriteFile(file, []byte(command[3]), 0o600))
 
 	// Expect shellcheck to be happy.
 	cmd := exec.Command(shellcheck, "--enable=all", file)

--- a/internal/pgbouncer/postgres_test.go
+++ b/internal/pgbouncer/postgres_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -57,7 +56,7 @@ func TestDisableInPostgreSQL(t *testing.T) {
 				`SELECT datname FROM pg_catalog.pg_database`,
 			), "expected all databases and templates")
 
-			b, err := ioutil.ReadAll(stdin)
+			b, err := io.ReadAll(stdin)
 			assert.NilError(t, err)
 			assert.Equal(t, string(b), strings.TrimSpace(`
 SET client_min_messages = WARNING;
@@ -100,7 +99,7 @@ COMMIT;`))
 				`SELECT pg_catalog.current_database()`,
 			), "expected the default database")
 
-			b, err := ioutil.ReadAll(stdin)
+			b, err := io.ReadAll(stdin)
 			assert.NilError(t, err)
 			assert.Equal(t, string(b), `SET client_min_messages = WARNING; DROP ROLE IF EXISTS :"username";`)
 			gomega.NewWithT(t).Expect(command).To(gomega.ContainElements(
@@ -143,7 +142,7 @@ func TestEnableInPostgreSQL(t *testing.T) {
 			`SELECT datname FROM pg_catalog.pg_database`,
 		), "expected all databases and templates")
 
-		b, err := ioutil.ReadAll(stdin)
+		b, err := io.ReadAll(stdin)
 		assert.NilError(t, err)
 		assert.Equal(t, string(b), strings.TrimSpace(`
 SET client_min_messages = WARNING;

--- a/internal/pki/pki_test.go
+++ b/internal/pki/pki_test.go
@@ -17,8 +17,8 @@ package pki
 
 import (
 	"crypto/x509"
-	"io/ioutil"
 	"net"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -152,7 +152,7 @@ func basicOpenSSLVerify(t *testing.T, openssl string, root, leaf *Certificate) {
 	rootFile := filepath.Join(dir, "root.crt")
 	rootBytes, err := root.MarshalText()
 	assert.NilError(t, err)
-	assert.NilError(t, ioutil.WriteFile(rootFile, rootBytes, 0600))
+	assert.NilError(t, os.WriteFile(rootFile, rootBytes, 0o600))
 
 	// The root certificate cannot be verified independently because it is self-signed.
 	// It is checked below by being the specified CA.
@@ -160,7 +160,7 @@ func basicOpenSSLVerify(t *testing.T, openssl string, root, leaf *Certificate) {
 	leafFile := filepath.Join(dir, "leaf.crt")
 	leafBytes, err := leaf.MarshalText()
 	assert.NilError(t, err)
-	assert.NilError(t, ioutil.WriteFile(leafFile, leafBytes, 0600))
+	assert.NilError(t, os.WriteFile(leafFile, leafBytes, 0o600))
 
 	// Older versions of OpenSSL have fewer options for verifying certificates.
 	// When the only flag available is "-CAfile", CAs must be bundled
@@ -182,7 +182,7 @@ func basicOpenSSLVerify(t *testing.T, openssl string, root, leaf *Certificate) {
 	// on the verification method given below.
 
 	bundleFile := filepath.Join(dir, "ca-chain.crt")
-	assert.NilError(t, ioutil.WriteFile(bundleFile, rootBytes, 0600))
+	assert.NilError(t, os.WriteFile(bundleFile, rootBytes, 0o600))
 
 	verify(t, "-CAfile", bundleFile, leafFile)
 	verify(t, "-CAfile", bundleFile, "-purpose", "sslclient", leafFile)
@@ -208,7 +208,7 @@ func strictOpenSSLVerify(t *testing.T, openssl string, root, leaf *Certificate) 
 	rootFile := filepath.Join(dir, "root.crt")
 	rootBytes, err := root.MarshalText()
 	assert.NilError(t, err)
-	assert.NilError(t, ioutil.WriteFile(rootFile, rootBytes, 0600))
+	assert.NilError(t, os.WriteFile(rootFile, rootBytes, 0o600))
 
 	// The root certificate cannot be verified independently because it is self-signed.
 	// Some checks are performed when it is a "trusted" certificate below.
@@ -216,7 +216,7 @@ func strictOpenSSLVerify(t *testing.T, openssl string, root, leaf *Certificate) 
 	leafFile := filepath.Join(dir, "leaf.crt")
 	leafBytes, err := leaf.MarshalText()
 	assert.NilError(t, err)
-	assert.NilError(t, ioutil.WriteFile(leafFile, leafBytes, 0600))
+	assert.NilError(t, os.WriteFile(leafFile, leafBytes, 0o600))
 
 	verify(t, "-trusted", rootFile, leafFile)
 	verify(t, "-trusted", rootFile, "-purpose", "sslclient", leafFile)

--- a/internal/postgis/postgis_test.go
+++ b/internal/postgis/postgis_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -38,7 +37,7 @@ func TestEnableInPostgreSQL(t *testing.T) {
 			`SELECT datname FROM pg_catalog.pg_database`,
 		), "expected all databases and templates")
 
-		b, err := ioutil.ReadAll(stdin)
+		b, err := io.ReadAll(stdin)
 		assert.NilError(t, err)
 		assert.Equal(t, string(b), `SET client_min_messages = WARNING;
 CREATE EXTENSION IF NOT EXISTS postgis;

--- a/internal/postgres/config_test.go
+++ b/internal/postgres/config_test.go
@@ -16,7 +16,6 @@
 package postgres
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -88,7 +87,7 @@ func TestBashSafeLink(t *testing.T) {
 		// assertSetupContents ensures that directory contents match setupDirectory.
 		assertSetupContents := func(t testing.TB, directory string) {
 			t.Helper()
-			entries, err := ioutil.ReadDir(directory)
+			entries, err := os.ReadDir(directory)
 			assert.NilError(t, err)
 			assert.Equal(t, len(entries), 1)
 			assert.Equal(t, entries[0].Name(), "original.file")
@@ -169,14 +168,14 @@ func TestBashSafeLink(t *testing.T) {
 			t.Helper()
 			root = t.TempDir()
 			current = filepath.Join(root, "original")
-			assert.NilError(t, ioutil.WriteFile(current, []byte(`treasure`), 0o600))
+			assert.NilError(t, os.WriteFile(current, []byte(`treasure`), 0o600))
 			return
 		}
 
 		// assertSetupContents ensures that file contents match setupFile.
 		assertSetupContents := func(t testing.TB, file string) {
 			t.Helper()
-			content, err := ioutil.ReadFile(file)
+			content, err := os.ReadFile(file)
 			assert.NilError(t, err)
 			assert.Equal(t, string(content), `treasure`)
 		}
@@ -252,7 +251,7 @@ func TestBashSafeLink(t *testing.T) {
 		assert.NilError(t, err, "expected symlink")
 		assert.Equal(t, result, current)
 
-		entries, err := ioutil.ReadDir(current)
+		entries, err := os.ReadDir(current)
 		assert.NilError(t, err)
 		assert.Equal(t, len(entries), 1)
 		assert.Equal(t, entries[0].Name(), "original.file")
@@ -281,7 +280,7 @@ func TestBashSafeLink(t *testing.T) {
 		assert.NilError(t, err, "expected symlink")
 		assert.Equal(t, result, desired)
 
-		entries, err := ioutil.ReadDir(desired)
+		entries, err := os.ReadDir(desired)
 		assert.NilError(t, err)
 		assert.Equal(t, len(entries), 1)
 		assert.Equal(t, entries[0].Name(), "original.file")
@@ -340,7 +339,7 @@ func TestStartupCommand(t *testing.T) {
 	// Write out that inline script.
 	dir := t.TempDir()
 	file := filepath.Join(dir, "script.bash")
-	assert.NilError(t, ioutil.WriteFile(file, []byte(command[3]), 0o600))
+	assert.NilError(t, os.WriteFile(file, []byte(command[3]), 0o600))
 
 	// Expect shellcheck to be happy.
 	cmd := exec.Command(shellcheck, "--enable=all", file)

--- a/internal/postgres/databases_test.go
+++ b/internal/postgres/databases_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -59,7 +58,7 @@ func TestCreateDatabasesInPostgreSQL(t *testing.T) {
 		) error {
 			calls++
 
-			b, err := ioutil.ReadAll(stdin)
+			b, err := io.ReadAll(stdin)
 			assert.NilError(t, err)
 			assert.Equal(t, string(b), strings.TrimLeft(`
 SET search_path TO '';
@@ -93,7 +92,7 @@ SELECT pg_catalog.format('CREATE DATABASE %I',
 		) error {
 			calls++
 
-			b, err := ioutil.ReadAll(stdin)
+			b, err := io.ReadAll(stdin)
 			assert.NilError(t, err)
 			assert.Assert(t, contains(string(b), `
 \copy input (data) from stdin with (format text)

--- a/internal/postgres/exec_test.go
+++ b/internal/postgres/exec_test.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -45,7 +45,7 @@ func TestExecutorExec(t *testing.T) {
 	fn := func(
 		_ context.Context, stdin io.Reader, stdout, stderr io.Writer, command ...string,
 	) error {
-		b, err := ioutil.ReadAll(stdin)
+		b, err := io.ReadAll(stdin)
 		assert.NilError(t, err)
 		assert.Equal(t, string(b), `statements; to run;`)
 
@@ -80,7 +80,7 @@ func TestExecutorExecInAllDatabases(t *testing.T) {
 	fn := func(
 		_ context.Context, stdin io.Reader, stdout, stderr io.Writer, command ...string,
 	) error {
-		b, err := ioutil.ReadAll(stdin)
+		b, err := io.ReadAll(stdin)
 		assert.NilError(t, err)
 		assert.Equal(t, string(b), `the; stuff;`)
 
@@ -126,7 +126,7 @@ func TestExecutorExecInDatabasesFromQuery(t *testing.T) {
 	fn := func(
 		_ context.Context, stdin io.Reader, stdout, stderr io.Writer, command ...string,
 	) error {
-		b, err := ioutil.ReadAll(stdin)
+		b, err := io.ReadAll(stdin)
 		assert.NilError(t, err)
 		assert.Equal(t, string(b), `statements; to run;`)
 
@@ -197,7 +197,7 @@ done <<< "${databases}"
 			// Write out that inline script.
 			dir := t.TempDir()
 			file := filepath.Join(dir, "script.bash")
-			assert.NilError(t, ioutil.WriteFile(file, []byte(script), 0o600))
+			assert.NilError(t, os.WriteFile(file, []byte(script), 0o600))
 
 			// Expect shellcheck to be happy.
 			cmd := exec.Command(shellcheck, "--enable=all", file)

--- a/internal/postgres/reconcile_test.go
+++ b/internal/postgres/reconcile_test.go
@@ -17,7 +17,7 @@ package postgres
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -816,7 +816,7 @@ func TestUpgradeCommand(t *testing.T) {
 	// Write out that inline script.
 	dir := t.TempDir()
 	file := filepath.Join(dir, "script.bash")
-	assert.NilError(t, ioutil.WriteFile(file, []byte(command[3]), 0o600))
+	assert.NilError(t, os.WriteFile(file, []byte(command[3]), 0o600))
 
 	// Expect shellcheck to be happy.
 	cmd := exec.Command(shellcheck, "--enable=all", file)

--- a/internal/postgres/users_test.go
+++ b/internal/postgres/users_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -61,7 +60,7 @@ func TestWriteUsersInPostgreSQL(t *testing.T) {
 		) error {
 			calls++
 
-			b, err := ioutil.ReadAll(stdin)
+			b, err := io.ReadAll(stdin)
 			assert.NilError(t, err)
 			assert.Equal(t, string(b), strings.TrimSpace(`
 SET search_path TO '';
@@ -113,7 +112,7 @@ COMMIT;`))
 		) error {
 			calls++
 
-			b, err := ioutil.ReadAll(stdin)
+			b, err := io.ReadAll(stdin)
 			assert.NilError(t, err)
 			assert.Assert(t, contains(string(b), `
 \copy input (data) from stdin with (format text)
@@ -154,7 +153,7 @@ COMMIT;`))
 		) error {
 			calls++
 
-			b, err := ioutil.ReadAll(stdin)
+			b, err := io.ReadAll(stdin)
 			assert.NilError(t, err)
 			assert.Assert(t, contains(string(b), `
 \copy input (data) from stdin with (format text)


### PR DESCRIPTION
The package was somewhat deprecated in Go 1.16. Identical functions are in the "io" and "os" packages.

See: https://go.dev/doc/go1.16#ioutil

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
