### PR TITLE
Remove pgAdmin Port Setting

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -8794,13 +8794,6 @@ spec:
                               type: string
                             type: object
                         type: object
-                      port:
-                        default: 5050
-                        description: Port on which pgAdmin should listen for client
-                          connections. Changing this value causes pgAdmin to restart.
-                        format: int32
-                        minimum: 1024
-                        type: integer
                       priorityClassName:
                         description: 'Priority class name for the pgAdmin pod. Changing
                           this value causes pgAdmin to restart. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/'

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -11601,11 +11601,6 @@ Defines a pgAdmin user interface.
         <td>Metadata contains metadata for PostgresCluster resources</td>
         <td>false</td>
       </tr><tr>
-        <td><b>port</b></td>
-        <td>integer</td>
-        <td>Port on which pgAdmin should listen for client connections. Changing this value causes pgAdmin to restart.</td>
-        <td>false</td>
-      </tr><tr>
         <td><b>priorityClassName</b></td>
         <td>string</td>
         <td>Priority class name for the pgAdmin pod. Changing this value causes pgAdmin to restart. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/</td>

--- a/internal/controller/postgrescluster/pgadmin.go
+++ b/internal/controller/postgrescluster/pgadmin.go
@@ -160,11 +160,10 @@ func (r *Reconciler) generatePGAdminService(
 	// which can happen during a rolling update.
 	//
 	// TODO(tjmoore4): A custom service port is not currently supported as this
-	// requires updates to the pgAdmin service configuration, but the spec
-	// structures are in place to facilitate further enhancement.
+	// requires updates to the pgAdmin service configuration.
 	service.Spec.Ports = []corev1.ServicePort{{
 		Name:       naming.PortPGAdmin,
-		Port:       *cluster.Spec.UserInterface.PGAdmin.Port,
+		Port:       *initialize.Int32(5050),
 		Protocol:   corev1.ProtocolTCP,
 		TargetPort: intstr.FromString(naming.PortPGAdmin),
 	}}

--- a/internal/controller/postgrescluster/pgadmin_test.go
+++ b/internal/controller/postgrescluster/pgadmin_test.go
@@ -159,9 +159,7 @@ namespace: my-ns
 	})
 
 	cluster.Spec.UserInterface = &v1beta1.UserInterfaceSpec{
-		PGAdmin: &v1beta1.PGAdminPodSpec{
-			Port: initialize.Int32(5050),
-		},
+		PGAdmin: &v1beta1.PGAdminPodSpec{},
 	}
 
 	alwaysExpect := func(t testing.TB, service *corev1.Service) {
@@ -289,9 +287,7 @@ func TestReconcilePGAdminService(t *testing.T) {
 	})
 
 	cluster.Spec.UserInterface = &v1beta1.UserInterfaceSpec{
-		PGAdmin: &v1beta1.PGAdminPodSpec{
-			Port: initialize.Int32(5050),
-		},
+		PGAdmin: &v1beta1.PGAdminPodSpec{},
 	}
 
 	t.Run("NoServiceSpec", func(t *testing.T) {
@@ -759,7 +755,6 @@ func pgAdminTestCluster(ns corev1.Namespace) *v1beta1.PostgresCluster {
 			},
 			UserInterface: &v1beta1.UserInterfaceSpec{
 				PGAdmin: &v1beta1.PGAdminPodSpec{
-					Port:  initialize.Int32(5050),
 					Image: "test-image",
 					DataVolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
 						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},

--- a/internal/pgadmin/config.go
+++ b/internal/pgadmin/config.go
@@ -54,7 +54,7 @@ const (
 	loginPassword = "admin"
 
 	// default pgAdmin port
-	defaultPort = 5050
+	pgAdminPort = 5050
 
 	// configMountPath is where to mount configuration files, secrets, etc.
 	configMountPath = "/etc/pgadmin/conf.d"

--- a/internal/pgadmin/reconcile.go
+++ b/internal/pgadmin/reconcile.go
@@ -176,12 +176,6 @@ func Pod(
 		return
 	}
 
-	// if a pgAdmin port is configured, use that. Otherwise, use the default
-	pgAdminPort := defaultPort
-	if inCluster.Spec.UserInterface.PGAdmin.Port != nil {
-		pgAdminPort = int(*inCluster.Spec.UserInterface.PGAdmin.Port)
-	}
-
 	// create the pgAdmin Pod volumes
 	tmp := corev1.Volume{Name: tmpVolume}
 	tmp.EmptyDir = &corev1.EmptyDirVolumeSource{

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgadmin_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgadmin_types.go
@@ -69,13 +69,6 @@ type PGAdminPodSpec struct {
 	// +optional
 	Image string `json:"image,omitempty"`
 
-	// Port on which pgAdmin should listen for client connections. Changing
-	// this value causes pgAdmin to restart.
-	// +optional
-	// +kubebuilder:default=5050
-	// +kubebuilder:validation:Minimum=1024
-	Port *int32 `json:"port,omitempty"`
-
 	// Priority class name for the pgAdmin pod. Changing this value causes pgAdmin
 	// to restart.
 	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
@@ -113,11 +106,6 @@ type PGAdminPodSpec struct {
 
 // Default sets the port and replica count for pgAdmin if not set
 func (s *PGAdminPodSpec) Default() {
-	if s.Port == nil {
-		s.Port = new(int32)
-		*s.Port = 5050
-	}
-
 	if s.Replicas == nil {
 		s.Replicas = new(int32)
 		*s.Replicas = 1

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
@@ -304,11 +304,6 @@ func (in *PGAdminPodSpec) DeepCopyInto(out *PGAdminPodSpec) {
 	}
 	in.Config.DeepCopyInto(&out.Config)
 	in.DataVolumeClaimSpec.DeepCopyInto(&out.DataVolumeClaimSpec)
-	if in.Port != nil {
-		in, out := &in.Port, &out.Port
-		*out = new(int32)
-		**out = **in
-	}
 	if in.PriorityClassName != nil {
 		in, out := &in.PriorityClassName, &out.PriorityClassName
 		*out = new(string)


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This commit removes the port setting for pgAdmin from the PostgresCluster
spec, userInterface.pgAdmin.port, as well as any related implementation
code or other references.


**Other Information**:
Issue: [sc-13852]