### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -19,19 +19,19 @@ jobs:
     if: ${{ github.repository == 'CrunchyData/postgres-operator' }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with: { go-version: 1.x }
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with: { languages: go }
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2
         # This action calls `make` which runs our "all" target and tries to build
         # container images. 😖 That fails, but the action ignores it and proceeds.
         # See "CODEQL_EXTRACTOR_GO_BUILD_COMMAND" in https://github.com/github/codeql-go

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Some versions of Ubuntu have an awk that does not recognize POSIX classes.
       # Log the version of awk and abort when it cannot match space U+0020.
@@ -29,14 +29,12 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with: { go-version: 1.x }
 
-      - uses: golangci/golangci-lint-action@v2
+      - uses: golangci/golangci-lint-action@v3
         with:
-          # https://github.com/golangci/golangci-lint-action/issues/365
-          skip-go-installation: true
           version: latest
           args: --timeout=5m
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -47,6 +47,7 @@ jobs:
             --max-issues-per-linter 0 \
             --max-same-issues 0 \
             --out-format json |
-          jq --color-output --sort-keys \
-            'reduce .Issues[] as $i ({}; .[$i.FromLinter] += 1)' ||
-          true
+          jq --sort-keys 'reduce .Issues[] as $i ({}; .[$i.FromLinter] += 1)' |
+          awk >> "${GITHUB_STEP_SUMMARY}" '
+            NR == 1 { print "```json" } { print } END { if (NR > 0) print "```" }
+          ' || true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,8 +12,8 @@ jobs:
   go-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.x
       - run: make check
@@ -27,8 +27,8 @@ jobs:
       matrix:
         kubernetes: [default]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with: { go-version: 1.x }
       - run: go mod download
       - run: ENVTEST_K8S_VERSION="${KUBERNETES#default}" make check-envtest
@@ -38,7 +38,7 @@ jobs:
 
       # Upload coverage to GitHub
       - run: gzip envtest.coverage
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "kubernetes-api=${{ matrix.kubernetes }}"
           path: envtest.coverage.gz
@@ -53,8 +53,8 @@ jobs:
       matrix:
         kubernetes: [latest, v1.19]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with: { go-version: 1.x }
 
       - name: Install k3d
@@ -101,7 +101,7 @@ jobs:
 
       # Upload coverage to GitHub
       - run: gzip envtest-existing.coverage
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "kubernetes-k3d=${{ matrix.kubernetes }}"
           path: envtest-existing.coverage.gz
@@ -113,10 +113,10 @@ jobs:
       - kubernetes-api
       - kubernetes-k3d
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with: { go-version: 1.x }
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with: { path: download }
 
       # Combine the coverage profiles by taking the mode line from any one file
@@ -134,7 +134,7 @@ jobs:
 
       # Upload coverage to GitHub
       - run: gzip total-coverage.html
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: coverage-report
           path: total-coverage.html.gz

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -108,6 +108,7 @@ jobs:
           retention-days: 1
 
   coverage-report:
+    if: ${{ success() || contains(needs.*.result, 'success') }}
     runs-on: ubuntu-latest
     needs:
       - kubernetes-api
@@ -120,8 +121,8 @@ jobs:
         with: { path: download }
 
       # Combine the coverage profiles by taking the mode line from any one file
-      # and the data from all files. Print a list of functions with less than
-      # 100% coverage, and upload a complete HTML report.
+      # and the data from all files. Write a list of functions with less than
+      # 100% coverage to the job summary, and upload a complete HTML report.
       - name: Generate report
         run: |
           gunzip --keep download/*/*.gz
@@ -129,8 +130,14 @@ jobs:
             tail -qn +2 download/*/*.coverage ) > total.coverage
           go tool cover --func total.coverage -o total-coverage.txt
           go tool cover --html total.coverage -o total-coverage.html
-          sed -e '/100.0%/d' -e "s,$(go list -m)/,," total-coverage.txt
-          awk 'END { print "::notice title=Total Coverage::" $3 " " $2 }' total-coverage.txt
+
+          awk < total-coverage.txt '
+            END { print "<details><summary>Total Coverage: <code>" $3 " " $2 "</code></summary>" }
+          ' >> "${GITHUB_STEP_SUMMARY}"
+
+          sed < total-coverage.txt -e '/100.0%/d' -e "s,$(go list -m)/,," | column -t | awk '
+            NR == 1 { print "\n\n```" } { print } END { if (NR > 0) print "```\n\n"; print "</details>" }
+          ' >> "${GITHUB_STEP_SUMMARY}"
 
       # Upload coverage to GitHub
       - run: gzip total-coverage.html

--- a/.golangci.next.yaml
+++ b/.golangci.next.yaml
@@ -23,7 +23,6 @@ linters:
     - tenv
     - thelper
     - tparallel
-    - unconvert
     - wastedassign
 
 issues:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,7 @@ linters:
     - gosimple
     - importas
     - misspell
+    - unconvert
   presets:
     - bugs
     - format

--- a/internal/controller/postgrescluster/patroni.go
+++ b/internal/controller/postgrescluster/patroni.go
@@ -554,14 +554,14 @@ func (r *Reconciler) reconcilePatroniSwitchover(ctx context.Context,
 	// In the default case we will be using SwitchoverAndWait. This API call uses
 	// a Patronictl switchover to move to the target instance.
 	action := func(ctx context.Context, exec patroni.Executor, next string) (bool, error) {
-		success, err := patroni.Executor(exec).SwitchoverAndWait(ctx, next)
+		success, err := exec.SwitchoverAndWait(ctx, next)
 		return success, errors.WithStack(err)
 	}
 
 	if spec.Type == v1beta1.PatroniSwitchoverTypeFailover {
 		// When a failover has been requested we use FailoverAndWait to change the primary.
 		action = func(ctx context.Context, exec patroni.Executor, next string) (bool, error) {
-			success, err := patroni.Executor(exec).FailoverAndWait(ctx, next)
+			success, err := exec.FailoverAndWait(ctx, next)
 			return success, errors.WithStack(err)
 		}
 	}

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -426,7 +426,7 @@ topologySpreadConstraints:
 				"involvedObject.kind":      "PostgresCluster",
 				"involvedObject.name":      clusterName,
 				"involvedObject.namespace": ns.Name,
-				"involvedObject.uid":       string(clusterUID),
+				"involvedObject.uid":       clusterUID,
 				"reason":                   "RepoHostCreated",
 			}); err != nil {
 				return false, err
@@ -739,7 +739,7 @@ func TestReconcileStanzaCreate(t *testing.T) {
 			"involvedObject.kind":      "PostgresCluster",
 			"involvedObject.name":      clusterName,
 			"involvedObject.namespace": ns.Name,
-			"involvedObject.uid":       string(clusterUID),
+			"involvedObject.uid":       clusterUID,
 			"reason":                   "StanzasCreated",
 		}); err != nil {
 			return false, err
@@ -783,7 +783,7 @@ func TestReconcileStanzaCreate(t *testing.T) {
 			"involvedObject.kind":      "PostgresCluster",
 			"involvedObject.name":      clusterName,
 			"involvedObject.namespace": ns.Name,
-			"involvedObject.uid":       string(clusterUID),
+			"involvedObject.uid":       clusterUID,
 			"reason":                   "UnableToCreateStanzas",
 		}); err != nil {
 			return false, err

--- a/internal/pgbackrest/pgbackrest.go
+++ b/internal/pgbackrest/pgbackrest.go
@@ -89,7 +89,7 @@ fi
 		// if the err returned from pgbackrest command is about a version mismatch
 		// then we should run upgrade rather than create
 		if strings.Contains(errReturn, errMsgBackupDbMismatch) {
-			return Executor(exec).StanzaCreateOrUpgrade(ctx, configHash, true)
+			return exec.StanzaCreateOrUpgrade(ctx, configHash, true)
 		}
 
 		// if none of the above errors, return the err


### PR DESCRIPTION
This bumps actions to their latest versions. A workaround for a fixed issue with `golangci-lint-action` with `setup-go` is removed.

Actions can now [add Markdown to the summary page](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/), so do that instead of printing to the logs.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

**What is the current behavior (link to any open issues here)?**

1. A JSON report from `golangci-lint` was [printed to the logs](https://github.com/CrunchyData/postgres-operator/runs/7080683229?check_suite_focus=true#step:5:14).
2. A text report from `go tool cover` was [printed to the logs](https://github.com/CrunchyData/postgres-operator/runs/7083924090?check_suite_focus=true#step:5:13).

**What is the new behavior (if this is a feature change)?**

1. The JSON report from `golangci-lint` appears on [the summary page](https://github.com/CrunchyData/postgres-operator/actions/runs/2573430010).
2. The text report from `go tool cover` appears on [the summary page](https://github.com/CrunchyData/postgres-operator/actions/runs/2573430009).