### PR TITLE
Update Kuttl tests to connect via Kube Job

### DIFF
--- a/testing/kuttl/e2e/cluster-start/00-assert.yaml
+++ b/testing/kuttl/e2e/cluster-start/00-assert.yaml
@@ -17,3 +17,8 @@ metadata:
     postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
 status:
   succeeded: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-start-primary

--- a/testing/kuttl/e2e/cluster-start/00-cluster.yaml
+++ b/testing/kuttl/e2e/cluster-start/00-cluster.yaml
@@ -3,7 +3,7 @@ kind: PostgresCluster
 metadata:
   name: cluster-start
 spec:
-  postgresVersion: 13
+  postgresVersion: 14
   instances:
     - name: instance1
       dataVolumeClaimSpec:

--- a/testing/kuttl/e2e/cluster-start/01-assert.yaml
+++ b/testing/kuttl/e2e/cluster-start/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/cluster-start/01-psql-connect.yaml
+++ b/testing/kuttl/e2e/cluster-start/01-psql-connect.yaml
@@ -1,10 +1,26 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-- script: CLUSTER=cluster-start $HOME/postgres-operator/testing/kuttl/script/port-forward.sh
-  background: true
-# this sleep is needed when running in cloud environments to ensure connection-psql.sh
-# will not fail when attempting the port-forward and has suffient time to connect, may 
-# not be needed when running locally
-- script: sleep 10
-- script: CLUSTER=cluster-start $HOME/postgres-operator/testing/kuttl/script/connect-psql.sh
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect
+spec:
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1
+          command:
+            - "bash"
+            - "-c"
+            - "psql -c 'select version();'"
+          env:
+          - name: PGHOST
+            valueFrom: { secretKeyRef: { name: cluster-start-pguser-cluster-start, key: host } }
+          - name: PGPORT
+            valueFrom: { secretKeyRef: { name: cluster-start-pguser-cluster-start, key: port } }
+          - name: PGDATABASE
+            valueFrom: { secretKeyRef: { name: cluster-start-pguser-cluster-start, key: dbname } }
+          - name: PGUSER
+            valueFrom: { secretKeyRef: { name: cluster-start-pguser-cluster-start, key: user } }
+          - name: PGPASSWORD
+            valueFrom: { secretKeyRef: { name: cluster-start-pguser-cluster-start, key: password } }

--- a/testing/kuttl/script/connect-psql.sh
+++ b/testing/kuttl/script/connect-psql.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-CLUSTER=${CLUSTER:-default}
-PG_CLUSTER_USER_SECRET_NAME=${PG_CLUSTER_USER_SECRET_NAME:-$CLUSTER-pguser-$CLUSTER}
-
-PGPASSWORD=$(kubectl get secrets -n $NAMESPACE "${PG_CLUSTER_USER_SECRET_NAME}" -o go-template='{{.data.password | base64decode}}') \
-PGUSER=$(kubectl get secrets -n $NAMESPACE "${PG_CLUSTER_USER_SECRET_NAME}" -o go-template='{{.data.user | base64decode}}') \
-PGDATABASE=$(kubectl get secrets -n $NAMESPACE "${PG_CLUSTER_USER_SECRET_NAME}" -o go-template='{{.data.dbname | base64decode}}') \
-psql -h localhost -c "select version();"

--- a/testing/kuttl/script/port-forward.sh
+++ b/testing/kuttl/script/port-forward.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-CLUSTER=${CLUSTER:-default}
-export PG_CLUSTER_PRIMARY_POD=$(kubectl get pod -n $NAMESPACE -o name -l postgres-operator.crunchydata.com/cluster=$CLUSTER,postgres-operator.crunchydata.com/role=master)
-kubectl -n $NAMESPACE port-forward "${PG_CLUSTER_PRIMARY_POD}" 5432:5432


### PR DESCRIPTION
Connecting to the cluster locally with automated tests can be finicky;
This change uses a Kube job that can access internally (using the
service to connect and mount the user secret as env variables).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
[sc-13231]