### PR TITLE
Change "status.instances.replicas" to include all pods

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -9151,12 +9151,11 @@ spec:
                       format: int32
                       type: integer
                     replicas:
-                      description: Total number of non-terminated pods.
+                      description: Total number of pods.
                       format: int32
                       type: integer
                     updatedReplicas:
-                      description: Total number of non-terminated pods that have the
-                        desired specification.
+                      description: Total number of pods that have the desired specification.
                       format: int32
                       type: integer
                   required:

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -13658,12 +13658,12 @@ Condition contains details for one aspect of the current state of this API Resou
       </tr><tr>
         <td><b>replicas</b></td>
         <td>integer</td>
-        <td>Total number of non-terminated pods.</td>
+        <td>Total number of pods.</td>
         <td>false</td>
       </tr><tr>
         <td><b>updatedReplicas</b></td>
         <td>integer</td>
-        <td>Total number of non-terminated pods that have the desired specification.</td>
+        <td>Total number of pods that have the desired specification.</td>
         <td>false</td>
       </tr></tbody>
 </table>

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -353,16 +353,15 @@ func (r *Reconciler) observeInstances(
 	cluster.Status.InstanceSets = cluster.Status.InstanceSets[:0]
 	for _, name := range observed.setNames.List() {
 		status := v1beta1.PostgresInstanceSetStatus{Name: name}
+
 		for _, instance := range observed.bySet[name] {
+			status.Replicas += int32(len(instance.Pods))
+
 			if ready, known := instance.IsReady(); known && ready {
 				status.ReadyReplicas++
 			}
-			if terminating, known := instance.IsTerminating(); known && !terminating {
-				status.Replicas++
-
-				if matches, known := instance.PodMatchesPodTemplate(); known && matches {
-					status.UpdatedReplicas++
-				}
+			if matches, known := instance.PodMatchesPodTemplate(); known && matches {
+				status.UpdatedReplicas++
 			}
 		}
 

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -493,11 +493,11 @@ type PostgresInstanceSetStatus struct {
 	// +optional
 	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
 
-	// Total number of non-terminated pods.
+	// Total number of pods.
 	// +optional
 	Replicas int32 `json:"replicas,omitempty"`
 
-	// Total number of non-terminated pods that have the desired specification.
+	// Total number of pods that have the desired specification.
 	// +optional
 	UpdatedReplicas int32 `json:"updatedReplicas,omitempty"`
 }


### PR DESCRIPTION
We added this field while implementing rolling updates and chose to populate it with semantics similar to the appsv1.Deployment controller which ignores terminating Pods. However, our controller does *not* ignore terminating PostgreSQL Pods because they are still writing to disk and still participating in HA quorum.

So, this field now reflects the number of observed Pods, regardless of their state. This is the same approach taken by the appsv1.StatefulSet controller. When this field is zero, we can be relatively certain that all PostgreSQL processes have stopped and disks are idle.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix

**What is the current behavior (link to any open issues here)?**

Terminating instances are not counted in PostgresCluster status.

**What is the new behavior (if this is a feature change)?**

Terminating instances are counted in PostgresCluster status.

**Other Information**:

Issue: [sc-13696]
See: https://issue.k8s.io/107920
See: e0a885ccb842a735fa007604576a2c31a80b2f7a