### PR TITLE
Align psql Job Backoff Limit & Restart Policy

### DIFF
--- a/testing/kuttl/e2e-other/gssapi/02-psql-connect.yaml
+++ b/testing/kuttl/e2e-other/gssapi/02-psql-connect.yaml
@@ -3,6 +3,7 @@ kind: Job
 metadata:
   name: psql-connect-gssapi
 spec:
+  backoffLimit: 6
   template:
     spec:
       restartPolicy: Never

--- a/testing/kuttl/e2e-other/postgis-cluster/01--psql-connect.yaml
+++ b/testing/kuttl/e2e-other/postgis-cluster/01--psql-connect.yaml
@@ -3,11 +3,12 @@ kind: Job
 metadata:
   name: psql-postgis-connect
 spec:
+  backoffLimit: 6
   template:
     metadata:
       labels: { postgres-operator-test: kuttl }
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/cluster-start/01--psql-connect.yaml
+++ b/testing/kuttl/e2e/cluster-start/01--psql-connect.yaml
@@ -3,9 +3,10 @@ kind: Job
 metadata:
   name: psql-connect
 spec:
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/password-change/01--psql-connect-uri.yaml
+++ b/testing/kuttl/e2e/password-change/01--psql-connect-uri.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-connect-uri
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/password-change/01--psql-connect.yaml
+++ b/testing/kuttl/e2e/password-change/01--psql-connect.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-connect
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/password-change/03--psql-connect-uri.yaml
+++ b/testing/kuttl/e2e/password-change/03--psql-connect-uri.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-connect-uri2
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/password-change/03--psql-connect.yaml
+++ b/testing/kuttl/e2e/password-change/03--psql-connect.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-connect2
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/password-change/05--psql-connect-uri.yaml
+++ b/testing/kuttl/e2e/password-change/05--psql-connect-uri.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-connect-uri3
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/password-change/05--psql-connect.yaml
+++ b/testing/kuttl/e2e/password-change/05--psql-connect.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-connect3
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/password-change/07--psql-connect-uri.yaml
+++ b/testing/kuttl/e2e/password-change/07--psql-connect-uri.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-connect-uri4
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/password-change/07--psql-connect.yaml
+++ b/testing/kuttl/e2e/password-change/07--psql-connect.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-connect4
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/password-change/09--psql-connect-uri.yaml
+++ b/testing/kuttl/e2e/password-change/09--psql-connect-uri.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-connect-uri5
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/password-change/09--psql-connect.yaml
+++ b/testing/kuttl/e2e/password-change/09--psql-connect.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-connect5
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/password-change/11--psql-connect-uri.yaml
+++ b/testing/kuttl/e2e/password-change/11--psql-connect-uri.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-connect-uri6
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/password-change/11--psql-connect.yaml
+++ b/testing/kuttl/e2e/password-change/11--psql-connect.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-connect6
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}

--- a/testing/kuttl/e2e/pgbouncer/01--psql-connect.yaml
+++ b/testing/kuttl/e2e/pgbouncer/01--psql-connect.yaml
@@ -4,7 +4,7 @@ metadata:
   name: psql-connect
   labels: { postgres-operator-test: kuttl }
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     metadata:
       labels: { postgres-operator-test: kuttl }

--- a/testing/kuttl/e2e/replica-read/01--psql-replica-read.yaml
+++ b/testing/kuttl/e2e/replica-read/01--psql-replica-read.yaml
@@ -3,10 +3,10 @@ kind: Job
 metadata:
   name: psql-replica-read
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   template:
     spec:
-      restartPolicy: "OnFailure"
+      restartPolicy: Never
       containers:
         - name: psql
           image: ${KUTTL_PSQL_IMAGE}


### PR DESCRIPTION
Sets the `backoffLimit` to `6`, and the `restartPolicy` to `never`, for all `psql` Jobs in the Kuttl test suite.  This has been done to to address `psql` Jobs that are sometimes reaching the current backoff limit and failing, while also better aligning all psql Jobs
within the Kuttl test suite.  Additionally, a `restartPolicy` of `never` should also help facilitate the debugging of failed `psql` Jobs.

_**Note**This change will need to be backpatched for both v5.0.x & v5.1.x._

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Most `psql` Jobs have a `backoffLimit` of `3` and a `restartPolicy` of `OnFailure`.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

All `psql` Jobs now have a `backoffLimit` of `6` and a `restartPolicy` of `Never`.

**Other Information**:

N/A