### PR TITLE
Use UpperCamelCase for the switchover enumeration

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -5141,27 +5141,23 @@ spec:
                           in a PostgresCluster
                         type: boolean
                       targetInstance:
-                        description: Define the instance that the operator will target
-                          in a switchover. When attempting to perform a manual switchover
-                          this field is optional. If target is specified, we will
-                          attempt to get to an instance that represents that target.
-                          If it is not specified, then we will attempt to get any
-                          instance. When attempting to perform a failover (i.e. Switchover.Type
-                          is `failover`) this field is required.
+                        description: The instance that should become primary during
+                          a switchover. This field is optional when Type is "Switchover"
+                          and required when Type is "Failover". When it is not specified,
+                          a healthy replica is automatically selected.
                         type: string
                       type:
-                        default: switchover
-                        description: 'Type allows you to specify the type of Patroni
-                          switchover that will be performed. `patronictl` supports
-                          both `switchovers` and `failovers` where a `failover` is
-                          effectively a "forced switchover". The main difference is
-                          that `failover` can be used when there is not currently
-                          a leader. A TargetInstance must be specified to failover.
-                          NOTE: The switchover type failover is reserved as the "last
-                          resort" case.'
+                        default: Switchover
+                        description: 'Type of switchover to perform. Valid options
+                          are Switchover and Failover. "Switchover" changes the primary
+                          instance of a healthy PostgresCluster. "Failover" forces
+                          a particular instance to be primary, regardless of other
+                          factors. A TargetInstance must be specified to failover.
+                          NOTE: The Failover type is reserved as the "last resort"
+                          case.'
                         enum:
-                        - switchover
-                        - failover
+                        - Switchover
+                        - Failover
                         type: string
                     required:
                     - enabled

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -7749,12 +7749,12 @@ Switchover gives options to perform ad hoc switchovers in a PostgresCluster.
       </tr><tr>
         <td><b>targetInstance</b></td>
         <td>string</td>
-        <td>Define the instance that the operator will target in a switchover. When attempting to perform a manual switchover this field is optional. If target is specified, we will attempt to get to an instance that represents that target. If it is not specified, then we will attempt to get any instance. When attempting to perform a failover (i.e. Switchover.Type is `failover`) this field is required.</td>
+        <td>The instance that should become primary during a switchover. This field is optional when Type is "Switchover" and required when Type is "Failover". When it is not specified, a healthy replica is automatically selected.</td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
-        <td>Type allows you to specify the type of Patroni switchover that will be performed. `patronictl` supports both `switchovers` and `failovers` where a `failover` is effectively a "forced switchover". The main difference is that `failover` can be used when there is not currently a leader. A TargetInstance must be specified to failover. NOTE: The switchover type failover is reserved as the "last resort" case.</td>
+        <td>Type of switchover to perform. Valid options are Switchover and Failover. "Switchover" changes the primary instance of a healthy PostgresCluster. "Failover" forces a particular instance to be primary, regardless of other factors. A TargetInstance must be specified to failover. NOTE: The Failover type is reserved as the "last resort" case.</td>
         <td>false</td>
       </tr></tbody>
 </table>

--- a/internal/controller/postgrescluster/patroni_test.go
+++ b/internal/controller/postgrescluster/patroni_test.go
@@ -576,14 +576,14 @@ func TestReconcilePatroniSwitchover(t *testing.T) {
 				desc:    "failover requested without a target",
 				enabled: true, trigger: "triggered", soType: "failover",
 				check: func(t *testing.T, err error) {
-					assert.Equal(t, err.Error(), "TargetInstance required when running failover")
+					assert.Error(t, err, "TargetInstance required when running failover")
 				},
 			},
 			{
 				desc:    "target instance was specified but not found",
 				enabled: true, trigger: "triggered", target: "bad-target",
 				check: func(t *testing.T, err error) {
-					assert.Equal(t, err.Error(), "TargetInstance was specified but not found in the cluster")
+					assert.Error(t, err, "TargetInstance was specified but not found in the cluster")
 				},
 			},
 		} {
@@ -644,7 +644,7 @@ func TestReconcilePatroniSwitchover(t *testing.T) {
 			}}
 			observed := &observedInstances{forCluster: instances}
 
-			assert.Equal(t, r.reconcilePatroniSwitchover(ctx, cluster, observed).Error(),
+			assert.Error(t, r.reconcilePatroniSwitchover(ctx, cluster, observed),
 				"TargetInstance should have one pod. Pods (0)")
 		})
 
@@ -668,7 +668,7 @@ func TestReconcilePatroniSwitchover(t *testing.T) {
 			}
 			observed := &observedInstances{forCluster: instances}
 
-			assert.Equal(t, r.reconcilePatroniSwitchover(ctx, cluster, observed).Error(),
+			assert.Error(t, r.reconcilePatroniSwitchover(ctx, cluster, observed),
 				"Could not find a running pod when attempting switchover.")
 		})
 	})
@@ -688,7 +688,7 @@ func TestReconcilePatroniSwitchover(t *testing.T) {
 		observed := &observedInstances{forCluster: []*Instance{{
 			Name: "target",
 		}}}
-		assert.Equal(t, r.reconcilePatroniSwitchover(ctx, cluster, observed).Error(),
+		assert.Error(t, r.reconcilePatroniSwitchover(ctx, cluster, observed),
 			"Need more than one instance to switchover")
 	})
 
@@ -709,7 +709,7 @@ func TestReconcilePatroniSwitchover(t *testing.T) {
 		}}
 		called, failover, callError, callFails = false, false, false, true
 		err := r.reconcilePatroniSwitchover(ctx, cluster, getObserved())
-		assert.Equal(t, err.Error(), "unable to switchover")
+		assert.Error(t, err, "unable to switchover")
 		assert.Assert(t, called)
 		assert.Assert(t, cluster.Status.Patroni.Switchover == nil)
 	})
@@ -731,7 +731,7 @@ func TestReconcilePatroniSwitchover(t *testing.T) {
 		}}
 		called, failover, callError, callFails = false, false, true, false
 		err := r.reconcilePatroniSwitchover(ctx, cluster, getObserved())
-		assert.Equal(t, err.Error(), "boom")
+		assert.Error(t, err, "boom")
 		assert.Assert(t, called)
 		assert.Assert(t, cluster.Status.Patroni.Switchover == nil)
 	})

--- a/internal/controller/postgrescluster/patroni_test.go
+++ b/internal/controller/postgrescluster/patroni_test.go
@@ -574,7 +574,7 @@ func TestReconcilePatroniSwitchover(t *testing.T) {
 			},
 			{
 				desc:    "failover requested without a target",
-				enabled: true, trigger: "triggered", soType: "failover",
+				enabled: true, trigger: "triggered", soType: "Failover",
 				check: func(t *testing.T, err error) {
 					assert.Error(t, err, "TargetInstance required when running failover")
 				},
@@ -613,8 +613,8 @@ func TestReconcilePatroniSwitchover(t *testing.T) {
 						},
 					}
 				}
-				if test.soType == "failover" {
-					cluster.Spec.Patroni.Switchover.Type = "failover"
+				if test.soType != "" {
+					cluster.Spec.Patroni.Switchover.Type = test.soType
 				}
 				if test.target != "" {
 					cluster.Spec.Patroni.Switchover.TargetInstance = initialize.String(test.target)
@@ -787,7 +787,7 @@ func TestReconcilePatroniSwitchover(t *testing.T) {
 		cluster.Spec.Patroni = &v1beta1.PatroniSpec{
 			Switchover: &v1beta1.PatroniSwitchover{
 				Enabled:        true,
-				Type:           "failover",
+				Type:           "Failover",
 				TargetInstance: initialize.String("target"),
 			},
 		}

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/patroni_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/patroni_types.go
@@ -70,25 +70,28 @@ type PatroniSwitchover struct {
 	// +required
 	Enabled bool `json:"enabled"`
 
-	// Define the instance that the operator will target in a switchover. When attempting to
-	// perform a manual switchover this field is optional. If target is specified, we will attempt
-	// to get to an instance that represents that target. If it is not specified, then we will
-	// attempt to get any instance. When attempting to perform a failover (i.e. Switchover.Type
-	// is `failover`) this field is required.
+	// The instance that should become primary during a switchover. This field is
+	// optional when Type is "Switchover" and required when Type is "Failover".
+	// When it is not specified, a healthy replica is automatically selected.
 	// +optional
 	TargetInstance *string `json:"targetInstance,omitempty"`
 
-	// Type allows you to specify the type of Patroni switchover that will be performed.
-	// `patronictl` supports both `switchovers` and `failovers` where a `failover` is
-	// effectively a "forced switchover". The main difference is that `failover` can be
-	// used when there is not currently a leader. A TargetInstance must be specified to
-	// failover.
-	// NOTE: The switchover type failover is reserved as the "last resort" case.
-	// +kubebuilder:validation:Enum={switchover,failover}
-	// +kubebuilder:default:=switchover
+	// Type of switchover to perform. Valid options are Switchover and Failover.
+	// "Switchover" changes the primary instance of a healthy PostgresCluster.
+	// "Failover" forces a particular instance to be primary, regardless of other
+	// factors. A TargetInstance must be specified to failover.
+	// NOTE: The Failover type is reserved as the "last resort" case.
+	// +kubebuilder:validation:Enum={Switchover,Failover}
+	// +kubebuilder:default:=Switchover
 	// +optional
 	Type string `json:"type,omitempty"`
 }
+
+// PatroniSwitchover types.
+const (
+	PatroniSwitchoverTypeFailover   = "Failover"
+	PatroniSwitchoverTypeSwitchover = "Switchover"
+)
 
 // Default sets the default values for certain Patroni configuration attributes,
 // including:

--- a/testing/kuttl/e2e/switchover/01-assert.yaml
+++ b/testing/kuttl/e2e/switchover/01-assert.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: switchover
+status:
+  instances:
+    - name: "00"
+      replicas: 2
+      readyReplicas: 2
+      updatedReplicas: 2

--- a/testing/kuttl/e2e/switchover/01-cluster.yaml
+++ b/testing/kuttl/e2e/switchover/01-cluster.yaml
@@ -1,0 +1,20 @@
+---
+# Create a cluster with multiple instances and manual switchover enabled.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: switchover
+spec:
+  postgresVersion: 14
+  patroni:
+    switchover:
+      enabled: true
+  instances:
+    - replicas: 2
+      dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+  backups:
+    pgbackrest:
+      repos:
+        - name: repo1
+          volume:
+            volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }

--- a/testing/kuttl/e2e/switchover/02-annotate.yaml
+++ b/testing/kuttl/e2e/switchover/02-annotate.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Label instance pods with their current role. These labels will stick around
+  # because switchover does not recreate any pods.
+  - script: |
+      kubectl label --namespace="${NAMESPACE}" pods \
+        --selector='postgres-operator.crunchydata.com/role=master' \
+        'testing/role-before=master'
+  - script: |
+      kubectl label --namespace="${NAMESPACE}" pods \
+        --selector='postgres-operator.crunchydata.com/role=replica' \
+        'testing/role-before=replica'
+
+  # Annotate the cluster to trigger a switchover.
+  - script: |
+      kubectl annotate --namespace="${NAMESPACE}" postgrescluster/switchover \
+        "postgres-operator.crunchydata.com/trigger-switchover=$(date)"

--- a/testing/kuttl/e2e/switchover/03-assert.yaml
+++ b/testing/kuttl/e2e/switchover/03-assert.yaml
@@ -1,0 +1,36 @@
+---
+# After switchover, a former replica should now be the primary.
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: switchover
+    postgres-operator.crunchydata.com/data: postgres
+
+    postgres-operator.crunchydata.com/role: master
+    testing/role-before: replica
+
+---
+# The former primary should now be a replica.
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: switchover
+    postgres-operator.crunchydata.com/data: postgres
+
+    postgres-operator.crunchydata.com/role: replica
+    testing/role-before: master
+
+---
+# All instances should be healthy.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: switchover
+status:
+  instances:
+    - name: "00"
+      replicas: 2
+      readyReplicas: 2
+      updatedReplicas: 2


### PR DESCRIPTION
[Kubernetes API conventions](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#constants) strongly recommend that enumerations be in UpperCamelCase.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix

**What is the current behavior (link to any open issues here)?**

The switchover type enumeration is lowercase, exactly matching the spelling used Patroni.

**What is the new behavior (if this is a feature change)?**
- [x] Breaking change (fix or feature that would cause existing functionality to change)

The enumeration uses UpperCamelCase as directed by Kubernetes API conventions.

**Other Information**:

I changed the switchover documentation to reference fields by their JSON/YAML spellings in [lower] camelCase. I also removed mention of the `promoted` label value which has gone away in the latest version of Patroni.

Issue: [sc-13360]