### PR TITLE
Initial test for exporter metrics

### DIFF
--- a/testing/kuttl/e2e/exporter/00--cluster.yaml
+++ b/testing/kuttl/e2e/exporter/00--cluster.yaml
@@ -1,0 +1,28 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: exporter
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi
+  monitoring:
+    pgmonitor:
+      exporter: {}

--- a/testing/kuttl/e2e/exporter/00-assert.yaml
+++ b/testing/kuttl/e2e/exporter/00-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: exporter
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: exporter
+    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
+status:
+  succeeded: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: exporter-primary

--- a/testing/kuttl/e2e/exporter/01--check-exporter.yaml
+++ b/testing/kuttl/e2e/exporter/01--check-exporter.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Ensure that the metrics endpoint is available from inside the exporter container
+  - script: |
+      name=$(kubectl -n ${NAMESPACE} get pods --no-headers -o custom-columns="name:{metadata.name}" \
+        --selector='postgres-operator.crunchydata.com/cluster=exporter,postgres-operator.crunchydata.com/instance-set=instance1')
+      kubectl -n ${NAMESPACE} exec $name -it -c exporter -- curl http://localhost:9187/metrics
+  # Ensure that the ccp_monitoring user exits in the database
+  - script: |
+      name=$(kubectl -n ${NAMESPACE} get pods --no-headers -o custom-columns="name:{metadata.name}" \
+        --selector='postgres-operator.crunchydata.com/cluster=exporter,postgres-operator.crunchydata.com/instance-set=instance1')
+      kubectl -n ${NAMESPACE} exec $name -it -c database -- \
+        psql -c "DO \$\$
+        DECLARE
+          result boolean;
+        BEGIN
+          SELECT 1 from pg_roles where rolname='ccp_monitoring' INTO result;
+          ASSERT result = 't', 'ccp_monitor not found';
+        END \$\$;"


### PR DESCRIPTION
Checks that the exporter sidecar is running and the metrics endpoint is
available from inside the container. This test also checks that the
ccp_monitoring user is available in the database

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
[sc-14033]