### PR TITLE
E2E Test for GSSAPI Authentication With PG

### DIFF
--- a/testing/kuttl/e2e-other/gssapi/00-assert.yaml
+++ b/testing/kuttl/e2e-other/gssapi/00-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: krb5
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: krb5-keytab

--- a/testing/kuttl/e2e-other/gssapi/00-krb5-keytab.yaml
+++ b/testing/kuttl/e2e-other/gssapi/00-krb5-keytab.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- command: kubectl exec -n krb5 -it krb5-kdc-0 -- /krb5-scripts/krb5.sh "${NAMESPACE}"

--- a/testing/kuttl/e2e-other/gssapi/01-assert.yaml
+++ b/testing/kuttl/e2e-other/gssapi/01-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: gssapi
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gssapi-primary

--- a/testing/kuttl/e2e-other/gssapi/01-cluster.yaml
+++ b/testing/kuttl/e2e-other/gssapi/01-cluster.yaml
@@ -1,0 +1,41 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: gssapi
+spec:
+  config:
+    files:
+    - secret:
+        name: krb5-keytab
+    - configMap:
+        name: krb5
+  patroni:
+    dynamicConfiguration:
+      postgresql:
+        pg_hba:
+        - host postgres postgres 0.0.0.0/0 scram-sha-256
+        - host all krb5hippo@PGO.CRUNCHYDATA.COM 0.0.0.0/0 gss
+        parameters:
+          krb_server_keyfile: /etc/postgres/krb5.keytab
+  users:
+  - name: postgres
+  postgresVersion: 14
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/testing/kuttl/e2e-other/gssapi/02-assert.yaml
+++ b/testing/kuttl/e2e-other/gssapi/02-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-gssapi
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e-other/gssapi/02-psql-connect.yaml
+++ b/testing/kuttl/e2e-other/gssapi/02-psql-connect.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect-gssapi
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: psql
+        image: us.gcr.io/container-suite/crunchy-postgres:centos8-14.1-5.1.0-rc.1-0
+        command:
+        - bash
+        - -c
+        - --
+        - |-
+          psql -c 'create user "krb5hippo@PGO.CRUNCHYDATA.COM";'
+          kinit -k -t /krb5-conf/krb5.keytab krb5hippo@PGO.CRUNCHYDATA.COM
+          psql -U krb5hippo@PGO.CRUNCHYDATA.COM -h gssapi-primary.$(NAMESPACE).svc.cluster.local -d postgres \
+            -c 'select version();'
+        env:
+        - name: NAMESPACE
+          valueFrom: { fieldRef: { fieldPath: metadata.namespace } }
+        - name: PGHOST
+          valueFrom: { secretKeyRef: { name: gssapi-pguser-postgres, key: host } }
+        - name: PGPORT
+          valueFrom: { secretKeyRef: { name: gssapi-pguser-postgres, key: port } }
+        - name: PGUSER
+          valueFrom: { secretKeyRef: { name: gssapi-pguser-postgres, key: user } }
+        - name: PGPASSWORD
+          valueFrom: { secretKeyRef: { name: gssapi-pguser-postgres, key: password } }
+        - name: PGDATABASE
+          value: postgres  
+        - name: KRB5_CONFIG
+          value: /krb5-conf/krb5.conf
+        volumeMounts:
+        - name: krb5-conf
+          mountPath: /krb5-conf
+      volumes:
+      - name: krb5-conf
+        projected:
+          sources:
+          - configMap:
+              name: krb5
+          - secret:
+              name: krb5-keytab

--- a/testing/kuttl/e2e-other/gssapi/README.md
+++ b/testing/kuttl/e2e-other/gssapi/README.md
@@ -1,0 +1,14 @@
+# GSSAPI Authentication
+
+This test verifies that it is possible to properly configure PostgreSQL for GSSAPI
+authentication.  This is done by configuring a PostgresCluster for GSSAPI authentication,
+and then utilizing a Kerberos ticket that has been issued by a Kerberos KDC server to log into
+PostgreSQL.
+
+## Assumptions
+
+- A Kerberos Key Distribution Center (KDC) Pod named `krb5-kdc-0` is deployed inside of a `krb5`
+namespace within the Kubernetes cluster
+- The KDC server (`krb5-kdc-0`) contains a `/krb5-conf/krb5.sh` script that can be run as part
+of the test to create the Kerberos principals, keytab secret and client configuration needed to
+successfully run the test


### PR DESCRIPTION
Adds an end-to-end test to verify the ability to properly configure PostgreSQL for GSSAPI authentication.  This is specifically done using Kerberos, i.e. a ticket issued by a Kerberos KDC server is utilized to log into PostgreSQL when running the test.

Please note that this specific test has been added to a `e2e-other` directory, since additional configuration and infrastructure (e.g. a a running Kerberos Key Distribution Center) must be in place in order to successfully run the test.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

There is no E2E test for authenticating into PG using GSSAPI.

[sc-13319]

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

There is now an E2E test for authenticating into PG using GSSAPI.

**Other Information**:

N/A