### PR TITLE
docs: fix spec.template.metadata.labels

### DIFF
--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -140,7 +140,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: keycloak
+      app.kubernetes.io/name: keycloak
   template:
     metadata:
       labels:


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

```bash
$ kc apply -f keycloak.yaml
The Deployment "keycloak" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app.kubernetes.io/name":"keycloak"}: `selector` does not match template `labels`
```


**What is the new behavior (if this is a feature change)?**

```bash
$ kc apply -f keycloak.yaml
deployment.apps/keycloak created
```
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
