### PR TITLE
Bump Operator Framework Versions, Other OLM updates

### DIFF
--- a/installers/olm/.gitignore
+++ b/installers/olm/.gitignore
@@ -1,3 +1,4 @@
 /bundles/
 /projects/
 /tools/
+/config/marketplace

--- a/installers/olm/Makefile
+++ b/installers/olm/Makefile
@@ -35,8 +35,10 @@ bundles/redhat:
 	./generate.sh redhat
 	env operator-sdk bundle validate $@ --select-optional='suite=operatorframework'
 
+# The 'marketplace' configuration is currently identical to the 'redhat', so we just copy it here.
 .PHONY: bundles/marketplace
 bundles/marketplace:
+	cp -r ./config/redhat/ ./config/marketplace
 	./generate.sh marketplace
 	env operator-sdk bundle validate $@ --select-optional='suite=operatorframework'
 

--- a/installers/olm/Makefile
+++ b/installers/olm/Makefile
@@ -80,13 +80,13 @@ tools/$(SYSTEM)/kubectl:
 tools: tools/$(SYSTEM)/operator-sdk
 tools/$(SYSTEM)/operator-sdk:
 	install -d '$(dir $@)'
-	curl -fSL -o '$@' 'https://github.com/operator-framework/operator-sdk/releases/download/v1.9.0/operator-sdk_$(OS_KERNEL)_$(OS_MACHINE)'
+	curl -fSL -o '$@' 'https://github.com/operator-framework/operator-sdk/releases/download/v1.18.0/operator-sdk_$(OS_KERNEL)_$(OS_MACHINE)'
 	chmod u+x '$@'
 
 tools: tools/$(SYSTEM)/opm
 tools/$(SYSTEM)/opm:
 	install -d '$(dir $@)'
-	curl -fSL -o '$@' 'https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$(OS_KERNEL)-$(OS_MACHINE)-opm'
+	curl -fSL -o '$@' 'https://github.com/operator-framework/operator-registry/releases/download/v1.20.0/$(OS_KERNEL)-$(OS_MACHINE)-opm'
 	chmod u+x '$@'
 
 tools/$(SYSTEM)/venv:

--- a/installers/olm/bundle.annotations.yaml
+++ b/installers/olm/bundle.annotations.yaml
@@ -26,14 +26,14 @@ annotations:
   # the value from the bundle with the highest semantic version.
   #
   # https://olm.operatorframework.io/docs/best-practices/channel-naming/
-  operators.operatorframework.io.bundle.channels.v1: stable
-  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: v5
+  operators.operatorframework.io.bundle.channel.default.v1: v5
 
   # OpenShift v4.6 is the first version to support CustomResourceDefinition v1.
   # https://github.com/operator-framework/community-operators/blob/8a36a33/docs/packaging-required-criteria-ocp.md
   # https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
   com.redhat.delivery.operator.bundle: true
-  com.redhat.openshift.versions: 'v4.6'
+  com.redhat.openshift.versions: 'v4.6-v4.9'
 
   # https://github.com/opencontainers/image-spec/blob/master/annotations.md
   org.opencontainers.image.authors: info@crunchydata.com


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?




**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This commit updates the Operator Framework toolkit's Operator SDK
and Operator Registry versions used to generate OLM bundles.

Additionally, it adjusts the OCP versions annotation and adds the expected 'marketplace'
configuration folder.

**Other Information**:
