### PR TITLE
Get logger from the passed context

### DIFF
--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -85,12 +85,11 @@ func main() {
 
 	// Enable upgrade checking
 	upgradeCheckingDisabled := strings.EqualFold(os.Getenv("CHECK_FOR_UPGRADES"), "false")
-	done := make(chan bool, 1)
 	if !upgradeCheckingDisabled {
 		log.Info("upgrade checking enabled")
 		// get the URL for the check for upgrades endpoint if set in the env
 		upgradeCheckURL := os.Getenv("CHECK_FOR_UPGRADES_URL")
-		go upgradecheck.CheckForUpgradesScheduler(done, versionString, upgradeCheckURL,
+		go upgradecheck.CheckForUpgradesScheduler(ctx, versionString, upgradeCheckURL,
 			mgr.GetClient(), mgr.GetConfig(), isOpenshift(ctx, mgr.GetConfig()),
 			mgr.GetCache(),
 		)
@@ -100,10 +99,6 @@ func main() {
 
 	assertNoError(mgr.Start(ctx))
 	log.Info("signal received, exiting")
-	if !upgradeCheckingDisabled {
-		// Send true to channel to cancel ticker cleanly
-		done <- true
-	}
 }
 
 // addControllersToManager adds all PostgreSQL Operator controllers to the provided controller

--- a/internal/upgradecheck/http.go
+++ b/internal/upgradecheck/http.go
@@ -141,13 +141,12 @@ func checkForUpgrades(ctx context.Context, versionString string, backoff wait.Ba
 }
 
 // CheckForUpgradesScheduler invokes the check func when the operator starts
-// and then on the given period schedule
-func CheckForUpgradesScheduler(channel chan bool,
+// and then on the given period schedule. It stops when the context is cancelled.
+func CheckForUpgradesScheduler(ctx context.Context,
 	versionString, url string, crclient crclient.Client,
 	cfg *rest.Config, isOpenShift bool,
 	cacheClient CacheWithWait,
 ) {
-	ctx := context.Background()
 	log := logging.FromContext(ctx)
 	defer func() {
 		if err := recover(); err != nil {
@@ -194,7 +193,7 @@ func CheckForUpgradesScheduler(channel chan bool,
 			} else {
 				log.V(1).Info(info)
 			}
-		case <-channel:
+		case <-ctx.Done():
 			ticker.Stop()
 			return
 		}

--- a/internal/upgradecheck/http.go
+++ b/internal/upgradecheck/http.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,8 +73,8 @@ func init() {
 	}
 }
 
-func checkForUpgrades(log logr.Logger, versionString string, backoff wait.Backoff,
-	crclient crclient.Client, ctx context.Context, cfg *rest.Config,
+func checkForUpgrades(ctx context.Context, versionString string, backoff wait.Backoff,
+	crclient crclient.Client, cfg *rest.Config,
 	isOpenShift bool) (message string, err error) {
 	var headerPayloadStruct *clientUpgradeData
 
@@ -95,7 +94,7 @@ func checkForUpgrades(log logr.Logger, versionString string, backoff wait.Backof
 		// generateHeader always returns some sort of struct, using defaults/nil values
 		// in case some of the checks return errors
 		headerPayloadStruct = generateHeader(ctx, cfg, crclient,
-			log, versionString, isOpenShift)
+			versionString, isOpenShift)
 		req, err = addHeader(req, headerPayloadStruct)
 	}
 
@@ -174,8 +173,8 @@ func CheckForUpgradesScheduler(channel chan bool,
 		return
 	}
 
-	info, err := checkForUpgrades(log, versionString, backoff,
-		crclient, ctx, cfg, isOpenShift)
+	info, err := checkForUpgrades(ctx, versionString, backoff,
+		crclient, cfg, isOpenShift)
 	if err != nil {
 		log.V(1).Info("could not complete upgrade check",
 			"response", err.Error())
@@ -187,8 +186,8 @@ func CheckForUpgradesScheduler(channel chan bool,
 	for {
 		select {
 		case <-ticker.C:
-			info, err = checkForUpgrades(log, versionString, backoff,
-				crclient, ctx, cfg, isOpenShift)
+			info, err = checkForUpgrades(ctx, versionString, backoff,
+				crclient, cfg, isOpenShift)
 			if err != nil {
 				log.V(1).Info("could not complete scheduled upgrade check",
 					"response", err.Error())

--- a/internal/upgradecheck/http_test.go
+++ b/internal/upgradecheck/http_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/wojas/genericr"
 	"gotest.tools/v3/assert"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -64,10 +63,8 @@ func (cc *MockCacheClient) WaitForCacheSync(ctx context.Context) bool {
 }
 
 func TestCheckForUpgrades(t *testing.T) {
-	discardLogs := logr.DiscardLogger{}
-
 	fakeClient := setupFakeClientWithPGOScheme(t, false)
-	ctx := context.Background()
+	ctx := logging.NewContext(context.Background(), logging.Discard())
 	cfg := &rest.Config{}
 
 	t.Run("success", func(t *testing.T) {
@@ -80,8 +77,8 @@ func TestCheckForUpgrades(t *testing.T) {
 			}, nil
 		}
 
-		res, err := checkForUpgrades(discardLogs, "4.7.3", backoff,
-			fakeClient, ctx, cfg, false)
+		res, err := checkForUpgrades(ctx, "4.7.3", backoff,
+			fakeClient, cfg, false)
 		assert.NilError(t, err)
 		assert.Equal(t, res, `{"pgo_versions":[{"tag":"v5.0.4"},{"tag":"v5.0.3"},{"tag":"v5.0.2"},{"tag":"v5.0.1"},{"tag":"v5.0.0"}]}`)
 	})
@@ -94,8 +91,8 @@ func TestCheckForUpgrades(t *testing.T) {
 			return &http.Response{}, errors.New("whoops")
 		}
 
-		res, err := checkForUpgrades(discardLogs, "4.7.3", backoff,
-			fakeClient, ctx, cfg, false)
+		res, err := checkForUpgrades(ctx, "4.7.3", backoff,
+			fakeClient, cfg, false)
 		// Two failed calls because of env var
 		assert.Equal(t, counter, 2)
 		assert.Equal(t, res, "")
@@ -110,8 +107,8 @@ func TestCheckForUpgrades(t *testing.T) {
 			panic(fmt.Errorf("oh no!"))
 		}
 
-		res, err := checkForUpgrades(discardLogs, "4.7.3", backoff,
-			fakeClient, ctx, cfg, false)
+		res, err := checkForUpgrades(ctx, "4.7.3", backoff,
+			fakeClient, cfg, false)
 		// One call because of panic
 		assert.Equal(t, counter, 1)
 		assert.Equal(t, res, "")
@@ -129,8 +126,8 @@ func TestCheckForUpgrades(t *testing.T) {
 			}, nil
 		}
 
-		res, err := checkForUpgrades(discardLogs, "4.7.3", backoff,
-			fakeClient, ctx, cfg, false)
+		res, err := checkForUpgrades(ctx, "4.7.3", backoff,
+			fakeClient, cfg, false)
 		assert.Equal(t, res, "")
 		// Two failed calls because of env var
 		assert.Equal(t, counter, 2)
@@ -157,8 +154,8 @@ func TestCheckForUpgrades(t *testing.T) {
 			}, nil
 		}
 
-		res, err := checkForUpgrades(discardLogs, "4.7.3", backoff,
-			fakeClient, ctx, cfg, false)
+		res, err := checkForUpgrades(ctx, "4.7.3", backoff,
+			fakeClient, cfg, false)
 		assert.Equal(t, counter, 2)
 		assert.NilError(t, err)
 		assert.Equal(t, res, `{"pgo_versions":[{"tag":"v5.0.4"},{"tag":"v5.0.3"},{"tag":"v5.0.2"},{"tag":"v5.0.1"},{"tag":"v5.0.0"}]}`)


### PR DESCRIPTION
This allows the logging of individual functions to be tested in isolation and should make it easier to upgrade go-logr.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other
