### PR TITLE
OLM installer bundle generation updates

### DIFF
--- a/installers/olm/bundle.annotations.yaml
+++ b/installers/olm/bundle.annotations.yaml
@@ -35,8 +35,4 @@ annotations:
   com.redhat.delivery.operator.bundle: true
   com.redhat.openshift.versions: 'v4.6-v4.9'
 
-  # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-  org.opencontainers.image.authors: info@crunchydata.com
-  org.opencontainers.image.url: https://crunchydata.com
-  org.opencontainers.image.vendor: Crunchy Data
 ...

--- a/installers/olm/bundle.relatedImages.yaml
+++ b/installers/olm/bundle.relatedImages.yaml
@@ -1,0 +1,25 @@
+  relatedImages:
+    - name: PGBACKREST
+      image: registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:<update_SHA_value>
+    - name: PGBOUNCER
+      image: registry.connect.redhat.com/crunchydata/crunchy-pgbouncer@sha256:<update_SHA_value>
+    - name: PGEXPORTER
+      image: registry.connect.redhat.com/crunchydata/crunchy-postgres-exporter@sha256:<update_SHA_value>
+    - name: POSTGRES_12
+      image: registry.connect.redhat.com/crunchydata/crunchy-postgres@sha256:<update_SHA_value>
+    - name: POSTGRES_13
+      image: registry.connect.redhat.com/crunchydata/crunchy-postgres@sha256:<update_SHA_value>
+    - name: POSTGRES_14
+      image: registry.connect.redhat.com/crunchydata/crunchy-postgres@sha256:<update_SHA_value>
+    - name: POSTGRES_12_GIS_2.5
+      image: registry.connect.redhat.com/crunchydata/crunchy-postgres-gis@sha256:<update_SHA_value>
+    - name: POSTGRES_12_GIS_3.0
+      image: registry.connect.redhat.com/crunchydata/crunchy-postgres-gis@sha256:<update_SHA_value>
+    - name: POSTGRES_13_GIS_3.0
+      image: registry.connect.redhat.com/crunchydata/crunchy-postgres-gis@sha256:<update_SHA_value>
+    - name: POSTGRES_13_GIS_3.1
+      image: registry.connect.redhat.com/crunchydata/crunchy-postgres-gis@sha256:<update_SHA_value>
+    - name: POSTGRES_14_GIS_3.1
+      image: registry.connect.redhat.com/crunchydata/crunchy-postgres-gis@sha256:<update_SHA_value>
+    - name: postgres-operator
+      image: registry.connect.redhat.com/crunchydata/postgres-operator@sha256:<update_SHA_value>


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This commit fixes the filenames of the ClusterServiceVersion files,
removes the 'org.opencontainers' annotations for both the 'redhat'
and 'marketplace' OLM installers and adds the required 'relatedImages'
for the 'marketplace' installer.


**Other Information**:
Issue: [sc-13923]