### PR TITLE
Execute Kubernetes tests in parallel

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -64,6 +64,12 @@ issues:
       path: _test[.]go$
       text: \`(net/http/httptest|[^`]*testing[^`]*)`
 
+    # Allow setupTestEnv and teardownTestEnv to remain unused for a while.
+    # TODO(cbandy): Remove these functions after setupKubernetes has landed.
+    - linters: [deadcode, unused]
+      path: internal/controller/postgrescluster/helpers_test.go
+      text: \`(setupTestEnv|teardownTestEnv)`
+
 run:
   build-tags:
     - envtest

--- a/internal/controller/postgrescluster/apply_test.go
+++ b/internal/controller/postgrescluster/apply_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,11 +54,7 @@ func TestServerSideApply(t *testing.T) {
 	cc, err := client.New(config, client.Options{})
 	assert.NilError(t, err)
 
-	ns := &corev1.Namespace{}
-	ns.GenerateName = "postgres-operator-test-"
-	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
-	assert.NilError(t, cc.Create(ctx, ns))
-	t.Cleanup(func() { assert.Check(t, cc.Delete(ctx, ns)) })
+	ns := setupNamespace(t, cc)
 
 	dc, err := discovery.NewDiscoveryClientForConfig(config)
 	assert.NilError(t, err)

--- a/internal/controller/postgrescluster/apply_test.go
+++ b/internal/controller/postgrescluster/apply_test.go
@@ -37,26 +37,18 @@ import (
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 )
 
 func TestServerSideApply(t *testing.T) {
-	// TODO: Update tests that include envtest package to better handle
-	// running in parallel
-	// t.Parallel()
-
 	ctx := context.Background()
-	env := &envtest.Environment{}
-	config, err := env.Start()
-	assert.NilError(t, err)
-	t.Cleanup(func() { assert.Check(t, env.Stop()) })
-
-	cc, err := client.New(config, client.Options{})
-	assert.NilError(t, err)
+	env, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	ns := setupNamespace(t, cc)
 
-	dc, err := discovery.NewDiscoveryClientForConfig(config)
+	dc, err := discovery.NewDiscoveryClientForConfig(env.Config)
 	assert.NilError(t, err)
 
 	server, err := dc.ServerVersion()

--- a/internal/controller/postgrescluster/cluster_test.go
+++ b/internal/controller/postgrescluster/cluster_test.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -93,13 +94,11 @@ var gvks = []schema.GroupVersionKind{{
 }}
 
 func TestCustomLabels(t *testing.T) {
-	t.Parallel()
-
-	env, cc, config := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	env, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 2)
 
 	reconciler := &Reconciler{}
-	ctx, cancel := setupManager(t, config, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, env.Config, func(mgr manager.Manager) {
 		reconciler = &Reconciler{
 			Client:   cc,
 			Owner:    client.FieldOwner(t.Name()),
@@ -351,13 +350,11 @@ func TestCustomLabels(t *testing.T) {
 }
 
 func TestCustomAnnotations(t *testing.T) {
-	t.Parallel()
-
-	env, cc, config := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	env, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 2)
 
 	reconciler := &Reconciler{}
-	ctx, cancel := setupManager(t, config, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, env.Config, func(mgr manager.Manager) {
 		reconciler = &Reconciler{
 			Client:   cc,
 			Owner:    client.FieldOwner(t.Name()),
@@ -614,20 +611,18 @@ func TestContainerSecurityContext(t *testing.T) {
 		t.Skip("Test requires pods to be created")
 	}
 
-	t.Parallel()
-
-	env, cc, config := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	env, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
 	reconciler := &Reconciler{}
-	ctx, cancel := setupManager(t, config, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, env.Config, func(mgr manager.Manager) {
 		reconciler = &Reconciler{
 			Client:   cc,
 			Owner:    client.FieldOwner(t.Name()),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
 			Tracer:   otel.Tracer(t.Name()),
 		}
-		podExec, err := newPodExecutor(config)
+		podExec, err := newPodExecutor(env.Config)
 		assert.NilError(t, err)
 		reconciler.PodExec = podExec
 	})
@@ -691,8 +686,8 @@ func TestContainerSecurityContext(t *testing.T) {
 }
 
 func TestGenerateClusterPrimaryService(t *testing.T) {
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	reconciler := &Reconciler{Client: cc}
 
@@ -792,8 +787,8 @@ subsets:
 
 func TestReconcileClusterPrimaryService(t *testing.T) {
 	ctx := context.Background()
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
 	reconciler := &Reconciler{Client: cc, Owner: client.FieldOwner(t.Name())}
 
@@ -813,8 +808,8 @@ func TestReconcileClusterPrimaryService(t *testing.T) {
 }
 
 func TestGenerateClusterReplicaServiceIntent(t *testing.T) {
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	reconciler := &Reconciler{Client: cc}
 

--- a/internal/controller/postgrescluster/controller_ref_manager_test.go
+++ b/internal/controller/postgrescluster/controller_ref_manager_test.go
@@ -19,34 +19,24 @@ package postgrescluster
 */
 
 import (
+	"context"
 	"testing"
 
-	"go.opentelemetry.io/otel"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/testing/require"
 )
 
 func TestManageControllerRefs(t *testing.T) {
-	tEnv, tClient := setupKubernetes(t)
+	_, tClient := setupKubernetes(t)
 	require.ParallelCapacity(t, 1)
 
-	r := &Reconciler{}
-	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
-		r = &Reconciler{
-			Client:   mgr.GetClient(),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Tracer:   otel.Tracer(ControllerName),
-			Owner:    ControllerName,
-		}
-	})
-	t.Cleanup(func() { teardownManager(cancel, t) })
-
+	ctx := context.Background()
+	r := &Reconciler{Client: tClient}
 	clusterName := "hippo"
 
 	cluster := testCluster()

--- a/internal/controller/postgrescluster/controller_ref_manager_test.go
+++ b/internal/controller/postgrescluster/controller_ref_manager_test.go
@@ -29,14 +29,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 )
 
 func TestManageControllerRefs(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -44,10 +45,7 @@ func TestManageControllerRefs(t *testing.T) {
 			Owner:    ControllerName,
 		}
 	})
-	t.Cleanup(func() {
-		teardownManager(cancel, t)
-		teardownTestEnv(t, tEnv)
-	})
+	t.Cleanup(func() { teardownManager(cancel, t) })
 
 	clusterName := "hippo"
 

--- a/internal/controller/postgrescluster/controller_test.go
+++ b/internal/controller/postgrescluster/controller_test.go
@@ -42,13 +42,14 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func TestDeleteControlled(t *testing.T) {
 	ctx := context.Background()
-	tEnv, cc, _ := setupTestEnv(t, t.Name())
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
 	ns := setupNamespace(t, cc)
 	reconciler := Reconciler{Client: cc}

--- a/internal/controller/postgrescluster/controller_test.go
+++ b/internal/controller/postgrescluster/controller_test.go
@@ -34,7 +34,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/tools/record"
@@ -51,13 +50,8 @@ func TestDeleteControlled(t *testing.T) {
 	tEnv, cc, _ := setupTestEnv(t, t.Name())
 	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 
+	ns := setupNamespace(t, cc)
 	reconciler := Reconciler{Client: cc}
-
-	ns := &corev1.Namespace{}
-	ns.GenerateName = "postgres-operator-test-"
-	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
-	assert.NilError(t, cc.Create(ctx, ns))
-	t.Cleanup(func() { assert.Check(t, cc.Delete(ctx, ns)) })
 
 	cluster := testCluster()
 	cluster.Namespace = ns.Name

--- a/internal/controller/postgrescluster/delete_test.go
+++ b/internal/controller/postgrescluster/delete_test.go
@@ -76,12 +76,7 @@ func TestReconcilerHandleDelete(t *testing.T) {
 	cc, err := client.New(config, options)
 	assert.NilError(t, err)
 
-	ns := &corev1.Namespace{}
-	ns.GenerateName = "postgres-operator-test-"
-	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
-	assert.NilError(t, cc.Create(ctx, ns))
-	t.Cleanup(func() { assert.Check(t, cc.Delete(ctx, ns)) })
-
+	ns := setupNamespace(t, cc)
 	reconciler := Reconciler{
 		Client:   cc,
 		Owner:    client.FieldOwner(t.Name()),
@@ -381,11 +376,7 @@ func TestReconcilerHandleDeleteNamespace(t *testing.T) {
 	cc, err := client.New(config, options)
 	assert.NilError(t, err)
 
-	ns := &corev1.Namespace{}
-	ns.GenerateName = "postgres-operator-test-"
-	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
-	assert.NilError(t, cc.Create(ctx, ns))
-	t.Cleanup(func() { assert.Check(t, client.IgnoreNotFound(cc.Delete(ctx, ns))) })
+	ns := setupNamespace(t, cc)
 
 	var mm struct {
 		manager.Manager

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -51,6 +51,7 @@ import (
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -1099,11 +1100,11 @@ func TestPodsToKeep(t *testing.T) {
 }
 
 func TestDeleteInstance(t *testing.T) {
-	env, cc, config := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	env, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
 	reconciler := &Reconciler{}
-	ctx, cancel := setupManager(t, config, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, env.Config, func(mgr manager.Manager) {
 		reconciler = &Reconciler{
 			Client:   cc,
 			Owner:    client.FieldOwner(t.Name()),
@@ -1705,11 +1706,13 @@ func TestFindAvailableInstanceNames(t *testing.T) {
 }
 
 func TestReconcileUpgrade(t *testing.T) {
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	tEnv, tClient := setupKubernetes(t)
+
+	// TODO(cbandy): Assume this should run alone for now.
+	require.ParallelCapacity(t, 99)
+
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -2048,12 +2051,13 @@ func TestReconcileUpgrade(t *testing.T) {
 }
 
 func TestObserveUpgradeEnv(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	// TODO(cbandy): Assume this should run alone for now.
+	require.ParallelCapacity(t, 99)
+
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   tClient,
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -2270,12 +2274,13 @@ func TestObserveUpgradeEnv(t *testing.T) {
 }
 
 func TestPrepareForUpgrade(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	// TODO(cbandy): Assume this should run alone for now.
+	require.ParallelCapacity(t, 99)
+
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   tClient,
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -2702,9 +2707,8 @@ func fakeUpgradeCluster(clusterName, namespace, clusterUID string) *v1beta1.Post
 
 func TestReconcileInstanceSetPodDisruptionBudget(t *testing.T) {
 	ctx := context.Background()
-
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
 	r := &Reconciler{
 		Client: cc,
@@ -2821,9 +2825,8 @@ func TestReconcileInstanceSetPodDisruptionBudget(t *testing.T) {
 
 func TestCleanupDisruptionBudgets(t *testing.T) {
 	ctx := context.Background()
-
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
 	r := &Reconciler{
 		Client: cc,

--- a/internal/controller/postgrescluster/patroni_test.go
+++ b/internal/controller/postgrescluster/patroni_test.go
@@ -42,12 +42,13 @@ import (
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func TestGeneratePatroniLeaderLeaseService(t *testing.T) {
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	reconciler := &Reconciler{Client: cc}
 
@@ -155,8 +156,8 @@ ownerReferences:
 
 func TestReconcilePatroniLeaderLease(t *testing.T) {
 	ctx := context.Background()
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
 	ns := setupNamespace(t, cc)
 	reconciler := &Reconciler{Client: cc, Owner: client.FieldOwner(t.Name())}
@@ -233,12 +234,11 @@ func TestPatroniReplicationSecret(t *testing.T) {
 		t.Skip("USE_EXISTING_CLUSTER: Test fails due to garbage collection")
 	}
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   tClient,
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -346,8 +346,8 @@ func TestPatroniReplicationSecret(t *testing.T) {
 
 func TestReconcilePatroniStatus(t *testing.T) {
 	ctx := context.Background()
-	tEnv, tClient, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	_, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	ns := setupNamespace(t, tClient)
 	r := &Reconciler{Client: tClient, Owner: client.FieldOwner(t.Name())}
@@ -450,8 +450,8 @@ func TestReconcilePatroniStatus(t *testing.T) {
 }
 
 func TestReconcilePatroniSwitchover(t *testing.T) {
-	env, client, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, client := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	var called, failover, callError, callFails bool
 	r := Reconciler{

--- a/internal/controller/postgrescluster/pgadmin_test.go
+++ b/internal/controller/postgrescluster/pgadmin_test.go
@@ -35,12 +35,13 @@ import (
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func TestGeneratePGAdminService(t *testing.T) {
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	reconciler := &Reconciler{Client: cc}
 
@@ -179,8 +180,8 @@ ownerReferences:
 
 func TestReconcilePGAdminService(t *testing.T) {
 	ctx := context.Background()
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
 	reconciler := &Reconciler{Client: cc, Owner: client.FieldOwner(t.Name())}
 
@@ -267,8 +268,8 @@ func TestReconcilePGAdminService(t *testing.T) {
 
 func TestReconcilePGAdminStatefulSet(t *testing.T) {
 	ctx := context.Background()
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
 	reconciler := &Reconciler{Client: cc, Owner: client.FieldOwner(t.Name())}
 
@@ -559,8 +560,8 @@ volumes:
 
 func TestReconcilePGAdminDataVolume(t *testing.T) {
 	ctx := context.Background()
-	tEnv, tClient, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	_, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
 	reconciler := &Reconciler{
 		Client: tClient,

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/pgbackrest"
 	"github.com/crunchydata/postgres-operator/internal/pki"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -178,11 +179,11 @@ func TestReconcilePGBackRest(t *testing.T) {
 		t.Skip("USE_EXISTING_CLUSTER: Test fails due to garbage collection")
 	}
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 2)
+
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -609,11 +610,11 @@ func TestReconcilePGBackRestRBAC(t *testing.T) {
 		t.Skip("USE_EXISTING_CLUSTER: Test fails due to garbage collection")
 	}
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
+
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -672,12 +673,11 @@ func TestReconcilePGBackRestRBAC(t *testing.T) {
 }
 
 func TestReconcileStanzaCreate(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -848,12 +848,11 @@ func TestGetPGBackRestExecSelector(t *testing.T) {
 }
 
 func TestReconcileReplicaCreateBackup(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -1015,12 +1014,11 @@ func TestReconcileReplicaCreateBackup(t *testing.T) {
 }
 
 func TestReconcileManualBackup(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 2)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 	r := &Reconciler{}
-	_, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	_, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -1465,11 +1463,11 @@ func TestGetPGBackRestResources(t *testing.T) {
 		t.Skip("USE_EXISTING_CLUSTER: Test fails due to garbage collection")
 	}
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
+
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -1777,12 +1775,11 @@ func TestGetPGBackRestResources(t *testing.T) {
 }
 
 func TestReconcilePostgresClusterDataSource(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 4)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   tClient,
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -2173,8 +2170,8 @@ volumes:
 }
 
 func TestGenerateRepoHostIntent(t *testing.T) {
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	r := Reconciler{Client: cc}
 
@@ -2225,8 +2222,8 @@ func TestGenerateRepoHostIntent(t *testing.T) {
 }
 
 func TestGenerateRestoreJobIntent(t *testing.T) {
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	r := Reconciler{
 		Client: cc,
@@ -2430,12 +2427,11 @@ func TestGenerateRestoreJobIntent(t *testing.T) {
 }
 
 func TestObserveRestoreEnv(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   tClient,
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -2654,12 +2650,11 @@ func TestObserveRestoreEnv(t *testing.T) {
 }
 
 func TestPrepareForRestore(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   tClient,
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -2906,11 +2901,11 @@ func TestPrepareForRestore(t *testing.T) {
 }
 
 func TestReconcileScheduledBackups(t *testing.T) {
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 2)
+
 	r := &Reconciler{}
-	_, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	_, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -3127,12 +3122,11 @@ func TestReconcileScheduledBackups(t *testing.T) {
 }
 
 func TestSetScheduledJobStatus(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -3222,12 +3216,11 @@ func TestSetScheduledJobStatus(t *testing.T) {
 }
 
 func TestPreparePGBackRestForPGUpgrade(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 4)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   tClient,
 			Recorder: mgr.GetEventRecorderFor(ControllerName),

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -610,19 +610,11 @@ func TestReconcilePGBackRestRBAC(t *testing.T) {
 		t.Skip("USE_EXISTING_CLUSTER: Test fails due to garbage collection")
 	}
 
-	tEnv, tClient := setupKubernetes(t)
+	ctx := context.Background()
+	_, tClient := setupKubernetes(t)
 	require.ParallelCapacity(t, 0)
 
-	r := &Reconciler{}
-	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
-		r = &Reconciler{
-			Client:   mgr.GetClient(),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Tracer:   otel.Tracer(ControllerName),
-			Owner:    ControllerName,
-		}
-	})
-	t.Cleanup(func() { teardownManager(cancel, t) })
+	r := &Reconciler{Client: tClient, Owner: client.FieldOwner(t.Name())}
 
 	clusterName := "hippocluster"
 	clusterUID := "hippouid"
@@ -848,19 +840,11 @@ func TestGetPGBackRestExecSelector(t *testing.T) {
 }
 
 func TestReconcileReplicaCreateBackup(t *testing.T) {
-	tEnv, tClient := setupKubernetes(t)
+	ctx := context.Background()
+	_, tClient := setupKubernetes(t)
 	require.ParallelCapacity(t, 1)
 
-	r := &Reconciler{}
-	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
-		r = &Reconciler{
-			Client:   mgr.GetClient(),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Tracer:   otel.Tracer(ControllerName),
-			Owner:    ControllerName,
-		}
-	})
-	t.Cleanup(func() { teardownManager(cancel, t) })
+	r := &Reconciler{Client: tClient, Owner: client.FieldOwner(t.Name())}
 
 	clusterName := "hippocluster"
 	clusterUID := "hippouid"
@@ -1463,19 +1447,11 @@ func TestGetPGBackRestResources(t *testing.T) {
 		t.Skip("USE_EXISTING_CLUSTER: Test fails due to garbage collection")
 	}
 
-	tEnv, tClient := setupKubernetes(t)
+	ctx := context.Background()
+	_, tClient := setupKubernetes(t)
 	require.ParallelCapacity(t, 1)
 
-	r := &Reconciler{}
-	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
-		r = &Reconciler{
-			Client:   mgr.GetClient(),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Tracer:   otel.Tracer(ControllerName),
-			Owner:    ControllerName,
-		}
-	})
-	t.Cleanup(func() { teardownManager(cancel, t) })
+	r := &Reconciler{Client: tClient, Owner: client.FieldOwner(t.Name())}
 
 	clusterName := "hippocluster"
 	clusterUID := "hippouid"
@@ -2427,20 +2403,11 @@ func TestGenerateRestoreJobIntent(t *testing.T) {
 }
 
 func TestObserveRestoreEnv(t *testing.T) {
-	tEnv, tClient := setupKubernetes(t)
+	ctx := context.Background()
+	_, tClient := setupKubernetes(t)
 	require.ParallelCapacity(t, 1)
 
-	r := &Reconciler{}
-	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
-		r = &Reconciler{
-			Client:   tClient,
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Tracer:   otel.Tracer(ControllerName),
-			Owner:    ControllerName,
-		}
-	})
-	t.Cleanup(func() { teardownManager(cancel, t) })
-
+	r := &Reconciler{Client: tClient, Owner: client.FieldOwner(t.Name())}
 	namespace := setupNamespace(t, tClient).Name
 
 	generateJob := func(clusterName string, completed, failed *bool) *batchv1.Job {
@@ -2650,20 +2617,11 @@ func TestObserveRestoreEnv(t *testing.T) {
 }
 
 func TestPrepareForRestore(t *testing.T) {
-	tEnv, tClient := setupKubernetes(t)
+	ctx := context.Background()
+	_, tClient := setupKubernetes(t)
 	require.ParallelCapacity(t, 1)
 
-	r := &Reconciler{}
-	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
-		r = &Reconciler{
-			Client:   tClient,
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Tracer:   otel.Tracer(ControllerName),
-			Owner:    ControllerName,
-		}
-	})
-	t.Cleanup(func() { teardownManager(cancel, t) })
-
+	r := &Reconciler{Client: tClient, Owner: client.FieldOwner(t.Name())}
 	namespace := setupNamespace(t, tClient).Name
 
 	generateJob := func(clusterName string) *batchv1.Job {
@@ -3122,19 +3080,11 @@ func TestReconcileScheduledBackups(t *testing.T) {
 }
 
 func TestSetScheduledJobStatus(t *testing.T) {
-	tEnv, tClient := setupKubernetes(t)
+	ctx := context.Background()
+	_, tClient := setupKubernetes(t)
 	require.ParallelCapacity(t, 0)
 
-	r := &Reconciler{}
-	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
-		r = &Reconciler{
-			Client:   mgr.GetClient(),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Tracer:   otel.Tracer(ControllerName),
-			Owner:    ControllerName,
-		}
-	})
-	t.Cleanup(func() { teardownManager(cancel, t) })
+	r := &Reconciler{Client: tClient, Owner: client.FieldOwner(t.Name())}
 
 	clusterName := "hippocluster"
 	clusterUID := "hippouid"
@@ -3216,20 +3166,11 @@ func TestSetScheduledJobStatus(t *testing.T) {
 }
 
 func TestPreparePGBackRestForPGUpgrade(t *testing.T) {
-	tEnv, tClient := setupKubernetes(t)
+	ctx := context.Background()
+	_, tClient := setupKubernetes(t)
 	require.ParallelCapacity(t, 4)
 
-	r := &Reconciler{}
-	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
-		r = &Reconciler{
-			Client:   tClient,
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Tracer:   otel.Tracer(ControllerName),
-			Owner:    ControllerName,
-		}
-	})
-	t.Cleanup(func() { teardownManager(cancel, t) })
-
+	r := &Reconciler{Client: tClient, Owner: client.FieldOwner(t.Name())}
 	ns := setupNamespace(t, tClient)
 
 	generateBackupJob := func(cluster *v1beta1.PostgresCluster, repoName string,

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -32,12 +32,13 @@ import (
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func TestGeneratePGBouncerService(t *testing.T) {
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	reconciler := &Reconciler{Client: cc}
 
@@ -176,8 +177,8 @@ ownerReferences:
 
 func TestReconcilePGBouncerService(t *testing.T) {
 	ctx := context.Background()
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
 	reconciler := &Reconciler{Client: cc, Owner: client.FieldOwner(t.Name())}
 
@@ -263,8 +264,8 @@ func TestReconcilePGBouncerService(t *testing.T) {
 }
 
 func TestGeneratePGBouncerDeployment(t *testing.T) {
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	reconciler := &Reconciler{Client: cc}
 
@@ -409,9 +410,8 @@ topologySpreadConstraints:
 
 func TestReconcilePGBouncerDisruptionBudget(t *testing.T) {
 	ctx := context.Background()
-
-	env, cc, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	r := &Reconciler{
 		Client: cc,

--- a/internal/controller/postgrescluster/pgmonitor_test.go
+++ b/internal/controller/postgrescluster/pgmonitor_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/pgmonitor"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -516,11 +517,11 @@ func TestReconcilePGMonitorSecret(t *testing.T) {
 		t.Skip("Test failing with existing cluster")
 	}
 
-	env, cc, config := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	env, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	reconciler := &Reconciler{}
-	ctx, cancel := setupManager(t, config, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, env.Config, func(mgr manager.Manager) {
 		reconciler = &Reconciler{
 			Client:   cc,
 			Owner:    client.FieldOwner(t.Name()),

--- a/internal/controller/postgrescluster/pgmonitor_test.go
+++ b/internal/controller/postgrescluster/pgmonitor_test.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"testing"
 
-	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,7 +34,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
@@ -517,19 +515,11 @@ func TestReconcilePGMonitorSecret(t *testing.T) {
 		t.Skip("Test failing with existing cluster")
 	}
 
-	env, cc := setupKubernetes(t)
+	ctx := context.Background()
+	_, cc := setupKubernetes(t)
 	require.ParallelCapacity(t, 0)
 
-	reconciler := &Reconciler{}
-	ctx, cancel := setupManager(t, env.Config, func(mgr manager.Manager) {
-		reconciler = &Reconciler{
-			Client:   cc,
-			Owner:    client.FieldOwner(t.Name()),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Tracer:   otel.Tracer(t.Name()),
-		}
-	})
-	t.Cleanup(func() { teardownManager(cancel, t) })
+	reconciler := &Reconciler{Client: cc, Owner: client.FieldOwner(t.Name())}
 
 	cluster := testCluster()
 	cluster.Default()

--- a/internal/controller/postgrescluster/pki_test.go
+++ b/internal/controller/postgrescluster/pki_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/pki"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -48,10 +49,9 @@ func TestReconcileCerts(t *testing.T) {
 		t.Skip("USE_EXISTING_CLUSTER: Test fails due to garbage collection")
 	}
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, _ := setupTestEnv(t, ControllerName)
+	_, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 2)
 	ctx := context.Background()
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 	namespace := setupNamespace(t, tClient).Name
 
 	r := &Reconciler{

--- a/internal/controller/postgrescluster/pki_test.go
+++ b/internal/controller/postgrescluster/pki_test.go
@@ -33,7 +33,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,16 +51,8 @@ func TestReconcileCerts(t *testing.T) {
 	// setup the test environment and ensure a clean teardown
 	tEnv, tClient, _ := setupTestEnv(t, ControllerName)
 	ctx := context.Background()
-	// set namespace name
-	ns := &corev1.Namespace{}
-	ns.GenerateName = "postgres-operator-test-"
-	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
-	assert.NilError(t, tClient.Create(ctx, ns))
-	t.Cleanup(func() {
-		assert.Check(t, tClient.Delete(ctx, ns))
-		teardownTestEnv(t, tEnv)
-	})
-	namespace := ns.Name
+	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	namespace := setupNamespace(t, tClient).Name
 
 	r := &Reconciler{
 		Client: tClient,

--- a/internal/controller/postgrescluster/pod_disruption_budget_test.go
+++ b/internal/controller/postgrescluster/pod_disruption_budget_test.go
@@ -26,12 +26,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func TestGeneratePodDisruptionBudget(t *testing.T) {
-	_, cc, _ := setupTestEnv(t, ControllerName)
+	_, cc := setupKubernetes(t)
 	r := &Reconciler{Client: cc}
+	require.ParallelCapacity(t, 0)
 
 	var (
 		minAvailable *intstr.IntOrString

--- a/internal/controller/postgrescluster/postgres_test.go
+++ b/internal/controller/postgrescluster/postgres_test.go
@@ -37,12 +37,13 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/postgres"
 	"github.com/crunchydata/postgres-operator/internal/testing/cmp"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func TestGeneratePostgresUserSecret(t *testing.T) {
-	tEnv, tClient, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	_, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	reconciler := &Reconciler{Client: tClient}
 
@@ -238,8 +239,8 @@ func TestGeneratePostgresUserSecret(t *testing.T) {
 
 func TestReconcilePostgresVolumes(t *testing.T) {
 	ctx := context.Background()
-	tEnv, tClient, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	_, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
 	reconciler := &Reconciler{
 		Client: tClient,
@@ -429,8 +430,8 @@ func TestReconcileDatabaseInitSQL(t *testing.T) {
 	var called bool
 
 	// Test Environment Setup
-	env, client, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, client := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	r := &Reconciler{
 		Client: client,
@@ -553,8 +554,8 @@ func TestReconcileDatabaseInitSQLConfigMap(t *testing.T) {
 	var called bool
 
 	// Test Environment Setup
-	env, client, _ := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, env) })
+	_, client := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	r := &Reconciler{
 		Client: client,

--- a/internal/controller/postgrescluster/postgres_test.go
+++ b/internal/controller/postgrescluster/postgres_test.go
@@ -30,7 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -247,14 +246,8 @@ func TestReconcilePostgresVolumes(t *testing.T) {
 		Owner:  client.FieldOwner(t.Name()),
 	}
 
-	ns := &corev1.Namespace{}
-	ns.GenerateName = "postgres-operator-test-"
-	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
-	assert.NilError(t, tClient.Create(ctx, ns))
-	t.Cleanup(func() { assert.Check(t, tClient.Delete(ctx, ns)) })
-
 	cluster := testCluster()
-	cluster.Namespace = ns.Name
+	cluster.Namespace = setupNamespace(t, tClient).Name
 
 	assert.NilError(t, tClient.Create(ctx, cluster))
 	t.Cleanup(func() { assert.Check(t, tClient.Delete(ctx, cluster)) })
@@ -452,11 +445,7 @@ func TestReconcileDatabaseInitSQL(t *testing.T) {
 	}
 
 	// Test Resources Setup
-	ns := &corev1.Namespace{}
-	ns.GenerateName = "postgres-operator-test-"
-	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
-	assert.NilError(t, client.Create(ctx, ns))
-	t.Cleanup(func() { assert.Check(t, client.Delete(ctx, ns)) })
+	ns := setupNamespace(t, client)
 
 	// Define a status to be set if sql has already been run
 	status := "set"
@@ -580,11 +569,7 @@ func TestReconcileDatabaseInitSQLConfigMap(t *testing.T) {
 	}
 
 	// Test Resources Setup
-	ns := &corev1.Namespace{}
-	ns.GenerateName = "postgres-operator-test-"
-	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
-	assert.NilError(t, client.Create(ctx, ns))
-	t.Cleanup(func() { assert.Check(t, client.Delete(ctx, ns)) })
+	ns := setupNamespace(t, client)
 
 	// reconcileDatabaseInitSQL expects to find a pod that is running with a writable
 	// database container. Define this pod in an observed instance so that

--- a/internal/controller/postgrescluster/scale_test.go
+++ b/internal/controller/postgrescluster/scale_test.go
@@ -67,11 +67,7 @@ func TestScaleDown(t *testing.T) {
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
 
-	ns := &corev1.Namespace{}
-	ns.GenerateName = "postgres-operator-test-"
-	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
-	assert.NilError(t, cc.Create(ctx, ns))
-	t.Cleanup(func() { assert.Check(t, cc.Delete(ctx, ns)) })
+	ns := setupNamespace(t, cc)
 
 	mustReconcile := func(t *testing.T, cluster *v1beta1.PostgresCluster) reconcile.Result {
 		t.Helper()

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -39,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/yaml"
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
@@ -604,19 +602,11 @@ func TestGetPVCNameMethods(t *testing.T) {
 }
 
 func TestReconcileConfigureExistingPVCs(t *testing.T) {
-	tEnv, tClient := setupKubernetes(t)
+	ctx := context.Background()
+	_, tClient := setupKubernetes(t)
 	require.ParallelCapacity(t, 1)
 
-	r := &Reconciler{}
-	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
-		r = &Reconciler{
-			Client:   mgr.GetClient(),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Tracer:   otel.Tracer(ControllerName),
-			Owner:    ControllerName,
-		}
-	})
-	t.Cleanup(func() { teardownManager(cancel, t) })
+	r := &Reconciler{Client: tClient, Owner: client.FieldOwner(t.Name())}
 
 	ns := setupNamespace(t, tClient)
 	cluster := &v1beta1.PostgresCluster{
@@ -872,19 +862,11 @@ func TestReconcileConfigureExistingPVCs(t *testing.T) {
 }
 
 func TestReconcileMoveDirectories(t *testing.T) {
-	tEnv, tClient := setupKubernetes(t)
+	ctx := context.Background()
+	_, tClient := setupKubernetes(t)
 	require.ParallelCapacity(t, 1)
 
-	r := &Reconciler{}
-	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
-		r = &Reconciler{
-			Client:   mgr.GetClient(),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Tracer:   otel.Tracer(ControllerName),
-			Owner:    ControllerName,
-		}
-	})
-	t.Cleanup(func() { teardownManager(cancel, t) })
+	r := &Reconciler{Client: tClient, Owner: client.FieldOwner(t.Name())}
 
 	ns := setupNamespace(t, tClient)
 	cluster := &v1beta1.PostgresCluster{

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -35,7 +35,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
@@ -57,11 +56,7 @@ func TestPersistentVolumeClaimLimitations(t *testing.T) {
 	tEnv, cc, _ := setupTestEnv(t, t.Name())
 	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 
-	ns := &corev1.Namespace{}
-	ns.GenerateName = "postgres-operator-test-"
-	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
-	assert.NilError(t, cc.Create(ctx, ns))
-	t.Cleanup(func() { assert.Check(t, cc.Delete(ctx, ns)) })
+	ns := setupNamespace(t, cc)
 
 	// Stub to see that handlePersistentVolumeClaimError returns nil.
 	cluster := new(v1beta1.PostgresCluster)
@@ -623,12 +618,7 @@ func TestReconcileConfigureExistingPVCs(t *testing.T) {
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
 
-	ns := &corev1.Namespace{}
-	ns.GenerateName = "postgres-operator-test-"
-	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
-	assert.NilError(t, tClient.Create(ctx, ns))
-	t.Cleanup(func() { assert.Check(t, tClient.Delete(ctx, ns)) })
-
+	ns := setupNamespace(t, tClient)
 	cluster := &v1beta1.PostgresCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testcluster",
@@ -897,12 +887,7 @@ func TestReconcileMoveDirectories(t *testing.T) {
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
 
-	ns := &corev1.Namespace{}
-	ns.GenerateName = "postgres-operator-test-"
-	ns.Labels = labels.Set{"postgres-operator-test": t.Name()}
-	assert.NilError(t, tClient.Create(ctx, ns))
-	t.Cleanup(func() { assert.Check(t, tClient.Delete(ctx, ns)) })
-
+	ns := setupNamespace(t, tClient)
 	cluster := &v1beta1.PostgresCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testcluster",

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -53,8 +54,8 @@ func TestPersistentVolumeClaimLimitations(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tEnv, cc, _ := setupTestEnv(t, t.Name())
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
 
 	ns := setupNamespace(t, cc)
 
@@ -603,12 +604,11 @@ func TestGetPVCNameMethods(t *testing.T) {
 }
 
 func TestReconcileConfigureExistingPVCs(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),
@@ -872,12 +872,11 @@ func TestReconcileConfigureExistingPVCs(t *testing.T) {
 }
 
 func TestReconcileMoveDirectories(t *testing.T) {
+	tEnv, tClient := setupKubernetes(t)
+	require.ParallelCapacity(t, 1)
 
-	// setup the test environment and ensure a clean teardown
-	tEnv, tClient, cfg := setupTestEnv(t, ControllerName)
-	t.Cleanup(func() { teardownTestEnv(t, tEnv) })
 	r := &Reconciler{}
-	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
+	ctx, cancel := setupManager(t, tEnv.Config, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
 			Recorder: mgr.GetEventRecorderFor(ControllerName),

--- a/internal/controller/runtime/runtime.go
+++ b/internal/controller/runtime/runtime.go
@@ -49,6 +49,7 @@ func CreateRuntimeManager(namespace string, config *rest.Config,
 		Scheme:     pgoScheme,
 	}
 	if disableMetrics {
+		options.HealthProbeBindAddress = "0"
 		options.MetricsBindAddress = "0"
 	}
 

--- a/internal/testing/require/parallel.go
+++ b/internal/testing/require/parallel.go
@@ -1,0 +1,37 @@
+/*
+ Copyright 2022 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package require
+
+import (
+	"sync"
+	"testing"
+)
+
+var capacity sync.Mutex
+
+// ParallelCapacity calls t.Parallel then waits for needed capacity. There is
+// no wait when needed is zero.
+func ParallelCapacity(t *testing.T, needed int) {
+	t.Helper()
+	t.Parallel()
+
+	if needed > 0 {
+		// Assume capacity of one; allow only one caller at a time.
+		// TODO: actually track how much capacity is available.
+		capacity.Lock()
+		t.Cleanup(capacity.Unlock)
+	}
+}


### PR DESCRIPTION
The crux of the solution is the counter in `setupKubernetes`. When a test calls it then `t.Parallel`, it shares the `envtest.Environment` with other tests that have done the same. When all such tests finish, the counter decrements to zero, and the environment is cleaned up.

Normally, `go test` allows [GOMAXPROCS parallel tests to run simulatenously](https://pkg.go.dev/cmd/go/internal/test). Some of our Kubernetes tests require more resources than others, so another function `require.ParallelCapacity` governs how many run at a time.

The idea is to let each test describe its "size" so that more "smaller" tests run together compared to fewer "bigger" tests. Something like,

```go
// ConfigMaps, Secrets, etc.
require.ParallelCapacity(t, 0)

// One replica.
require.ParallelCapacity(t, 1)

// Two replicas, or
// One replica plus one PgBouncer, or
// One replica plus one pgAdmin, etc.
require.ParallelCapacity(t, 2)

// Three replicas, etc.
require.ParallelCapacity(t, 3)
```

The current implementation assumes a capacity of one so that anything other than `0` runs alone. I imagine, in the future, the capacity should be configurable so the person running the suite can dial up the parallelism when they know the Kubernetes cluster can handle it.

As it stands, the time it takes to run the suite is reduced significantly.

On my under-powered Chromebook, `make check-envtest` takes around ten minutes and I must raise the test timeout. This PR takes less than two minutes.

<details>
  <summary>Before: <code>10m12.720s</code></summary>

```
● time make check-envtest GO_TEST='go test -timeout=15m'
KUBEBUILDER_ASSETS="…/hack/tools/envtest/bin" PGO_NAMESPACE="postgres-operator" go test -timeout=15m -count=1 -cover -tags=envtest ./...
…
ok      github.com/crunchydata/postgres-operator/internal/controller/postgrescluster    596.626s        coverage: 79.7% of statements
…
ok      github.com/crunchydata/postgres-operator/internal/upgradecheck  8.134s  coverage: 89.1% of statements
…

real    10m12.720s
user    10m23.519s
sys     2m54.173s
```

</details>

<details>
  <summary>After: <code>1m42.354s</code></summary>

```
● time make check-envtest
KUBEBUILDER_ASSETS="…/hack/tools/envtest/bin" PGO_NAMESPACE="postgres-operator" go test -count=1 -cover -tags=envtest ./...
…
ok      github.com/crunchydata/postgres-operator/internal/controller/postgrescluster    94.946s coverage: 79.7% of statements
…
ok      github.com/crunchydata/postgres-operator/internal/upgradecheck  8.157s  coverage: 89.1% of statements
…

real    1m42.354s
user    1m46.585s
sys     0m48.762s
```

</details>


<br/>

On my k3s VM, `make check-envtest-existing` also takes almost ten minutes. This PR takes six minutes.

<details>
  <summary>Before: <code>9m23.969s</code></summary>

```
● time make check-envtest-existing GO_TEST='go test -timeout=15m'
…
USE_EXISTING_CLUSTER=true PGO_NAMESPACE="postgres-operator" go test -timeout=15m -count=1 -cover -p=1 -tags=envtest ./...
…
ok      github.com/crunchydata/postgres-operator/internal/controller/postgrescluster    519.946s        coverage: 83.8% of statements
…
ok      github.com/crunchydata/postgres-operator/internal/upgradecheck  14.516s coverage: 96.0% of statements
…

real    9m23.969s
user    1m12.260s
sys     0m10.612s
```

</details>


<details>
  <summary>After: <code>6m3.493s</code></summary>

```
● time make check-envtest-existing

USE_EXISTING_CLUSTER=true PGO_NAMESPACE="postgres-operator" go test -count=1 -cover -p=1 -tags=envtest ./...
…
ok      github.com/crunchydata/postgres-operator/internal/controller/postgrescluster    317.367s        coverage: 84.2% of statements
…
ok      github.com/crunchydata/postgres-operator/internal/upgradecheck  15.235s coverage: 96.0% of statements
…

real    6m3.493s
user    0m36.161s
sys     0m7.087s
```

</details>

---

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

**What is the current behavior (link to any open issues here)?**

`envtest` tests run sequentially.

**What is the new behavior (if this is a feature change)?**

`envtest` tests can run in parallel. Most do.

**Other Information**:

Issue: [sc-12206]
Issue: [sc-12208]