### PR TITLE
Postgres Major Upgrade E2E

### DIFF
--- a/testing/kuttl/README.md
+++ b/testing/kuttl/README.md
@@ -15,7 +15,7 @@ KUTTL gives you the option to suppress events from the test logging output. To e
 update the `kuttl` parameter when calling the `make` target
 
 ```
-KUTTL_TEST='kuttl test --suppress-logs=events' make check-kuttl
+KUTTL_TEST='kuttl test --suppress-log=events' make check-kuttl
 ```
 
 To suppress the events permanently, you can add the following to the KUTTL config (kuttl-test.yaml)

--- a/testing/kuttl/e2e/major-upgrade/00--cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade/00--cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade
+spec:
+  postgresVersion: 13
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/testing/kuttl/e2e/major-upgrade/00-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/00-assert.yaml
@@ -1,0 +1,21 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade
+spec:
+  postgresVersion: 13
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: major-upgrade
+    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/major-upgrade/01-postgres-connect.yaml
+++ b/testing/kuttl/e2e/major-upgrade/01-postgres-connect.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# When the cluster comes up, verify that the Postgres major version is correct
+- script: CLUSTER=major-upgrade ../../scripts/postgres-version-check.sh "13"

--- a/testing/kuttl/e2e/major-upgrade/02--cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade/02--cluster.yaml
@@ -1,0 +1,28 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade
+spec:
+  upgrade:
+    enabled: true
+    fromPostgresVersion: 13
+  postgresVersion: 14
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/testing/kuttl/e2e/major-upgrade/02-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/02-assert.yaml
@@ -1,0 +1,30 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade
+spec:
+  postgresVersion: 14
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: major-upgrade
+    postgres-operator.crunchydata.com/pgupgrade: ""
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: major-upgrade
+    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/major-upgrade/03-postgres-connect.yaml
+++ b/testing/kuttl/e2e/major-upgrade/03-postgres-connect.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# When the cluster comes back up, check that the Postgres major version has changed
+- script: CLUSTER=major-upgrade ../../scripts/postgres-version-check.sh "14"

--- a/testing/kuttl/e2e/major-upgrade/README.md
+++ b/testing/kuttl/e2e/major-upgrade/README.md
@@ -1,0 +1,5 @@
+### Postgres major upgrade test
+* 00: Create a standard Postgres 13 cluster; verify that the cluster instance is created as expected and that the initial backup job completed successfully.
+* 01: Run postgres-version-check.sh, which verifies the expected Postgres version is returned.
+* 02: Update the spec from step 00 to upgrade from 13 to 14; verify that the instance is ready, the version on the spec is correct, and both the backup and upgrade Jobs have completed successfully.
+* 03: Rerun postgres-version-check.sh to verify the expected Postgres version is returned.

--- a/testing/kuttl/kuttl-test.yaml
+++ b/testing/kuttl/kuttl-test.yaml
@@ -2,7 +2,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 testDirs:
 - testing/kuttl/e2e/
-timeout: 120
+timeout: 180
 parallel: 2
 # by default kuttl will run in a generated namespace to override
 # that functionality simply uncomment the line below and replace

--- a/testing/kuttl/scripts/postgres-version-check.sh
+++ b/testing/kuttl/scripts/postgres-version-check.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+EXPECTED_VERSION=$1
+
+CLUSTER=${CLUSTER:-default}
+
+POSTGRES_POD=$(kubectl -n ${NAMESPACE} get pod --selector=postgres-operator.crunchydata.com/cluster=${CLUSTER},postgres-operator.crunchydata.com/instance-set=instance1 --no-headers -o custom-columns=":metadata.name")
+
+# Grab the Postgres major version from `version()` output to compare to the provided value
+VERSION=$(kubectl -n ${NAMESPACE} exec -i ${POSTGRES_POD} -c database -- psql -tc "SELECT version();" |
+    xargs |
+    cut -d' ' -f 2 |
+    cut -d. -f 1)
+
+if [[ "$VERSION" != "$EXPECTED_VERSION" ]]; then
+    echo "Expected ${EXPECTED_VERSION} but got ${VERSION}"
+    exit 1
+fi


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
    
Adds a KUTTL E2E test to verify the Postgres major upgrade feature
works as expected. A standard Postgres 13 PostgresCluster is created
and validated then upgraded to Postgres 14 and validated again. The
expected pgBackRest backup Jobs and the pg_upgrade Job are also
checked to ensure they complete successfully.

This update also fixes a syntax error in the KUTTL
README. The flag should be `--suppress-log` not
`--suppress-logs`.



**Other Information**:
Issue: [sc-13182]