### PR TITLE
Move pgadmin scripts

### DIFF
--- a/internal/controller/postgrescluster/util.go
+++ b/internal/controller/postgrescluster/util.go
@@ -38,14 +38,83 @@ const (
 	devSHMDir = "/dev/shm"
 	// nssWrapperDir is the directory in a container for the nss_wrapper passwd and group files
 	nssWrapperDir = "/tmp/nss_wrapper/%s/%s"
-	// postgresNSSWrapperCmd is the command for setting up nss_wrapper in the
-	// container when using the 'postgres' user
-	postgresNSSWrapperCmd = `NSS_WRAPPER_SUBDIR=postgres CRUNCHY_NSS_USERNAME=postgres ` +
-		`CRUNCHY_NSS_USER_DESC="postgres" /opt/crunchy/bin/nss_wrapper.sh`
-	// pgAdminNSSWrapperCmd is the command for setting up nss_wrapper in the
-	// container when using the 'pgadmin' user
-	pgAdminNSSWrapperCmd = `NSS_WRAPPER_SUBDIR=pgadmin CRUNCHY_NSS_USERNAME=pgadmin ` +
-		`CRUNCHY_NSS_USER_DESC="pgadmin" /opt/crunchy/bin/nss_wrapper.sh`
+	// postgresNSSWrapperPrefix sets the required variables when running the NSS
+	// wrapper script for the 'postgres' user
+	postgresNSSWrapperPrefix = `export NSS_WRAPPER_SUBDIR=postgres CRUNCHY_NSS_USERNAME=postgres ` +
+		`CRUNCHY_NSS_USER_DESC="postgres" `
+	// pgAdminNSSWrapperPrefix sets the required variables when running the NSS
+	// wrapper script for the 'pgadmin' user
+	pgAdminNSSWrapperPrefix = `export NSS_WRAPPER_SUBDIR=pgadmin CRUNCHY_NSS_USERNAME=pgadmin ` +
+		`CRUNCHY_NSS_USER_DESC="pgadmin" `
+	// nssWrapperScript sets up an nss_wrapper environment in accordance with OpenShift
+	// guidance for supporting arbitrary user ID's is the script for the configuration
+	// and startup of the pgAdmin service.
+	// It is based on the nss_wrapper.sh script from the Crunchy Containers Project.
+	// - https://github.com/CrunchyData/crunchy-containers/blob/master/bin/common/nss_wrapper.sh
+	nssWrapperScript = `
+# Define nss_wrapper directory and passwd & group files that will be utilized by nss_wrapper.  The
+# nss_wrapper_env.sh script (which also sets these vars) isn't sourced here since the nss_wrapper
+# has not yet been setup, and we therefore don't yet want the nss_wrapper vars in the environment.
+mkdir -p /tmp/nss_wrapper
+chmod g+rwx /tmp/nss_wrapper
+
+NSS_WRAPPER_DIR="/tmp/nss_wrapper/${NSS_WRAPPER_SUBDIR}"
+NSS_WRAPPER_PASSWD="${NSS_WRAPPER_DIR}/passwd"
+NSS_WRAPPER_GROUP="${NSS_WRAPPER_DIR}/group"
+
+# create the nss_wrapper directory
+mkdir -p "${NSS_WRAPPER_DIR}"
+
+# grab the current user ID and group ID
+USER_ID=$(id -u)
+export USER_ID
+GROUP_ID=$(id -g)
+export GROUP_ID
+
+# get copies of the passwd and group files
+[[ -f "${NSS_WRAPPER_PASSWD}" ]] || cp "/etc/passwd" "${NSS_WRAPPER_PASSWD}"
+[[ -f "${NSS_WRAPPER_GROUP}" ]] || cp "/etc/group" "${NSS_WRAPPER_GROUP}"
+
+# if the username is missing from the passwd file, then add it
+if [[ ! $(cat "${NSS_WRAPPER_PASSWD}") =~ ${CRUNCHY_NSS_USERNAME}:x:${USER_ID} ]]; then
+    echo "nss_wrapper: adding user"
+    passwd_tmp="${NSS_WRAPPER_DIR}/passwd_tmp"
+    cp "${NSS_WRAPPER_PASSWD}" "${passwd_tmp}"
+    sed -i "/${CRUNCHY_NSS_USERNAME}:x:/d" "${passwd_tmp}"
+    # needed for OCP 4.x because crio updates /etc/passwd with an entry for USER_ID
+    sed -i "/${USER_ID}:x:/d" "${passwd_tmp}"
+    printf '${CRUNCHY_NSS_USERNAME}:x:${USER_ID}:${GROUP_ID}:${CRUNCHY_NSS_USER_DESC}:${HOME}:/bin/bash\n' >> "${passwd_tmp}"
+    envsubst < "${passwd_tmp}" > "${NSS_WRAPPER_PASSWD}"
+    rm "${passwd_tmp}"
+else
+    echo "nss_wrapper: user exists"
+fi
+
+# if the username (which will be the same as the group name) is missing from group file, then add it
+if [[ ! $(cat "${NSS_WRAPPER_GROUP}") =~ ${CRUNCHY_NSS_USERNAME}:x:${USER_ID} ]]; then
+    echo "nss_wrapper: adding group"
+    group_tmp="${NSS_WRAPPER_DIR}/group_tmp"
+    cp "${NSS_WRAPPER_GROUP}" "${group_tmp}"
+    sed -i "/${CRUNCHY_NSS_USERNAME}:x:/d" "${group_tmp}"
+    printf '${CRUNCHY_NSS_USERNAME}:x:${USER_ID}:${CRUNCHY_NSS_USERNAME}\n' >> "${group_tmp}"
+    envsubst < "${group_tmp}" > "${NSS_WRAPPER_GROUP}"
+    rm "${group_tmp}"
+else
+    echo "nss_wrapper: group exists"
+fi
+
+# export the nss_wrapper env vars
+# define nss_wrapper directory and passwd & group files that will be utilized by nss_wrapper
+NSS_WRAPPER_DIR="/tmp/nss_wrapper/${NSS_WRAPPER_SUBDIR}"
+NSS_WRAPPER_PASSWD="${NSS_WRAPPER_DIR}/passwd"
+NSS_WRAPPER_GROUP="${NSS_WRAPPER_DIR}/group"
+
+export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+export NSS_WRAPPER_PASSWD="${NSS_WRAPPER_PASSWD}"
+export NSS_WRAPPER_GROUP="${NSS_WRAPPER_GROUP}"
+
+echo "nss_wrapper: environment configured"
+`
 )
 
 // addDevSHM adds the shared memory "directory" to a Pod, which is needed by
@@ -117,7 +186,7 @@ func addTMPEmptyDir(template *corev1.PodTemplateSpec) {
 // compatibility with OpenShift: https://access.redhat.com/articles/4859371.
 func addNSSWrapper(image string, imagePullPolicy corev1.PullPolicy, template *corev1.PodTemplateSpec) {
 
-	nssWrapperCmd := postgresNSSWrapperCmd
+	nssWrapperCmd := postgresNSSWrapperPrefix + nssWrapperScript
 	for i, c := range template.Spec.Containers {
 		switch c.Name {
 		case naming.ContainerDatabase, naming.PGBackRestRepoContainerName,
@@ -130,7 +199,7 @@ func addNSSWrapper(image string, imagePullPolicy corev1.PullPolicy, template *co
 				{Name: "NSS_WRAPPER_GROUP", Value: group},
 			}...)
 		case naming.ContainerPGAdmin:
-			nssWrapperCmd = pgAdminNSSWrapperCmd
+			nssWrapperCmd = pgAdminNSSWrapperPrefix + nssWrapperScript
 			passwd := fmt.Sprintf(nssWrapperDir, "pgadmin", "passwd")
 			group := fmt.Sprintf(nssWrapperDir, "pgadmin", "group")
 			template.Spec.Containers[i].Env = append(template.Spec.Containers[i].Env, []corev1.EnvVar{

--- a/internal/pgadmin/config.go
+++ b/internal/pgadmin/config.go
@@ -27,7 +27,9 @@ const (
 	// tmp volume to hold the nss_wrapper, process and socket files
 	// both the '/tmp' mount path and '/etc/httpd/run' mount path
 	// mount the 'tmp' volume
-	tmpVolume    = "tmp"
+	tmpVolume = "tmp"
+
+	// runMountPath holds the pgAdmin run path, which mounts the 'tmp' volume
 	runMountPath = "/etc/httpd/run"
 
 	// log volume and path where the pgadmin4.log is located

--- a/internal/pgadmin/config.go
+++ b/internal/pgadmin/config.go
@@ -28,7 +28,6 @@ const (
 	// both the '/tmp' mount path and '/etc/httpd/run' mount path
 	// mount the 'tmp' volume
 	tmpVolume    = "tmp"
-	tmpMountPath = "/tmp"
 	runMountPath = "/etc/httpd/run"
 
 	// log volume and path where the pgadmin4.log is located

--- a/internal/pgadmin/reconcile.go
+++ b/internal/pgadmin/reconcile.go
@@ -29,6 +29,115 @@ import (
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
+// startupScript is the script for the configuration and startup of the pgAdmin service.
+// It is based on the start-pgadmin4.sh script from the Crunchy Containers Project.
+// Any required functions from common_lib.sh are added as required.
+// - https://github.com/CrunchyData/crunchy-containers/blob/master/bin/pgadmin4/start-pgadmin4.sh
+// - https://github.com/CrunchyData/crunchy-containers/blob/master/bin/common/common_lib.sh
+const startupScript = `CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+PGADMIN_DIR=/usr/lib/python3.6/site-packages/pgadmin4-web
+APACHE_PIDFILE='/tmp/httpd.pid'
+export PATH=$PATH:/usr/pgsql-*/bin
+
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+RESET="\033[0m"
+
+CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+
+function enable_debugging() {
+    if [[ ${CRUNCHY_DEBUG:-false} == "true" ]]
+    then
+        echo_info "Turning debugging on.."
+        export PS4='+(${BASH_SOURCE}:${LINENO})> ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+        set -x
+    fi
+}
+
+function env_check_err() {
+    if [[ -z ${!1} ]]
+    then
+        echo_err "$1 environment variable is not set, aborting."
+        exit 1
+    fi
+}
+
+function echo_info() {
+    echo -e "${GREEN?}$(date) INFO: ${1?}${RESET?}"
+}
+
+function echo_err() {
+    echo -e "${RED?}$(date) ERROR: ${1?}${RESET?}"
+}
+
+function err_check {
+    RC=${1?}
+    CONTEXT=${2?}
+    ERROR=${3?}
+
+    if [[ ${RC?} != 0 ]]
+    then
+        echo_err "${CONTEXT?}: ${ERROR?}"
+        exit ${RC?}
+    fi
+}
+
+function trap_sigterm() {
+    echo_info "Doing trap logic.."
+    echo_warn "Clean shutdown of Apache.."
+    /usr/sbin/httpd -k stop
+    kill -SIGINT $(head -1 $APACHE_PIDFILE)
+}
+
+enable_debugging
+trap 'trap_sigterm' SIGINT SIGTERM
+
+env_check_err "PGADMIN_SETUP_EMAIL"
+env_check_err "PGADMIN_SETUP_PASSWORD"
+
+if [[ ${ENABLE_TLS:-false} == 'true' ]]
+then
+    echo_info "TLS enabled. Applying https configuration.."
+    if [[ ( ! -f /certs/server.key ) || ( ! -f /certs/server.crt ) ]]
+    then
+        echo_err "ENABLE_TLS true but /certs/server.key or /certs/server.crt not found, aborting"
+        exit 1
+    fi
+    cp "${CRUNCHY_DIR}/conf/pgadmin-https.conf" /var/lib/pgadmin/pgadmin.conf
+else
+    echo_info "TLS disabled. Applying http configuration.."
+    cp "${CRUNCHY_DIR}/conf/pgadmin-http.conf" /var/lib/pgadmin/pgadmin.conf
+fi
+
+cp "${CRUNCHY_DIR}/conf/config_local.py" /var/lib/pgadmin/config_local.py
+
+if [[ -z "${SERVER_PATH}" ]]
+then
+    sed -i "/RedirectMatch/d" /var/lib/pgadmin/pgadmin.conf
+fi
+
+sed -i "s|SERVER_PATH|${SERVER_PATH:-/}|g" /var/lib/pgadmin/pgadmin.conf
+sed -i "s|SERVER_PORT|${SERVER_PORT:-5050}|g" /var/lib/pgadmin/pgadmin.conf
+sed -i "s/^DEFAULT_SERVER_PORT.*/DEFAULT_SERVER_PORT = ${SERVER_PORT:-5050}/" /var/lib/pgadmin/config_local.py
+sed -i "s|\"pg\":.*|\"pg\": \"/usr/pgsql-${PGVERSION?}/bin\",|g" /var/lib/pgadmin/config_local.py
+
+cd ${PGADMIN_DIR?}
+
+if [[ ! -f /var/lib/pgadmin/pgadmin4.db ]]
+then
+    echo_info "Setting up pgAdmin4 database.."
+    python3 setup.py > /tmp/pgadmin4.stdout 2> /tmp/pgadmin4.stderr
+    err_check "$?" "pgAdmin4 Database Setup" "Could not create pgAdmin4 database: \n$(cat /tmp/pgadmin4.stderr)"
+fi
+
+cd ${PGADMIN_DIR?}
+
+echo_info "Starting Apache web server.."
+/usr/sbin/httpd -D FOREGROUND &
+echo $! > $APACHE_PIDFILE
+
+wait`
+
 // ConfigMap populates a ConfigMap with the configuration needed to run pgAdmin.
 func ConfigMap(
 	inCluster *v1beta1.PostgresCluster,
@@ -127,6 +236,7 @@ func Pod(
 				Value: loginPassword,
 			},
 		},
+		Command:         []string{"bash", "-c", startupScript},
 		Image:           config.PGAdminContainerImage(inCluster),
 		ImagePullPolicy: inCluster.Spec.ImagePullPolicy,
 		Resources:       inCluster.Spec.UserInterface.PGAdmin.Resources,
@@ -141,10 +251,6 @@ func Pod(
 		VolumeMounts: []corev1.VolumeMount{
 			startupVolumeMount,
 			configVolumeMount,
-			{
-				Name:      tmpVolume,
-				MountPath: tmpMountPath,
-			},
 			{
 				Name:      tmpVolume,
 				MountPath: runMountPath,
@@ -197,6 +303,6 @@ func Pod(
 
 	outPod.Containers = []corev1.Container{container}
 	outPod.InitContainers = []corev1.Container{startup}
-	outPod.Volumes = []corev1.Volume{tmp, pgAdminLog, pgAdminData, configVolume, startupVolume}
-
+	// add all volumes other than 'tmp' as that is added later
+	outPod.Volumes = []corev1.Volume{pgAdminLog, pgAdminData, configVolume, startupVolume}
 }

--- a/internal/pgadmin/reconcile_test.go
+++ b/internal/pgadmin/reconcile_test.go
@@ -104,7 +104,114 @@ func TestPod(t *testing.T) {
 
 		assert.Assert(t, cmp.MarshalMatches(pod, `
 containers:
-- env:
+- command:
+  - bash
+  - -c
+  - |-
+    CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+    PGADMIN_DIR=/usr/lib/python3.6/site-packages/pgadmin4-web
+    APACHE_PIDFILE='/tmp/httpd.pid'
+    export PATH=$PATH:/usr/pgsql-*/bin
+
+    RED="\033[0;31m"
+    GREEN="\033[0;32m"
+    RESET="\033[0m"
+
+    CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+
+    function enable_debugging() {
+        if [[ ${CRUNCHY_DEBUG:-false} == "true" ]]
+        then
+            echo_info "Turning debugging on.."
+            export PS4='+(${BASH_SOURCE}:${LINENO})> ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+            set -x
+        fi
+    }
+
+    function env_check_err() {
+        if [[ -z ${!1} ]]
+        then
+            echo_err "$1 environment variable is not set, aborting."
+            exit 1
+        fi
+    }
+
+    function echo_info() {
+        echo -e "${GREEN?}$(date) INFO: ${1?}${RESET?}"
+    }
+
+    function echo_err() {
+        echo -e "${RED?}$(date) ERROR: ${1?}${RESET?}"
+    }
+
+    function err_check {
+        RC=${1?}
+        CONTEXT=${2?}
+        ERROR=${3?}
+
+        if [[ ${RC?} != 0 ]]
+        then
+            echo_err "${CONTEXT?}: ${ERROR?}"
+            exit ${RC?}
+        fi
+    }
+
+    function trap_sigterm() {
+        echo_info "Doing trap logic.."
+        echo_warn "Clean shutdown of Apache.."
+        /usr/sbin/httpd -k stop
+        kill -SIGINT $(head -1 $APACHE_PIDFILE)
+    }
+
+    enable_debugging
+    trap 'trap_sigterm' SIGINT SIGTERM
+
+    env_check_err "PGADMIN_SETUP_EMAIL"
+    env_check_err "PGADMIN_SETUP_PASSWORD"
+
+    if [[ ${ENABLE_TLS:-false} == 'true' ]]
+    then
+        echo_info "TLS enabled. Applying https configuration.."
+        if [[ ( ! -f /certs/server.key ) || ( ! -f /certs/server.crt ) ]]
+        then
+            echo_err "ENABLE_TLS true but /certs/server.key or /certs/server.crt not found, aborting"
+            exit 1
+        fi
+        cp "${CRUNCHY_DIR}/conf/pgadmin-https.conf" /var/lib/pgadmin/pgadmin.conf
+    else
+        echo_info "TLS disabled. Applying http configuration.."
+        cp "${CRUNCHY_DIR}/conf/pgadmin-http.conf" /var/lib/pgadmin/pgadmin.conf
+    fi
+
+    cp "${CRUNCHY_DIR}/conf/config_local.py" /var/lib/pgadmin/config_local.py
+
+    if [[ -z "${SERVER_PATH}" ]]
+    then
+        sed -i "/RedirectMatch/d" /var/lib/pgadmin/pgadmin.conf
+    fi
+
+    sed -i "s|SERVER_PATH|${SERVER_PATH:-/}|g" /var/lib/pgadmin/pgadmin.conf
+    sed -i "s|SERVER_PORT|${SERVER_PORT:-5050}|g" /var/lib/pgadmin/pgadmin.conf
+    sed -i "s/^DEFAULT_SERVER_PORT.*/DEFAULT_SERVER_PORT = ${SERVER_PORT:-5050}/" /var/lib/pgadmin/config_local.py
+    sed -i "s|\"pg\":.*|\"pg\": \"/usr/pgsql-${PGVERSION?}/bin\",|g" /var/lib/pgadmin/config_local.py
+
+    cd ${PGADMIN_DIR?}
+
+    if [[ ! -f /var/lib/pgadmin/pgadmin4.db ]]
+    then
+        echo_info "Setting up pgAdmin4 database.."
+        python3 setup.py > /tmp/pgadmin4.stdout 2> /tmp/pgadmin4.stderr
+        err_check "$?" "pgAdmin4 Database Setup" "Could not create pgAdmin4 database: \n$(cat /tmp/pgadmin4.stderr)"
+    fi
+
+    cd ${PGADMIN_DIR?}
+
+    echo_info "Starting Apache web server.."
+    /usr/sbin/httpd -D FOREGROUND &
+    echo $! > $APACHE_PIDFILE
+
+    wait
+  env:
   - name: PGADMIN_SETUP_EMAIL
     value: admin
   - name: PGADMIN_SETUP_PASSWORD
@@ -137,8 +244,6 @@ containers:
   - mountPath: /etc/pgadmin/conf.d
     name: pgadmin-config
     readOnly: true
-  - mountPath: /tmp
-    name: tmp
   - mountPath: /etc/httpd/run
     name: tmp
   - mountPath: /var/log/pgadmin
@@ -173,9 +278,6 @@ initContainers:
     name: pgadmin-config
     readOnly: true
 volumes:
-- emptyDir:
-    medium: Memory
-  name: tmp
 - emptyDir:
     medium: Memory
   name: pgadmin-log
@@ -217,7 +319,114 @@ volumes:
 
 		assert.Assert(t, cmp.MarshalMatches(pod, `
 containers:
-- env:
+- command:
+  - bash
+  - -c
+  - |-
+    CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+    PGADMIN_DIR=/usr/lib/python3.6/site-packages/pgadmin4-web
+    APACHE_PIDFILE='/tmp/httpd.pid'
+    export PATH=$PATH:/usr/pgsql-*/bin
+
+    RED="\033[0;31m"
+    GREEN="\033[0;32m"
+    RESET="\033[0m"
+
+    CRUNCHY_DIR=${CRUNCHY_DIR:-'/opt/crunchy'}
+
+    function enable_debugging() {
+        if [[ ${CRUNCHY_DEBUG:-false} == "true" ]]
+        then
+            echo_info "Turning debugging on.."
+            export PS4='+(${BASH_SOURCE}:${LINENO})> ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+            set -x
+        fi
+    }
+
+    function env_check_err() {
+        if [[ -z ${!1} ]]
+        then
+            echo_err "$1 environment variable is not set, aborting."
+            exit 1
+        fi
+    }
+
+    function echo_info() {
+        echo -e "${GREEN?}$(date) INFO: ${1?}${RESET?}"
+    }
+
+    function echo_err() {
+        echo -e "${RED?}$(date) ERROR: ${1?}${RESET?}"
+    }
+
+    function err_check {
+        RC=${1?}
+        CONTEXT=${2?}
+        ERROR=${3?}
+
+        if [[ ${RC?} != 0 ]]
+        then
+            echo_err "${CONTEXT?}: ${ERROR?}"
+            exit ${RC?}
+        fi
+    }
+
+    function trap_sigterm() {
+        echo_info "Doing trap logic.."
+        echo_warn "Clean shutdown of Apache.."
+        /usr/sbin/httpd -k stop
+        kill -SIGINT $(head -1 $APACHE_PIDFILE)
+    }
+
+    enable_debugging
+    trap 'trap_sigterm' SIGINT SIGTERM
+
+    env_check_err "PGADMIN_SETUP_EMAIL"
+    env_check_err "PGADMIN_SETUP_PASSWORD"
+
+    if [[ ${ENABLE_TLS:-false} == 'true' ]]
+    then
+        echo_info "TLS enabled. Applying https configuration.."
+        if [[ ( ! -f /certs/server.key ) || ( ! -f /certs/server.crt ) ]]
+        then
+            echo_err "ENABLE_TLS true but /certs/server.key or /certs/server.crt not found, aborting"
+            exit 1
+        fi
+        cp "${CRUNCHY_DIR}/conf/pgadmin-https.conf" /var/lib/pgadmin/pgadmin.conf
+    else
+        echo_info "TLS disabled. Applying http configuration.."
+        cp "${CRUNCHY_DIR}/conf/pgadmin-http.conf" /var/lib/pgadmin/pgadmin.conf
+    fi
+
+    cp "${CRUNCHY_DIR}/conf/config_local.py" /var/lib/pgadmin/config_local.py
+
+    if [[ -z "${SERVER_PATH}" ]]
+    then
+        sed -i "/RedirectMatch/d" /var/lib/pgadmin/pgadmin.conf
+    fi
+
+    sed -i "s|SERVER_PATH|${SERVER_PATH:-/}|g" /var/lib/pgadmin/pgadmin.conf
+    sed -i "s|SERVER_PORT|${SERVER_PORT:-5050}|g" /var/lib/pgadmin/pgadmin.conf
+    sed -i "s/^DEFAULT_SERVER_PORT.*/DEFAULT_SERVER_PORT = ${SERVER_PORT:-5050}/" /var/lib/pgadmin/config_local.py
+    sed -i "s|\"pg\":.*|\"pg\": \"/usr/pgsql-${PGVERSION?}/bin\",|g" /var/lib/pgadmin/config_local.py
+
+    cd ${PGADMIN_DIR?}
+
+    if [[ ! -f /var/lib/pgadmin/pgadmin4.db ]]
+    then
+        echo_info "Setting up pgAdmin4 database.."
+        python3 setup.py > /tmp/pgadmin4.stdout 2> /tmp/pgadmin4.stderr
+        err_check "$?" "pgAdmin4 Database Setup" "Could not create pgAdmin4 database: \n$(cat /tmp/pgadmin4.stderr)"
+    fi
+
+    cd ${PGADMIN_DIR?}
+
+    echo_info "Starting Apache web server.."
+    /usr/sbin/httpd -D FOREGROUND &
+    echo $! > $APACHE_PIDFILE
+
+    wait
+  env:
   - name: PGADMIN_SETUP_EMAIL
     value: admin
   - name: PGADMIN_SETUP_PASSWORD
@@ -254,8 +463,6 @@ containers:
   - mountPath: /etc/pgadmin/conf.d
     name: pgadmin-config
     readOnly: true
-  - mountPath: /tmp
-    name: tmp
   - mountPath: /etc/httpd/run
     name: tmp
   - mountPath: /var/log/pgadmin
@@ -294,9 +501,6 @@ initContainers:
     name: pgadmin-config
     readOnly: true
 volumes:
-- emptyDir:
-    medium: Memory
-  name: tmp
 - emptyDir:
     medium: Memory
   name: pgadmin-log


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
Right now when pgAdmin is deployed by PGO, scripts within the
container are utilized as the entrypoint and command for running
the container.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

The first commit converts the startup script to a commands within the
pgAdmin Pod template to lessen the dependency on scripts contained
within the pgAdmin container. Additionally, this commit updates the
NSS_WRAPPER setup to use the standard functions used by other Pods
managed by PGO.

Note that the various configuration files within the container
(whether for Apache, pgAdmin, etc.) are still be utilized to
configure pgAdmin.

Additionally, an nss wrapper script located on the relevant containers
(including database, repo host, pgAdmin, etc) is run to ensure proper
operation on Openshift (see https://access.redhat.com/articles/4859371
for more information). The second commit copies that script into PGO to
remove the local script dependency. Functionality is otherwise
identical and tests are updated as needed.

**Other Information**:
Issue: [sc-13629]