### PR TITLE
Add ImagePullSecrets to directory move jobs

### DIFF
--- a/internal/controller/postgrescluster/volumes.go
+++ b/internal/controller/postgrescluster/volumes.go
@@ -457,8 +457,13 @@ func (r *Reconciler) reconcileMovePGDataDir(ctx context.Context,
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: labels},
 			Spec: corev1.PodSpec{
-				Containers:      []corev1.Container{container},
-				SecurityContext: postgres.PodSecurityContext(cluster),
+				// Set the image pull secrets, if any exist.
+				// This is set here rather than using the service account due to the lack
+				// of propagation to existing pods when the CRD is updated:
+				// https://github.com/kubernetes/kubernetes/issues/88456
+				ImagePullSecrets: cluster.Spec.ImagePullSecrets,
+				Containers:       []corev1.Container{container},
+				SecurityContext:  postgres.PodSecurityContext(cluster),
 				// Set RestartPolicy to "Never" since we want a new Pod to be
 				// created by the Job controller when there is a failure
 				// (instead of the container simply restarting).
@@ -570,8 +575,13 @@ func (r *Reconciler) reconcileMoveWALDir(ctx context.Context,
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: labels},
 			Spec: corev1.PodSpec{
-				Containers:      []corev1.Container{container},
-				SecurityContext: postgres.PodSecurityContext(cluster),
+				// Set the image pull secrets, if any exist.
+				// This is set here rather than using the service account due to the lack
+				// of propagation to existing pods when the CRD is updated:
+				// https://github.com/kubernetes/kubernetes/issues/88456
+				ImagePullSecrets: cluster.Spec.ImagePullSecrets,
+				Containers:       []corev1.Container{container},
+				SecurityContext:  postgres.PodSecurityContext(cluster),
 				// Set RestartPolicy to "Never" since we want a new Pod to be
 				// created by the Job controller when there is a failure
 				// (instead of the container simply restarting).
@@ -688,8 +698,13 @@ func (r *Reconciler) reconcileMoveRepoDir(ctx context.Context,
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: labels},
 			Spec: corev1.PodSpec{
-				Containers:      []corev1.Container{container},
-				SecurityContext: postgres.PodSecurityContext(cluster),
+				// Set the image pull secrets, if any exist.
+				// This is set here rather than using the service account due to the lack
+				// of propagation to existing pods when the CRD is updated:
+				// https://github.com/kubernetes/kubernetes/issues/88456
+				ImagePullSecrets: cluster.Spec.ImagePullSecrets,
+				Containers:       []corev1.Container{container},
+				SecurityContext:  postgres.PodSecurityContext(cluster),
 				// Set RestartPolicy to "Never" since we want a new Pod to be created by the Job
 				// controller when there is a failure (instead of the container simply restarting).
 				RestartPolicy: corev1.RestartPolicyNever,

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -878,6 +878,9 @@ func TestReconcileMoveDirectories(t *testing.T) {
 			PostgresVersion: 13,
 			Image:           "example.com/crunchy-postgres-ha:test",
 			ImagePullPolicy: corev1.PullAlways,
+			ImagePullSecrets: []corev1.LocalObjectReference{{
+				Name: "test-secret",
+			}},
 			DataSource: &v1beta1.DataSource{
 				Volumes: &v1beta1.DataSourceVolumes{
 					PGDataVolume: &v1beta1.DataSourceVolume{
@@ -995,6 +998,8 @@ containers:
     name: postgres-data
 dnsPolicy: ClusterFirst
 enableServiceLinks: false
+imagePullSecrets:
+- name: test-secret
 priorityClassName: some-priority-class
 restartPolicy: Never
 schedulerName: default-scheduler
@@ -1046,6 +1051,8 @@ containers:
     name: postgres-wal
 dnsPolicy: ClusterFirst
 enableServiceLinks: false
+imagePullSecrets:
+- name: test-secret
 priorityClassName: some-priority-class
 restartPolicy: Never
 schedulerName: default-scheduler
@@ -1099,6 +1106,8 @@ containers:
     name: pgbackrest-repo
 dnsPolicy: ClusterFirst
 enableServiceLinks: false
+imagePullSecrets:
+- name: test-secret
 priorityClassName: some-priority-class
 restartPolicy: Never
 schedulerName: default-scheduler


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
Directory move jobs do not have `ImagePullSecrets` defined from the spec.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This change adds them to each job pod template.


**Other Information**:
Issue: [sc-13658]