### PR TITLE
Pause/Resume PostgresCluster Reconciliation

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -6375,6 +6375,10 @@ spec:
                     minimum: 1
                     type: integer
                 type: object
+              paused:
+                description: Suspends the rollout and reconciliation of changes made
+                  to the PostgresCluster spec.
+                type: boolean
               port:
                 default: 5432
                 description: The port on which PostgreSQL should listen.
@@ -9043,7 +9047,7 @@ spec:
               conditions:
                 description: 'conditions represent the observations of postgrescluster''s
                   current state. Known .status.conditions.type are: "PersistentVolumeResizing",
-                  "ProxyAvailable"'
+                  "Progressing", "ProxyAvailable"'
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -165,6 +165,11 @@ PostgresClusterSpec defines the desired state of PostgresCluster
         <td></td>
         <td>false</td>
       </tr><tr>
+        <td><b>paused</b></td>
+        <td>boolean</td>
+        <td>Suspends the rollout and reconciliation of changes made to the PostgresCluster spec.</td>
+        <td>false</td>
+      </tr><tr>
         <td><b>port</b></td>
         <td>integer</td>
         <td>The port on which PostgreSQL should listen.</td>
@@ -13420,7 +13425,7 @@ PostgresClusterStatus defines the observed state of PostgresCluster
     <tbody><tr>
         <td><b><a href="#postgresclusterstatusconditionsindex">conditions</a></b></td>
         <td>[]object</td>
-        <td>conditions represent the observations of postgrescluster's current state. Known .status.conditions.type are: "PersistentVolumeResizing", "ProxyAvailable"</td>
+        <td>conditions represent the observations of postgrescluster's current state. Known .status.conditions.type are: "PersistentVolumeResizing", "Progressing", "ProxyAvailable"</td>
         <td>false</td>
       </tr><tr>
         <td><b>databaseInitSQL</b></td>

--- a/docs/content/tutorial/administrative-tasks.md
+++ b/docs/content/tutorial/administrative-tasks.md
@@ -20,7 +20,7 @@ Watch your hippo cluster: you will see the rolling update has been triggered and
 
 ## Shutdown
 
-You can shut down a Postgres cluster by setting the `spec.shutdown` attribute to `true`. You can do this by editing the manifest, or, in the case of the `hippo` cluster, executing a comand like the below:
+You can shut down a Postgres cluster by setting the `spec.shutdown` attribute to `true`. You can do this by editing the manifest, or, in the case of the `hippo` cluster, executing a command like the below:
 
 ```
 kubectl patch postgrescluster/hippo -n postgres-operator --type merge \
@@ -30,6 +30,25 @@ kubectl patch postgrescluster/hippo -n postgres-operator --type merge \
 Shutting down a cluster will terminate all of the active Pods. Any Statefulsets or Deployments are scaled to `0`.
 
 To turn a Postgres cluster that is shut down back on, you can set `spec.shutdown` to `false`.
+
+## Pausing Reconciliation and Rollout
+
+You can pause the Postgres cluster reconciliation process by setting the
+`spec.paused` attribute to `true`. You can do this by editing the manifest, or,
+in the case of the `hippo` cluster, executing a command like the below:
+
+```
+kubectl patch postgrescluster/hippo -n postgres-operator --type merge \
+  --patch '{"spec":{"paused": true}}'
+```
+
+Pausing a cluster will suspend any changes to the cluster’s current state until
+reconciliation is resumed. This allows you to fully control when changes to
+the PostgresCluster spec are rolled out to the Postgres cluster. While paused,
+no statuses are updated other than the "Progressing" condition.
+
+To resume reconciliation of a Postgres cluster, you can either set `spec.paused`
+to `false` or remove the setting from your manifest.
 
 ## Rotating TLS Certificates
 

--- a/internal/controller/postgrescluster/volumes.go
+++ b/internal/controller/postgrescluster/volumes.go
@@ -765,7 +765,6 @@ func (r *Reconciler) handlePersistentVolumeClaimError(
 			Message: "One or more volumes cannot be resized",
 
 			ObservedGeneration: cluster.Generation,
-			LastTransitionTime: metav1.Now(),
 		})
 	}
 

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -109,6 +109,11 @@ type PostgresClusterSpec struct {
 	// +optional
 	Patroni *PatroniSpec `json:"patroni,omitempty"`
 
+	// Suspends the rollout and reconciliation of changes made to the
+	// PostgresCluster spec.
+	// +optional
+	Paused *bool `json:"paused,omitempty"`
+
 	// The port on which PostgreSQL should listen.
 	// +optional
 	// +kubebuilder:default=5432
@@ -375,7 +380,7 @@ type PostgresClusterStatus struct {
 
 	// conditions represent the observations of postgrescluster's current state.
 	// Known .status.conditions.type are: "PersistentVolumeResizing",
-	// "ProxyAvailable"
+	// "Progressing", "ProxyAvailable"
 	// +optional
 	// +listType=map
 	// +listMapKey=type
@@ -385,8 +390,9 @@ type PostgresClusterStatus struct {
 
 // PostgresClusterStatus condition types.
 const (
-	PersistentVolumeResizing = "PersistentVolumeResizing"
-	ProxyAvailable           = "ProxyAvailable"
+	PersistentVolumeResizing   = "PersistentVolumeResizing"
+	PostgresClusterProgressing = "Progressing"
+	ProxyAvailable             = "ProxyAvailable"
 )
 
 type PostgresInstanceSetSpec struct {

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
@@ -1183,6 +1183,11 @@ func (in *PostgresClusterSpec) DeepCopyInto(out *PostgresClusterSpec) {
 		*out = new(PatroniSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Paused != nil {
+		in, out := &in.Paused, &out.Paused
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
 		*out = new(int32)

--- a/testing/kuttl/e2e/cluster-pause/00--cluster.yaml
+++ b/testing/kuttl/e2e/cluster-pause/00--cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: cluster-pause
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/testing/kuttl/e2e/cluster-pause/00-assert.yaml
+++ b/testing/kuttl/e2e/cluster-pause/00-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: cluster-pause
+status:
+  conditions:
+    - message: pgBackRest dedicated repository host is ready
+      reason: RepoHostReady
+      status: "True"
+      type: PGBackRestRepoHostReady
+    - message: pgBackRest replica create repo is ready for backups
+      reason: StanzaCreated
+      status: "True"
+      type: PGBackRestReplicaRepoReady
+    - message: pgBackRest replica creation is now possible
+      reason: RepoBackupComplete
+      status: "True"
+      type: PGBackRestReplicaCreate
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1

--- a/testing/kuttl/e2e/cluster-pause/01--cluster-paused.yaml
+++ b/testing/kuttl/e2e/cluster-pause/01--cluster-paused.yaml
@@ -1,0 +1,16 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: cluster-pause
+spec:
+  paused: true
+  instances:
+    - name: instance1
+      # We set replicas to 2, but this won't result in a new replica until we resume
+      replicas: 2
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi

--- a/testing/kuttl/e2e/cluster-pause/01-assert.yaml
+++ b/testing/kuttl/e2e/cluster-pause/01-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: cluster-pause
+status:
+  conditions:
+    - message: pgBackRest dedicated repository host is ready
+      reason: RepoHostReady
+      status: "True"
+      type: PGBackRestRepoHostReady
+    - message: pgBackRest replica create repo is ready for backups
+      reason: StanzaCreated
+      status: "True"
+      type: PGBackRestReplicaRepoReady
+    - message: pgBackRest replica creation is now possible
+      reason: RepoBackupComplete
+      status: "True"
+      type: PGBackRestReplicaCreate
+    - message: No spec changes will be applied and no other statuses will be updated.
+      reason: Paused
+      status: "False"
+      type: Progressing
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1

--- a/testing/kuttl/e2e/cluster-pause/02--cluster-resume.yaml
+++ b/testing/kuttl/e2e/cluster-pause/02--cluster-resume.yaml
@@ -1,0 +1,6 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: cluster-pause
+spec:
+  paused: false

--- a/testing/kuttl/e2e/cluster-pause/02-assert.yaml
+++ b/testing/kuttl/e2e/cluster-pause/02-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: cluster-pause
+status:
+  conditions:
+    - message: pgBackRest dedicated repository host is ready
+      reason: RepoHostReady
+      status: "True"
+      type: PGBackRestRepoHostReady
+    - message: pgBackRest replica create repo is ready for backups
+      reason: StanzaCreated
+      status: "True"
+      type: PGBackRestReplicaRepoReady
+    - message: pgBackRest replica creation is now possible
+      reason: RepoBackupComplete
+      status: "True"
+      type: PGBackRestReplicaCreate
+  instances:
+    - name: instance1
+      readyReplicas: 2
+      replicas: 2
+      updatedReplicas: 2


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
Adds the ability to pause the Postgres cluster reconciliation
process by setting the `spec.pause` attribute to `true`.

Pausing a cluster suspends any changes to the cluster’s current
state until reconciliation is resumed. Reconciliation is resumed
by either setting `spec.shutdown` to `false` or remove the setting
from your manifest.


**Other Information**:
Issue: [sc-11606]