### PR TITLE
Remove recovery.signal from replicas created by pgBackRest

### DIFF
--- a/internal/pgbackrest/reconcile.go
+++ b/internal/pgbackrest/reconcile.go
@@ -410,6 +410,13 @@ func ReplicaCreateCommand(
 			"--stanza=" + DefaultStanzaName,
 			"--repo=" + strings.TrimPrefix(repoName, "repo"),
 			"--link-map=pg_wal=" + postgres.WALDirectory(cluster, instance),
+
+			// Do not create a recovery signal file on PostgreSQL v12 or later;
+			// Patroni creates a standby signal file which takes precedence.
+			// Patroni manages recovery.conf prior to PostgreSQL v12.
+			// - https://github.com/pgbackrest/pgbackrest/blob/release/2.38/src/command/restore/restore.c#L1824
+			// - https://www.postgresql.org/docs/12/runtime-config-wal.html
+			"--type=standby",
 		}
 	}
 

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -803,7 +803,7 @@ func TestReplicaCreateCommand(t *testing.T) {
 
 		assert.DeepEqual(t, ReplicaCreateCommand(cluster, instance), []string{
 			"pgbackrest", "restore", "--delta", "--stanza=db", "--repo=2",
-			"--link-map=pg_wal=/pgdata/pg0_wal",
+			"--link-map=pg_wal=/pgdata/pg0_wal", "--type=standby",
 		})
 	})
 
@@ -816,7 +816,7 @@ func TestReplicaCreateCommand(t *testing.T) {
 
 		assert.DeepEqual(t, ReplicaCreateCommand(cluster, instance), []string{
 			"pgbackrest", "restore", "--delta", "--stanza=db", "--repo=7",
-			"--link-map=pg_wal=/pgdata/pg0_wal",
+			"--link-map=pg_wal=/pgdata/pg0_wal", "--type=standby",
 		})
 	})
 }

--- a/internal/postgres/config.go
+++ b/internal/postgres/config.go
@@ -255,6 +255,15 @@ func startupCommand(
 		// - https://git.postgresql.org/gitweb/?p=postgresql.git;f=src/bin/pg_basebackup/pg_basebackup.c;hb=REL_13_0#l2621
 		`safelink "${pgwal_directory}" "${postgres_data_directory}/pg_wal"`,
 		`results 'wal directory' "$(realpath "${postgres_data_directory}/pg_wal")"`,
+
+		// Early versions of PGO create replicas with a recovery signal file.
+		// Patroni also creates a standby signal file before starting Postgres,
+		// causing Postgres to remove only one, the standby. Remove the extra
+		// signal file now, if it exists, and let Patroni manage the standby
+		// signal file instead.
+		// - https://git.postgresql.org/gitweb/?p=postgresql.git;f=src/backend/access/transam/xlog.c;hb=REL_12_0#l5318
+		// TODO(cbandy): Remove this after 5.0 is EOL.
+		`rm -f "${postgres_data_directory}/recovery.signal"`,
 	}, "\n")
 
 	return append([]string{"bash", "-ceu", "--", script, "startup"}, args...)

--- a/internal/postgres/reconcile_test.go
+++ b/internal/postgres/reconcile_test.go
@@ -221,6 +221,7 @@ initContainers:
     [ "${postgres_data_version}" = "${expected_major_version}" ]
     safelink "${pgwal_directory}" "${postgres_data_directory}/pg_wal"
     results 'wal directory' "$(realpath "${postgres_data_directory}/pg_wal")"
+    rm -f "${postgres_data_directory}/recovery.signal"
   - startup
   - "11"
   - /pgdata/pg11_wal

--- a/testing/kuttl/e2e/pgbackrest-init/04--cluster.yaml
+++ b/testing/kuttl/e2e/pgbackrest-init/04--cluster.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: init-pgbackrest
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      replicas: 2
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      manual:
+        repoName: repo2
+        options:
+         - --type=full
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi
+      # Adding a second PVC repo for testing, rather than test with S3/GCS/Azure
+      - name: repo2
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/testing/kuttl/e2e/pgbackrest-init/04-assert.yaml
+++ b/testing/kuttl/e2e/pgbackrest-init/04-assert.yaml
@@ -1,0 +1,34 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: init-pgbackrest
+status:
+  instances:
+  - name: instance1
+    readyReplicas: 2
+    replicas: 2
+    updatedReplicas: 2
+  pgbackrest:
+    repoHost:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      ready: true
+    repos:
+# Assert that the status has the two repos, with only the first having the `replicaCreateBackupComplete` field
+    - bound: true
+      name: repo1
+      replicaCreateBackupComplete: true
+      stanzaCreated: true
+    - bound: true
+      name: repo2
+      stanzaCreated: true
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: init-pgbackrest
+    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo1
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/pgbackrest-init/05-pgbackrest-connect.yaml
+++ b/testing/kuttl/e2e/pgbackrest-init/05-pgbackrest-connect.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    # Assumes the cluster only has a single replica
+    NEW_REPLICA=$(
+        kubectl get pod --namespace "${NAMESPACE}" \
+          --output name --selector '
+            postgres-operator.crunchydata.com/cluster=init-pgbackrest,
+            postgres-operator.crunchydata.com/role=replica'
+      )
+
+    LIST=$(
+    kubectl exec --namespace "${NAMESPACE}" "${NEW_REPLICA}" -- \
+      ls /pgdata/pg${KUTTL_PG_VERSION}/
+    )
+
+    contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+    {
+      !(contains "${LIST}" 'recovery.signal')
+    } || {
+      echo >&2 'Signal file(s) found'
+      echo "${LIST}"
+      exit 1
+    }


### PR DESCRIPTION
Patroni creates `standby.signal` before starting PostgreSQL, causing `recovery.signal` to remain even after recovery completes. This file does no harm on replicas nor when restoring, but it does cause the disk of the primary to enter recovery after a clean shutdown.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix

**What is the current behavior (link to any open issues here)?**

Tools that inspect the primary disk while PostgreSQL is shut down will find that it is poised for recovery.

**What is the new behavior (if this is a feature change)?**

No more `recovery.signal` on instances. Running clusters will remove it during their next restart.

**Other Information**:

Issue: [sc-14190]