### PR TITLE
Remove CrunchyData packages from PGO controller image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,15 +131,29 @@ build-crunchy-postgres-exporter:
 $(PGOROOT)/build/%/Dockerfile:
 	$(error No Dockerfile found for $* naming pattern: [$@])
 
-%-img-build: pgo-base-$(IMGBUILDER) build-% $(PGOROOT)/build/%/Dockerfile
+crunchy-postgres-exporter-img-build: pgo-base-$(IMGBUILDER) build-crunchy-postgres-exporter $(PGOROOT)/build/crunchy-postgres-exporter/Dockerfile
 	$(IMGCMDSTEM) \
-		-f $(PGOROOT)/build/$*/Dockerfile \
-		-t $(PGO_IMAGE_PREFIX)/$*:$(PGO_IMAGE_TAG) \
+		-f $(PGOROOT)/build/crunchy-postgres-exporter/Dockerfile \
+		-t $(PGO_IMAGE_PREFIX)/crunchy-postgres-exporter:$(PGO_IMAGE_TAG) \
 		--build-arg BASEOS=$(PGO_BASEOS) \
 		--build-arg BASEVER=$(PGO_VERSION) \
 		--build-arg PACKAGER=$(PACKAGER) \
 		--build-arg PGVERSION=$(PGO_PG_VERSION) \
 		--build-arg PREFIX=$(PGO_IMAGE_PREFIX) \
+		$(PGOROOT)
+
+postgres-operator-img-build: build-postgres-operator $(PGOROOT)/build/postgres-operator/Dockerfile
+	$(IMGCMDSTEM) \
+		-f $(PGOROOT)/build/postgres-operator/Dockerfile \
+		-t $(PGO_IMAGE_PREFIX)/postgres-operator:$(PGO_IMAGE_TAG) \
+		--build-arg BASE_IMAGE_OS=$(BASE_IMAGE_OS) \
+		--build-arg PACKAGER=$(PACKAGER) \
+		--build-arg PGVERSION=$(PGO_PG_VERSION) \
+		--build-arg RELVER=$(PGO_VERSION) \
+		--build-arg DOCKERBASEREGISTRY=$(DOCKERBASEREGISTRY) \
+		--build-arg PACKAGER=$(PACKAGER) \
+		--build-arg PG_FULL=$(PGO_PG_FULLVERSION) \
+		--build-arg PGVERSION=$(PGO_PG_VERSION) \
 		$(PGOROOT)
 
 %-img-buildah: %-img-build ;

--- a/build/postgres-operator/Dockerfile
+++ b/build/postgres-operator/Dockerfile
@@ -1,11 +1,29 @@
-ARG BASEOS
-ARG BASEVER
-ARG PREFIX
-FROM ${PREFIX}/pgo-base:${BASEOS}-${BASEVER}
+ARG BASE_IMAGE_OS
+ARG DOCKERBASEREGISTRY
+FROM ${DOCKERBASEREGISTRY}${BASE_IMAGE_OS}
 
-LABEL name="postgres-operator" \
+ARG PGVERSION
+ARG PG_FULL
+ARG PACKAGER
+ARG RELVER
+
+MAINTAINER info@crunchydata.com
+
+LABEL vendor="Crunchy Data" \
+	url="https://crunchydata.com" \
+	release="${RELVER}" \
+	postgresql.version.major="${PGVERSION}" \
+	postgresql.version="${PG_FULL}" \
+	org.opencontainers.image.vendor="Crunchy Data" \
+	io.openshift.tags="postgresql,postgres,sql,nosql,crunchy" \
+	io.k8s.description="Trusted open source PostgreSQL-as-a-Service" \
+	name="postgres-operator" \
 	summary="Crunchy PostgreSQL Operator" \
 	description="Crunchy PostgreSQL Operator"
+
+COPY licenses /licenses
+
+RUN ${PACKAGER} -y update && ${PACKAGER} -y clean all
 
 ADD bin/postgres-operator /usr/local/bin
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x ] Other


**What is the current behavior (link to any open issues here)?**
CrunchyData RPMs are required when building the PGO controller image.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This update allows the PGO controller image to be built without
CrunchyData specific RPMs. All existing make targets continue to
function in the same way as before, but the PGO controller image
no longer utilizes the base image. The base image is still used
by the Crunchy Postgres Exporter image.


**Other Information**:
Issue: [sc-14268]