### PR TITLE
Allow Use Of External WAL With Major PG Upgrades

### DIFF
--- a/internal/postgres/reconcile_test.go
+++ b/internal/postgres/reconcile_test.go
@@ -753,15 +753,14 @@ spec:
           readOnly: true
         - mountPath: /pgdata
           name: postgres-data
+        - mountPath: /pgwal
+          name: postgres-wal
       restartPolicy: Never
       securityContext:
         fsGroup: 26
         runAsNonRoot: true
       serviceAccountName: hippo-sa
       volumes:
-      - name: postgres-data
-        persistentVolumeClaim:
-          claimName: datavol
       - name: cert-volume
         projected:
           defaultMode: 384
@@ -782,6 +781,12 @@ spec:
               - key: tls.key
                 path: replication/tls.key
               name: repl-secret
+      - name: postgres-data
+        persistentVolumeClaim:
+          claimName: datavol
+      - name: postgres-wal
+        persistentVolumeClaim:
+          claimName: walvol
 status: {}
 `))
 }


### PR DESCRIPTION
Adds support for upgrading clusters that utilize external WAL volumes.  Specifically, the `pg_upgrade` Job now mounts an external WAL volume if configured for the instance being upgraded, therefore ensuring `pg_upgrade` is able to complete successfully.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

 - Clusters utilizing external WAL volumes cannot be upgraded to a new major PG version using the major PG upgrade process.

[sc-13289]

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- Clusters utilizing external WAL volumes can now be successfully upgraded to a new major PG version.

**Other Information**:

N/A
