### PR TITLE
Bump Max OpenShift Version for OLM

### DIFF
--- a/installers/olm/bundle.annotations.yaml
+++ b/installers/olm/bundle.annotations.yaml
@@ -33,6 +33,6 @@ annotations:
   # https://github.com/operator-framework/community-operators/blob/8a36a33/docs/packaging-required-criteria-ocp.md
   # https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
   com.redhat.delivery.operator.bundle: true
-  com.redhat.openshift.versions: 'v4.6-v4.9'
+  com.redhat.openshift.versions: 'v4.6-v4.10'
 
 ...


### PR DESCRIPTION
The default annotations file used for generating the PGO OLM installers now specifies `v4.10` as the maximum supported version of OpenShift (specifically by specifying `v4.6-v4.10` for the `com.redhat.openshift.versions` annotation.

[sc-13979]