### PR TITLE
Postgres instance sidecars

### DIFF
--- a/build/crd/condition.yaml
+++ b/build/crd/condition.yaml
@@ -6,3 +6,11 @@
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/conditions/items/properties/type/description
   value: type of condition in CamelCase.
+- op: add
+  path: "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/instances/items/properties/containers/items\
+    /properties/securityContext/properties/seccompProfile/properties/type/description"
+  value: >-
+    type indicates which kind of seccomp profile will be applied. Valid options are:
+    Localhost - a profile defined in a file on the node should be used.
+    RuntimeDefault - the container runtime default profile should be used.
+    Unconfined - no profile should be applied.

--- a/build/crd/todos.yaml
+++ b/build/crd/todos.yaml
@@ -36,6 +36,18 @@
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/imagePullSecrets/items/properties/name/description
 - op: copy
   from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/instances/items/properties/containers/items/properties/env/items/properties/valueFrom/properties/configMapKeyRef/properties/name/description
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/instances/items/properties/containers/items/properties/env/items/properties/valueFrom/properties/secretKeyRef/properties/name/description
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/instances/items/properties/containers/items/properties/envFrom/items/properties/configMapRef/properties/name/description
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/instances/items/properties/containers/items/properties/envFrom/items/properties/secretRef/properties/name/description
+- op: copy
+  from: /work
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/monitoring/properties/pgmonitor/properties/exporter/properties/configuration/items/properties/configMap/properties/name/description
 - op: copy
   from: /work
@@ -58,5 +70,25 @@
 - op: copy
   from: /work
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/userInterface/properties/pgAdmin/properties/config/properties/ldapBindPassword/properties/name/description
+- op: remove
+  path: /work
+- op: add
+  path: /work
+  value: TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/instances/items/properties/containers/items/properties/lifecycle/properties/postStart/properties/tcpSocket/description
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/instances/items/properties/containers/items/properties/lifecycle/properties/preStop/properties/tcpSocket/description
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/instances/items/properties/containers/items/properties/livenessProbe/properties/tcpSocket/description
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/instances/items/properties/containers/items/properties/readinessProbe/properties/tcpSocket/description
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/instances/items/properties/containers/items/properties/startupProbe/properties/tcpSocket/description
 - op: remove
   path: /work

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -5472,6 +5472,1122 @@ spec:
                               type: array
                           type: object
                       type: object
+                    containers:
+                      description: Defines custom sidecars for the PostgreSQL instance
+                        pods
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The docker
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. The $(VAR_NAME)
+                              syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                              Escaped references will never be expanded, regardless
+                              of whether the variable exists or not. Cannot be updated.
+                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The docker image''s ENTRYPOINT is used if this
+                              is not provided. Variable references $(VAR_NAME) are
+                              expanded using the container''s environment. If a variable
+                              cannot be resolved, the reference in the input string
+                              will be unchanged. The $(VAR_NAME) syntax can be escaped
+                              with a double $$, ie: $$(VAR_NAME). Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previous defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    The $(VAR_NAME) syntax can be escaped with a double
+                                    $$, ie: $$(VAR_NAME). Escaped references will
+                                    never be expanded, regardless of whether the variable
+                                    exists or not. Defaults to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: 'Image pull policy. One of Always, Never,
+                              IfNotPresent. Defaults to Always if :latest tag is specified,
+                              or IfNotPresent otherwise. Cannot be updated. More info:
+                              https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: One and only one of the following
+                                      should be specified. Exec specifies the action
+                                      to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: Scheme to use for connecting
+                                          to the host. Defaults to HTTP.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving
+                                      a TCP port. TCP hooks not yet supported
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The reason for termination is passed to the
+                                  handler. The Pod''s termination grace period countdown
+                                  begins before the PreStop hooked is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period. Other management of the container
+                                  blocks until the hook completes or until the termination
+                                  grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: One and only one of the following
+                                      should be specified. Exec specifies the action
+                                      to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: Scheme to use for connecting
+                                          to the host. Defaults to HTTP.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving
+                                      a TCP port. TCP hooks not yet supported
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Exposing a port here gives the system additional information
+                              about the network connections a container uses, but
+                              is primarily informational. Not specifying a port here
+                              DOES NOT prevent that port from being exposed. Any port
+                              which is listening on the default "0.0.0.0" address
+                              inside a container will be accessible from the network.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: Protocol for port. Must be UDP, TCP,
+                                    or SCTP. Defaults to "TCP".
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'Security options the pod should run with.
+                              More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: 'type indicates which kind of seccomp
+                                      profile will be applied. Valid options are:
+                                      Localhost - a profile defined in a file on the
+                                      node should be used. RuntimeDefault - the container
+                                      runtime default profile should be used. Unconfined
+                                      - no profile should be applied.'
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: Indicate how the termination message should
+                              be populated. File will use the contents of terminationMessagePath
+                              to populate the container status message on both success
+                              and failure. FallbackToLogsOnError will use the last
+                              chunk of container log output if the termination message
+                              file is empty and the container exited with an error.
+                              The log output is limited to 2048 bytes or 80 lines,
+                              whichever is smaller. Defaults to File. Cannot be updated.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
                     dataVolumeClaimSpec:
                       description: 'Defines a PersistentVolumeClaim for PostgreSQL
                         data. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes'

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -3716,6 +3716,11 @@ Resource requirements for a sidecar container
         <td>Scheduling constraints of a PostgreSQL pod. Changing this value causes PostgreSQL to restart. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node</td>
         <td>false</td>
       </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindex">containers</a></b></td>
+        <td>[]object</td>
+        <td>Defines custom sidecars for the PostgreSQL instance pods</td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#postgresclusterspecinstancesindexmetadata">metadata</a></b></td>
         <td>object</td>
         <td>Metadata contains metadata for PostgresCluster resources</td>
@@ -4851,6 +4856,1826 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>values</b></td>
         <td>[]string</td>
         <td>values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindex">
+  PostgresCluster.spec.instances[index].containers[index]
+  <sup><sup><a href="#postgresclusterspecinstancesindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+A single application container that you want to run within a pod.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>args</b></td>
+        <td>[]string</td>
+        <td>Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>command</b></td>
+        <td>[]string</td>
+        <td>Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexenvindex">env</a></b></td>
+        <td>[]object</td>
+        <td>List of environment variables to set in the container. Cannot be updated.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexenvfromindex">envFrom</a></b></td>
+        <td>[]object</td>
+        <td>List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>image</b></td>
+        <td>string</td>
+        <td>Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>imagePullPolicy</b></td>
+        <td>string</td>
+        <td>Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlifecycle">lifecycle</a></b></td>
+        <td>object</td>
+        <td>Actions that the management system should take in response to container lifecycle events. Cannot be updated.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlivenessprobe">livenessProbe</a></b></td>
+        <td>object</td>
+        <td>Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexportsindex">ports</a></b></td>
+        <td>[]object</td>
+        <td>List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexreadinessprobe">readinessProbe</a></b></td>
+        <td>object</td>
+        <td>Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexresources">resources</a></b></td>
+        <td>object</td>
+        <td>Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexsecuritycontext">securityContext</a></b></td>
+        <td>object</td>
+        <td>Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexstartupprobe">startupProbe</a></b></td>
+        <td>object</td>
+        <td>StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>stdin</b></td>
+        <td>boolean</td>
+        <td>Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>stdinOnce</b></td>
+        <td>boolean</td>
+        <td>Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>terminationMessagePath</b></td>
+        <td>string</td>
+        <td>Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>terminationMessagePolicy</b></td>
+        <td>string</td>
+        <td>Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>tty</b></td>
+        <td>boolean</td>
+        <td>Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexvolumedevicesindex">volumeDevices</a></b></td>
+        <td>[]object</td>
+        <td>volumeDevices is the list of block devices to be used by the container.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexvolumemountsindex">volumeMounts</a></b></td>
+        <td>[]object</td>
+        <td>Pod volumes to mount into the container's filesystem. Cannot be updated.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>workingDir</b></td>
+        <td>string</td>
+        <td>Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexenvindex">
+  PostgresCluster.spec.instances[index].containers[index].env[index]
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+EnvVar represents an environment variable present in a Container.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>Name of the environment variable. Must be a C_IDENTIFIER.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>value</b></td>
+        <td>string</td>
+        <td>Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexenvindexvaluefrom">valueFrom</a></b></td>
+        <td>object</td>
+        <td>Source for the environment variable's value. Cannot be used if value is not empty.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexenvindexvaluefrom">
+  PostgresCluster.spec.instances[index].containers[index].env[index].valueFrom
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexenvindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+Source for the environment variable's value. Cannot be used if value is not empty.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexenvindexvaluefromconfigmapkeyref">configMapKeyRef</a></b></td>
+        <td>object</td>
+        <td>Selects a key of a ConfigMap.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexenvindexvaluefromfieldref">fieldRef</a></b></td>
+        <td>object</td>
+        <td>Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexenvindexvaluefromresourcefieldref">resourceFieldRef</a></b></td>
+        <td>object</td>
+        <td>Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexenvindexvaluefromsecretkeyref">secretKeyRef</a></b></td>
+        <td>object</td>
+        <td>Selects a key of a secret in the pod's namespace</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexenvindexvaluefromconfigmapkeyref">
+  PostgresCluster.spec.instances[index].containers[index].env[index].valueFrom.configMapKeyRef
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexenvindexvaluefrom">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+Selects a key of a ConfigMap.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>The key to select.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>optional</b></td>
+        <td>boolean</td>
+        <td>Specify whether the ConfigMap or its key must be defined</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexenvindexvaluefromfieldref">
+  PostgresCluster.spec.instances[index].containers[index].env[index].valueFrom.fieldRef
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexenvindexvaluefrom">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>fieldPath</b></td>
+        <td>string</td>
+        <td>Path of the field to select in the specified API version.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>apiVersion</b></td>
+        <td>string</td>
+        <td>Version of the schema the FieldPath is written in terms of, defaults to "v1".</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexenvindexvaluefromresourcefieldref">
+  PostgresCluster.spec.instances[index].containers[index].env[index].valueFrom.resourceFieldRef
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexenvindexvaluefrom">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>resource</b></td>
+        <td>string</td>
+        <td>Required: resource to select</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>containerName</b></td>
+        <td>string</td>
+        <td>Container name: required for volumes, optional for env vars</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>divisor</b></td>
+        <td>int or string</td>
+        <td>Specifies the output format of the exposed resources, defaults to "1"</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexenvindexvaluefromsecretkeyref">
+  PostgresCluster.spec.instances[index].containers[index].env[index].valueFrom.secretKeyRef
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexenvindexvaluefrom">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+Selects a key of a secret in the pod's namespace
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>The key of the secret to select from.  Must be a valid secret key.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>optional</b></td>
+        <td>boolean</td>
+        <td>Specify whether the Secret or its key must be defined</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexenvfromindex">
+  PostgresCluster.spec.instances[index].containers[index].envFrom[index]
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+EnvFromSource represents the source of a set of ConfigMaps
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexenvfromindexconfigmapref">configMapRef</a></b></td>
+        <td>object</td>
+        <td>The ConfigMap to select from</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>prefix</b></td>
+        <td>string</td>
+        <td>An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexenvfromindexsecretref">secretRef</a></b></td>
+        <td>object</td>
+        <td>The Secret to select from</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexenvfromindexconfigmapref">
+  PostgresCluster.spec.instances[index].containers[index].envFrom[index].configMapRef
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexenvfromindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+The ConfigMap to select from
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>optional</b></td>
+        <td>boolean</td>
+        <td>Specify whether the ConfigMap must be defined</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexenvfromindexsecretref">
+  PostgresCluster.spec.instances[index].containers[index].envFrom[index].secretRef
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexenvfromindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+The Secret to select from
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>optional</b></td>
+        <td>boolean</td>
+        <td>Specify whether the Secret must be defined</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlifecycle">
+  PostgresCluster.spec.instances[index].containers[index].lifecycle
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlifecyclepoststart">postStart</a></b></td>
+        <td>object</td>
+        <td>PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlifecycleprestop">preStop</a></b></td>
+        <td>object</td>
+        <td>PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlifecyclepoststart">
+  PostgresCluster.spec.instances[index].containers[index].lifecycle.postStart
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlifecycle">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlifecyclepoststartexec">exec</a></b></td>
+        <td>object</td>
+        <td>One and only one of the following should be specified. Exec specifies the action to take.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlifecyclepoststarthttpget">httpGet</a></b></td>
+        <td>object</td>
+        <td>HTTPGet specifies the http request to perform.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlifecyclepoststarttcpsocket">tcpSocket</a></b></td>
+        <td>object</td>
+        <td>TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlifecyclepoststartexec">
+  PostgresCluster.spec.instances[index].containers[index].lifecycle.postStart.exec
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlifecyclepoststart">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+One and only one of the following should be specified. Exec specifies the action to take.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>command</b></td>
+        <td>[]string</td>
+        <td>Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlifecyclepoststarthttpget">
+  PostgresCluster.spec.instances[index].containers[index].lifecycle.postStart.httpGet
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlifecyclepoststart">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+HTTPGet specifies the http request to perform.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>port</b></td>
+        <td>int or string</td>
+        <td>Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>host</b></td>
+        <td>string</td>
+        <td>Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlifecyclepoststarthttpgethttpheadersindex">httpHeaders</a></b></td>
+        <td>[]object</td>
+        <td>Custom headers to set in the request. HTTP allows repeated headers.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>path</b></td>
+        <td>string</td>
+        <td>Path to access on the HTTP server.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>scheme</b></td>
+        <td>string</td>
+        <td>Scheme to use for connecting to the host. Defaults to HTTP.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlifecyclepoststarthttpgethttpheadersindex">
+  PostgresCluster.spec.instances[index].containers[index].lifecycle.postStart.httpGet.httpHeaders[index]
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlifecyclepoststarthttpget">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+HTTPHeader describes a custom header to be used in HTTP probes
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>The header field name</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>value</b></td>
+        <td>string</td>
+        <td>The header field value</td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlifecyclepoststarttcpsocket">
+  PostgresCluster.spec.instances[index].containers[index].lifecycle.postStart.tcpSocket
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlifecyclepoststart">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>port</b></td>
+        <td>int or string</td>
+        <td>Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>host</b></td>
+        <td>string</td>
+        <td>Optional: Host name to connect to, defaults to the pod IP.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlifecycleprestop">
+  PostgresCluster.spec.instances[index].containers[index].lifecycle.preStop
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlifecycle">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlifecycleprestopexec">exec</a></b></td>
+        <td>object</td>
+        <td>One and only one of the following should be specified. Exec specifies the action to take.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlifecycleprestophttpget">httpGet</a></b></td>
+        <td>object</td>
+        <td>HTTPGet specifies the http request to perform.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlifecycleprestoptcpsocket">tcpSocket</a></b></td>
+        <td>object</td>
+        <td>TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlifecycleprestopexec">
+  PostgresCluster.spec.instances[index].containers[index].lifecycle.preStop.exec
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlifecycleprestop">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+One and only one of the following should be specified. Exec specifies the action to take.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>command</b></td>
+        <td>[]string</td>
+        <td>Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlifecycleprestophttpget">
+  PostgresCluster.spec.instances[index].containers[index].lifecycle.preStop.httpGet
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlifecycleprestop">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+HTTPGet specifies the http request to perform.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>port</b></td>
+        <td>int or string</td>
+        <td>Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>host</b></td>
+        <td>string</td>
+        <td>Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlifecycleprestophttpgethttpheadersindex">httpHeaders</a></b></td>
+        <td>[]object</td>
+        <td>Custom headers to set in the request. HTTP allows repeated headers.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>path</b></td>
+        <td>string</td>
+        <td>Path to access on the HTTP server.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>scheme</b></td>
+        <td>string</td>
+        <td>Scheme to use for connecting to the host. Defaults to HTTP.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlifecycleprestophttpgethttpheadersindex">
+  PostgresCluster.spec.instances[index].containers[index].lifecycle.preStop.httpGet.httpHeaders[index]
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlifecycleprestophttpget">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+HTTPHeader describes a custom header to be used in HTTP probes
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>The header field name</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>value</b></td>
+        <td>string</td>
+        <td>The header field value</td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlifecycleprestoptcpsocket">
+  PostgresCluster.spec.instances[index].containers[index].lifecycle.preStop.tcpSocket
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlifecycleprestop">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>port</b></td>
+        <td>int or string</td>
+        <td>Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>host</b></td>
+        <td>string</td>
+        <td>Optional: Host name to connect to, defaults to the pod IP.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlivenessprobe">
+  PostgresCluster.spec.instances[index].containers[index].livenessProbe
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlivenessprobeexec">exec</a></b></td>
+        <td>object</td>
+        <td>One and only one of the following should be specified. Exec specifies the action to take.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>failureThreshold</b></td>
+        <td>integer</td>
+        <td>Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlivenessprobehttpget">httpGet</a></b></td>
+        <td>object</td>
+        <td>HTTPGet specifies the http request to perform.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>initialDelaySeconds</b></td>
+        <td>integer</td>
+        <td>Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>periodSeconds</b></td>
+        <td>integer</td>
+        <td>How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>successThreshold</b></td>
+        <td>integer</td>
+        <td>Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlivenessprobetcpsocket">tcpSocket</a></b></td>
+        <td>object</td>
+        <td>TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>timeoutSeconds</b></td>
+        <td>integer</td>
+        <td>Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlivenessprobeexec">
+  PostgresCluster.spec.instances[index].containers[index].livenessProbe.exec
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlivenessprobe">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+One and only one of the following should be specified. Exec specifies the action to take.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>command</b></td>
+        <td>[]string</td>
+        <td>Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlivenessprobehttpget">
+  PostgresCluster.spec.instances[index].containers[index].livenessProbe.httpGet
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlivenessprobe">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+HTTPGet specifies the http request to perform.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>port</b></td>
+        <td>int or string</td>
+        <td>Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>host</b></td>
+        <td>string</td>
+        <td>Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexlivenessprobehttpgethttpheadersindex">httpHeaders</a></b></td>
+        <td>[]object</td>
+        <td>Custom headers to set in the request. HTTP allows repeated headers.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>path</b></td>
+        <td>string</td>
+        <td>Path to access on the HTTP server.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>scheme</b></td>
+        <td>string</td>
+        <td>Scheme to use for connecting to the host. Defaults to HTTP.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlivenessprobehttpgethttpheadersindex">
+  PostgresCluster.spec.instances[index].containers[index].livenessProbe.httpGet.httpHeaders[index]
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlivenessprobehttpget">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+HTTPHeader describes a custom header to be used in HTTP probes
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>The header field name</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>value</b></td>
+        <td>string</td>
+        <td>The header field value</td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexlivenessprobetcpsocket">
+  PostgresCluster.spec.instances[index].containers[index].livenessProbe.tcpSocket
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexlivenessprobe">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>port</b></td>
+        <td>int or string</td>
+        <td>Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>host</b></td>
+        <td>string</td>
+        <td>Optional: Host name to connect to, defaults to the pod IP.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexportsindex">
+  PostgresCluster.spec.instances[index].containers[index].ports[index]
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+ContainerPort represents a network port in a single container.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>containerPort</b></td>
+        <td>integer</td>
+        <td>Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>hostIP</b></td>
+        <td>string</td>
+        <td>What host IP to bind the external port to.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>hostPort</b></td>
+        <td>integer</td>
+        <td>Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>protocol</b></td>
+        <td>string</td>
+        <td>Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexreadinessprobe">
+  PostgresCluster.spec.instances[index].containers[index].readinessProbe
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexreadinessprobeexec">exec</a></b></td>
+        <td>object</td>
+        <td>One and only one of the following should be specified. Exec specifies the action to take.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>failureThreshold</b></td>
+        <td>integer</td>
+        <td>Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexreadinessprobehttpget">httpGet</a></b></td>
+        <td>object</td>
+        <td>HTTPGet specifies the http request to perform.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>initialDelaySeconds</b></td>
+        <td>integer</td>
+        <td>Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>periodSeconds</b></td>
+        <td>integer</td>
+        <td>How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>successThreshold</b></td>
+        <td>integer</td>
+        <td>Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexreadinessprobetcpsocket">tcpSocket</a></b></td>
+        <td>object</td>
+        <td>TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>timeoutSeconds</b></td>
+        <td>integer</td>
+        <td>Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexreadinessprobeexec">
+  PostgresCluster.spec.instances[index].containers[index].readinessProbe.exec
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexreadinessprobe">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+One and only one of the following should be specified. Exec specifies the action to take.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>command</b></td>
+        <td>[]string</td>
+        <td>Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexreadinessprobehttpget">
+  PostgresCluster.spec.instances[index].containers[index].readinessProbe.httpGet
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexreadinessprobe">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+HTTPGet specifies the http request to perform.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>port</b></td>
+        <td>int or string</td>
+        <td>Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>host</b></td>
+        <td>string</td>
+        <td>Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexreadinessprobehttpgethttpheadersindex">httpHeaders</a></b></td>
+        <td>[]object</td>
+        <td>Custom headers to set in the request. HTTP allows repeated headers.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>path</b></td>
+        <td>string</td>
+        <td>Path to access on the HTTP server.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>scheme</b></td>
+        <td>string</td>
+        <td>Scheme to use for connecting to the host. Defaults to HTTP.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexreadinessprobehttpgethttpheadersindex">
+  PostgresCluster.spec.instances[index].containers[index].readinessProbe.httpGet.httpHeaders[index]
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexreadinessprobehttpget">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+HTTPHeader describes a custom header to be used in HTTP probes
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>The header field name</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>value</b></td>
+        <td>string</td>
+        <td>The header field value</td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexreadinessprobetcpsocket">
+  PostgresCluster.spec.instances[index].containers[index].readinessProbe.tcpSocket
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexreadinessprobe">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>port</b></td>
+        <td>int or string</td>
+        <td>Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>host</b></td>
+        <td>string</td>
+        <td>Optional: Host name to connect to, defaults to the pod IP.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexresources">
+  PostgresCluster.spec.instances[index].containers[index].resources
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>limits</b></td>
+        <td>map[string]int or string</td>
+        <td>Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>requests</b></td>
+        <td>map[string]int or string</td>
+        <td>Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexsecuritycontext">
+  PostgresCluster.spec.instances[index].containers[index].securityContext
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>allowPrivilegeEscalation</b></td>
+        <td>boolean</td>
+        <td>AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexsecuritycontextcapabilities">capabilities</a></b></td>
+        <td>object</td>
+        <td>The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>privileged</b></td>
+        <td>boolean</td>
+        <td>Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>procMount</b></td>
+        <td>string</td>
+        <td>procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>readOnlyRootFilesystem</b></td>
+        <td>boolean</td>
+        <td>Whether this container has a read-only root filesystem. Default is false.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>runAsGroup</b></td>
+        <td>integer</td>
+        <td>The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>runAsNonRoot</b></td>
+        <td>boolean</td>
+        <td>Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>runAsUser</b></td>
+        <td>integer</td>
+        <td>The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexsecuritycontextselinuxoptions">seLinuxOptions</a></b></td>
+        <td>object</td>
+        <td>The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexsecuritycontextseccompprofile">seccompProfile</a></b></td>
+        <td>object</td>
+        <td>The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexsecuritycontextwindowsoptions">windowsOptions</a></b></td>
+        <td>object</td>
+        <td>The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexsecuritycontextcapabilities">
+  PostgresCluster.spec.instances[index].containers[index].securityContext.capabilities
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexsecuritycontext">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>add</b></td>
+        <td>[]string</td>
+        <td>Added capabilities</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>drop</b></td>
+        <td>[]string</td>
+        <td>Removed capabilities</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexsecuritycontextselinuxoptions">
+  PostgresCluster.spec.instances[index].containers[index].securityContext.seLinuxOptions
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexsecuritycontext">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>level</b></td>
+        <td>string</td>
+        <td>Level is SELinux level label that applies to the container.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>role</b></td>
+        <td>string</td>
+        <td>Role is a SELinux role label that applies to the container.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>string</td>
+        <td>Type is a SELinux type label that applies to the container.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>user</b></td>
+        <td>string</td>
+        <td>User is a SELinux user label that applies to the container.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexsecuritycontextseccompprofile">
+  PostgresCluster.spec.instances[index].containers[index].securityContext.seccompProfile
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexsecuritycontext">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>type</b></td>
+        <td>string</td>
+        <td>type indicates which kind of seccomp profile will be applied. Valid options are: Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>localhostProfile</b></td>
+        <td>string</td>
+        <td>localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexsecuritycontextwindowsoptions">
+  PostgresCluster.spec.instances[index].containers[index].securityContext.windowsOptions
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexsecuritycontext">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>gmsaCredentialSpec</b></td>
+        <td>string</td>
+        <td>GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>gmsaCredentialSpecName</b></td>
+        <td>string</td>
+        <td>GMSACredentialSpecName is the name of the GMSA credential spec to use.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>runAsUserName</b></td>
+        <td>string</td>
+        <td>The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexstartupprobe">
+  PostgresCluster.spec.instances[index].containers[index].startupProbe
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexstartupprobeexec">exec</a></b></td>
+        <td>object</td>
+        <td>One and only one of the following should be specified. Exec specifies the action to take.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>failureThreshold</b></td>
+        <td>integer</td>
+        <td>Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexstartupprobehttpget">httpGet</a></b></td>
+        <td>object</td>
+        <td>HTTPGet specifies the http request to perform.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>initialDelaySeconds</b></td>
+        <td>integer</td>
+        <td>Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>periodSeconds</b></td>
+        <td>integer</td>
+        <td>How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>successThreshold</b></td>
+        <td>integer</td>
+        <td>Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexstartupprobetcpsocket">tcpSocket</a></b></td>
+        <td>object</td>
+        <td>TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>timeoutSeconds</b></td>
+        <td>integer</td>
+        <td>Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexstartupprobeexec">
+  PostgresCluster.spec.instances[index].containers[index].startupProbe.exec
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexstartupprobe">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+One and only one of the following should be specified. Exec specifies the action to take.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>command</b></td>
+        <td>[]string</td>
+        <td>Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexstartupprobehttpget">
+  PostgresCluster.spec.instances[index].containers[index].startupProbe.httpGet
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexstartupprobe">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+HTTPGet specifies the http request to perform.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>port</b></td>
+        <td>int or string</td>
+        <td>Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>host</b></td>
+        <td>string</td>
+        <td>Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecinstancesindexcontainersindexstartupprobehttpgethttpheadersindex">httpHeaders</a></b></td>
+        <td>[]object</td>
+        <td>Custom headers to set in the request. HTTP allows repeated headers.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>path</b></td>
+        <td>string</td>
+        <td>Path to access on the HTTP server.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>scheme</b></td>
+        <td>string</td>
+        <td>Scheme to use for connecting to the host. Defaults to HTTP.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexstartupprobehttpgethttpheadersindex">
+  PostgresCluster.spec.instances[index].containers[index].startupProbe.httpGet.httpHeaders[index]
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexstartupprobehttpget">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+HTTPHeader describes a custom header to be used in HTTP probes
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>The header field name</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>value</b></td>
+        <td>string</td>
+        <td>The header field value</td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexstartupprobetcpsocket">
+  PostgresCluster.spec.instances[index].containers[index].startupProbe.tcpSocket
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindexstartupprobe">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>port</b></td>
+        <td>int or string</td>
+        <td>Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>host</b></td>
+        <td>string</td>
+        <td>Optional: Host name to connect to, defaults to the pod IP.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexvolumedevicesindex">
+  PostgresCluster.spec.instances[index].containers[index].volumeDevices[index]
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+volumeDevice describes a mapping of a raw block device within a container.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>devicePath</b></td>
+        <td>string</td>
+        <td>devicePath is the path inside of the container that the device will be mapped to.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>name must match the name of a persistentVolumeClaim in the pod</td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecinstancesindexcontainersindexvolumemountsindex">
+  PostgresCluster.spec.instances[index].containers[index].volumeMounts[index]
+  <sup><sup><a href="#postgresclusterspecinstancesindexcontainersindex">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+VolumeMount describes a mounting of a Volume within a container.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>mountPath</b></td>
+        <td>string</td>
+        <td>Path within the container at which the volume should be mounted.  Must not contain ':'.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>This must match the Name of a Volume.</td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>mountPropagation</b></td>
+        <td>string</td>
+        <td>mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>readOnly</b></td>
+        <td>boolean</td>
+        <td>Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>subPath</b></td>
+        <td>string</td>
+        <td>Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>subPathExpr</b></td>
+        <td>string</td>
+        <td>Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.</td>
         <td>false</td>
       </tr></tbody>
 </table>

--- a/hack/create-todo-patch.sh
+++ b/hack/create-todo-patch.sh
@@ -17,10 +17,12 @@ directory=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 crd_build_dir="$directory"/../build/crd
 
 # Generate a Kustomize patch file for removing any TODOs we inherit from the Kubernetes API.
-# Right now the only TODO in our CRD comes from the following:
+# Right now there are two TODOs in our CRD. This script focuses on removing these specific TODOs
+# anywhere they are found in the CRD.
+
+# The first TODO comes from the following:
 # https://github.com/kubernetes/api/blob/25b7aa9e86de7bba38c35cbe56701d2c1ff207e9/core/v1/types.go#L5609
-# Therefore, this script focused on removing that specific TODO anywhere it is found in the CRD.
-# Additionally, the hope is that this script can be removed once the following issue is addressed
+# Additionally, the hope is that this step can be removed once the following issue is addressed
 # in the kubebuilder controller-tools project:
 # https://github.com/kubernetes-sigs/controller-tools/issues/649
 
@@ -29,16 +31,37 @@ echo "Generating Kustomize patch file for removing Kube API TODOs"
 # Get the description of the "name" field with the TODO from any place it is used in the CRD and
 # store it in a variable. Then, create another variable with the TODO stripped out.
 name_desc_with_todo=$(
-  yq -r \
+  python3 -m yq -r \
     .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.customTLSSecret.properties.name.description \
     "${crd_build_dir}/generated/postgres-operator.crunchydata.com_postgresclusters.yaml"
 )
 name_desc_without_todo=$(sed 's/ TODO.*//g' <<< "${name_desc_with_todo}")
 
 # Generate a JSON patch file to update the "name" description for all applicable paths in the CRD.
-yq -y --arg old "${name_desc_with_todo}" --arg new "${name_desc_without_todo}" '
+python3 -m yq -y --arg old "${name_desc_with_todo}" --arg new "${name_desc_without_todo}" '
 	[{ op: "add", path: "/work", value: $new }] +
 	[paths(select(. == $old)) | { op: "copy", from: "/work", path: "/\(map(tostring) | join("/"))" }] +
 	[{ op: "remove", path: "/work" }]
 ' \
 	"${crd_build_dir}/generated/postgres-operator.crunchydata.com_postgresclusters.yaml" > "${crd_build_dir}/todos.yaml"
+
+# The second TODO comes from:
+# https://github.com/kubernetes/api/blob/v0.20.8/core/v1/types.go#L2361
+# This TODO is removed as of v0.23.0, so it will exist only while we stay on an earlier version.
+
+# Get the description of the "tcpSocket" field with the TODO so we can search for any place it is used
+# in the CRD and store it in a variable. Then, create another variable with the TODO stripped out.
+name_desc_with_todo=$(
+  python3 -m yq -r \
+    .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.instances.items.properties.containers.items.properties.livenessProbe.properties.tcpSocket.description \
+    "${crd_build_dir}/generated/postgres-operator.crunchydata.com_postgresclusters.yaml"
+)
+name_desc_without_todo=$(sed 's/ TODO.*//g' <<< "${name_desc_with_todo}")
+
+# Generate a JSON patch file to update the "tcpSocket" description for all applicable paths in the CRD.
+python3 -m yq -y --arg old "${name_desc_with_todo}" --arg new "${name_desc_without_todo}" '
+	[{ op: "add", path: "/work", value: $new }] +
+	[paths(select(. == $old)) | { op: "copy", from: "/work", path: "/\(map(tostring) | join("/"))" }] +
+	[{ op: "remove", path: "/work" }]
+' \
+	"${crd_build_dir}/generated/postgres-operator.crunchydata.com_postgresclusters.yaml" >> "${crd_build_dir}/todos.yaml"

--- a/internal/controller/postgrescluster/controller_test.go
+++ b/internal/controller/postgrescluster/controller_test.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/testing/require"
+	"github.com/crunchydata/postgres-operator/internal/util"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -113,6 +114,9 @@ var _ = Describe("PostgresCluster Reconciler", func() {
 		test.Namespace = &corev1.Namespace{}
 		test.Namespace.Name = "postgres-operator-test-" + rand.String(6)
 		Expect(suite.Client.Create(ctx, test.Namespace)).To(Succeed())
+
+		// Initialize the feature gate
+		Expect(util.AddAndSetFeatureGates("")).To(Succeed())
 
 		test.Recorder = record.NewFakeRecorder(100)
 		test.Recorder.IncludeObject = true

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/testing/require"
+	"github.com/crunchydata/postgres-operator/internal/util"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -1111,6 +1112,9 @@ func TestDeleteInstance(t *testing.T) {
 		Recorder: new(record.FakeRecorder),
 		Tracer:   otel.Tracer(t.Name()),
 	}
+
+	// Initialize the feature gate
+	assert.NilError(t, util.AddAndSetFeatureGates(""))
 
 	// Define, Create, and Reconcile a cluster to get an instance running in kube
 	cluster := testCluster()

--- a/internal/postgres/reconcile.go
+++ b/internal/postgres/reconcile.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/config"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/internal/util"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -247,6 +248,14 @@ func InstancePod(ctx context.Context,
 	}
 
 	outInstancePod.Containers = []corev1.Container{container, reloader}
+
+	// If the InstanceSidecars feature gate is enabled and instance sidecars are
+	// defined, add the defined container to the Pod.
+	if util.DefaultMutableFeatureGate.Enabled(util.InstanceSidecars) &&
+		inInstanceSpec.Containers != nil {
+		outInstancePod.Containers = append(outInstancePod.Containers, inInstanceSpec.Containers...)
+	}
+
 	outInstancePod.InitContainers = []corev1.Container{startup}
 }
 

--- a/internal/util/README.md
+++ b/internal/util/README.md
@@ -107,3 +107,14 @@ following message
 
 Also, the features must have boolean values, otherwise you will see
 `panic: unable to parse and store configured feature gates. invalid value`
+
+When dealing with tests that do not invoke `cmd/postgres-operator/main.go`, keep
+in mind that you will need to ensure that you invoke the `AddAndSetFeatureGates`
+function. Otherwise, any test that references the undefined feature gate will fail
+with a panic message similar to
+"feature "FeatureName" is not registered in FeatureGate"
+
+To correct for this, you simply need a line similar to
+```
+err := util.AddAndSetFeatureGates("")
+```

--- a/internal/util/features.go
+++ b/internal/util/features.go
@@ -22,17 +22,18 @@ import (
 )
 
 const (
-// Every feature gate should add a key here following this template:
-//
-// // Enables FeatureName...
-// FeatureName featuregate.Feature = "FeatureName"
-//
-// - https://releases.k8s.io/v1.20.0/pkg/features/kube_features.go#L27
-//
-// Feature gates should be listed in alphabetical, case-sensitive
-// (upper before any lower case character) order.
-//
-// TODO(tjmoore4): Features will start here
+	// Every feature gate should add a key here following this template:
+	//
+	// // Enables FeatureName...
+	// FeatureName featuregate.Feature = "FeatureName"
+	//
+	// - https://releases.k8s.io/v1.20.0/pkg/features/kube_features.go#L27
+	//
+	// Feature gates should be listed in alphabetical, case-sensitive
+	// (upper before any lower case character) order.
+	//
+	// Enables support of custom sidecars for PostgreSQL instance Pods
+	InstanceSidecars featuregate.Feature = "InstanceSidecars"
 )
 
 // pgoFeatures consists of all known PGO feature keys.
@@ -42,8 +43,9 @@ const (
 //   FeatureName: {Default: false, PreRelease: featuregate.Alpha},
 //
 // - https://releases.k8s.io/v1.20.0/pkg/features/kube_features.go#L729-732
-// TODO(tjmoore4): Features will be added to this map in upcoming commits
-var pgoFeatures = map[featuregate.Feature]featuregate.FeatureSpec{}
+var pgoFeatures = map[featuregate.Feature]featuregate.FeatureSpec{
+	InstanceSidecars: {Default: false, PreRelease: featuregate.Alpha},
+}
 
 // DefaultMutableFeatureGate is a mutable, shared global FeatureGate.
 // It is used to indicate whether a given feature is enabled or not.

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -428,6 +428,10 @@ type PostgresInstanceSetSpec struct {
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 
+	// Defines custom sidecars for the PostgreSQL instance pods
+	// +optional
+	Containers []corev1.Container `json:"containers,omitempty"`
+
 	// Defines a PersistentVolumeClaim for PostgreSQL data.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
 	// +kubebuilder:validation:Required

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
@@ -1306,6 +1306,13 @@ func (in *PostgresInstanceSetSpec) DeepCopyInto(out *PostgresInstanceSetSpec) {
 		*out = new(v1.Affinity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Containers != nil {
+		in, out := &in.Containers, &out.Containers
+		*out = make([]v1.Container, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.DataVolumeClaimSpec.DeepCopyInto(&out.DataVolumeClaimSpec)
 	if in.PriorityClassName != nil {
 		in, out := &in.PriorityClassName, &out.PriorityClassName


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
Allows you to configure custom sidecar Containers for 
any of your PostgreSQL instance Pods. To use this feature, currently 
in `Alpha`, you will need to enable it via the relevant PGO feature 
gate. This is done by setting the `PGO_FEATURE_GATES` environment
variable on the PGO Deployment to

'PGO_FEATURE_GATES="InstanceSidecars=true'

Also:
- Updates the script used to patch the PostgresCluster CRD
to remove any 'TODO' references from the upstream Container spec.
It also updates the generated patch file and modifies the script's
'yq' command to more clearly use Python YQ.

- Adds an entry to conditions.yaml to remove a newline character
from the seccompProfile type description so the 'trailing space'
documentation linter will pass.


**Other Information**:
Issue: [sc-12621]