### PR TITLE
Add kuttl test to check password changes

### DIFF
--- a/testing/kuttl/e2e/password-change/00-assert.yaml
+++ b/testing/kuttl/e2e/password-change/00-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: password-change
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: password-change-primary

--- a/testing/kuttl/e2e/password-change/00-cluster.yaml
+++ b/testing/kuttl/e2e/password-change/00-cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: password-change
+spec:
+  postgresVersion: 14
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/testing/kuttl/e2e/password-change/01-assert.yaml
+++ b/testing/kuttl/e2e/password-change/01-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-uri
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/password-change/01-psql-connect-uri.yaml
+++ b/testing/kuttl/e2e/password-change/01-psql-connect-uri.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-uri
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+          command:
+            - psql
+            - "$(PGURI)"
+            - -c
+            - "select version();"
+          env:
+          - name: PGURI
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: uri } }

--- a/testing/kuttl/e2e/password-change/01-psql-connect.yaml
+++ b/testing/kuttl/e2e/password-change/01-psql-connect.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+          command:
+            - psql
+            - -c
+            - "select version();"
+          env:
+          - name: PGHOST
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: host } }
+          - name: PGPORT
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: port } }
+          - name: PGDATABASE
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: dbname } }
+          - name: PGUSER
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: user } }
+          - name: PGPASSWORD
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: password } }

--- a/testing/kuttl/e2e/password-change/02-errors.yaml
+++ b/testing/kuttl/e2e/password-change/02-errors.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: password-change-pguser-password-change
+data:
+  # `02-secret.yaml` changes the password and removes the verifier field,
+  # so when PGO reconciles the secret, it should fill in the empty verifier field;
+  # if it does not fill in the verifier field by a certain time this step will error
+  # and KUTTL will mark the test as failed.
+  verifier: ""

--- a/testing/kuttl/e2e/password-change/02-secret.yaml
+++ b/testing/kuttl/e2e/password-change/02-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: password-change-pguser-password-change
+data:
+  # Hardcoding the password as "datalake"
+  password: ZGF0YWxha2U=
+  verifier: ""

--- a/testing/kuttl/e2e/password-change/03-assert.yaml
+++ b/testing/kuttl/e2e/password-change/03-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect2
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-uri2
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/password-change/03-psql-connect-uri.yaml
+++ b/testing/kuttl/e2e/password-change/03-psql-connect-uri.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-uri2
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+          command:
+            - psql
+            - "$(PGURI)"
+            - -c
+            - "select version();"
+          env:
+          # The ./02-errors.yaml checks that the secret is not in the state that we set it to
+          # in the ./02-secret.yaml file, i.e., the secret has been reconciled by PGO,
+          # so the uri field of the secret should be updated with the new password by this time
+          - name: PGURI
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: uri } }

--- a/testing/kuttl/e2e/password-change/03-psql-connect.yaml
+++ b/testing/kuttl/e2e/password-change/03-psql-connect.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect2
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+          command:
+            - psql
+            - -c
+            - "select version();"
+          env:
+          - name: PGHOST
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: host } }
+          - name: PGPORT
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: port } }
+          - name: PGDATABASE
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: dbname } }
+          - name: PGUSER
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: user } }
+          # Hardcoding the password here to be equal to what we changed the password to in 
+          # ./02-secret.yaml
+          # The ./02-errors.yaml checks that the secret is not in the state that we set it to
+          # in the ./02-secret.yaml file, i.e., the secret has been reconciled by PGO
+          - name: PGPASSWORD
+            value: datalake

--- a/testing/kuttl/e2e/password-change/04-errors.yaml
+++ b/testing/kuttl/e2e/password-change/04-errors.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: password-change-pguser-password-change
+data:
+  # `04-secret.yaml` changes the password and removes the verifier field,
+  # so when PGO reconciles the secret, it should fill in the empty verifier field;
+  # if it does not fill in the verifier field by a certain time this step will error
+  # and KUTTL will mark the test as failed.
+  uri: ""

--- a/testing/kuttl/e2e/password-change/04-secret.yaml
+++ b/testing/kuttl/e2e/password-change/04-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: password-change-pguser-password-change
+# Updating the password with the stringData field and an md5-based verifier
+stringData:
+  password: infopond
+  verifier: "md585eb8fa4f697b2ea949d3aba788e8631"
+  uri: ""

--- a/testing/kuttl/e2e/password-change/05-assert.yaml
+++ b/testing/kuttl/e2e/password-change/05-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect3
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-uri3
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/password-change/05-psql-connect-uri.yaml
+++ b/testing/kuttl/e2e/password-change/05-psql-connect-uri.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-uri3
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+          command:
+            - psql
+            - "$(PGURI)"
+            - -c
+            - "select version();"
+          env:
+          # The ./04-errors.yaml checks that the secret is not in the state that we set it to
+          # in the ./04-secret.yaml file, i.e., the secret has been reconciled by PGO,
+          # so the uri field of the secret should be updated with the new password by this time
+          - name: PGURI
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: uri } }

--- a/testing/kuttl/e2e/password-change/05-psql-connect.yaml
+++ b/testing/kuttl/e2e/password-change/05-psql-connect.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect3
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+          command:
+            - psql
+            - -c
+            - "select version();"
+          env:
+          - name: PGHOST
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: host } }
+          - name: PGPORT
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: port } }
+          - name: PGDATABASE
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: dbname } }
+          - name: PGUSER
+            valueFrom: { secretKeyRef: { name: password-change-pguser-password-change, key: user } }
+          # Hardcoding the password here to be equal to what we changed the password to in 
+          # ./04-secret.yaml
+          # The ./04-errors.yaml checks that the secret is not in the state that we set it to
+          # in the ./04-secret.yaml file, i.e., the secret has been reconciled by PGO
+          - name: PGPASSWORD
+            value: infopond

--- a/testing/kuttl/e2e/password-change/06-assert.yaml
+++ b/testing/kuttl/e2e/password-change/06-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: password-change
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: password-change-primary

--- a/testing/kuttl/e2e/password-change/06-cluster.yaml
+++ b/testing/kuttl/e2e/password-change/06-cluster.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: password-change
+spec:
+  # Adding a custom user to the spec
+  users:
+    - name: rhino
+      databases:
+        - rhino

--- a/testing/kuttl/e2e/password-change/07-assert.yaml
+++ b/testing/kuttl/e2e/password-change/07-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect4
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-uri4
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/password-change/07-psql-connect-uri.yaml
+++ b/testing/kuttl/e2e/password-change/07-psql-connect-uri.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-uri4
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+          command:
+            - psql
+            - "$(PGURI)"
+            - -c
+            - "select version();"
+          env:
+          - name: PGURI
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: uri } }

--- a/testing/kuttl/e2e/password-change/07-psql-connect.yaml
+++ b/testing/kuttl/e2e/password-change/07-psql-connect.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect4
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+          command:
+            - psql
+            - -c
+            - "select version();"
+          env:
+          - name: PGHOST
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: host } }
+          - name: PGPORT
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: port } }
+          - name: PGDATABASE
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: dbname } }
+          - name: PGUSER
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: user } }
+          - name: PGPASSWORD
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: password } }

--- a/testing/kuttl/e2e/password-change/08-errors.yaml
+++ b/testing/kuttl/e2e/password-change/08-errors.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: password-change-pguser-rhino
+data:
+  # `08-secret.yaml` changes the password and removes the verifier field,
+  # so when PGO reconciles the secret, it should fill in the empty verifier field;
+  # if it does not fill in the verifier field by a certain time this step will error
+  # and KUTTL will mark the test as failed.
+  verifier: ""

--- a/testing/kuttl/e2e/password-change/08-secret.yaml
+++ b/testing/kuttl/e2e/password-change/08-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: password-change-pguser-rhino
+data:
+  # Hardcoding the password as "datalake"
+  password: ZGF0YWxha2U=
+  verifier: ""

--- a/testing/kuttl/e2e/password-change/09-assert.yaml
+++ b/testing/kuttl/e2e/password-change/09-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect5
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-uri5
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/password-change/09-psql-connect-uri.yaml
+++ b/testing/kuttl/e2e/password-change/09-psql-connect-uri.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-uri5
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+          command:
+            - psql
+            - "$(PGURI)"
+            - -c
+            - "select version();"
+          env:
+          # The ./08-errors.yaml checks that the secret is not in the state that we set it to
+          # in the ./08-secret.yaml file, i.e., the secret has been reconciled by PGO,
+          # so the uri field of the secret should be updated with the new password by this time
+          - name: PGURI
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: uri } }

--- a/testing/kuttl/e2e/password-change/09-psql-connect.yaml
+++ b/testing/kuttl/e2e/password-change/09-psql-connect.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect5
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+          command:
+            - psql
+            - -c
+            - "select version();"
+          env:
+          - name: PGHOST
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: host } }
+          - name: PGPORT
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: port } }
+          - name: PGDATABASE
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: dbname } }
+          - name: PGUSER
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: user } }
+          # Hardcoding the password here to be equal to what we changed the password to in 
+          # ./08-secret.yaml
+          # The ./08-errors.yaml checks that the secret is not in the state that we set it to
+          # in the ./08-secret.yaml file, i.e., the secret has been reconciled by PGO
+          - name: PGPASSWORD
+            value: datalake

--- a/testing/kuttl/e2e/password-change/10-errors.yaml
+++ b/testing/kuttl/e2e/password-change/10-errors.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: password-change-pguser-rhino
+data:
+  # `10-secret.yaml` changes the password and removes the verifier field,
+  # so when PGO reconciles the secret, it should fill in the empty verifier field;
+  # if it does not fill in the verifier field by a certain time this step will error
+  # and KUTTL will mark the test as failed.
+  uri: ""

--- a/testing/kuttl/e2e/password-change/10-secret.yaml
+++ b/testing/kuttl/e2e/password-change/10-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: password-change-pguser-rhino
+# Updating the password with the stringData field and a scram verifier
+stringData:
+  password: infopond
+  verifier: "SCRAM-SHA-256$4096:RI03PMRQH2oAFMH6AOQHdA==$D74VOn98ErW3J8CIiFYldUVO+kjsXj+Ju7jhmMURHQo=:c5hC/1V2TYNnoJ6VcaSJCcoGQ2eTcYJBP/pfKFv+k54="
+  uri: ""

--- a/testing/kuttl/e2e/password-change/11-assert.yaml
+++ b/testing/kuttl/e2e/password-change/11-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect6
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-uri6
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/password-change/11-psql-connect-uri.yaml
+++ b/testing/kuttl/e2e/password-change/11-psql-connect-uri.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-uri6
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+          command:
+            - psql
+            - "$(PGURI)"
+            - -c
+            - "select version();"
+          env:
+          # The ./10-errors.yaml checks that the secret is not in the state that we set it to
+          # in the ./10-secret.yaml file, i.e., the secret has been reconciled by PGO,
+          # so the uri field of the secret should be updated with the new password by this time
+          - name: PGURI
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: uri } }

--- a/testing/kuttl/e2e/password-change/11-psql-connect.yaml
+++ b/testing/kuttl/e2e/password-change/11-psql-connect.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect6
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: psql
+          image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+          command:
+            - psql
+            - -c
+            - "select version();"
+          env:
+          - name: PGHOST
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: host } }
+          - name: PGPORT
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: port } }
+          - name: PGDATABASE
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: dbname } }
+          - name: PGUSER
+            valueFrom: { secretKeyRef: { name: password-change-pguser-rhino, key: user } }
+          # Hardcoding the password here to be equal to what we changed the password to in 
+          # ./10-secret.yaml
+          # The ./10-errors.yaml checks that the secret is not in the state that we set it to
+          # in the ./10-secret.yaml file, i.e., the secret has been reconciled by PGO
+          - name: PGPASSWORD
+            value: infopond

--- a/testing/kuttl/e2e/password-change/README.md
+++ b/testing/kuttl/e2e/password-change/README.md
@@ -1,0 +1,27 @@
+### Password Change Test with Kuttl
+
+This Kuttl routine runs through the following steps:
+
+#### Create cluster and test connection
+
+- 00: Creates the cluster and verifies that it exists and is ready for connection
+- 01: Connects to the cluster with the PGO-generated password (both with env vars and with the URI)
+
+#### Default user connection tests
+
+- 02: Change the password (using Kuttl's update object method on the secret's `data` field) and verify that the password changes by asserting that the `verifier` field is not blank (using KUTTL's `errors` method, which makes sure that a state is _not_ met by a certain time)
+- 03: Connects to the cluster with the user-defined password (both with env vars and with the URI)
+- 04: Change the password and verifier (using Kuttl's update object method on the secret's `stringData` field) and verify that the password changes by asserting that the `uri` field is not blank (using KUTTL's `errors` method, which makes sure that a state is _not_ met by a certain time)
+- 05: Connects to the cluster with the second user-defined password (both with env vars and with the URI)
+
+#### Create custom user and test connection
+
+- 06: Updates the postgrescluster spec with a custom user and password
+- 07: Connects to the cluster with the PGO-generated password (both with env vars and with the URI) for the custom user
+
+#### Custom user connection tests
+
+- 08: Change the custom user's password (using Kuttl's update object method on the secret's `data` field) and verify that the password changes by asserting that the `verifier` field is not blank (using KUTTL's `errors` method, which makes sure that a state is _not_ met by a certain time)
+- 09: Connects to the cluster with the user-defined password (both with env vars and with the URI) for the custom user
+- 10: Change the custom user's password and verifier (using Kuttl's update object method on the secret's `stringData` field) and verify that the password changes by asserting that the `uri` field is not blank (using KUTTL's `errors` method, which makes sure that a state is _not_ met by a certain time)
+- 11: Connects to the cluster with the second user-defined password (both with env vars and with the URI) for the custom user


### PR DESCRIPTION
This adds a kuttl test to run through some password change scenarios:
* for the default user, add a new password
* for the default user, add a new password and md5 verifier
* for a custom user, add a new pasword
* for a custom user, add a new pasword and scram verifier

The test is considered successful if the specified user is able to
log in with the updated password, both with a URI specified and with
individual PG<vars> specified

**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other

**Other Information**:
Issue [sc-12965]
