### PR TITLE
Enable Support for Secrets for pgAdmin LDAP_BIND_PASSWORD

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -8632,6 +8632,26 @@ spec:
                                   type: object
                               type: object
                             type: array
+                          ldapBindPassword:
+                            description: 'A Secret containing the value for the LDAP_BIND_PASSWORD
+                              setting. More info: https://www.pgadmin.org/docs/pgadmin4/latest/ldap.html'
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
                           settings:
                             description: 'Settings for the pgAdmin server process.
                               Keys should be uppercase and values must be constants.

--- a/docs/content/architecture/pgadmin4.md
+++ b/docs/content/architecture/pgadmin4.md
@@ -87,6 +87,42 @@ field. For example, set `SHOW_GRAVATAR_IMAGE` to `False` to disable automatic pr
           SHOW_GRAVATAR_IMAGE: False
 ```
 
+You can also add a Secret containing the pgAdmin `LDAP_BIND_PASSWORD` through the
+[`userInterface.pgAdmin.config.ldapBindPassword`]
+({{< relref "/references/crd#postgresclusterspecuserinterfacepgadminconfigldapbindpassword" >}})
+field. This is one of the configuration settings needed to enable LDAP authentication
+for pgAdmin and is handled separately from the other pgAdmin settings to allow for
+proper storage of the sensitive value in a Secret rather than a ConfigMap.
+
+```yaml
+  userInterface:
+    pgAdmin:
+      config:
+        ldapBindPassword:
+          name: ldappass
+          key: mypw
+```
+
+Lastly, you can also use Secrets and ConfigMaps to mount required files to your
+pgAdmin container through the
+[`userInterface.pgAdmin.config.files`]
+({{< relref "/references/crd#postgresclusterspecuserinterfacepgadminconfigfilesindex" >}})
+field. The contents of the Secrets and ConfigMaps defined here are mounted at
+`/etc/pgadmin/conf.d` and can be referenced from various pgAdmin configuration
+settings as needed.
+
+```yaml
+  userInterface:
+    pgAdmin:
+      config:
+        files:
+          - secret:
+              name: mysecret
+          - configMap:
+              name: myconfigmap
+              optional: false
+```
+
 ## Deleting pgAdmin 4
 
 You can remove the pgAdmin 4 deployment by removing the `userInterface` field from the spec.

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -12750,6 +12750,11 @@ Configuration settings for the pgAdmin process. Changes to any of these values w
         <td>Files allows the user to mount projected volumes into the pgAdmin container so that files can be referenced by pgAdmin as needed.</td>
         <td>false</td>
       </tr><tr>
+        <td><b><a href="#postgresclusterspecuserinterfacepgadminconfigldapbindpassword">ldapBindPassword</a></b></td>
+        <td>object</td>
+        <td>A Secret containing the value for the LDAP_BIND_PASSWORD setting. More info: https://www.pgadmin.org/docs/pgadmin4/latest/ldap.html</td>
+        <td>false</td>
+      </tr><tr>
         <td><b>settings</b></td>
         <td>object</td>
         <td>Settings for the pgAdmin server process. Keys should be uppercase and values must be constants. More info: https://www.pgadmin.org/docs/pgadmin4/latest/config_py.html</td>
@@ -13118,6 +13123,43 @@ information about the serviceAccountToken data to project
         <td><b>expirationSeconds</b></td>
         <td>integer</td>
         <td>ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecuserinterfacepgadminconfigldapbindpassword">
+  PostgresCluster.spec.userInterface.pgAdmin.config.ldapBindPassword
+  <sup><sup><a href="#postgresclusterspecuserinterfacepgadminconfig">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+A Secret containing the value for the LDAP_BIND_PASSWORD setting. More info: https://www.pgadmin.org/docs/pgadmin4/latest/ldap.html
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>The key of the secret to select from.  Must be a valid secret key.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>optional</b></td>
+        <td>boolean</td>
+        <td>Specify whether the Secret or its key must be defined</td>
         <td>false</td>
       </tr></tbody>
 </table>

--- a/internal/pgadmin/config.go
+++ b/internal/pgadmin/config.go
@@ -40,6 +40,10 @@ const (
 	dataVolume    = "pgadmin-data"
 	dataMountPath = "/var/lib/pgadmin"
 
+	// ldapPasswordPath is the path for mounting the LDAP Bind Password
+	ldapPasswordPath         = "~postgres-operator/ldap-bind-password" /* #nosec */
+	ldapPasswordAbsolutePath = configMountPath + "/" + ldapPasswordPath
+
 	// TODO(tjmoore4): The login and password implementation will be updated in
 	// upcoming enhancement work.
 
@@ -74,7 +78,7 @@ const (
 // podConfigFiles returns projections of pgAdmin's configuration files to
 // include in the configuration volume.
 func podConfigFiles(configmap *corev1.ConfigMap, spec v1beta1.PGAdminPodSpec) []corev1.VolumeProjection {
-	return append(append([]corev1.VolumeProjection{}, spec.Config.Files...),
+	config := append(append([]corev1.VolumeProjection{}, spec.Config.Files...),
 		[]corev1.VolumeProjection{
 			{
 				ConfigMap: &corev1.ConfigMapProjection{
@@ -90,6 +94,31 @@ func podConfigFiles(configmap *corev1.ConfigMap, spec v1beta1.PGAdminPodSpec) []
 				},
 			},
 		}...)
+
+	// To enable LDAP authentication for pgAdmin, various LDAP settings must be configured.
+	// While most of the required configuration can be set using the 'settings'
+	// feature on the spec (.Spec.UserInterface.PGAdmin.Config.Settings), those
+	// values are stored in a ConfigMap in plaintext.
+	// As a special case, here we mount a provided Secret containing the LDAP_BIND_PASSWORD
+	// for use with the other pgAdmin LDAP configuration.
+	// - https://www.pgadmin.org/docs/pgadmin4/latest/config_py.html
+	// - https://www.pgadmin.org/docs/pgadmin4/development/enabling_ldap_authentication.html
+	if spec.Config.LDAPBindPassword != nil {
+		config = append(config, corev1.VolumeProjection{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: spec.Config.LDAPBindPassword.LocalObjectReference,
+				Optional:             spec.Config.LDAPBindPassword.Optional,
+				Items: []corev1.KeyToPath{
+					{
+						Key:  spec.Config.LDAPBindPassword.Key,
+						Path: ldapPasswordPath,
+					},
+				},
+			},
+		})
+	}
+
+	return config
 }
 
 // startupCommand returns an entrypoint that prepares the filesystem for pgAdmin.
@@ -113,16 +142,25 @@ func startupCommand() []string {
 	// Set all remaining variables from the JSON in settingsAbsolutePath. All
 	// pgAdmin settings are uppercase with underscores, so ignore any keys/names
 	// that are not.
+	//
+	// Lastly, set pgAdmin's LDAP_BIND_PASSWORD setting, if the value was provided
+	// via Secret. As this assignment happens after any values provided via the
+	// 'Settings' ConfigMap loaded above, this value will overwrite any previous
+	// configuration of LDAP_BIND_PASSWORD (that is, last write wins).
 	const configSystem = `
-import glob, json, re
+import glob, json, re, os
 DEFAULT_BINARY_PATHS = {'pg': sorted([''] + glob.glob('/usr/pgsql-*/bin')).pop()}
 with open('` + settingsAbsolutePath + `') as _f:
     _conf, _data = re.compile(r'[A-Z_]+'), json.load(_f)
     if type(_data) is dict:
         globals().update({k: v for k, v in _data.items() if _conf.fullmatch(k)})
+if os.path.isfile('` + ldapPasswordAbsolutePath + `'):
+    with open('` + ldapPasswordAbsolutePath + `') as _f:
+        LDAP_BIND_PASSWORD = _f.read()
 `
 
 	args := []string{strings.TrimLeft(configSystem, "\n")}
+
 	script := strings.Join([]string{
 		// Write the system configuration into a read-only file.
 		`(umask a-w && echo "$1" > ` + configSystemAbsolutePath + `)`,

--- a/internal/pgadmin/config_test.go
+++ b/internal/pgadmin/config_test.go
@@ -52,13 +52,16 @@ func TestStartupCommand(t *testing.T) {
 - (umask a-w && echo "$1" > /etc/pgadmin/config_system.py)
 - startup
 - |
-  import glob, json, re
+  import glob, json, re, os
   DEFAULT_BINARY_PATHS = {'pg': sorted([''] + glob.glob('/usr/pgsql-*/bin')).pop()}
   with open('/etc/pgadmin/conf.d/~postgres-operator/pgadmin.json') as _f:
       _conf, _data = re.compile(r'[A-Z_]+'), json.load(_f)
       if type(_data) is dict:
           globals().update({k: v for k, v in _data.items() if _conf.fullmatch(k)})
-	`))
+  if os.path.isfile('/etc/pgadmin/conf.d/~postgres-operator/ldap-bind-password'):
+      with open('/etc/pgadmin/conf.d/~postgres-operator/ldap-bind-password') as _f:
+          LDAP_BIND_PASSWORD = _f.read()
+`))
 
 	t.Run("ShellCheck", func(t *testing.T) {
 		command := startupCommand()

--- a/internal/pgadmin/reconcile.go
+++ b/internal/pgadmin/reconcile.go
@@ -301,8 +301,9 @@ func Pod(
 	// The startup container is the only one allowed to write to the startup volume.
 	startup.VolumeMounts[0].ReadOnly = false
 
-	outPod.Containers = []corev1.Container{container}
 	outPod.InitContainers = []corev1.Container{startup}
 	// add all volumes other than 'tmp' as that is added later
 	outPod.Volumes = []corev1.Volume{pgAdminLog, pgAdminData, configVolume, startupVolume}
+
+	outPod.Containers = []corev1.Container{container}
 }

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgadmin_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgadmin_types.go
@@ -25,6 +25,11 @@ type PGAdminConfiguration struct {
 	// container so that files can be referenced by pgAdmin as needed.
 	Files []corev1.VolumeProjection `json:"files,omitempty"`
 
+	// A Secret containing the value for the LDAP_BIND_PASSWORD setting.
+	// More info: https://www.pgadmin.org/docs/pgadmin4/latest/ldap.html
+	// +optional
+	LDAPBindPassword *corev1.SecretKeySelector `json:"ldapBindPassword,omitempty"`
+
 	// Settings for the pgAdmin server process. Keys should be uppercase and
 	// values must be constants.
 	// More info: https://www.pgadmin.org/docs/pgadmin4/latest/config_py.html

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
@@ -271,6 +271,11 @@ func (in *PGAdminConfiguration) DeepCopyInto(out *PGAdminConfiguration) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.LDAPBindPassword != nil {
+		in, out := &in.LDAPBindPassword, &out.LDAPBindPassword
+		*out = new(v1.SecretKeySelector)
+		(*in).DeepCopyInto(*out)
+	}
 	in.Settings.DeepCopyInto(&out.Settings)
 }
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [ ] Other



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This update allows the use of a mounted Secret that contains
the desired LDAP_BIND_PASSWORD setting for pgAdmin which is used
for the pgAdmin login user when LDAP authentication is enabled.
This allows the password value to be encoded in a Secret rather
than stored in plaintext in a ConfigMap with the other pgAdmin
configuration settings.

This PR also includes documentation for mounting this Secret, as well
as other more generic Secrets and ConfigMaps used for pgAdmin configuration.

**Other Information**:
Issue: [sc-13712]