### PR TITLE
Remove "TODO" from CRD reference documentation

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,6 +20,7 @@ jobs:
             BEGIN { print "::add-matcher::.github/actions/awk-matcher.json" }
 
             /[[:space:]]$/ { errors++; print FILENAME ":" FNR " error: Trailing space" }
+            /TODO/ { errors++; print FILENAME ":" FNR " error: Found TODO. Try running hack/create-todo-patch.sh" }
 
             END { print "::remove-matcher owner=awk::" }
             END { exit errors != 0 }

--- a/build/crd/todos.yaml
+++ b/build/crd/todos.yaml
@@ -27,6 +27,12 @@
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/customTLSSecret/properties/name/description
 - op: copy
   from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/dataSource/properties/pgbackrest/properties/configuration/items/properties/configMap/properties/name/description
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/dataSource/properties/pgbackrest/properties/configuration/items/properties/secret/properties/name/description
+- op: copy
+  from: /work
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/imagePullSecrets/items/properties/name/description
 - op: copy
   from: /work
@@ -43,5 +49,14 @@
 - op: copy
   from: /work
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/proxy/properties/pgBouncer/properties/customTLSSecret/properties/name/description
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/userInterface/properties/pgAdmin/properties/config/properties/files/items/properties/configMap/properties/name/description
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/userInterface/properties/pgAdmin/properties/config/properties/files/items/properties/secret/properties/name/description
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/userInterface/properties/pgAdmin/properties/config/properties/ldapBindPassword/properties/name/description
 - op: remove
   path: /work

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -3497,9 +3497,7 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 optional:
                                   description: Specify whether the ConfigMap or its
@@ -3632,9 +3630,7 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 optional:
                                   description: Specify whether the Secret or its key
@@ -8444,9 +8440,7 @@ spec:
                                       type: array
                                     name:
                                       description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or
@@ -8589,9 +8583,7 @@ spec:
                                       type: array
                                     name:
                                       description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its
@@ -8641,9 +8633,7 @@ spec:
                                   be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -7365,7 +7365,7 @@ information about the configMap data to project
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
-        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?</td>
+        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
@@ -7577,7 +7577,7 @@ information about the secret data to project
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
-        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?</td>
+        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
@@ -12831,7 +12831,7 @@ information about the configMap data to project
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
-        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?</td>
+        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
@@ -13043,7 +13043,7 @@ information about the secret data to project
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
-        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?</td>
+        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
@@ -13154,7 +13154,7 @@ A Secret containing the value for the LDAP_BIND_PASSWORD setting. More info: htt
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
-        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?</td>
+        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>


### PR DESCRIPTION
This language is pulled in by `controller-gen` from upstream comments on Go struct fields. Our `hack/create-todo-patch.sh` script generates the patch that corrects it.

I've added a line to our documentation linter that rejects any `TODO`. It covers more than the CRD reference, but also the only `TODO`s were in our CRD reference.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Documentation
