### PR TITLE
Generate a coverage report during GitHub actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,8 +31,18 @@ jobs:
       - uses: actions/setup-go@v2
         with: { go-version: 1.x }
       - run: go mod download
-      - env: { KUBERNETES: "${{ matrix.kubernetes }}" }
-        run: ENVTEST_K8S_VERSION="${KUBERNETES#default}" make check-envtest
+      - run: ENVTEST_K8S_VERSION="${KUBERNETES#default}" make check-envtest
+        env:
+          KUBERNETES: "${{ matrix.kubernetes }}"
+          GO_TEST: go test --coverprofile 'envtest.coverage' --coverpkg ./internal/...
+
+      # Upload coverage to GitHub
+      - run: gzip envtest.coverage
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "kubernetes-api=${{ matrix.kubernetes }}"
+          path: envtest.coverage.gz
+          retention-days: 1
 
   kubernetes-k3d:
     if: "${{ github.repository == 'CrunchyData/postgres-operator' }}"
@@ -84,5 +94,48 @@ jobs:
             kubectl rollout status daemonset.apps/image-prefetch --timeout=90s ||
             kubectl describe daemonset.apps/image-prefetch
           }
-      - env: { PGO_TEST_TIMEOUT_SCALE: 1.2 }
-        run: make createnamespaces check-envtest-existing
+      - run: make createnamespaces check-envtest-existing
+        env:
+          PGO_TEST_TIMEOUT_SCALE: 1.2
+          GO_TEST: go test --coverprofile 'envtest-existing.coverage' --coverpkg ./internal/...
+
+      # Upload coverage to GitHub
+      - run: gzip envtest-existing.coverage
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "kubernetes-k3d=${{ matrix.kubernetes }}"
+          path: envtest-existing.coverage.gz
+          retention-days: 1
+
+  coverage-report:
+    runs-on: ubuntu-latest
+    needs:
+      - kubernetes-api
+      - kubernetes-k3d
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with: { go-version: 1.x }
+      - uses: actions/download-artifact@v2
+        with: { path: download }
+
+      # Combine the coverage profiles by taking the mode line from any one file
+      # and the data from all files. Print a list of functions with less than
+      # 100% coverage, and upload a complete HTML report.
+      - name: Generate report
+        run: |
+          gunzip --keep download/*/*.gz
+          ( sed -e '1q' download/*/*.coverage
+            tail -qn +2 download/*/*.coverage ) > total.coverage
+          go tool cover --func total.coverage -o total-coverage.txt
+          go tool cover --html total.coverage -o total-coverage.html
+          sed -e '/100.0%/d' -e "s,$(go list -m)/,," total-coverage.txt
+          awk 'END { print "::notice title=Total Coverage::" $3 " " $2 }' total-coverage.txt
+
+      # Upload coverage to GitHub
+      - run: gzip total-coverage.html
+      - uses: actions/upload-artifact@v2
+        with:
+          name: coverage-report
+          path: total-coverage.html.gz
+          retention-days: 15


### PR DESCRIPTION
This uses GitHub artifacts and the reports provided by the built-in `go tool cover` command. Functions without complete coverage are printed to the GitHub action logs, and a full HTML report is uploaded as an artifact. The total percent of statements covered appears on the workflow run summary as an annotation.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

**Other Information**:

Artifacts and annotations appear on the [summary page](https://github.com/CrunchyData/postgres-operator/actions/runs/1787439361) after the workflow finishes.