### PR TITLE
Update check to support older pg versions

### DIFF
--- a/testing/kuttl/e2e/pgbackrest-restore/17--check-replication.yaml
+++ b/testing/kuttl/e2e/pgbackrest-restore/17--check-replication.yaml
@@ -16,7 +16,7 @@ commands:
           --file=- <<'SQL'
         DO $$
         BEGIN
-          ASSERT pg_is_in_recovery(), 'expected replica';
-          ASSERT current_setting('primary_conninfo') <> '', 'expected streaming';
+          PERFORM * FROM pg_stat_wal_receiver WHERE status = 'streaming';
+          ASSERT FOUND, 'expected streaming replication';
         END $$
       SQL


### PR DESCRIPTION
The `primary_conninfo` setting is not available in Postgres Versions 10
and 11. This change updates the test to use a more general check that
works in all versions

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
