### PR TITLE
Update pgAdmin SecurityContext

### DIFF
--- a/internal/controller/postgrescluster/pgadmin.go
+++ b/internal/controller/postgrescluster/pgadmin.go
@@ -31,6 +31,7 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/logging"
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/pgadmin"
+	"github.com/crunchydata/postgres-operator/internal/postgres"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -231,7 +232,7 @@ func (r *Reconciler) reconcilePGAdminStatefulSet(
 	// ServiceAccount and do not mount its credentials.
 	sts.Spec.Template.Spec.AutomountServiceAccountToken = initialize.Bool(false)
 
-	sts.Spec.Template.Spec.SecurityContext = initialize.RestrictedPodSecurityContext()
+	sts.Spec.Template.Spec.SecurityContext = postgres.PodSecurityContext(cluster)
 
 	// set the image pull secrets, if any exist
 	sts.Spec.Template.Spec.ImagePullSecrets = cluster.Spec.ImagePullSecrets

--- a/internal/controller/postgrescluster/pgadmin_test.go
+++ b/internal/controller/postgrescluster/pgadmin_test.go
@@ -369,6 +369,7 @@ dnsPolicy: ClusterFirst
 restartPolicy: Always
 schedulerName: default-scheduler
 securityContext:
+  fsGroup: 26
   runAsNonRoot: true
 terminationGracePeriodSeconds: 30
 volumes:
@@ -534,6 +535,7 @@ imagePullSecrets:
 restartPolicy: Always
 schedulerName: default-scheduler
 securityContext:
+  fsGroup: 26
   runAsNonRoot: true
 terminationGracePeriodSeconds: 30
 tolerations:


### PR DESCRIPTION
Updates the security context for the pgAdmin StatefulSet to include the proper `fsGroup` and `supplementalGroups` settings.  Specifically, `fsGroup` is now set to 26 if not running in OpenShift, while any supplemental groups defined in the spec are also applied.  This ensures mounted  pgAdmin volumes are writeable as required by the pgAdmin application.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

- `fsGroup` is not applied to the pgAdmin StatefultSet.

[sc-13287]

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- `fsGroup` is applied to the pgAdmin StatefultSet.

**Other Information**:

N/A