### PR TITLE
Enable seccomp on containers

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,4 +38,6 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       serviceAccountName: pgo

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -563,6 +563,8 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbackrest/server
     name: pgbackrest-server
@@ -610,6 +612,8 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbackrest/server
     name: pgbackrest-server
@@ -665,6 +669,8 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbackrest/server
     name: pgbackrest-server
@@ -712,6 +718,8 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbackrest/server
     name: pgbackrest-server

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -2504,6 +2504,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbackrest/conf.d
     name: pgbackrest-config

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -991,6 +991,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   terminationMessagePath: /dev/termination-log
   terminationMessagePolicy: File
   volumeMounts:
@@ -1044,6 +1046,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   terminationMessagePath: /dev/termination-log
   terminationMessagePolicy: File
   volumeMounts:
@@ -1099,6 +1103,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   terminationMessagePath: /dev/termination-log
   terminationMessagePolicy: File
   volumeMounts:

--- a/internal/initialize/security.go
+++ b/internal/initialize/security.go
@@ -20,6 +20,9 @@ import (
 )
 
 // RestrictedPodSecurityContext returns a v1.PodSecurityContext with safe defaults.
+// Note: All current containers have security context set by `RestrictedSecurityContext`
+// which has recommended limits; if more pods/containers are added
+// make sure to set the SC on the container
 // See https://docs.k8s.io/concepts/security/pod-security-standards/
 func RestrictedPodSecurityContext() *corev1.PodSecurityContext {
 	return &corev1.PodSecurityContext{
@@ -43,5 +46,12 @@ func RestrictedSecurityContext() *corev1.SecurityContext {
 
 		// Fail to start the container if its image runs as UID 0 (root).
 		RunAsNonRoot: Bool(true),
+
+		// Restrict syscalls with RuntimeDefault seccomp.
+		// Set this on the container-level to avoid interfering
+		// with sidecars and injected containers.
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 }

--- a/internal/initialize/security_test.go
+++ b/internal/initialize/security_test.go
@@ -97,8 +97,11 @@ func TestRestrictedSecurityContext(t *testing.T) {
 				"Containers must be required to run as non-root users.")
 		}
 
-		assert.Assert(t, sc.SeccompProfile == nil,
-			"The RuntimeDefault seccomp profile must be required, or allow specific additional profiles.")
+		if assert.Check(t, sc.SeccompProfile != nil) {
+			assert.Assert(t, sc.SeccompProfile.Type == "RuntimeDefault",
+				"Seccomp profile must be explicitly set to one of the allowed values.")
+		}
+
 	})
 
 	if assert.Check(t, sc.ReadOnlyRootFilesystem != nil) {

--- a/internal/pgadmin/reconcile_test.go
+++ b/internal/pgadmin/reconcile_test.go
@@ -241,6 +241,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgadmin
     name: pgadmin-startup
@@ -278,6 +280,8 @@ initContainers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgadmin
     name: pgadmin-startup
@@ -473,6 +477,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgadmin
     name: pgadmin-startup
@@ -514,6 +520,8 @@ initContainers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgadmin
     name: pgadmin-startup

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -571,6 +571,8 @@ func TestAddServerToInstancePod(t *testing.T) {
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbackrest/server
     name: pgbackrest-server
@@ -617,6 +619,8 @@ func TestAddServerToInstancePod(t *testing.T) {
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbackrest/server
     name: pgbackrest-server
@@ -701,6 +705,8 @@ func TestAddServerToRepoPod(t *testing.T) {
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbackrest/server
     name: pgbackrest-server
@@ -743,6 +749,8 @@ func TestAddServerToRepoPod(t *testing.T) {
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbackrest/server
     name: pgbackrest-server

--- a/internal/pgbouncer/reconcile_test.go
+++ b/internal/pgbouncer/reconcile_test.go
@@ -141,6 +141,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbouncer
     name: pgbouncer-config
@@ -169,6 +171,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbouncer
     name: pgbouncer-config
@@ -245,6 +249,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbouncer
     name: pgbouncer-config
@@ -278,6 +284,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbouncer
     name: pgbouncer-config
@@ -345,6 +353,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbouncer
     name: pgbouncer-config
@@ -377,6 +387,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /etc/pgbouncer
     name: pgbouncer-config

--- a/internal/postgres/reconcile_test.go
+++ b/internal/postgres/reconcile_test.go
@@ -143,6 +143,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /pgconf/tls
     name: cert-volume
@@ -181,6 +183,8 @@ containers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /pgconf/tls
     name: cert-volume
@@ -247,6 +251,8 @@ initContainers:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - mountPath: /pgconf/tls
     name: cert-volume

--- a/testing/kuttl/e2e/security-context/00-assert.yaml
+++ b/testing/kuttl/e2e/security-context/00-assert.yaml
@@ -35,6 +35,8 @@ spec:
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
 ---
 # instance
 apiVersion: v1
@@ -54,30 +56,40 @@ spec:
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   - name: replication-cert-copy
     securityContext:
       allowPrivilegeEscalation: false
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   - name: pgbackrest
     securityContext:
       allowPrivilegeEscalation: false
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   - name: pgbackrest-config
     securityContext:
       allowPrivilegeEscalation: false
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   - name: exporter
     securityContext:
       allowPrivilegeEscalation: false
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   initContainers:
   - name: postgres-startup
     securityContext:
@@ -85,12 +97,16 @@ spec:
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   - name: nss-wrapper-init
     securityContext:
       allowPrivilegeEscalation: false
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
 ---
 # pgAdmin
 apiVersion: v1
@@ -110,6 +126,8 @@ spec:
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   initContainers:
   - name: pgadmin-startup
     securityContext:
@@ -117,12 +135,16 @@ spec:
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   - name: nss-wrapper-init
     securityContext:
       allowPrivilegeEscalation: false
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
 ---
 # pgBouncer
 apiVersion: v1
@@ -139,12 +161,16 @@ spec:
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   - name: pgbouncer-config
     securityContext:
       allowPrivilegeEscalation: false
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
 ---
 # pgBackRest repo
 apiVersion: v1
@@ -165,12 +191,16 @@ spec:
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   - name: pgbackrest-config
     securityContext:
       allowPrivilegeEscalation: false
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   initContainers:
   - name: pgbackrest-log-dir
     securityContext:
@@ -178,9 +208,13 @@ spec:
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   - name: nss-wrapper-init
     securityContext:
       allowPrivilegeEscalation: false
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault


### PR DESCRIPTION
**Checklist:**
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other -- security enhancement


**What is the current behavior (link to any open issues here)?**

As of Kubernetes v1.19, SecurityContext has a seccompProfile field that can be set to RuntimeDefault to limit syscalls. We were not using that.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This PR adds that setting to the containers in order to
(a) limit syscalls from PGO-managed containers, while
(b) not preventing users from using other tools involving sidecars, etc.

**Other Information**:
Issue [sc-11286]