### PR TITLE
Correct docs on s3-uri-style configuration option

### DIFF
--- a/docs/content/tutorial/backups.md
+++ b/docs/content/tutorial/backups.md
@@ -126,7 +126,8 @@ If you are using MinIO, you may need to set the URI style to use `path` mode. Yo
 spec:
   backups:
     pgbackrest:
-      repo1-s3-uri-style: path
+      global:
+        repo1-s3-uri-style: path
 ```
 
 When your configuration is saved, you can deploy your cluster:


### PR DESCRIPTION
The documentation incorrectly states that the `<repo>-s3-uri-style` option could be placed in `spec.backups.pgbackrest`, but in fact it must be placed in `spec.backups.pgbackrest.global`.

This commit modifies the example to show the correct configuration.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

(I've added no tests because this is a doc change.)

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Incorrect documentation re: `s3-uri-style` setting.
