### PR TITLE
Update to pgBackRest 2.37

### DIFF
--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -555,7 +555,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
   resources: {}
 - command:
   - pgbackrest
-  - server-start
+  - server
   livenessProbe:
     exec:
       command:
@@ -589,7 +589,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     until read -r -t 5 -u "${fd}"; do
       if
         [ "${filename}" -nt "/proc/self/fd/${fd}" ] &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --dereference --format='Loaded configuration dated %y' "${filename}"
@@ -597,7 +597,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
         { [ "${directory}" -nt "/proc/self/fd/${fd}" ] ||
           [ "${authority}" -nt "/proc/self/fd/${fd}" ]
         } &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --format='Loaded certificates dated %y' "${directory}"
@@ -653,7 +653,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
 			assert.Assert(t, marshalMatches(out.Containers[2:], `
 - command:
   - pgbackrest
-  - server-start
+  - server
   livenessProbe:
     exec:
       command:
@@ -691,7 +691,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     until read -r -t 5 -u "${fd}"; do
       if
         [ "${filename}" -nt "/proc/self/fd/${fd}" ] &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --dereference --format='Loaded configuration dated %y' "${filename}"
@@ -699,7 +699,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
         { [ "${directory}" -nt "/proc/self/fd/${fd}" ] ||
           [ "${authority}" -nt "/proc/self/fd/${fd}" ]
         } &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --format='Loaded certificates dated %y' "${directory}"

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -564,11 +564,8 @@ func (r *Reconciler) generateRepoHostIntent(postgresCluster *v1beta1.PostgresClu
 	// - https://docs.k8s.io/concepts/workloads/pods/pod-lifecycle/#restart-policy
 	repo.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways
 
-	// The pgBackRest TLS server handles client connections in detached/orphaned
-	// child processes which it expects to be reaped by an init system (PID 1).
 	// When ShareProcessNamespace is enabled, Kubernetes' pause process becomes
 	// PID 1 and reaps those processes when they complete.
-	// - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/command/server/server.c#L51
 	// - https://github.com/kubernetes/kubernetes/commit/81d27aa23969b77f
 	//
 	// The pgBackRest TLS server must be signaled when its configuration or

--- a/internal/pgbackrest/certificates.go
+++ b/internal/pgbackrest/certificates.go
@@ -93,7 +93,7 @@ func clientCertificates() []corev1.KeyToPath {
 
 			// pgBackRest requires that certificate keys not be readable by any
 			// other user.
-			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/io/tls/common.c#L128
+			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/common/io/tls/common.c#L128
 			Mode: initialize.Int32(0o600),
 		},
 	}
@@ -125,7 +125,7 @@ func instanceServerCertificates() []corev1.KeyToPath {
 
 			// pgBackRest requires that certificate keys not be readable by any
 			// other user.
-			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/io/tls/common.c#L128
+			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/common/io/tls/common.c#L128
 			Mode: initialize.Int32(0o600),
 		},
 	}
@@ -145,7 +145,7 @@ func repositoryServerCertificates() []corev1.KeyToPath {
 
 			// pgBackRest requires that certificate keys not be readable by any
 			// other user.
-			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/io/tls/common.c#L128
+			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/common/io/tls/common.c#L128
 			Mode: initialize.Int32(0o600),
 		},
 	}

--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -398,12 +398,14 @@ func reloadCommand(name string) []string {
 	// volume and configuration file. When either changes, signal pgBackRest
 	// and print the observed timestamp.
 	//
-	// We send SIGTERM because the TLS server in pgBackRest 2.36 must be
-	// restarted to change. We filter by parent process to ignore the forked
-	// connection handlers. Their parent process is one because they are
-	// detached/orphaned from the server. The server parent process is zero
-	// because it is started by Kubernetes.
-	//
+	// We send SIGHUP because this allows the TLS server configuration to be
+	// reloaded in pgBackRest 2.37. We filter by parent process to ignore the forked
+	// connection handlers.
+	// - https://github.com/pgbackrest/pgbackrest/commit/7b3ea883c7c010aafbeb14d150d073a113b703e4
+
+	// Their parent process is one because they are detached/orphaned from the server.
+	// The server parent process is zero because it is started by Kubernetes.
+
 	// Coreutils `sleep` uses a lot of memory, so the following opens a file
 	// descriptor and uses the timeout of the builtin `read` to wait. That same
 	// descriptor gets closed and reopened to use the builtin `[ -nt` to check
@@ -414,7 +416,7 @@ exec {fd}<> <(:)
 until read -r -t 5 -u "${fd}"; do
   if
     [ "${filename}" -nt "/proc/self/fd/${fd}" ] &&
-    pkill --exact --parent=0 pgbackrest
+    pkill -HUP --exact --parent=0 pgbackrest
   then
     exec {fd}>&- && exec {fd}<> <(:)
     stat --dereference --format='Loaded configuration dated %y' "${filename}"
@@ -422,7 +424,7 @@ until read -r -t 5 -u "${fd}"; do
     { [ "${directory}" -nt "/proc/self/fd/${fd}" ] ||
       [ "${authority}" -nt "/proc/self/fd/${fd}" ]
     } &&
-    pkill --exact --parent=0 pgbackrest
+    pkill -HUP --exact --parent=0 pgbackrest
   then
     exec {fd}>&- && exec {fd}<> <(:)
     stat --format='Loaded certificates dated %y' "${directory}"
@@ -477,7 +479,7 @@ func serverConfig(cluster *v1beta1.PostgresCluster) iniSectionSet {
 	//
 	// The "trace" level shows when a connection is accepted, but nothing about
 	// the remote address or what commands it might send.
-	// - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/command/server/server.c#L47-L48
+	// - https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/command/server/server.c#L158-L159
 	// - https://pgbackrest.org/configuration.html#section-log
 	server.Set("log-level-console", "detail")
 	server.Set("log-level-stderr", "error")
@@ -485,7 +487,7 @@ func serverConfig(cluster *v1beta1.PostgresCluster) iniSectionSet {
 	server.Set("log-timestamp", "n")
 
 	return iniSectionSet{
-		"global":              global,
-		"global:server-start": server,
+		"global":        global,
+		"global:server": server,
 	}
 }

--- a/internal/pgbackrest/config.md
+++ b/internal/pgbackrest/config.md
@@ -183,7 +183,7 @@ options in less specific sections.
 
 [default-config]:  https://pgbackrest.org/configuration.html#introduction
 [file-precedence]: https://pgbackrest.org/user-guide.html#quickstart/configure-stanza
-[parse.auto.c]: https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/config/parse.auto.c
+[parse.auto.c]: https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/config/parse.auto.c
 
 ```console
 $ tail -vn+0 pgbackrest.conf conf.d/*

--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -337,7 +337,7 @@ tls-server-ca-file = /etc/pgbackrest/conf.d/~postgres-operator/tls-ca.crt
 tls-server-cert-file = /etc/pgbackrest/server/server-tls.crt
 tls-server-key-file = /etc/pgbackrest/server/server-tls.key
 
-[global:server-start]
+[global:server]
 log-level-console = detail
 log-level-file = off
 log-level-stderr = error

--- a/internal/pgbackrest/reconcile.go
+++ b/internal/pgbackrest/reconcile.go
@@ -266,7 +266,7 @@ func addServerContainerAndVolume(
 
 	container := corev1.Container{
 		Name:            naming.PGBackRestRepoContainerName,
-		Command:         []string{"pgbackrest", "server-start"},
+		Command:         []string{"pgbackrest", "server"},
 		Image:           config.PGBackRestContainerImage(cluster),
 		ImagePullPolicy: cluster.Spec.ImagePullPolicy,
 		SecurityContext: initialize.RestrictedSecurityContext(),

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -504,7 +504,7 @@ func TestAddServerToInstancePod(t *testing.T) {
   resources: {}
 - command:
   - pgbackrest
-  - server-start
+  - server
   livenessProbe:
     exec:
       command:
@@ -537,7 +537,7 @@ func TestAddServerToInstancePod(t *testing.T) {
     until read -r -t 5 -u "${fd}"; do
       if
         [ "${filename}" -nt "/proc/self/fd/${fd}" ] &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --dereference --format='Loaded configuration dated %y' "${filename}"
@@ -545,7 +545,7 @@ func TestAddServerToInstancePod(t *testing.T) {
         { [ "${directory}" -nt "/proc/self/fd/${fd}" ] ||
           [ "${authority}" -nt "/proc/self/fd/${fd}" ]
         } &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --format='Loaded certificates dated %y' "${directory}"
@@ -634,7 +634,7 @@ func TestAddServerToRepoPod(t *testing.T) {
   resources: {}
 - command:
   - pgbackrest
-  - server-start
+  - server
   livenessProbe:
     exec:
       command:
@@ -663,7 +663,7 @@ func TestAddServerToRepoPod(t *testing.T) {
     until read -r -t 5 -u "${fd}"; do
       if
         [ "${filename}" -nt "/proc/self/fd/${fd}" ] &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --dereference --format='Loaded configuration dated %y' "${filename}"
@@ -671,7 +671,7 @@ func TestAddServerToRepoPod(t *testing.T) {
         { [ "${directory}" -nt "/proc/self/fd/${fd}" ] ||
           [ "${authority}" -nt "/proc/self/fd/${fd}" ]
         } &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --format='Loaded certificates dated %y' "${directory}"

--- a/internal/pgbackrest/tls-server.md
+++ b/internal/pgbackrest/tls-server.md
@@ -37,44 +37,69 @@ to the repository host to [send and receive WAL files][archiving].
 The `pgbackrest` command acts as a TLS client and connects to a pgBackRest TLS
 server when `pg-host-type=tls` and/or `repo-host-type=tls`. The default for these is `ssh`:
 
-- https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/config/parse.auto.c#L3580
-- https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/config/parse.auto.c#L5941
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/config/parse.auto.c#L3631
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/config/parse.auto.c#L5997
 
 
 The pgBackRest TLS server is configured through the `tls-server-*` [options](config.md).
-In pgBackRest 2.36, changing any of these options or changing certificate contents
-requires a restart of the server.
+In pgBackRest 2.37, changing any of these options or changing certificate contents
+requires a reload of the server, as shown in the "Setup TLS Server" section of the
+documentation, with the command configured as
+
+```
+ExecReload=kill -HUP $MAINPID
+```
+
+- https://pgbackrest.org/user-guide-rhel.html#repo-host/setup-tls
 
 - `tls-server-address`, `tls-server-port` <br/>
-  The network address and port on which to listen. pgBackRest 2.36 listens on
+  The network address and port on which to listen. pgBackRest 2.37 listens on
   the *first* address returned by `getaddrinfo()`. There is no way to listen on
   all interfaces.
 
-  - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/io/socket/server.c#L169
-  - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/io/socket/common.c#L87
+  - https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/common/io/socket/server.c#L172
+  - https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/common/io/socket/common.c#L87
 
 - `tls-server-cert-file`, `tls-server-key-file` <br/>
   The [certificate chain][certificates] and private key pair used to encrypt connections.
 
 - `tls-server-ca-file` <br/>
   The certificate used to verify client [certificates][].
-  [Required](https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/config/parse.auto.c#L8487).
+  [Required](https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/config/parse.auto.c#L8550).
 
 - `tls-server-auth` <br/>
   A map/hash/dictionary of certificate common names and the stanzas they are authorized
   to interact with.
-  [Required](https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/config/parse.auto.c#L8471).
+  [Required](https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/config/parse.auto.c#L8534).
 
 
-In pgBackRest 2.36, sending SIGHUP, SIGINT, or SIGTERM to the TLS server all
-cause it to exit with code 63, TermError.
+In pgBackRest 2.37, as mentioned above, sending SIGHUP causes a configuration reload.
 
-- https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/exit.c#L73-L75
-- https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/exit.c#L62
-- https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/error.auto.c#L48
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/command/server/server.c#L178
+
 
 ```
-P00   INFO: server-start command end: terminated on signal [SIGHUP]
-P00   INFO: server-start command end: terminated on signal [SIGINT]
-P00   INFO: server-start command end: terminated on signal [SIGTERM]
+P00 DETAIL: configuration reload begin
+P00   INFO: server command begin 2.37...
+P00 DETAIL: configuration reload end
+```
+
+Sending SIGINT to the TLS server causes it to exit with code 63, TermError.
+
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/common/exit.c#L73-L75
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/common/exit.c#L62
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/common/error.auto.c#L48
+
+
+```
+P00   INFO: server command end: terminated on signal [SIGINT]
+```
+
+Sending SIGTERM exits the signal loop and lead to the command termination.
+
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.37/src/command/server/server.c#L194
+
+
+```
+P00   INFO: server command end: completed successfully
 ```


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other


**What is the current behavior (link to any open issues here)?**
pgBackrest 2.36 is used.


**What is the new behavior (if this is a feature change)?**
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This commit allows PGO to use pgBackRest 2.37:
https://pgbackrest.org/release.html#2.37
Changes include updating the current 'server-start' command to the
new 'server' command and updating the TLS configuration using a
SIGHUP instead of the current SIGTERM.
- https://github.com/pgbackrest/pgbackrest/commit/7b3ea883c7c010aafbeb14d150d073a113b703e4


**Other Information**:
Issue: [sc-13390]