### PR TITLE
Document the max length of instance set names

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -5631,7 +5631,9 @@ spec:
                       default: ""
                       description: Name that associates this set of PostgreSQL pods.
                         This field is optional when only one instance set is defined.
-                        Each instance set in a cluster must have a unique name.
+                        Each instance set in a cluster must have a unique name. The
+                        combined length of this and the cluster name must be 46 characters
+                        or less.
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
                       type: string
                     priorityClassName:

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -3723,7 +3723,7 @@ Resource requirements for a sidecar container
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
-        <td>Name that associates this set of PostgreSQL pods. This field is optional when only one instance set is defined. Each instance set in a cluster must have a unique name.</td>
+        <td>Name that associates this set of PostgreSQL pods. This field is optional when only one instance set is defined. Each instance set in a cluster must have a unique name. The combined length of this and the cluster name must be 46 characters or less.</td>
         <td>false</td>
       </tr><tr>
         <td><b>priorityClassName</b></td>

--- a/internal/naming/limitations.md
+++ b/internal/naming/limitations.md
@@ -1,0 +1,114 @@
+<!--
+ Copyright 2022 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+# Definitions
+
+[k8s-names]: https://docs.k8s.io/concepts/overview/working-with-objects/names/
+
+### DNS subdomain
+
+Most resource types require this kind of name. It must be 253 characters or less,
+lowercase, and alphanumeric with hyphens U+002D and dots U+002E allowed in between.
+
+- [k8s.io/apimachinery/pkg/util/validation.IsDNS1123Subdomain](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/validation#IsDNS1123Subdomain)
+
+### DNS label
+
+Some resource types require this kind of name. It must be 63 characters or less,
+lowercase, and alphanumeric with hyphens U+002D allowed in between.
+
+Some have a stricter requirement to start with an alphabetic (nonnumerical) character.
+
+- [k8s.io/apimachinery/pkg/util/validation.IsDNS1123Label](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/validation#IsDNS1123Label)
+- [k8s.io/apimachinery/pkg/util/validation.IsDNS1035Label](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/validation#IsDNS1035Label)
+
+
+# Labels
+
+[k8s-labels]: https://docs.k8s.io/concepts/overview/working-with-objects/labels/
+
+Label names must be 317 characters or less. The portion before an optional slash U+002F
+must be a DNS subdomain. The portion after must be 63 characters or less.
+
+Label values must be 63 characters or less and can be empty.
+
+Both label names and values must be alphanumeric with hyphens U+002D, underscores U+005F,
+and dots U+002E allowed in between.
+
+- [k8s.io/apimachinerypkg/util/validation.IsQualifiedName](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/validation#IsQualifiedName)
+- [k8s.io/apimachinerypkg/util/validation.IsValidLabelValue](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/validation#IsValidLabelValue)
+
+
+# Annotations
+
+[k8s-annotations]: https://docs.k8s.io/concepts/overview/working-with-objects/annotations/
+
+Annotation names must be 317 characters or less. The portion before an optional slash U+002F
+must be a DNS subdomain. The portion after must be 63 characters or less and alphanumeric with
+hyphens U+002D, underscores U+005F, and dots U+002E allowed in between.
+
+Annotation values may contain anything, but the combined size of *all* names and values
+must be 256 KiB or less.
+
+- [https://pkg.go.dev/k8s.io/apimachinery/pkg/api/validation.ValidateAnnotations](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/validation#ValidateAnnotations)
+
+
+# Specifics
+
+The Kubernetes API validates custom resource metadata.
+[Custom resource names are DNS subdomains](https://releases.k8s.io/v1.23.0/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/validator.go#L60).
+It may be possible to limit this further through validation. This is a stated
+goal of [CEL expression validation](https://docs.k8s.io/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules).
+
+[ConfigMap names are DNS subdomains](https://releases.k8s.io/v1.23.0/pkg/apis/core/validation/validation.go#L5618).
+
+[CronJob names are DNS subdomains](https://docs.k8s.io/concepts/workloads/controllers/cron-jobs/)
+but must be [52 characters or less](https://releases.k8s.io/v1.23.0/pkg/apis/batch/validation/validation.go#L281).
+
+[Deployment names are DNS subdomains](https://releases.k8s.io/v1.23.0/pkg/apis/apps/validation/validation.go#L632).
+
+[Job names are DNS subdomains](https://releases.k8s.io/v1.23.0/pkg/apis/batch/validation/validation.go#L86).
+When `.spec.completionMode = Indexed`, the name must be shorter (closer to 61 characters, it depends).
+When `.spec.manualSelector` is unset, its Pods get (and must have) a "job-name" label, limiting the
+name to 63 characters or less.
+
+[Namespace names are DNS labels](https://releases.k8s.io/v1.23.0/pkg/apis/core/validation/validation.go#L5963).
+
+[PersistentVolumeClaim (PVC) names are DNS subdomains](https://releases.k8s.io/v1.23.0/pkg/apis/core/validation/validation.go#L2066).
+
+[Pod names are DNS subdomains](https://releases.k8s.io/v1.23.0/pkg/apis/core/validation/validation.go#L3443).
+The strategy for [generating Pod names](https://releases.k8s.io/v1.23.0/pkg/registry/core/pod/strategy.go#L62) truncates to 63 characters.
+The `.spec.hostname` field must be 63 characters or less.
+
+PodDisruptionBudget (PDB)
+
+[ReplicaSet names are DNS subdomains](https://releases.k8s.io/v1.23.0/pkg/apis/apps/validation/validation.go#L655).
+
+Role
+
+RoleBinding
+
+[Secret names are DNS subdomains](https://releases.k8s.io/v1.23.0/pkg/apis/core/validation/validation.go#L5515).
+
+[Service names are DNS labels](https://docs.k8s.io/concepts/services-networking/service/)
+that must begin with a letter.
+
+ServiceAccount (subdomain)
+
+[StatefulSet names are DNS subdomains](https://docs.k8s.io/concepts/workloads/controllers/statefulset/),
+but its Pods get [hostnames](https://releases.k8s.io/v1.23.0/pkg/apis/core/validation/validation.go#L3561)
+so it must be shorter (closer to 61 characters, it depends). Its Pods also get a "controller-revision-hash"
+label with [11 characters appended](https://issue.k8s.io/64023), limiting the name to 52 characters or less.
+

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -393,13 +393,24 @@ type PostgresInstanceSetSpec struct {
 	// +optional
 	Metadata *Metadata `json:"metadata,omitempty"`
 
-	// This value goes into the name of an appsv1.StatefulSet and the hostname
-	// of a corev1.Pod. The pattern below is IsDNS1123Label wrapped in "()?" to
-	// accommodate the empty default.
+	// This value goes into the name of an appsv1.StatefulSet, the hostname of
+	// a corev1.Pod, and label values. The pattern below is IsDNS1123Label
+	// wrapped in "()?" to accommodate the empty default.
+	//
+	// The Pods created by a StatefulSet have a "controller-revision-hash" label
+	// comprised of the StatefulSet name, a dash, and a 10-character hash.
+	// The length below is derived from limitations on label values:
+	//
+	//   63 (max) ≥ len(cluster) + 1 (dash)
+	//                + len(set) + 1 (dash) + 4 (id)
+	//                + 1 (dash) + 10 (hash)
+	//
+	// See: https://issue.k8s.io/64023
 
 	// Name that associates this set of PostgreSQL pods. This field is optional
 	// when only one instance set is defined. Each instance set in a cluster
-	// must have a unique name.
+	// must have a unique name. The combined length of this and the cluster name
+	// must be 46 characters or less.
 	// +optional
 	// +kubebuilder:default=""
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$`


### PR DESCRIPTION
The name of an instance set goes into the name of a StatefulSet which, in turn, goes into a label value on its Pods. That label value includes a hash generated by Kubernetes.

We cannot perform or specify any cross-field validation at this time. Describe the maximum length of these fields in their documentation, instead.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Documentation

**What is the current behavior (link to any open issues here)?**

Cluster names or instance set names that are too long fail to start any pods.

**Other Information**:

See: https://issue.k8s.io/64023