### PR TITLE
Typo in update-cluster

### DIFF
--- a/docs/content/tutorial/update-cluster.md
+++ b/docs/content/tutorial/update-cluster.md
@@ -20,7 +20,7 @@ spec:
   image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-0
 ```
 
-Diving into the tag a bit further, you will notice the `13.4-0` portion. This represents the Postgres minor version (`13.4`) and the patch number of the release `0`. If the patch number is incremented (e.g. `13.4-1`), this means that the container is rebuilt, but there are no changes to the Postgres version. If the minor version is incremented (e.g. `13.4-0`), this means that the is a newer bug fix release of Postgres within the container.
+Diving into the tag a bit further, you will notice the `13.4-0` portion. This represents the Postgres minor version (`13.4`) and the patch number of the release `0`. If the patch number is incremented (e.g. `13.4-1`), this means that the container is rebuilt, but there are no changes to the Postgres version. If the minor version is incremented (e.g. `13.4-0`), this means that there is a newer bug fix release of Postgres within the container.
 
 To update the image, you just need to modify the `spec.image` field with the new image reference, e.g.
 


### PR DESCRIPTION
Is it a typo?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [ ] Other