### PR TITLE
Bind pgBackRest server to IPv4 addresses only

### DIFF
--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -278,7 +278,7 @@ func TestServerConfig(t *testing.T) {
 
 	assert.Equal(t, serverConfig(cluster).String(), `
 [global]
-tls-server-address = ::
+tls-server-address = 0.0.0.0
 tls-server-auth = pgbackrest@shoe=*
 tls-server-ca-file = /etc/pgbackrest/conf.d/~postgres-operator/tls-ca.crt
 tls-server-cert-file = /etc/pgbackrest/server/server-tls.crt


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix

**What is the current behavior (link to any open issues here)?**

We bind to the IPv6 wildcard address to get at all addresses on a dual-stack system.

**What is the new behavior (if this is a feature change)?**

We bind to the IPv4 wildcard address to work on systems without IPv6.

**Other Information**:

Issue: [sc-13293]