### PR TITLE
Pgbackrest 2.38

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -27,6 +27,7 @@ highlightClientSide = false # set true to use highlight.pack.js instead of the d
 menushortcutsnewtab = true # set true to open shortcuts links to a new tab/window
 enableGitInfo = true
 operatorVersion = "5.1.0"
+operatorVersionLatestRel5_0 = "5.0.5"
 centosBase = "centos8"
 imageCrunchyPostgres = "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1"
 imageCrunchyPostgresPrivate = "registry.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.1-1"

--- a/docs/content/installation/upgrade.md
+++ b/docs/content/installation/upgrade.md
@@ -62,3 +62,54 @@ kubectl delete sts hippo-repo-host
 Additionally, please be sure to update and apply all PostgresCluster custom resources in accordance
 with any applicable spec changes described in the
 [PGO v5.0.3 release notes]({{< relref "../releases/5.0.3.md" >}}).
+
+## Upgrading from PGO v5.0 to v5.1
+
+Starting in PGO v5.1, new pgBackRest features available in version 2.38 are used
+that impact both the `crunchy-postgres` and `crunchy-pgbackrest` images. For any
+existing clusters, you will need to update these image values BEFORE upgrading to
+PGO 5.1. These changes will need to be made in one of two places, depending on
+your desired configuration.
+
+If you are setting the image values on your `PostgresCluster` manifest,
+you would update the images value as shown (updating the `image` values as
+appropriate for your environment):
+
+```yaml
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: hippo
+spec:
+  image: {{< param imageCrunchyPostgres >}}
+  postgresVersion: {{< param postgresVersion >}}
+...
+  backups:
+    pgbackrest:
+      image: {{< param imageCrunchyPGBackrest >}}
+...
+```
+
+After updating these values, you will apply these changes to your PostgresCluster
+custom resources. After these changes are completed and the new images are in place,
+you may update PGO to 5.1.
+
+Relatedly, if you are instead using the `RELATED_IMAGE` environment variables to
+set the image values, you would instead check and update these as needed before
+redeploying PGO.
+
+For Kustomize installations, these can be found in the `manager` directory and
+`manager.yaml` file. Here you will note various key/value pairs, these will need
+to be updated before deploying PGO 5.1. Besides updating the
+`RELATED_IMAGE_PGBACKREST` value, you will also need to update the relevant
+Postgres image for your environment. For example, if you are using PostgreSQL 14,
+you would update the value for `RELATED_IMAGE_POSTGRES_14`. If instead you are
+using the PostGIS 3.1 enabled PostgreSQL 13 image, you would update the value
+for `RELATED_IMAGE_POSTGRES_13_GIS_3.1`.
+
+For Helm deployments, you would instead need to similarly update your `values.yaml`
+file, found in the `install` directory. There you will note a `relatedImages`
+section, followed by similar values as mentioned above. Again, be sure to update
+`pgbackrest` as well as the appropriate `postgres` value for your clusters.
+
+Once there values have been properly verified, you may deploy PGO 5.1.

--- a/docs/content/references/components.md
+++ b/docs/content/references/components.md
@@ -28,7 +28,8 @@ Note that for the 5.0.3 release and beyond, the Postgres containers were renamed
 
 | Component | Version | PGO Version Min. | PGO Version Max. |
 |-----------|---------|------------------|------------------|
-| `crunchy-pgbackrest` | 2.36 | 5.0.4 | {{< param operatorVersion >}} |
+| `crunchy-pgbackrest` | 2.38 | 5.1.0 | {{< param operatorVersion >}} |
+| `crunchy-pgbackrest` | 2.36 | 5.0.4 | {{< param operatorVersionLatestRel5_0 >}} |
 | `crunchy-pgbackrest` | 2.35 | 5.0.3 | 5.0.3 |
 | `crunchy-pgbackrest` | 2.33 | 5.0.0 | 5.0.2 |
 | `crunchy-pgbouncer` | 1.16.1 | 5.0.4 | {{< param operatorVersion >}} |

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -550,7 +550,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
   resources: {}
 - command:
   - pgbackrest
-  - server-start
+  - server
   livenessProbe:
     exec:
       command:
@@ -584,7 +584,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     until read -r -t 5 -u "${fd}"; do
       if
         [ "${filename}" -nt "/proc/self/fd/${fd}" ] &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --dereference --format='Loaded configuration dated %y' "${filename}"
@@ -592,7 +592,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
         { [ "${directory}" -nt "/proc/self/fd/${fd}" ] ||
           [ "${authority}" -nt "/proc/self/fd/${fd}" ]
         } &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --format='Loaded certificates dated %y' "${directory}"
@@ -648,7 +648,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
 			assert.Assert(t, marshalMatches(out.Containers[2:], `
 - command:
   - pgbackrest
-  - server-start
+  - server
   livenessProbe:
     exec:
       command:
@@ -686,7 +686,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     until read -r -t 5 -u "${fd}"; do
       if
         [ "${filename}" -nt "/proc/self/fd/${fd}" ] &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --dereference --format='Loaded configuration dated %y' "${filename}"
@@ -694,7 +694,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
         { [ "${directory}" -nt "/proc/self/fd/${fd}" ] ||
           [ "${authority}" -nt "/proc/self/fd/${fd}" ]
         } &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --format='Loaded certificates dated %y' "${directory}"

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -566,11 +566,8 @@ func (r *Reconciler) generateRepoHostIntent(postgresCluster *v1beta1.PostgresClu
 	// - https://docs.k8s.io/concepts/workloads/pods/pod-lifecycle/#restart-policy
 	repo.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways
 
-	// The pgBackRest TLS server handles client connections in detached/orphaned
-	// child processes which it expects to be reaped by an init system (PID 1).
 	// When ShareProcessNamespace is enabled, Kubernetes' pause process becomes
 	// PID 1 and reaps those processes when they complete.
-	// - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/command/server/server.c#L51
 	// - https://github.com/kubernetes/kubernetes/commit/81d27aa23969b77f
 	//
 	// The pgBackRest TLS server must be signaled when its configuration or

--- a/internal/pgbackrest/certificates.go
+++ b/internal/pgbackrest/certificates.go
@@ -93,7 +93,7 @@ func clientCertificates() []corev1.KeyToPath {
 
 			// pgBackRest requires that certificate keys not be readable by any
 			// other user.
-			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/io/tls/common.c#L128
+			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/common/io/tls/common.c#L128
 			Mode: initialize.Int32(0o600),
 		},
 	}
@@ -125,7 +125,7 @@ func instanceServerCertificates() []corev1.KeyToPath {
 
 			// pgBackRest requires that certificate keys not be readable by any
 			// other user.
-			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/io/tls/common.c#L128
+			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/common/io/tls/common.c#L128
 			Mode: initialize.Int32(0o600),
 		},
 	}
@@ -145,7 +145,7 @@ func repositoryServerCertificates() []corev1.KeyToPath {
 
 			// pgBackRest requires that certificate keys not be readable by any
 			// other user.
-			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/io/tls/common.c#L128
+			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/common/io/tls/common.c#L128
 			Mode: initialize.Int32(0o600),
 		},
 	}

--- a/internal/pgbackrest/config.md
+++ b/internal/pgbackrest/config.md
@@ -183,7 +183,7 @@ options in less specific sections.
 
 [default-config]:  https://pgbackrest.org/configuration.html#introduction
 [file-precedence]: https://pgbackrest.org/user-guide.html#quickstart/configure-stanza
-[parse.auto.c]: https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/config/parse.auto.c
+[parse.auto.c]: https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/config/parse.auto.c
 
 ```console
 $ tail -vn+0 pgbackrest.conf conf.d/*

--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -337,7 +337,7 @@ tls-server-ca-file = /etc/pgbackrest/conf.d/~postgres-operator/tls-ca.crt
 tls-server-cert-file = /etc/pgbackrest/server/server-tls.crt
 tls-server-key-file = /etc/pgbackrest/server/server-tls.key
 
-[global:server-start]
+[global:server]
 log-level-console = detail
 log-level-file = off
 log-level-stderr = error

--- a/internal/pgbackrest/reconcile.go
+++ b/internal/pgbackrest/reconcile.go
@@ -278,7 +278,7 @@ func addServerContainerAndVolume(
 
 	container := corev1.Container{
 		Name:            naming.PGBackRestRepoContainerName,
-		Command:         []string{"pgbackrest", "server-start"},
+		Command:         []string{"pgbackrest", "server"},
 		Image:           config.PGBackRestContainerImage(cluster),
 		ImagePullPolicy: cluster.Spec.ImagePullPolicy,
 		SecurityContext: initialize.RestrictedSecurityContext(),

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -556,7 +556,7 @@ func TestAddServerToInstancePod(t *testing.T) {
   resources: {}
 - command:
   - pgbackrest
-  - server-start
+  - server
   livenessProbe:
     exec:
       command:
@@ -589,7 +589,7 @@ func TestAddServerToInstancePod(t *testing.T) {
     until read -r -t 5 -u "${fd}"; do
       if
         [ "${filename}" -nt "/proc/self/fd/${fd}" ] &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --dereference --format='Loaded configuration dated %y' "${filename}"
@@ -597,7 +597,7 @@ func TestAddServerToInstancePod(t *testing.T) {
         { [ "${directory}" -nt "/proc/self/fd/${fd}" ] ||
           [ "${authority}" -nt "/proc/self/fd/${fd}" ]
         } &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --format='Loaded certificates dated %y' "${directory}"
@@ -686,7 +686,7 @@ func TestAddServerToRepoPod(t *testing.T) {
   resources: {}
 - command:
   - pgbackrest
-  - server-start
+  - server
   livenessProbe:
     exec:
       command:
@@ -715,7 +715,7 @@ func TestAddServerToRepoPod(t *testing.T) {
     until read -r -t 5 -u "${fd}"; do
       if
         [ "${filename}" -nt "/proc/self/fd/${fd}" ] &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --dereference --format='Loaded configuration dated %y' "${filename}"
@@ -723,7 +723,7 @@ func TestAddServerToRepoPod(t *testing.T) {
         { [ "${directory}" -nt "/proc/self/fd/${fd}" ] ||
           [ "${authority}" -nt "/proc/self/fd/${fd}" ]
         } &&
-        pkill --exact --parent=0 pgbackrest
+        pkill -HUP --exact --parent=0 pgbackrest
       then
         exec {fd}>&- && exec {fd}<> <(:)
         stat --format='Loaded certificates dated %y' "${directory}"

--- a/internal/pgbackrest/tls-server.md
+++ b/internal/pgbackrest/tls-server.md
@@ -37,44 +37,68 @@ to the repository host to [send and receive WAL files][archiving].
 The `pgbackrest` command acts as a TLS client and connects to a pgBackRest TLS
 server when `pg-host-type=tls` and/or `repo-host-type=tls`. The default for these is `ssh`:
 
-- https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/config/parse.auto.c#L3580
-- https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/config/parse.auto.c#L5941
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/config/parse.auto.c#L3771
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/config/parse.auto.c#L6137
 
 
 The pgBackRest TLS server is configured through the `tls-server-*` [options](config.md).
-In pgBackRest 2.36, changing any of these options or changing certificate contents
-requires a restart of the server.
+In pgBackRest 2.38, changing any of these options or changing certificate contents
+requires a reload of the server, as shown in the "Setup TLS Server" section of the
+documentation, with the command configured as
+
+```
+ExecReload=kill -HUP $MAINPID
+```
+
+- https://pgbackrest.org/user-guide-rhel.html#repo-host/setup-tls
 
 - `tls-server-address`, `tls-server-port` <br/>
-  The network address and port on which to listen. pgBackRest 2.36 listens on
+  The network address and port on which to listen. pgBackRest 2.38 listens on
   the *first* address returned by `getaddrinfo()`. There is no way to listen on
   all interfaces.
 
-  - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/io/socket/server.c#L169
-  - https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/io/socket/common.c#L87
+  - https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/common/io/socket/server.c#L172
+  - https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/common/io/socket/common.c#L87
 
 - `tls-server-cert-file`, `tls-server-key-file` <br/>
   The [certificate chain][certificates] and private key pair used to encrypt connections.
 
 - `tls-server-ca-file` <br/>
   The certificate used to verify client [certificates][].
-  [Required](https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/config/parse.auto.c#L8487).
+  [Required](https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/config/parse.auto.c#L8767).
 
 - `tls-server-auth` <br/>
   A map/hash/dictionary of certificate common names and the stanzas they are authorized
   to interact with.
-  [Required](https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/config/parse.auto.c#L8471).
+  [Required](https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/config/parse.auto.c#L8751).
 
 
-In pgBackRest 2.36, sending SIGHUP, SIGINT, or SIGTERM to the TLS server all
-cause it to exit with code 63, TermError.
+In pgBackRest 2.38, as mentioned above, sending SIGHUP causes a configuration reload.
 
-- https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/exit.c#L73-L75
-- https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/exit.c#L62
-- https://github.com/pgbackrest/pgbackrest/blob/release/2.36/src/common/error.auto.c#L48
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/command/server/server.c#L178
 
 ```
-P00   INFO: server-start command end: terminated on signal [SIGHUP]
-P00   INFO: server-start command end: terminated on signal [SIGINT]
-P00   INFO: server-start command end: terminated on signal [SIGTERM]
+P00 DETAIL: configuration reload begin
+P00   INFO: server command begin 2.38...
+P00 DETAIL: configuration reload end
+```
+
+Sending SIGINT to the TLS server causes it to exit with code 63, TermError.
+
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/common/exit.c#L73-L75
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/common/exit.c#L62
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/common/error.auto.c#L48
+
+
+```
+P00   INFO: server command end: terminated on signal [SIGINT]
+```
+
+Sending SIGTERM exits the signal loop and lead to the command termination.
+
+- https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/command/server/server.c#L194
+
+
+```
+P00   INFO: server command end: completed successfully
 ```


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
    pgBackRest 2.38 Documentation Updates

This allows PGO to use pgBackRest 2.38:
https://pgbackrest.org/release.html#2.38
Changes include updating the current 'server-start' command to the
new 'server' command and updating the TLS configuration using a
SIGHUP instead of the current SIGTERM.
- https://github.com/pgbackrest/pgbackrest/commit/7b3ea883c7c010aafbeb14d150d073a113b703e4

Also included are instructions for updating the new Postgres
and pgBackRest images before upgrading to PGO 5.1 and notes which
versions use 2.38.


**Other Information**:
Issue: [sc-14096]