### PR TITLE
Add test to read from replica

### DIFF
--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -190,7 +190,7 @@ There is a full example for how to deploy Keycloak with the Postgres Operator in
 
 Congratulations, you've got your Postgres cluster up and running, perhaps with an application connected to it! &#x1f44f; &#x1f44f; &#x1f44f;
 
-You can find out more about the [`postgresclusters` custom resource definition]({{< relref "references/crd.md" >}}) through the [documentation]({{< relref "references/crd.md" >}}) and through `kubectl explain`, i.e:
+You can find out more about the [`postgresclusters` custom resource definition]({{< relref "references/crd.md" >}}) through the [documentation]({{< relref "references/crd.md" >}}) and through `kubectl explain`, i.e.:
 
 ```
 kubectl explain postgresclusters

--- a/docs/content/tutorial/customize-cluster.md
+++ b/docs/content/tutorial/customize-cluster.md
@@ -121,7 +121,7 @@ kubectl create secret generic -n postgres-operator hippo.tls \
   --from-file=tls.crt=hippo.crt
 ```
 
-You can specify the custom TLS Secret in the `spec.customTLSSecret.name` field in your `postgrescluster.postgres-operator.crunchydata.com` custom resource, e.g:
+You can specify the custom TLS Secret in the `spec.customTLSSecret.name` field in your `postgrescluster.postgres-operator.crunchydata.com` custom resource, e.g.:
 
 ```
 spec:

--- a/testing/kuttl/e2e/replica-read/00-assert.yaml
+++ b/testing/kuttl/e2e/replica-read/00-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: replica-read
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 2
+      replicas: 2
+      updatedReplicas: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: replica-read-replicas

--- a/testing/kuttl/e2e/replica-read/00-cluster.yaml
+++ b/testing/kuttl/e2e/replica-read/00-cluster.yaml
@@ -1,0 +1,26 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: replica-read
+spec:
+  postgresVersion: 14
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+      replicas: 2
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/testing/kuttl/e2e/replica-read/01-assert.yaml
+++ b/testing/kuttl/e2e/replica-read/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-replica-read
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/replica-read/01-psql-replica-read.yaml
+++ b/testing/kuttl/e2e/replica-read/01-psql-replica-read.yaml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-replica-read
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1
+          command:
+            # https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html#PLPGSQL-STATEMENTS-ASSERT
+            # If run on a non-replica, this assertion fails, resulting in the pod erroring
+            # Note: the `$$$$` is reduced to `$$` by kuttl
+            # - https://kuttl.dev/docs/testing/steps.html#running-commands
+            - psql
+            - -qc
+            - |
+                DO $$$$ 
+                BEGIN 
+                  ASSERT pg_is_in_recovery(); 
+                END $$$$;
+          env:
+          # The Replica svc is not held in the user secret, so we hard-code the Service address
+          # (using the downstream API for the namespace)
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PGHOST
+            value: "replica-read-replicas.$(NAMESPACE).svc"
+          - name: PGPORT
+            valueFrom: { secretKeyRef: { name: replica-read-pguser-replica-read, key: port } }
+          - name: PGDATABASE
+            valueFrom: { secretKeyRef: { name: replica-read-pguser-replica-read, key: dbname } }
+          - name: PGUSER
+            valueFrom: { secretKeyRef: { name: replica-read-pguser-replica-read, key: user } }
+          - name: PGPASSWORD
+            valueFrom: { secretKeyRef: { name: replica-read-pguser-replica-read, key: password } }

--- a/testing/kuttl/kuttl-test.yaml
+++ b/testing/kuttl/kuttl-test.yaml
@@ -10,4 +10,7 @@ parallel: 2
 # namespace: postgres-operator
 suppress: 
 - events
-
+# By default kuttl deletes the resources created during a test.
+# For debugging, it may be helpful to uncomment the following line
+# in order to inspect the resources.
+# skipDelete: true


### PR DESCRIPTION
This adds a Kuttl test that starts a cluster with >1 replicas and
attempts to connect to the replica, testing that the replica is
in a recovery state

**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

No e2e replica-connection test

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Adds replica-connection test

**Other Information**:
Issue [sc-13324]