### PR TITLE
Do not inject service environment variables

### DIFF
--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1270,6 +1270,11 @@ func generateInstanceStatefulSetIntent(_ context.Context,
 	// - https://docs.k8s.io/tasks/configure-pod-container/share-process-namespace/
 	sts.Spec.Template.Spec.ShareProcessNamespace = initialize.Bool(true)
 
+	// Patroni calls the Kubernetes API and pgBackRest may interact with a cloud
+	// storage provider. Use the instance ServiceAccount and automatically mount
+	// its Kubernetes credentials.
+	// - https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity
+	// - https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
 	sts.Spec.Template.Spec.ServiceAccountName = instanceServiceAccountName
 
 	sts.Spec.Template.Spec.SecurityContext = postgres.PodSecurityContext(cluster)

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1277,6 +1277,11 @@ func generateInstanceStatefulSetIntent(_ context.Context,
 	// - https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
 	sts.Spec.Template.Spec.ServiceAccountName = instanceServiceAccountName
 
+	// Disable environment variables for services other than the Kubernetes API.
+	// - https://docs.k8s.io/concepts/services-networking/connect-applications-service/#accessing-the-service
+	// - https://releases.k8s.io/v1.23.0/pkg/kubelet/kubelet_pods.go#L553-L563
+	sts.Spec.Template.Spec.EnableServiceLinks = initialize.Bool(false)
+
 	sts.Spec.Template.Spec.SecurityContext = postgres.PodSecurityContext(cluster)
 
 	// Set the image pull secrets, if any exist.

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -1521,6 +1521,10 @@ func TestGenerateInstanceStatefulSetIntent(t *testing.T) {
 			)
 
 			test.run(t, sts)
+
+			if assert.Check(t, sts.Spec.Template.Spec.EnableServiceLinks != nil) {
+				assert.Equal(t, *sts.Spec.Template.Spec.EnableServiceLinks, false)
+			}
 		})
 	}
 }

--- a/internal/controller/postgrescluster/pgadmin.go
+++ b/internal/controller/postgrescluster/pgadmin.go
@@ -232,6 +232,9 @@ func (r *Reconciler) reconcilePGAdminStatefulSet(
 	// ServiceAccount and do not mount its credentials.
 	sts.Spec.Template.Spec.AutomountServiceAccountToken = initialize.Bool(false)
 
+	// Do not add environment variables describing services in this namespace.
+	sts.Spec.Template.Spec.EnableServiceLinks = initialize.Bool(false)
+
 	sts.Spec.Template.Spec.SecurityContext = postgres.PodSecurityContext(cluster)
 
 	// set the image pull secrets, if any exist

--- a/internal/controller/postgrescluster/pgadmin_test.go
+++ b/internal/controller/postgrescluster/pgadmin_test.go
@@ -366,6 +366,7 @@ containers:
   - mountPath: /var/lib/pgadmin
     name: pgadmin-data
 dnsPolicy: ClusterFirst
+enableServiceLinks: false
 restartPolicy: Always
 schedulerName: default-scheduler
 securityContext:
@@ -530,6 +531,7 @@ containers:
   - mountPath: /var/lib/pgadmin
     name: pgadmin-data
 dnsPolicy: ClusterFirst
+enableServiceLinks: false
 imagePullSecrets:
 - name: myImagePullSecret
 restartPolicy: Always

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -2407,6 +2407,9 @@ func TestGenerateRestoreJobIntent(t *testing.T) {
 						})
 						t.Run("ServiceAccount", func(t *testing.T) {
 							assert.Equal(t, job.Spec.Template.Spec.ServiceAccountName, "test-instance")
+							if assert.Check(t, job.Spec.Template.Spec.AutomountServiceAccountToken != nil) {
+								assert.Equal(t, *job.Spec.Template.Spec.AutomountServiceAccountToken, false)
+							}
 						})
 					})
 				})

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -418,6 +418,9 @@ func (r *Reconciler) generatePGBouncerDeployment(
 	// ServiceAccount and do not mount its credentials.
 	deploy.Spec.Template.Spec.AutomountServiceAccountToken = initialize.Bool(false)
 
+	// Do not add environment variables describing services in this namespace.
+	deploy.Spec.Template.Spec.EnableServiceLinks = initialize.Bool(false)
+
 	deploy.Spec.Template.Spec.SecurityContext = initialize.RestrictedPodSecurityContext()
 
 	// set the image pull secrets, if any exist

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -378,6 +378,7 @@ namespace: ns3
 		assert.Assert(t, marshalMatches(deploy.Spec.Template.Spec, `
 automountServiceAccountToken: false
 containers: null
+enableServiceLinks: false
 restartPolicy: Always
 securityContext:
   runAsNonRoot: true

--- a/internal/controller/postgrescluster/volumes.go
+++ b/internal/controller/postgrescluster/volumes.go
@@ -463,9 +463,10 @@ func (r *Reconciler) reconcileMovePGDataDir(ctx context.Context,
 				// created by the Job controller when there is a failure
 				// (instead of the container simply restarting).
 				RestartPolicy: corev1.RestartPolicyNever,
-				// Since these Jobs don't make Kubernetes API calls, we can just
-				// use the default ServiceAccount and mount the credentials.
+				// These Jobs don't make Kubernetes API calls, so we can just
+				// use the default ServiceAccount and not mount its credentials.
 				AutomountServiceAccountToken: initialize.Bool(false),
+				EnableServiceLinks:           initialize.Bool(false),
 				Volumes: []corev1.Volume{{
 					Name: "postgres-data",
 					VolumeSource: corev1.VolumeSource{
@@ -575,9 +576,10 @@ func (r *Reconciler) reconcileMoveWALDir(ctx context.Context,
 				// created by the Job controller when there is a failure
 				// (instead of the container simply restarting).
 				RestartPolicy: corev1.RestartPolicyNever,
-				// Since these Jobs don't make Kubernetes API calls, we can just
-				// use the default ServiceAccount and mount the credentials.
+				// These Jobs don't make Kubernetes API calls, so we can just
+				// use the default ServiceAccount and not mount its credentials.
 				AutomountServiceAccountToken: initialize.Bool(false),
+				EnableServiceLinks:           initialize.Bool(false),
 				Volumes: []corev1.Volume{{
 					Name: "postgres-wal",
 					VolumeSource: corev1.VolumeSource{
@@ -691,9 +693,10 @@ func (r *Reconciler) reconcileMoveRepoDir(ctx context.Context,
 				// Set RestartPolicy to "Never" since we want a new Pod to be created by the Job
 				// controller when there is a failure (instead of the container simply restarting).
 				RestartPolicy: corev1.RestartPolicyNever,
-				// Since these Jobs don't make Kubernetes API calls, we can just
-				// use the default ServiceAccount and mount the credentials.
+				// These Jobs don't make Kubernetes API calls, so we can just
+				// use the default ServiceAccount and not mount its credentials.
 				AutomountServiceAccountToken: initialize.Bool(false),
+				EnableServiceLinks:           initialize.Bool(false),
 				Volumes: []corev1.Volume{{
 					Name: "pgbackrest-repo",
 					VolumeSource: corev1.VolumeSource{

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -1028,6 +1028,7 @@ containers:
   - mountPath: /pgdata
     name: postgres-data
 dnsPolicy: ClusterFirst
+enableServiceLinks: false
 priorityClassName: some-priority-class
 restartPolicy: Never
 schedulerName: default-scheduler
@@ -1078,6 +1079,7 @@ containers:
   - mountPath: /pgwal
     name: postgres-wal
 dnsPolicy: ClusterFirst
+enableServiceLinks: false
 priorityClassName: some-priority-class
 restartPolicy: Never
 schedulerName: default-scheduler
@@ -1130,6 +1132,7 @@ containers:
   - mountPath: /pgbackrest
     name: pgbackrest-repo
 dnsPolicy: ClusterFirst
+enableServiceLinks: false
 priorityClassName: some-priority-class
 restartPolicy: Never
 schedulerName: default-scheduler

--- a/testing/policies/kyverno/service_links.yaml
+++ b/testing/policies/kyverno/service_links.yaml
@@ -1,0 +1,43 @@
+# Copyright 2022 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disable-service-links
+  annotations:
+    policies.kyverno.io/title: Disable Injection of Service Environment Variables
+    policies.kyverno.io/category: PGO
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Kubernetes automatically adds environment variables describing every Service in a Pod's namespace.
+      This can inadvertently change the behavior of things that read from the environment. For example,
+      a PodSpec that worked in the past might start to fail when the Pod is recreated with new Services
+      around.
+
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+  - name: validate-enableServiceLinks
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: Do not inject Service environment variables.
+      pattern:
+        spec:
+          enableServiceLinks: false


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix

**What is the current behavior (link to any open issues here)?**

A service starting with `pgbackrest` in the same namespace caused warnings in `pgbackrest` commands:

```
PGBACKREST_WRONG_HA_SERVICE_HOST=10.43.228.168

WARN: environment contains invalid option 'wrong-ha-service-host'
```

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

All pods are created with `spec.enableServiceLinks: false`. No such environment variables and no more warnings.

**Other Information**:

I verified with the attached Kyverno policy. It's not wired up to anything directly at this time.

Issue: [sc-13361]