### PR TITLE
Mention RFC 1123 label in user name error messages

### DIFF
--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -339,13 +339,13 @@ func (r *Reconciler) reconcilePostgresUserSecrets(
 		if n := len(cluster.Name); n > 63 {
 			allErrors = append(allErrors,
 				field.Invalid(path, cluster.Name,
-					fmt.Sprintf("should be at most %d chars long", 63)))
+					fmt.Sprintf("should be at most %d chars long (a RFC 1123 label)", 63)))
 		}
 		// See v1beta1.PostgresRoleSpec validation markers.
 		if !reUser.MatchString(cluster.Name) {
 			allErrors = append(allErrors,
 				field.Invalid(path, cluster.Name,
-					fmt.Sprintf("should match '%s'", reUser)))
+					fmt.Sprintf("should match '%s' (a RFC 1123 label)", reUser)))
 		}
 
 		if len(allErrors) > 0 {


### PR DESCRIPTION
**Checklist:**

 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**

 - [ ] New feature
 - [] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [x] Other


**What is the current behavior (link to any open issues here)?**

Current error messages with naming of a user do not give a precise reason. In particular this can be an issue for `user.name` since it does not allow `_` which is permitted in the underlying postgres server. This relates to reducing investigation time if  #2949's error is encountered.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

The error message also mentions that the name uses the RFC 1123 label constraints