### PR TITLE
Copy pgBackRest configuration resources when performing a restore

### DIFF
--- a/internal/naming/labels.go
+++ b/internal/naming/labels.go
@@ -220,7 +220,8 @@ func PGBackRestRestoreConfigSelector(clusterName string) labels.Selector {
 	return PGBackRestRestoreConfigLabels(clusterName).AsSelector()
 }
 
-// PGBackRestRestoreJobLabels provides labels for pgBackRest restore Jobs.
+// PGBackRestRestoreJobLabels provides labels for pgBackRest restore Jobs and
+// associated configuration ConfigMaps and Secrets.
 func PGBackRestRestoreJobLabels(clusterName string) labels.Set {
 	commonLabels := PGBackRestLabels(clusterName)
 	jobLabels := map[string]string{

--- a/internal/naming/names.go
+++ b/internal/naming/names.go
@@ -177,6 +177,12 @@ const (
 	// Deprecated: Repository hosts use mTLS for encryption, authentication, and authorization.
 	// TODO(tjmoore4): Once we no longer need this for cleanup purposes, this should be removed.
 	sshSecretNameSuffix = "%s-ssh"
+
+	// RestoreConfigCopySuffix is the suffix used for ConfigMap or Secret configuration
+	// resources needed when restoring from a PostgresCluster data source. If, for
+	// example, a Secret is named 'mysecret' and is the first item in the configuration
+	// slice, the copied Secret will be named 'mysecret-restorecopy-0'
+	RestoreConfigCopySuffix = "%s-restorecopy-%d"
 )
 
 // AsObjectKey converts the ObjectMeta API type to a client.ObjectKey.

--- a/internal/pgbackrest/reconcile.go
+++ b/internal/pgbackrest/reconcile.go
@@ -179,7 +179,7 @@ func AddConfigToRepoPod(
 // for the restore job of cluster to pod. The pgBackRest containers must
 // already be in pod.
 func AddConfigToRestorePod(
-	cluster *v1beta1.PostgresCluster, pod *corev1.PodSpec,
+	cluster *v1beta1.PostgresCluster, sourceCluster *v1beta1.PostgresCluster, pod *corev1.PodSpec,
 ) {
 	configmap := corev1.VolumeProjection{ConfigMap: &corev1.ConfigMapProjection{}}
 	configmap.ConfigMap.Name = naming.PGBackRestConfig(cluster).Name
@@ -210,6 +210,12 @@ func AddConfigToRestorePod(
 		cluster.Spec.DataSource.PGBackRest != nil &&
 		cluster.Spec.DataSource.PGBackRest.Configuration != nil {
 		sources = append(sources, cluster.Spec.DataSource.PGBackRest.Configuration...)
+	}
+
+	// For a PostgresCluster restore, append all pgBackRest configuration from
+	// the source cluster for the restore
+	if sourceCluster != nil {
+		sources = append(sources, sourceCluster.Spec.Backups.PGBackRest.Configuration...)
 	}
 
 	addConfigVolumeAndMounts(pod, append(sources, configmap, secret))

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -421,8 +421,16 @@ func TestAddConfigToRestorePod(t *testing.T) {
 			{ConfigMap: &custom},
 		}
 
+		custom2 := corev1.SecretProjection{}
+		custom2.Name = "source-custom-secret"
+
+		sourceCluster := cluster.DeepCopy()
+		sourceCluster.Spec.Backups.PGBackRest.Configuration = []corev1.VolumeProjection{
+			{Secret: &custom2},
+		}
+
 		out := pod.DeepCopy()
-		AddConfigToRestorePod(cluster, out)
+		AddConfigToRestorePod(cluster, sourceCluster, out)
 		alwaysExpect(t, out)
 
 		// Instance configuration files and optional client certificates
@@ -433,6 +441,8 @@ func TestAddConfigToRestorePod(t *testing.T) {
     sources:
     - configMap:
         name: custom-configmap
+    - secret:
+        name: source-custom-secret
     - configMap:
         items:
         - key: pgbackrest_instance.conf
@@ -464,7 +474,7 @@ func TestAddConfigToRestorePod(t *testing.T) {
 		}
 
 		out := pod.DeepCopy()
-		AddConfigToRestorePod(cluster, out)
+		AddConfigToRestorePod(cluster, nil, out)
 		alwaysExpect(t, out)
 
 		// Instance configuration files and optional client certificates


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This commit copies pgBackRest configuration and related ConfigMaps
and Secrets used by the source cluster as VolumeProjections when
bootstrapping a new cluster using pgBackRest restore. The
configuration copied are given a unique name to avoids conflicts
with any other clusters and is removed once cluster bootstrap is
complete. If the ConfigMap or Secret VolumeProjections are configured
as "optional" in the source cluster, those resources may be absent
without any error or failure when the copying is attempted.



**Other Information**:
Issue: [sc-13601]