### PR TITLE
Envtest fixes

### DIFF
--- a/internal/controller/postgrescluster/apply.go
+++ b/internal/controller/postgrescluster/apply.go
@@ -167,12 +167,6 @@ func applyPodTemplateSpec(
 func applyServiceSpec(
 	patch *kubeapi.JSON6902, actual, intent corev1.ServiceSpec, path ...string,
 ) {
-	// Empty "omitempty" slices are ignored until Kubernetes 1.19.
-	// - https://issue.k8s.io/89273
-	if !equality.Semantic.DeepEqual(actual.ExternalIPs, intent.ExternalIPs) {
-		patch.Replace(append(path, "externalIPs")...)(intent.ExternalIPs)
-	}
-
 	// Service.Spec.Selector is not +mapType=atomic until Kubernetes 1.22.
 	// - https://issue.k8s.io/97970
 	if !equality.Semantic.DeepEqual(actual.Selector, intent.Selector) {

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -940,7 +940,7 @@ func TestReconcileReplicaCreateBackup(t *testing.T) {
 			naming.BackupReplicaCreate),
 	})
 	assert.NilError(t, err)
-	assert.Assert(t, len(jobs.Items) == 1)
+	assert.Equal(t, len(jobs.Items), 1, "expected 1 job")
 	backupJob := jobs.Items[0]
 
 	var foundOwnershipRef bool

--- a/internal/controller/postgrescluster/postgres_test.go
+++ b/internal/controller/postgrescluster/postgres_test.go
@@ -414,8 +414,11 @@ volumeMode: Filesystem
 					assert.Assert(t, returned == nil)
 
 					key, fetched := client.ObjectKeyFromObject(pvc), &corev1.PersistentVolumeClaim{}
-					assert.NilError(t, tClient.Get(ctx, key, fetched))
-					assert.Assert(t, fetched.DeletionTimestamp != nil, "expected deleted")
+					if err := tClient.Get(ctx, key, fetched); err == nil {
+						assert.Assert(t, fetched.DeletionTimestamp != nil, "expected deleted")
+					} else {
+						assert.Assert(t, apierrors.IsNotFound(err), "expected NotFound, got %v", err)
+					}
 
 					// Pods will redeploy while the PVC is scheduled for deletion.
 					observed.Pods = nil

--- a/internal/controller/postgrescluster/scale_test.go
+++ b/internal/controller/postgrescluster/scale_test.go
@@ -203,6 +203,7 @@ func TestScaleDown(t *testing.T) {
 
 			// Continue until instances are healthy.
 			var instances []appsv1.StatefulSet
+			var ready int32
 			assert.NilError(t, wait.Poll(time.Second, Scale(time.Minute), func() (bool, error) {
 				mustReconcile(t, cluster)
 
@@ -218,12 +219,12 @@ func TestScaleDown(t *testing.T) {
 
 				instances = list.Items
 
-				ready := int32(0)
+				ready = int32(0)
 				for i := range instances {
 					ready += instances[i].Status.ReadyReplicas
 				}
 				return ready == test.createRunningInstances, nil
-			}), "expected %v instances to be ready, got:\n%+v", test.createRunningInstances, instances)
+			}), "expected %v instances to be ready, got:\n%+v", test.createRunningInstances, ready)
 
 			if test.primaryTest != nil {
 				// Grab the old primary name to use later

--- a/internal/upgradecheck/header_test.go
+++ b/internal/upgradecheck/header_test.go
@@ -35,6 +35,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
+
+	// Google Kubernetes Engine / Google Cloud Platform authentication provider
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"


### PR DESCRIPTION
A few changes to get envtests running against an existing GKE cluster
- When checking for the deletion timestamp it is possible for the item to
not be found (i.e. is already deleted). Ignore not found errors
- Import GCP client auth package
- We no longer write external IPs for the primary cluster service. This
test can be removed.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
[sc-13356]