### PR TITLE
Add the --server-side flag to apply commands in documentation

### DIFF
--- a/docs/content/guides/private-registries.md
+++ b/docs/content/guides/private-registries.md
@@ -100,7 +100,7 @@ patchesJson6902:
 You can then install PGO from the private registry using the standard installation procedure, e.g.:
 
 ```shell
-kubectl apply -k kustomize/install
+kubectl apply --server-side -k kustomize/install/default
 ```
 
 ## Deploy a Postgres cluster from a Private Registry

--- a/docs/content/installation/kustomize.md
+++ b/docs/content/installation/kustomize.md
@@ -118,14 +118,14 @@ are deploying the operator with cluster-wide or namespace-limited permissions).
 To install PGO itself in cluster-wide mode, apply the kustomization file in the `default` folder:
 
 ```shell
-kubectl apply -k kustomize/install/default
+kubectl apply --server-side -k kustomize/install/default
 ```
 
 To install PGO itself in namespace-limited mode, apply the kustomization file in the
 `singlenamespace` folder:
 
 ```shell
-kubectl apply -k kustomize/install/singlenamespace
+kubectl apply --server-side -k kustomize/install/singlenamespace
 ```
 
 The `kustomization.yaml` files in those folders take care of applying the appropriate permissions.

--- a/docs/content/installation/upgrade.md
+++ b/docs/content/installation/upgrade.md
@@ -38,7 +38,7 @@ Then, once both the Deployment and ServiceAccount have been deleted, proceed wit
 by applying the new version of the Kustomize installer:
 
 ```bash
-kubectl apply -k kustomize/install/bases
+kubectl apply --server-side -k kustomize/install/default
 ```
 
 ## Upgrading from PGO v5.0.2 and Below

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -35,7 +35,7 @@ You can install PGO, the Postgres Operator from Crunchy Data, using the command 
 
 ```
 kubectl apply -k kustomize/install/namespace
-kubectl apply -k kustomize/install/default
+kubectl apply --server-side -k kustomize/install/default
 ```
 
 This will create a namespace called `postgres-operator` and create all of the objects required to deploy PGO.

--- a/docs/content/tutorial/getting-started.md
+++ b/docs/content/tutorial/getting-started.md
@@ -10,7 +10,7 @@ If you have not done so, please install PGO by following the [quickstart]({{< re
 As part of the installation, please be sure that you have done the following:
 
 1. [Forked the Postgres Operator examples repository](https://github.com/CrunchyData/postgres-operator-examples/fork) and cloned it to your host machine.
-1. Installed PGO to the `postgres-operator` namespace. If you are inside your `postgres-operator-examples` directory, you can run the `kubectl apply -k kustomize/install` command.
+1. Installed PGO to the `postgres-operator` namespace. If you are inside your `postgres-operator-examples` directory, you can run the `kubectl apply --server-side -k kustomize/install/default` command.
 
 Note if you are using this guide in conjunction with images from the [Crunchy Data Customer Portal](https://access.crunchydata.com), please follow the [private registries]({{< relref "guides/private-registries.md" >}}) guide for additional setup instructions.
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [ ] Other



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This commit adds the '--server-side' flag to the installation
'apply' commands in the documentation. This is done to remove
the `kubectl.kubernetes.io/last-applied-configuration` from the
CRD so as to avoid violating the limit on the size of
`metadata.annotations`.


**Other Information**:
