### PR TITLE
Show events in kuttl logs by default

### DIFF
--- a/testing/kuttl/README.md
+++ b/testing/kuttl/README.md
@@ -9,6 +9,21 @@ Options:
     and `kubectl krew install kuttl`
 ## Cheat sheet
 
+### Suppressing Noisy Logs
+
+KUTTL gives you the option to suppress events from the test logging output. To enable this feature
+update the `kuttl` parameter when calling the `make` target
+
+```
+KUTTL_TEST='kuttl test --suppress-logs=events' make check-kuttl
+```
+
+To suppress the events permanently, you can add the following to the KUTTL config (kuttl-test.yaml)
+```
+suppress: 
+- events
+```
+
 ### Run test suite
 
 Make sure that the operator is running in your kubernetes environment and that your `kubeconfig` is

--- a/testing/kuttl/kuttl-test.yaml
+++ b/testing/kuttl/kuttl-test.yaml
@@ -8,8 +8,6 @@ parallel: 2
 # that functionality simply uncomment the line below and replace
 # postgres-operator with the desired namespace to run in.
 # namespace: postgres-operator
-suppress: 
-- events
 # By default kuttl deletes the resources created during a test.
 # For debugging, it may be helpful to uncomment the following line
 # in order to inspect the resources.


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
We are suppressing events in KUTTL test logs.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
Show events for objects created by KUTTL test, this can help debug automated testing in temporary environments.


**Other Information**:
