### PR TITLE
Disable the "gci" Go linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,7 @@
 linters:
   disable:
     - errchkjson
+    - gci
     - gofumpt
     - scopelint
   enable:


### PR DESCRIPTION
Recent changes to this linter trigger false positives in a majority of files. It was enabled as part of the "format" preset. We did nothing to configure it so its behavior matches that of "goimports". The latter is also enabled as part of the "format" preset and supports the "--fix" flag to automatically correct imports before committing.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
