### PR TITLE
Add more assertions to delete and switchover tests

### DIFF
--- a/testing/kuttl/e2e/delete-namespace/02--delete-namespace.yaml
+++ b/testing/kuttl/e2e/delete-namespace/02--delete-namespace.yaml
@@ -1,5 +1,5 @@
 ---
-# Remove the cluster.
+# Remove the namespace.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 delete:

--- a/testing/kuttl/e2e/delete-namespace/02-errors.yaml
+++ b/testing/kuttl/e2e/delete-namespace/02-errors.yaml
@@ -11,6 +11,13 @@ namespace: kuttl-test-delete-namespace
 labels:
     postgres-operator.crunchydata.com/cluster: delete
 ---
+# Patroni DCS objects are not owned by the PostgresCluster.
+apiVersion: v1
+kind: Endpoints
+namespace: kuttl-test-delete-namespace
+labels:
+    postgres-operator.crunchydata.com/cluster: delete
+---
 apiVersion: v1
 kind: Pod
 namespace: kuttl-test-delete-namespace

--- a/testing/kuttl/e2e/delete/02-errors.yaml
+++ b/testing/kuttl/e2e/delete/02-errors.yaml
@@ -9,6 +9,12 @@ kind: StatefulSet
 labels:
     postgres-operator.crunchydata.com/cluster: delete
 ---
+# Patroni DCS objects are not owned by the PostgresCluster.
+apiVersion: v1
+kind: Endpoints
+labels:
+    postgres-operator.crunchydata.com/cluster: delete
+---
 apiVersion: v1
 kind: Pod
 labels:

--- a/testing/kuttl/e2e/delete/10-assert.yaml
+++ b/testing/kuttl/e2e/delete/10-assert.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
@@ -8,6 +9,22 @@ status:
       readyReplicas: 2
       replicas: 2
       updatedReplicas: 2
+---
+# Patroni labels and readiness happen separately.
+# The next step expects to find pods by their role label; wait for them here.
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: delete-switchover
+    postgres-operator.crunchydata.com/role: master
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: delete-switchover
+    postgres-operator.crunchydata.com/role: replica
 ---
 apiVersion: batch/v1
 kind: Job

--- a/testing/kuttl/e2e/delete/11-annotate.yaml
+++ b/testing/kuttl/e2e/delete/11-annotate.yaml
@@ -2,7 +2,8 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  # Label instance pods with their current role for assert
+  # Label instance pods with their current role. These labels will stick around
+  # because switchover does not recreate any pods.
   - script: |
       kubectl label --namespace="${NAMESPACE}" pods \
         --selector='postgres-operator.crunchydata.com/role=master' \

--- a/testing/kuttl/e2e/delete/12-assert.yaml
+++ b/testing/kuttl/e2e/delete/12-assert.yaml
@@ -1,5 +1,5 @@
 ---
-# After switchover, a former replica should now be the primary.
+# Wait for switchover to finish. A former replica should now be the primary.
 apiVersion: v1
 kind: Pod
 metadata:

--- a/testing/kuttl/e2e/delete/14-errors.yaml
+++ b/testing/kuttl/e2e/delete/14-errors.yaml
@@ -9,6 +9,12 @@ kind: StatefulSet
 labels:
     postgres-operator.crunchydata.com/cluster: delete-switchover
 ---
+# Patroni DCS objects are not owned by the PostgresCluster.
+apiVersion: v1
+kind: Endpoints
+labels:
+    postgres-operator.crunchydata.com/cluster: delete-switchover
+---
 apiVersion: v1
 kind: Pod
 labels:

--- a/testing/kuttl/e2e/delete/22-errors.yaml
+++ b/testing/kuttl/e2e/delete/22-errors.yaml
@@ -9,6 +9,12 @@ kind: StatefulSet
 labels:
     postgres-operator.crunchydata.com/cluster: delete-not-running
 ---
+# Patroni DCS objects are not owned by the PostgresCluster.
+apiVersion: v1
+kind: Endpoints
+labels:
+    postgres-operator.crunchydata.com/cluster: delete-not-running
+---
 apiVersion: v1
 kind: Pod
 labels:

--- a/testing/kuttl/e2e/switchover/01-assert.yaml
+++ b/testing/kuttl/e2e/switchover/01-assert.yaml
@@ -9,3 +9,19 @@ status:
       replicas: 2
       readyReplicas: 2
       updatedReplicas: 2
+---
+# Patroni labels and readiness happen separately.
+# The next step expects to find pods by their role label; wait for them here.
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: switchover
+    postgres-operator.crunchydata.com/role: master
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: switchover
+    postgres-operator.crunchydata.com/role: replica


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

**What is the current behavior (link to any open issues here)?**

The switchover test occasionally fails when it does not find pods that have changed their role. It's possible that we aren't detecting the change because we aren't effectively recording the role before the switchover.

**What is the new behavior (if this is a feature change)?**

Wait for the expected labels before using a selector to record their original values.

As a follow-up to c13154e93977c09e03a3f046eae4493a54bbb135, this also checks that Patroni endpoints are removed during cluster deletion.