### PR TITLE
Updating Keycloak example documentation

### DIFF
--- a/docs/content/tutorial/connect-cluster.md
+++ b/docs/content/tutorial/connect-cluster.md
@@ -139,6 +139,7 @@ spec:
     spec:
       containers:
       - image: quay.io/keycloak/keycloak:latest
+        args: ["start-dev"]
         name: keycloak
         env:
         - name: DB_VENDOR
@@ -153,12 +154,12 @@ spec:
           valueFrom: { secretKeyRef: { name: hippo-pguser-hippo, key: user } }
         - name: DB_PASSWORD
           valueFrom: { secretKeyRef: { name: hippo-pguser-hippo, key: password } }
-        - name: KEYCLOAK_USER
+        - name: KEYCLOAK_ADMIN
           value: "admin"
-        - name: KEYCLOAK_PASSWORD
+        - name: KEYCLOAK_ADMIN_PASSWORD
           value: "admin"
-        - name: PROXY_ADDRESS_FORWARDING
-          value: "true"
+        - name: KC_PROXY
+          value: "edge"
         ports:
         - name: http
           containerPort: 8080
@@ -166,7 +167,7 @@ spec:
           containerPort: 8443
         readinessProbe:
           httpGet:
-            path: /auth/realms/master
+            path: /realms/master
             port: 8080
       restartPolicy: Always
 EOF


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
 - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
When Keycloak [migrated to Quarkus](https://www.keycloak.org/migration/migrating-to-quarkus) when it hit version 17, a number of changes were made that impacted the "[Connect an application](https://access.crunchydata.com/documentation/postgres-operator/latest/tutorial/connect-cluster/#connect-an-application)" portion of the tutorial.

- /auth was removed from the default context path (affects the readiness probe path)
- An argument needs to be passed to the container
- The [admin auth](https://www.keycloak.org/server/configuration#_setup_of_the_initial_admin_user) environment variables changed
- The [proxy environment variable](https://www.keycloak.org/server/reverseproxy) changed

There's an [open issue](https://github.com/CrunchyData/postgres-operator-examples/issues/116) in the postgres-operator-examples repository where the existing documentation has impacted a user.

```
  Warning  Unhealthy  15s                kubelet            Readiness probe failed: Get "http://10.42.2.146:8080/auth/realms/master": dial tcp 10.42.2.146:8080: connect: connection refused
  Warning  BackOff    13s (x5 over 35s)  kubelet            Back-off restarting failed container
```

**What is the new behavior (if this is a feature change)?**
The readiness probe, argument line addition, and environment variable changes allow the container to fully initialize and begin receiving traffic. The changes roughly match what [Keycloak provides](https://www.keycloak.org/getting-started/getting-started-kube#_run_keycloak) in its [example manifest](https://raw.githubusercontent.com/keycloak/keycloak-quickstarts/latest/kubernetes-examples/keycloak.yaml).

- [ ] Breaking change (fix or feature that would cause existing functionality to change)


**Other Information**:
