### PR TITLE
Do Not Remove Certain Status for Major PG Upgrade

### DIFF
--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1802,10 +1802,6 @@ func (r *Reconciler) prepareForUpgrade(ctx context.Context,
 	}
 
 	// if everything is gone, proceed with re-bootstrapping the cluster
-	if len(cluster.Status.Conditions) > 0 {
-		// TODO: remove guard with move to controller-runtime 0.9.0 https://issue.k8s.io/99714
-		meta.RemoveStatusCondition(&cluster.Status.Conditions, ConditionPostgresDataInitialized)
-	}
 	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
 		ObservedGeneration: cluster.GetGeneration(),
 		Type:               ConditionPGUpgradeProgressing,

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -2587,8 +2587,8 @@ func TestPrepareForUpgrade(t *testing.T) {
 				ObservedGeneration: cluster.GetGeneration(),
 				Type:               ConditionPostgresDataInitialized,
 				Status:             metav1.ConditionTrue,
-				Reason:             "PGUpgradeComplete",
-				Message:            "pg_upgrade completed successfully",
+				Reason:             "test",
+				Message:            "test",
 			})
 
 			testResources := tc.createResources(t, cluster)
@@ -2658,11 +2658,13 @@ func TestPrepareForUpgrade(t *testing.T) {
 					assert.Assert(t, cluster.Status.Proxy.PGBouncer.PostgreSQLRevision == "")
 					assert.Assert(t, cluster.Status.Monitoring.ExporterConfiguration == "")
 					assert.Assert(t, meta.FindStatusCondition(cluster.Status.Conditions,
-						ConditionPostgresDataInitialized) == nil)
-					assert.Assert(t, meta.FindStatusCondition(cluster.Status.Conditions,
 						ConditionPGUpgradeCompleted) == nil)
 				}
 			}
+
+			// ensure the PostgresDataInitialized condition is never removed
+			assert.Assert(t, meta.FindStatusCondition(cluster.Status.Conditions,
+				ConditionPostgresDataInitialized) != nil)
 		})
 	}
 }

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -2665,7 +2665,9 @@ func (r *Reconciler) preparePGBackRestForPGUpgrade(ctx context.Context,
 		}
 	}
 
-	cluster.Status.PGBackRest = nil
+	if cluster.Status.PGBackRest != nil {
+		cluster.Status.PGBackRest.Repos = nil
+	}
 	if len(cluster.Status.Conditions) > 0 {
 		meta.RemoveStatusCondition(&cluster.Status.Conditions,
 			ConditionRepoHostReady)

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -3362,7 +3362,7 @@ func TestPreparePGBackRestForPGUpgrade(t *testing.T) {
 			},
 		},
 	}, {
-		desc: "clear pgBackRest status",
+		desc: "clear pgBackRest repo status",
 		pgBackRestStatus: &v1beta1.PGBackRestStatus{
 			Repos:            []v1beta1.RepoStatus{},
 			ManualBackup:     &v1beta1.PGBackRestJobStatus{},
@@ -3371,7 +3371,13 @@ func TestPreparePGBackRestForPGUpgrade(t *testing.T) {
 			Restore:          &v1beta1.PGBackRestJobStatus{},
 		},
 		result: testResult{
-			expectedPGBackRestStatus: nil,
+			// ensure only the "repos" section of the status is removed
+			expectedPGBackRestStatus: &v1beta1.PGBackRestStatus{
+				ManualBackup:     &v1beta1.PGBackRestJobStatus{},
+				ScheduledBackups: []v1beta1.PGBackRestScheduledBackupStatus{},
+				RepoHost:         &v1beta1.RepoHostStatus{},
+				Restore:          &v1beta1.PGBackRestJobStatus{},
+			},
 			expectedConditions: []metav1.Condition{
 				{Type: ConditionPGBackRestPostPGUpgrade},
 			},
@@ -3426,7 +3432,7 @@ func TestPreparePGBackRestForPGUpgrade(t *testing.T) {
 				assert.Assert(t, readyCondition.Message == "pgBackRest has been prepared for a major PG upgrade")
 			}
 
-			assert.Assert(t, cluster.Status.PGBackRest == tc.result.expectedPGBackRestStatus)
+			assert.DeepEqual(t, cluster.Status.PGBackRest, tc.result.expectedPGBackRestStatus)
 		})
 	}
 }


### PR DESCRIPTION
When preparing a cluster for a major PG upgrade, only the `repos` section of the pgBackRest status is removed, while the `PostgresDataInitialized` condition (if present) is now also preserved.  This ensures that only the status and conditions that are pertinent to the upgrade process are removed, and all other status is preserved.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

The entire pgBackRest status, as well as the `PostgresDataInitialized` condition, is removed when preparing for a major PG upgrade.

[sc-13310]

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Only the `repos` section of the pgBackRest status is removed when preparing for a major PG upgrade, while the `PostgresDataInitialized` condition is also preserved.

**Other Information**:

N/A
