### PR TITLE
Add pgAdmin Kerberos Environment Variables

### DIFF
--- a/internal/pgadmin/reconcile.go
+++ b/internal/pgadmin/reconcile.go
@@ -229,6 +229,19 @@ func Pod(
 				Name:  "PGADMIN_SETUP_PASSWORD",
 				Value: loginPassword,
 			},
+			// Setting the KRB5_CONFIG for kerberos
+			// - https://web.mit.edu/kerberos/krb5-current/doc/admin/conf_files/krb5_conf.html
+			{
+				Name:  "KRB5_CONFIG",
+				Value: configMountPath + "/krb5.conf",
+			},
+			// In testing it was determined that we need to set this env var for the replay cache
+			// otherwise it defaults to the read-only location `/var/tmp/`
+			// - https://web.mit.edu/kerberos/krb5-current/doc/basic/rcache_def.html#replay-cache-types
+			{
+				Name:  "KRB5RCACHEDIR",
+				Value: "/tmp",
+			},
 		},
 		Command:         []string{"bash", "-c", startupScript},
 		Image:           config.PGAdminContainerImage(inCluster),

--- a/internal/pgadmin/reconcile_test.go
+++ b/internal/pgadmin/reconcile_test.go
@@ -216,6 +216,10 @@ containers:
     value: admin
   - name: PGADMIN_SETUP_PASSWORD
     value: admin
+  - name: KRB5_CONFIG
+    value: /etc/pgadmin/conf.d/krb5.conf
+  - name: KRB5RCACHEDIR
+    value: /tmp
   livenessProbe:
     initialDelaySeconds: 15
     periodSeconds: 20
@@ -440,6 +444,10 @@ containers:
     value: admin
   - name: PGADMIN_SETUP_PASSWORD
     value: admin
+  - name: KRB5_CONFIG
+    value: /etc/pgadmin/conf.d/krb5.conf
+  - name: KRB5RCACHEDIR
+    value: /tmp
   image: new-image
   imagePullPolicy: Always
   livenessProbe:


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This adds the necessary 'KRB5_CONFIG' and 'KRB5RCACHEDIR' environment
variables needed to configure Kerberos with pgAdmin, specifically
allowing for a custom configuration file and a writable cache directory.


**Other Information**:
