### PR TITLE
Replace TestReconcileCerts owner reference test with Kuttl test

### DIFF
--- a/testing/kuttl/e2e/root-cert-ownership/00--cluster.yaml
+++ b/testing/kuttl/e2e/root-cert-ownership/00--cluster.yaml
@@ -1,0 +1,35 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: owner1
+  labels: { postgres-operator-test: kuttl }
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      replicas: 1
+      dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: owner2
+  labels: { postgres-operator-test: kuttl }
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      replicas: 1
+      dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }

--- a/testing/kuttl/e2e/root-cert-ownership/00-assert.yaml
+++ b/testing/kuttl/e2e/root-cert-ownership/00-assert.yaml
@@ -1,0 +1,26 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: owner1
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: owner2
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pgo-root-cacert

--- a/testing/kuttl/e2e/root-cert-ownership/01-check-owners.yaml
+++ b/testing/kuttl/e2e/root-cert-ownership/01-check-owners.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Get a list of the current owners of the root ca cert secret and verify that
+  # both owners are listed.
+  - script: |
+      CURRENT_OWNERS=$(kubectl --namespace="${NAMESPACE}" get secret \
+        pgo-root-cacert -o jsonpath='{.metadata.ownerReferences[*].name}')
+      if [[ "$CURRENT_OWNERS" != *"owner1"* ]]; then
+          exit 1
+      fi
+      if [[ "$CURRENT_OWNERS" != *"owner2"* ]]; then
+          exit 1
+      fi

--- a/testing/kuttl/e2e/root-cert-ownership/02--delete-owner1.yaml
+++ b/testing/kuttl/e2e/root-cert-ownership/02--delete-owner1.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: postgres-operator.crunchydata.com/v1beta1
+  kind: PostgresCluster
+  name: owner1

--- a/testing/kuttl/e2e/root-cert-ownership/02-assert.yaml
+++ b/testing/kuttl/e2e/root-cert-ownership/02-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: owner2
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pgo-root-cacert

--- a/testing/kuttl/e2e/root-cert-ownership/02-errors.yaml
+++ b/testing/kuttl/e2e/root-cert-ownership/02-errors.yaml
@@ -1,0 +1,4 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: owner1

--- a/testing/kuttl/e2e/root-cert-ownership/03-check-owners.yaml
+++ b/testing/kuttl/e2e/root-cert-ownership/03-check-owners.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Get a list of the current owners of the root ca cert secret and verify that
+  # owner1 is no longer listed and owner2 is found.
+  - script: |
+      sleep 2 # this sleep allows time for the owner reference list to be updated
+      CURRENT_OWNERS=$(kubectl --namespace="${NAMESPACE}" get secret \
+        pgo-root-cacert -o jsonpath='{.metadata.ownerReferences[*].name}')
+      if [[ "$CURRENT_OWNERS" == *"owner1"* ]]; then
+          exit 1
+      fi
+      if [[ "$CURRENT_OWNERS" != *"owner2"* ]]; then
+          exit 1
+      fi

--- a/testing/kuttl/e2e/root-cert-ownership/04--delete-owner2.yaml
+++ b/testing/kuttl/e2e/root-cert-ownership/04--delete-owner2.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: postgres-operator.crunchydata.com/v1beta1
+  kind: PostgresCluster
+  name: owner2

--- a/testing/kuttl/e2e/root-cert-ownership/04-errors.yaml
+++ b/testing/kuttl/e2e/root-cert-ownership/04-errors.yaml
@@ -1,0 +1,9 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: owner1
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: owner2

--- a/testing/kuttl/e2e/root-cert-ownership/05--check-secret.yaml
+++ b/testing/kuttl/e2e/root-cert-ownership/05--check-secret.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # If there are other PostgresClusters in the namespace, ensure that 'owner2'
+  # and 'owner2' are not listed.
+  # If there are no other PostgresClusters in the namespace, the 'pgo-root-cacert'
+  # secret should be deleted.
+  - script: |
+      NUM_CLUSTERS=$(kubectl --namespace="${NAMESPACE}" get postgrescluster --output name | wc -l)
+      if [[ "$NUM_CLUSTERS" != 0 ]]; then
+          CURRENT_OWNERS=$(kubectl --namespace="${NAMESPACE}" get secret \
+            pgo-root-cacert -o jsonpath='{.metadata.ownerReferences[*].name}')
+          if [[ "$CURRENT_OWNERS" == *"owner1"* ]]; then
+              exit 1
+          fi
+          if [[ "$CURRENT_OWNERS" == *"owner2"* ]]; then
+              exit 1
+          fi
+      else
+          ROOT_SECRET=$(kubectl --namespace="${NAMESPACE}" get --ignore-not-found \
+            secret pgo-root-cacert --output name | wc -l)
+          if [[ "$ROOT_SECRET" != 0 ]]; then
+              exit 1
+          fi
+      fi

--- a/testing/kuttl/e2e/root-cert-ownership/README.md
+++ b/testing/kuttl/e2e/root-cert-ownership/README.md
@@ -1,0 +1,23 @@
+### Root Certificate Ownership Test
+
+This Kuttl routine runs through the following steps:
+
+#### Create two clusters and verify the root certificate secret ownership
+
+- 00: Creates the two clusters and verifies they and the root cert secret exist
+- 01: Check that the secret shows both clusters as owners
+
+#### Delete the first cluster and verify the root certificate secret ownership
+
+- 02: Delete the first cluster, assert that the second cluster and the root cert
+secret are still present and that the first cluster is not present
+- 03: Check that the secret shows the second cluster as an owner but does not show
+the first cluster as an owner
+
+#### Delete the second cluster and verify the root certificate secret ownership
+
+- 04: Delete the second cluster, assert that both clusters are not present
+- 05: Check the number of clusters in the namespace. If there are any remaining
+clusters, ensure that the secret shows neither the first nor second cluster as an
+owner. If there are no clusters remaining in the namespace, ensure the root cert
+secret has been deleted.


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other




**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This creates a Kuttl test to verify proper owner references are
set on the root CA certificate secret which replaces the current
EnvTest implementation.



**Other Information**:
Issue: [sc-14269]