### PR TITLE
updated broken contributing link to now point to faq.md

### DIFF
--- a/docs/content/faq/_index.md
+++ b/docs/content/faq/_index.md
@@ -3,6 +3,9 @@ title: "FAQ"
 date:
 draft: false
 weight: 105
+
+aliases:
+ - /contributing
 ---
 
 ## Project FAQ


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ x] Have you updated or added documentation for the change, as applicable?
 - [ x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x ] Bug fix
 - [ x] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
when clicking on the "i" a 404 occurs because it points to contributing.md which
does not exist


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

added an alias to faq.md. When clicking on the "i" on the docs you are directed the faq page
which covers all the elements and more of the contributing.md from 4.7

**Other Information**:

issue: [sc-13603]
