### PR TITLE
Update Scheduled Backup CronJob Name and Reconcile by Labels

### DIFF
--- a/docs/content/tutorial/disaster-recovery.md
+++ b/docs/content/tutorial/disaster-recovery.md
@@ -315,7 +315,7 @@ NAME                             READY   AGE
 statefulset.apps/hippo-00-lwgx   0/0     1h
 
 NAME                                        SCHEDULE   SUSPEND   ACTIVE
-cronjob.batch/hippo-pgbackrest-repo1-full   @daily     True      0
+cronjob.batch/hippo-repo1-full   @daily     True      0
 ```
 
 We can then promote the standby cluster by removing or disabling its

--- a/internal/naming/names.go
+++ b/internal/naming/names.go
@@ -418,7 +418,7 @@ func PGBackRestBackupJob(cluster *v1beta1.PostgresCluster) metav1.ObjectMeta {
 func PGBackRestCronJob(cluster *v1beta1.PostgresCluster, backuptype, repoName string) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Namespace: cluster.GetNamespace(),
-		Name:      cluster.Name + "-pgbackrest-" + repoName + "-" + backuptype,
+		Name:      cluster.Name + "-" + repoName + "-" + backuptype,
 	}
 }
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This commit updates the scheduled backup CronJob name format,
previously `<cluster name>-pgbackrest-repo#-<upgrade type>`, to a
new shorter format, `<cluster name>-repo#-<upgrade type>`, to
better support longer PostgresCluster names. Also, to facilitate
moving from older PGO versions using the previous format, the
scheduled backup CronJobs are now reconciled by Label to ensure
any existing CronJobs can continue to be used by the cluster.

For more information on name limitations, see:
https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/


**Other Information**:
Issue: [sc-14068]