### PR TITLE
Skip TestDeleteInstance when connected to an existing cluster

### DIFF
--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -21,7 +21,9 @@ package postgrescluster
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -1095,6 +1097,10 @@ func TestPodsToKeep(t *testing.T) {
 }
 
 func TestDeleteInstance(t *testing.T) {
+	if strings.EqualFold(os.Getenv("USE_EXISTING_CLUSTER"), "true") {
+		t.Skip("FLAKE: other controllers (PVC, STS) update objects causing conflicts when we deleteControlled")
+	}
+
 	ctx := context.Background()
 	_, cc := setupKubernetes(t)
 	require.ParallelCapacity(t, 1)


### PR DESCRIPTION
Other controllers touch PersistentVolumeClaims and StatefulSets after we create them, causing conflicts when we delete them with preconditions. Outside of tests, the entire reconciliation is retried, so skip this test for now.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

**What is the current behavior (link to any open issues here)?**

Flakes in PR checks:
- https://github.com/CrunchyData/postgres-operator/runs/6782278299#step:7:121
  ```
  --- FAIL: TestDeleteInstance (2.10s)
      instance_test.go:1141: assertion failed: error is not nil: Operation cannot be fulfilled on StatefulSet.apps "hippo-instance1-lcht": the ResourceVersion in the precondition (1897) does not match the ResourceVersion in record (1943). The object might have been modified
    ```
- https://github.com/CrunchyData/postgres-operator/runs/6782863278#step:7:121
  ```
  --- FAIL: TestDeleteInstance (1.72s)
      instance_test.go:1141: assertion failed: error is not nil: Operation cannot be fulfilled on PersistentVolumeClaim "hippo-instance1-vgsh-pgdata": the ResourceVersion in the precondition (1911) does not match the ResourceVersion in record (1912). The object might have been modified
  ```
