### PR TITLE
Operator logging for database init SQL failures

### DIFF
--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -739,7 +739,8 @@ func (r *Reconciler) reconcileDatabaseInitSQL(ctx context.Context,
 	// A writable pod executor has been found and we have the sql provided by
 	// the user. Setup a write function to execute the sql using the podExecutor
 	write := func(ctx context.Context, exec postgres.Executor) error {
-		_, _, err := exec.Exec(ctx, strings.NewReader(data), map[string]string{})
+		stdout, stderr, err := exec.Exec(ctx, strings.NewReader(data), map[string]string{})
+		log.V(1).Info("applied init SQL", "stdout", stdout, "stderr", stderr)
 		return err
 	}
 


### PR DESCRIPTION
If there is an error in the init SQL that runs as part of reconcileDatabaseInitSQL, then there is no way for the user to know what the error is.  Adding this additional log statement will make it easier for users to know when init sql operations have succeeded and/or failed.  It also brings this part of the code up to par with other similar operations in the codebase.

**Checklist:**
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
    No.  I tried to build the Docker image locally but ran into some issues, likely because my local env is a mac I'm guessing.  Any tips here would be appreciated.
   - [x] Have you added automated tests? (n/a)

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other (logging addition)

**What is the current behavior (link to any open issues here)?**
Issue: #3029

**What is the new behavior (if this is a feature change)?**
Additional Logging to help users diagnose failures

**Other Information**:
None