### PR TITLE
Remove the status field from generated CRD YAML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,19 +83,9 @@ createnamespaces:
 deletenamespaces:
 	$(PGO_KUBE_CLIENT) delete -k ./config/namespace
 
-# Note: For 'install', 'deploy' and 'deploy-dev' below
-# Using `--server-side --force-conflicts` when applying the K8s objects in order to 
-# A) remove the `kubectl.kubernetes.io/last-applied-configuration` from the CRD since it 
-# was violating the limit on size of `metadata.annotations`
-# - https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go#L36
-# B) overriding conflicts around managed fields during subsequent applies;
-# the fields that were erroring in a local k3s cluster were `.status.conditions`,
-# `.status.acceptedNames.kind`, and `.status.acceptedNames.plural`, which were managed by 
-# `k3s` rather than by `kubectl`
-
 # Install the postgrescluster CRD
 install:
-	$(PGO_KUBE_CLIENT) apply --server-side --force-conflicts -k ./config/crd
+	$(PGO_KUBE_CLIENT) apply --server-side -k ./config/crd
 
 # Delete the postgrescluster CRD
 uninstall:
@@ -103,11 +93,11 @@ uninstall:
 
 # Deploy the PostgreSQL Operator (enables the postgrescluster controller)
 deploy:
-	$(PGO_KUBE_CLIENT) apply --server-side --force-conflicts -k ./config/default
+	$(PGO_KUBE_CLIENT) apply --server-side -k ./config/default
 
 # Deploy the PostgreSQL Operator locally
 deploy-dev: build-postgres-operator createnamespaces
-	$(PGO_KUBE_CLIENT) apply --server-side --force-conflicts -k ./config/dev
+	$(PGO_KUBE_CLIENT) apply --server-side -k ./config/dev
 	hack/create-kubeconfig.sh postgres-operator pgo
 	env \
 		CRUNCHY_DEBUG=true \
@@ -197,17 +187,9 @@ check-envtest: hack/tools/envtest
 	KUBEBUILDER_ASSETS="$(CURDIR)/$^/bin" PGO_NAMESPACE="postgres-operator" $(GO_TEST) -count=1 -cover -tags=envtest ./...
 
 # - PGO_TEST_TIMEOUT_SCALE=1
-# Note: using `--server-side --force-conflicts` when applying the K8s objects in order to 
-# A) remove the `kubectl.kubernetes.io/last-applied-configuration` from the CRD since it 
-# was violating the limit on size of `metadata.annotations`
-# - https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go#L36
-# B) overriding conflicts around managed fields during subsequent applies;
-# the fields that were erroring in a local k3s cluster were `.status.conditions`,
-# `.status.acceptedNames.kind`, and `.status.acceptedNames.plural`, which were managed by 
-# `k3s` rather than by `kubectl`
 .PHONY: check-envtest-existing
 check-envtest-existing: createnamespaces
-	${PGO_KUBE_CLIENT} apply --server-side --force-conflicts -k ./config/dev
+	${PGO_KUBE_CLIENT} apply --server-side -k ./config/dev
 	USE_EXISTING_CLUSTER=true PGO_NAMESPACE="postgres-operator" $(GO_TEST) -count=1 -cover -p=1 -tags=envtest ./...
 	${PGO_KUBE_CLIENT} delete -k ./config/dev
 

--- a/build/crd/kustomization.yaml
+++ b/build/crd/kustomization.yaml
@@ -16,6 +16,12 @@ patchesJson6902:
     version: v1
     kind: CustomResourceDefinition
     name: postgresclusters.postgres-operator.crunchydata.com
+  path: status.yaml
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: postgresclusters.postgres-operator.crunchydata.com
   path: todos.yaml
 - target:
     group: apiextensions.k8s.io

--- a/build/crd/status.yaml
+++ b/build/crd/status.yaml
@@ -1,0 +1,6 @@
+# Remove the zero status field included by controller-gen@v0.8.0. These zero
+# values conflict with the CRD controller in Kubernetes before v1.22.
+# - https://github.com/kubernetes-sigs/controller-tools/pull/630
+# - https://pr.k8s.io/100970
+- op: remove
+  path: /status

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -9406,9 +9406,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
We use server-side apply to manage our large CRD, but older versions of Kubernetes do not ignore sub-resource fields.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix

**What is the current behavior (link to any open issues here)?**

An error when trying to `apply --server-side`:

```
error: Apply failed with 3 conflicts: … using apiextensions.k8s.io/v1:
- .status.conditions
- .status.acceptedNames.kind
- .status.acceptedNames.plural
```

**What is the new behavior (if this is a feature change)?**

No error:

```
customresourcedefinition.apiextensions.k8s.io/postgresclusters.postgres-operator.crunchydata.com serverside-applied
```

**Other Information**:

Issue: [sc-14162]