### PR TITLE
Move pgBackRest Logs Out of the /tmp Directory

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -587,6 +587,9 @@ func (r *Reconciler) generateRepoHostIntent(postgresCluster *v1beta1.PostgresClu
 
 	pgbackrest.AddServerToRepoPod(postgresCluster, &repo.Spec.Template.Spec)
 
+	// add the init container to make the pgBackRest repo volume log directory
+	pgbackrest.MakePGBackrestLogDir(&repo.Spec.Template, postgresCluster)
+
 	// add pgBackRest repo volumes to pod
 	if err := pgbackrest.AddRepoVolumesToPod(postgresCluster, &repo.Spec.Template,
 		getRepoPVCNames(postgresCluster, repoResources.pvcs),

--- a/internal/naming/names.go
+++ b/internal/naming/names.go
@@ -59,6 +59,10 @@ const (
 	// for the nss_wrapper
 	ContainerNSSWrapperInit = "nss-wrapper-init"
 
+	// ContainerPGBackRestLogDirInit is the name of the init container utilized to make
+	// a pgBackRest log directory when using a dedicated repo host.
+	ContainerPGBackRestLogDirInit = "pgbackrest-log-dir"
+
 	// ContainerPGMonitorExporter is the name of a container running postgres_exporter
 	ContainerPGMonitorExporter = "exporter"
 
@@ -146,6 +150,14 @@ const (
 
 	// PGBackRestRepoName is the name used for a pgbackrest repository
 	PGBackRestRepoName = "%s-pgbackrest-repo-%s"
+
+	// PGBackRestPGDataLogPath is the pgBackRest default log path configuration used by the
+	// PostgreSQL instance.
+	PGBackRestPGDataLogPath = "/pgdata/pgbackrest/log"
+
+	// PGBackRestRepoLogPath is the pgBackRest default log path configuration used by the
+	// dedicated repo host, if configured.
+	PGBackRestRepoLogPath = "/pgbackrest/%s/log"
 
 	// suffix used with postgrescluster name for associated configmap.
 	// for instance, if the cluster is named 'mycluster', the

--- a/internal/naming/names_test.go
+++ b/internal/naming/names_test.go
@@ -47,6 +47,7 @@ func TestContainerNamesUniqueAndValid(t *testing.T) {
 		ContainerNSSWrapperInit,
 		ContainerPGAdmin,
 		ContainerPGBackRestConfig,
+		ContainerPGBackRestLogDirInit,
 		ContainerPGBouncer,
 		ContainerPGBouncerConfig,
 		ContainerPostgresStartup,

--- a/internal/pgbackrest/reconcile.go
+++ b/internal/pgbackrest/reconcile.go
@@ -60,6 +60,25 @@ func AddRepoVolumesToPod(postgresCluster *v1beta1.PostgresCluster, template *cor
 			},
 		})
 
+		var initContainerFound bool
+		var index int
+		for index = range template.Spec.InitContainers {
+			if template.Spec.InitContainers[index].Name == naming.ContainerPGBackRestLogDirInit {
+				initContainerFound = true
+				break
+			}
+		}
+		if !initContainerFound {
+			return errors.Errorf(
+				"Unable to find init container %q when adding pgBackRest repo volumes",
+				naming.ContainerPGBackRestLogDirInit)
+		}
+		template.Spec.InitContainers[index].VolumeMounts =
+			append(template.Spec.InitContainers[index].VolumeMounts, corev1.VolumeMount{
+				Name:      repo.Name,
+				MountPath: "/pgbackrest/" + repo.Name,
+			})
+
 		for _, name := range containerNames {
 			var containerFound bool
 			var index int

--- a/internal/postgres/config.go
+++ b/internal/postgres/config.go
@@ -180,9 +180,9 @@ func startupCommand(
 	version := fmt.Sprint(cluster.Spec.PostgresVersion)
 	walDir := WALDirectory(cluster, instance)
 
-	args := []string{version, walDir}
+	args := []string{version, walDir, naming.PGBackRestPGDataLogPath}
 	script := strings.Join([]string{
-		`declare -r expected_major_version="$1" pgwal_directory="$2"`,
+		`declare -r expected_major_version="$1" pgwal_directory="$2" pgbrLog_directory="$3"`,
 
 		// Function to log values in a basic structured format.
 		`results() { printf '::postgres-operator: %s::%s\n' "$@"; }`,
@@ -219,6 +219,10 @@ func startupCommand(
 		// - https://git.postgresql.org/gitweb/?p=postgresql.git;f=src/backend/utils/init/miscinit.c;hb=REL_13_0#l319
 		// - https://issue.k8s.io/93802#issuecomment-717646167
 		`install --directory --mode=0700 "${postgres_data_directory}"`,
+
+		// Create the pgBackRest log directory.
+		`results 'pgBackRest log directory' "${pgbrLog_directory}"`,
+		`install --directory --mode=0775 "${pgbrLog_directory}"`,
 
 		// Copy replication client certificate files
 		// from the /pgconf/tls/replication directory to the /tmp/replication directory in order


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
Currently, the pgBackRest logs stored in the PostgreSQL instance
and pgBackRest repo Pods are located in the /tmp directory. This
is limited to the default 16MB emptyDir configuration set by PGO
and is not sufficient in certain cases.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This update changes the log locations. PGBackRest logs from the
PostgreSQL instance will now be stored at '/pgdata/pgbackrest/log'
on the pgData volume. PGBackRest logs from the repo host will be
stored at '/pgbackrest/repo#/log' where 'repo#' corresponds to the
first configured repository on the PostgresCluster spec that is
configured with a storage volume. That is, if the first configured
repo is 'repo1', and 'repo1' has a configured volume,  the log path
will be '/pgbackrest/repo1/log' so that those logs will be stored on
the 'repo1' volume. However, if 'repo1' does not have a configured
volume, the path will be set based so that the logs are stored on the
first repo configured with a storage volume.

Please note that the initial backup is taken on the first configured
repository. As such, this will determine where certain initial logs
are stored, i.e. db-backup.log, etc


**Other Information**:
Issue: [sc-13395]