### PR TITLE
Add wait for delete test

### DIFF
--- a/testing/kuttl/e2e/delete/13-delete-cluster-and-check.yaml
+++ b/testing/kuttl/e2e/delete/13-delete-cluster-and-check.yaml
@@ -26,7 +26,7 @@ commands:
 
       kubectl delete postgrescluster -n "${NAMESPACE}" delete-switchover
       
-      kubectl wait pod/"${REPLICA}" --namespace "${NAMESPACE}" --for=delete --timeout=-1s
+      kubectl wait "pod/${REPLICA}" --namespace "${NAMESPACE}" --for=delete --timeout=180s
 
       KILLING_REPLICA_TIMESTAMP=$(
         kubectl get events --namespace="${NAMESPACE}" \
@@ -34,7 +34,7 @@ commands:
           --output=jsonpath={.items..firstTimestamp}
       )
 
-      kubectl wait pod/"${PRIMARY}" --namespace "${NAMESPACE}" --for=delete --timeout=-1s
+      kubectl wait "pod/${PRIMARY}" --namespace "${NAMESPACE}" --for=delete --timeout=180s
 
       KILLING_PRIMARY_TIMESTAMP=$(
         kubectl get events --namespace="${NAMESPACE}" \

--- a/testing/kuttl/e2e/delete/13-delete-cluster-and-check.yaml
+++ b/testing/kuttl/e2e/delete/13-delete-cluster-and-check.yaml
@@ -25,16 +25,20 @@ commands:
       if [ -z "$REPLICA" ]; then exit 1; fi
 
       kubectl delete postgrescluster -n "${NAMESPACE}" delete-switchover
+      
+      kubectl wait pod/"${REPLICA}" --namespace "${NAMESPACE}" --for=delete --timeout=-1s
+
+      KILLING_REPLICA_TIMESTAMP=$(
+        kubectl get events --namespace="${NAMESPACE}" \
+          --field-selector reason="Killing",involvedObject.fieldPath="spec.containers{database}",involvedObject.name="${REPLICA}" \
+          --output=jsonpath={.items..firstTimestamp}
+      )
+
+      kubectl wait pod/"${PRIMARY}" --namespace "${NAMESPACE}" --for=delete --timeout=-1s
 
       KILLING_PRIMARY_TIMESTAMP=$(
         kubectl get events --namespace="${NAMESPACE}" \
           --field-selector reason="Killing",involvedObject.fieldPath="spec.containers{database}",involvedObject.name="${PRIMARY}" \
-          --output=jsonpath={.items..firstTimestamp}
-      )
-      
-      KILLING_REPLICA_TIMESTAMP=$(
-        kubectl get events --namespace="${NAMESPACE}" \
-          --field-selector reason="Killing",involvedObject.fieldPath="spec.containers{database}",involvedObject.name="${REPLICA}" \
           --output=jsonpath={.items..firstTimestamp}
       )
 


### PR DESCRIPTION
**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Our delete KUTTL test wasn't waiting for the pods to delete before comparing delete events.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Now we wait, also grab the replica time first since that should happen first.

**Other Information**:
