### PR TITLE
Drop default container runtime capabilities

### DIFF
--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -560,6 +560,9 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
   resources: {}
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -607,6 +610,9 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
   resources: {}
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -662,6 +668,9 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
       cpu: 5m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -709,6 +718,9 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
   resources: {}
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -2505,6 +2505,9 @@ containers:
   resources: {}
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true

--- a/internal/controller/postgrescluster/pgmonitor_test.go
+++ b/internal/controller/postgrescluster/pgmonitor_test.go
@@ -96,6 +96,9 @@ func TestAddPGMonitorExporterToInstancePodSpec(t *testing.T) {
 		assert.Equal(t, container.ImagePullPolicy, corev1.PullAlways)
 		assert.DeepEqual(t, container.Resources, resources)
 		assert.DeepEqual(t, container.Command, []string{"/opt/cpm/bin/start.sh"})
+		assert.DeepEqual(t, container.SecurityContext.Capabilities, &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		})
 		assert.Equal(t, *container.SecurityContext.Privileged, false)
 		assert.Equal(t, *container.SecurityContext.ReadOnlyRootFilesystem, true)
 		assert.Equal(t, *container.SecurityContext.AllowPrivilegeEscalation, false)

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -775,6 +775,9 @@ containers:
       cpu: 1m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -828,6 +831,9 @@ containers:
       cpu: 1m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -883,6 +889,9 @@ containers:
       cpu: 1m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true

--- a/internal/initialize/security.go
+++ b/internal/initialize/security.go
@@ -35,6 +35,13 @@ func RestrictedSecurityContext() *corev1.SecurityContext {
 		// Prevent any container processes from gaining privileges.
 		AllowPrivilegeEscalation: Bool(false),
 
+		// Drop any capabilities granted by the container runtime.
+		// This must be uppercase to pass Pod Security Admission.
+		// - https://releases.k8s.io/v1.24.0/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+
 		// Processes in privileged containers are essentially root on the host.
 		Privileged: Bool(false),
 

--- a/internal/initialize/security_test.go
+++ b/internal/initialize/security_test.go
@@ -16,6 +16,7 @@
 package initialize_test
 
 import (
+	"fmt"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -72,8 +73,10 @@ func TestRestrictedSecurityContext(t *testing.T) {
 				"Privileged Pods disable most security mechanisms and must be disallowed.")
 		}
 
-		assert.Assert(t, sc.Capabilities == nil,
-			"Adding additional capabilities beyond the default set must be disallowed.")
+		if assert.Check(t, sc.Capabilities != nil) {
+			assert.Assert(t, sc.Capabilities.Add == nil,
+				"Adding additional capabilities … must be disallowed.")
+		}
 
 		assert.Assert(t, sc.SELinuxOptions == nil,
 			"Setting custom SELinux options should be disallowed.")
@@ -90,6 +93,11 @@ func TestRestrictedSecurityContext(t *testing.T) {
 		if assert.Check(t, sc.AllowPrivilegeEscalation != nil) {
 			assert.Assert(t, *sc.AllowPrivilegeEscalation == false,
 				"Privilege escalation (such as via set-user-ID or set-group-ID file mode) should not be allowed.")
+		}
+
+		if assert.Check(t, sc.Capabilities != nil) {
+			assert.Assert(t, fmt.Sprint(sc.Capabilities.Drop) == `[ALL]`,
+				"Containers must drop ALL capabilities, and are only permitted to add back the NET_BIND_SERVICE capability.")
 		}
 
 		if assert.Check(t, sc.RunAsNonRoot != nil) {

--- a/internal/pgadmin/reconcile_test.go
+++ b/internal/pgadmin/reconcile_test.go
@@ -238,6 +238,9 @@ containers:
   resources: {}
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -275,6 +278,9 @@ initContainers:
   resources: {}
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -470,6 +476,9 @@ containers:
       cpu: 100m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -511,6 +520,9 @@ initContainers:
       cpu: 100m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -567,6 +567,9 @@ func TestAddServerToInstancePod(t *testing.T) {
       cpu: 5m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -613,6 +616,9 @@ func TestAddServerToInstancePod(t *testing.T) {
       cpu: 17m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -697,6 +703,9 @@ func TestAddServerToRepoPod(t *testing.T) {
       cpu: 5m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -739,6 +748,9 @@ func TestAddServerToRepoPod(t *testing.T) {
       cpu: 19m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true

--- a/internal/pgbouncer/reconcile_test.go
+++ b/internal/pgbouncer/reconcile_test.go
@@ -138,6 +138,9 @@ containers:
   resources: {}
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -166,6 +169,9 @@ containers:
   resources: {}
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -242,6 +248,9 @@ containers:
       cpu: 100m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -275,6 +284,9 @@ containers:
       memory: 16Mi
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -342,6 +354,9 @@ containers:
       cpu: 100m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -374,6 +389,9 @@ containers:
       cpu: 200m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true

--- a/internal/postgres/reconcile_test.go
+++ b/internal/postgres/reconcile_test.go
@@ -140,6 +140,9 @@ containers:
       cpu: 9m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -178,6 +181,9 @@ containers:
       cpu: 21m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -244,6 +250,9 @@ initContainers:
       cpu: 9m
   securityContext:
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true

--- a/testing/kuttl/e2e/security-context/00-assert.yaml
+++ b/testing/kuttl/e2e/security-context/00-assert.yaml
@@ -32,6 +32,7 @@ spec:
   - name: pgbackrest
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -51,30 +52,35 @@ spec:
   - name: database
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: replication-cert-copy
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: pgbackrest
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: pgbackrest-config
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: exporter
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -82,12 +88,14 @@ spec:
   - name: postgres-startup
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: nss-wrapper-init
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -107,6 +115,7 @@ spec:
   - name: pgadmin
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -114,12 +123,14 @@ spec:
   - name: pgadmin-startup
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: nss-wrapper-init
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -136,12 +147,14 @@ spec:
   - name: pgbouncer
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: pgbouncer-config
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -162,12 +175,14 @@ spec:
   - name: pgbackrest
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: pgbackrest-config
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -175,12 +190,14 @@ spec:
   - name: pgbackrest-log-dir
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: nss-wrapper-init
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true


### PR DESCRIPTION
The restricted profile of [Kubernetes' Pod Security Standards](https://docs.k8s.io/concepts/security/pod-security-standards/) requires dropping all POSIX capabilities.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature

**What is the current behavior (link to any open issues here)?**

Containers run with the default capabilities granted by the container runtime. Pods deployed by PGO conform to the baseline policy.

**What is the new behavior (if this is a feature change)?**

Containers run with the minimum capabilities required by the container runtime. One step closer to conforming to the restricted policy.

**Other Information**:

Issue: [sc-10828]