### PR TITLE
typo fixing on disaster-recovery page

### DIFF
--- a/docs/content/architecture/disaster-recovery.md
+++ b/docs/content/architecture/disaster-recovery.md
@@ -26,7 +26,7 @@ few environmental setups:
 - An external storage system, using one of the following:
   - S3, or an external storage system that uses the S3 protocol
   - GCS
-  - Azure Blog Storage
+  - Azure Blob Storage
   - A Kubernetes storage system that can span multiple clusters
 
 At a high-level, the PostgreSQL Operator follows the "active-standby" data


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
When I lookup a backup solution for `Azure blob storage`, I found a typo `Azure Blog Storage` on the [disaster-recoverypage](
https://access.crunchydata.com/documentation/postgres-operator/v5/architecture/disaster-recovery/)


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
