### PR TITLE
Kuttl test to create a cluster and resize the PVC

### DIFF
--- a/testing/kuttl/e2e-other/resize-volume/00-assert.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/00-assert.yaml
@@ -1,0 +1,7 @@
+# Ensure that the default StorageClass supports VolumeExpansion
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+allowVolumeExpansion: true

--- a/testing/kuttl/e2e-other/resize-volume/01--cluster.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/01--cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: resize-volume-up
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/testing/kuttl/e2e-other/resize-volume/01-assert.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/01-assert.yaml
@@ -1,0 +1,59 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: resize-volume-up
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: resize-volume-up
+    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
+status:
+  succeeded: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: resize-volume-up-primary
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: resize-volume-up
+    postgres-operator.crunchydata.com/instance-set: instance1
+spec:
+  resources:
+    requests:
+      storage: 1Gi
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: resize-volume-up
+    postgres-operator.crunchydata.com/data: pgbackrest
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo1
+spec:
+  resources:
+    requests:
+      storage: 1Gi
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound

--- a/testing/kuttl/e2e-other/resize-volume/02--create-data.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/02--create-data.yaml
@@ -1,0 +1,31 @@
+---
+# Create some data that should be present after resizing.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-data
+  labels: { postgres-operator-test: kuttl }
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels: { postgres-operator-test: kuttl }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: psql
+          image: ${KUTTL_PSQL_IMAGE}
+          env:
+            - name: PGURI
+              valueFrom: { secretKeyRef: { name: resize-volume-up-pguser-resize-volume-up, key: uri } }
+
+            # Do not wait indefinitely.
+            - { name: PGCONNECT_TIMEOUT, value: '5' }
+
+          command:
+            - psql
+            - $(PGURI)
+            - --set=ON_ERROR_STOP=1
+            - --command
+            - |
+              CREATE TABLE important (data) AS VALUES ('treasure');

--- a/testing/kuttl/e2e-other/resize-volume/02-assert.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/02-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-data
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e-other/resize-volume/03--resize.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/03--resize.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: resize-volume-up
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 2Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 2Gi

--- a/testing/kuttl/e2e-other/resize-volume/03-assert.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/03-assert.yaml
@@ -1,0 +1,37 @@
+# We know that the PVC sizes have change so now we can check that they have been
+# updated to have the expected size
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: resize-volume-up
+    postgres-operator.crunchydata.com/instance-set: instance1
+spec:
+  resources:
+    requests:
+      storage: 2Gi
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 2Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: resize-volume-up
+    postgres-operator.crunchydata.com/data: pgbackrest
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo1
+spec:
+  resources:
+    requests:
+      storage: 2Gi
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 2Gi
+  phase: Bound

--- a/testing/kuttl/e2e-other/resize-volume/06--check-data.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/06--check-data.yaml
@@ -1,0 +1,40 @@
+---
+# Confirm that all the data still exists.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-data
+  labels: { postgres-operator-test: kuttl }
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels: { postgres-operator-test: kuttl }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: psql
+          image: ${KUTTL_PSQL_IMAGE}
+          env:
+            - name: PGURI
+              valueFrom: { secretKeyRef: { name: resize-volume-up-pguser-resize-volume-up, key: uri } }
+
+            # Do not wait indefinitely.
+            - { name: PGCONNECT_TIMEOUT, value: '5' }
+
+          # Confirm that all the data still exists.
+          # Note: the `$$$$` is reduced to `$$` by Kubernetes.
+          # - https://kubernetes.io/docs/tasks/inject-data-application/
+          command:
+            - psql
+            - $(PGURI)
+            - --set=ON_ERROR_STOP=1
+            - --command
+            - |
+              DO $$$$
+              DECLARE
+                keep_data jsonb;
+              BEGIN
+                SELECT jsonb_agg(important) INTO keep_data FROM important;
+                ASSERT keep_data = '[{"data":"treasure"}]', format('got %L', keep_data);
+              END $$$$;

--- a/testing/kuttl/e2e-other/resize-volume/06-assert.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/06-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-data
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e-other/resize-volume/11--cluster.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/11--cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: resize-volume-down
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 2Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 2Gi

--- a/testing/kuttl/e2e-other/resize-volume/11-assert.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/11-assert.yaml
@@ -1,0 +1,59 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: resize-volume-down
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: resize-volume-down
+    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
+status:
+  succeeded: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: resize-volume-down-primary
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: resize-volume-down
+    postgres-operator.crunchydata.com/instance-set: instance1
+spec:
+  resources:
+    requests:
+      storage: 2Gi
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 2Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: resize-volume-down
+    postgres-operator.crunchydata.com/data: pgbackrest
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo1
+spec:
+  resources:
+    requests:
+      storage: 2Gi
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 2Gi
+  phase: Bound

--- a/testing/kuttl/e2e-other/resize-volume/13--resize.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/13--resize.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: resize-volume-down
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/testing/kuttl/e2e-other/resize-volume/13-assert.yaml
+++ b/testing/kuttl/e2e-other/resize-volume/13-assert.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Event
+type: Warning
+involvedObject:
+  apiVersion: postgres-operator.crunchydata.com/v1beta1
+  kind: PostgresCluster
+  name: resize-volume-down
+reason: PersistentVolumeError
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: resize-volume-down
+    postgres-operator.crunchydata.com/instance-set: instance1
+spec:
+  resources:
+    requests:
+      storage: 2Gi
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 2Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: resize-volume-down
+    postgres-operator.crunchydata.com/data: pgbackrest
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo1
+spec:
+  resources:
+    requests:
+      storage: 2Gi
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 2Gi
+  phase: Bound


### PR DESCRIPTION
This test creates two simple clusters with a single primary and a repo
host. In the first cluster we create data then increase the size of the
pvc. Then we check that the pvc size has changed, the size matches the
new expected side and the data is still present.

In the second cluster we attempt decrease the size of the volume and
expect the PersistentVolumeError.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
[sc-14270]