### PR TITLE
Add missing KUTTL filles

### DIFF
--- a/testing/kuttl/e2e/cluster-start/00-assert.yaml
+++ b/testing/kuttl/e2e/cluster-start/00-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: cluster-start
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: cluster-start
+    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
+status:
+  succeeded: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-start-primary

--- a/testing/kuttl/e2e/cluster-start/01-assert.yaml
+++ b/testing/kuttl/e2e/cluster-start/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-connect
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/replica-read/00-assert.yaml
+++ b/testing/kuttl/e2e/replica-read/00-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: replica-read
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 2
+      replicas: 2
+      updatedReplicas: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: replica-read-replicas

--- a/testing/kuttl/e2e/replica-read/01-assert.yaml
+++ b/testing/kuttl/e2e/replica-read/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: psql-replica-read
+status:
+  succeeded: 1


### PR DESCRIPTION
When putting the KUTTL envsubst framework in, some of the
original KUTTL files were removed; this PR adds them back
for our CI tests that still run these KUTTL tests. (We can
remove them when our CI runs the envsubst-generated tests.)

**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other

**What is the current behavior (link to any open issues here)?**

KUTTL tests cluster-start and replica-read were missing assert files

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Those tests now have the missing assert files.

**Other Information**:
There is a ticket for changing tests from hard-coded to the envsubst version and wiring up Jenkins to test from those generated files; when that is completed, we can remove the non-generated files.