### PR TITLE
Install k3d and k3s directly in GitHub actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,13 +46,21 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with: { go-version: 1.x }
-      - uses: nolar/setup-k3d-k3s@v1
-        with:
-          version: "${{ matrix.kubernetes }}"
-          k3d-tag: v4.4.8
-          k3d-args: --no-lb
+
+      - name: Install k3d
+        # Git tag from https://github.com/rancher/k3d/releases or "latest"
+        env: { K3D_TAG: latest }
+        run: |
+          curl --fail --silent https://raw.githubusercontent.com/rancher/k3d/main/install.sh |
+            TAG="${K3D_TAG#latest}" bash && k3d version | head -n1
+
+      - name: Start k3s
+        # https://rancher.com/docs/k3s/latest/en/upgrades/basic/#release-channels
+        env: { K3S_CHANNEL: "${{ matrix.kubernetes }}" }
+        run: k3d cluster create --image="+${K3S_CHANNEL}" --no-lb --timeout=2m --wait
+
       - name: Prefetch container images
-        run: >
+        run: |
           {
             echo '"registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0"'
             echo '"registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0"'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [latest, v1.18]
+        kubernetes: [latest, v1.19]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2


### PR DESCRIPTION
Recent versions of k3d know how to work with the release channels recently offered by k3s. Installation is now two commands and not worth hiding in another action.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

**Other Information**:

This also appears to be a bit faster than the action.

[Before](https://github.com/CrunchyData/postgres-operator/runs/4798684695):
```
Run nolar/setup-k3d-k3s@v1 (30s)
```
[After](https://github.com/CrunchyData/postgres-operator/runs/4798873248):
```
Install k3d (1s)
Start k3s (11s)
```

Issue: [sc-12809]