### PR TITLE
Disable errchkjson linter temporarily

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,9 +42,8 @@ jobs:
       # Count issues reported by disabled linters. The command always
       # exits zero to ensure it does not fail the pull request check.
       - name: Count non-blocking issues
-        run: >
-          golangci-lint run \
-            --config .golangci.next.yaml \
+        run: |
+          golangci-lint run --config .golangci.next.yaml \
             --issues-exit-code 0 \
             --max-issues-per-linter 0 \
             --max-same-issues 0 \

--- a/.golangci.next.yaml
+++ b/.golangci.next.yaml
@@ -8,6 +8,7 @@
 linters:
   disable-all: true
   enable:
+    - errchkjson
     - gocritic
     - godot
     - godox
@@ -30,6 +31,9 @@ issues:
   exclude-use-default: false
 
 linters-settings:
+  errchkjson:
+    check-error-free-encoding: true
+
   thelper:
     # https://github.com/kulti/thelper/issues/27
     tb:   { begin: true, first: true }

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,7 @@
 
 linters:
   disable:
+    - errchkjson
     - gofumpt
     - scopelint
   enable:


### PR DESCRIPTION
The `errchkjson` linter looks specifically at calls that encode or marshal values to JSON. It does not ignore assignments to the blank identifier like the `errcheck` linter. Instead, it recommends ignoring the error only when the type being marshaled is guaranteed to marshal.

Without configuration, it recommends changes to our tests. When configured to analyze the types being marshaled, it recommends changes to our code. Disable it entirely for now and add it to the list of possible future linters.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other

**Other Information**:

Issue: [sc-13607]