### PR TITLE
Remove the postmaster.pid file prior to pgBackRest restore

### DIFF
--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -207,7 +207,7 @@ func RestoreCommand(pgdata string, args ...string) []string {
 	const restoreScript = `declare -r pgdata="$1" opts="$2"
 install --directory --mode=0700 "${pgdata}"
 rm -f "${pgdata}/postmaster.pid"
-eval "pgbackrest restore ${opts}"
+bash -xc "pgbackrest restore ${opts}"
 rm -f "${pgdata}/patroni.dynamic.json"
 export PGDATA="${pgdata}" PGHOST='/tmp'
 

--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -197,11 +197,16 @@ func RestoreCommand(pgdata string, args ...string) []string {
 	// - https://www.postgresql.org/docs/current/hot-standby.html
 	// - https://www.postgresql.org/docs/current/app-pgcontroldata.html
 
+	// The postmaster.pid file is removed, if it exists, before attempting a restore.
+	// This allows the restore to be tried more than once without the causing an
+	// error due to the presence of the file in subsequent attempts.
+
 	// The 'pg_ctl' timeout is set to a very large value (1 year) to ensure there
 	// are no timeouts when starting or stopping Postgres.
 
 	const restoreScript = `declare -r pgdata="$1" opts="$2"
 install --directory --mode=0700 "${pgdata}"
+rm -f "${pgdata}/postmaster.pid"
 eval "pgbackrest restore ${opts}"
 rm -f "${pgdata}/patroni.dynamic.json"
 export PGDATA="${pgdata}" PGHOST='/tmp'


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
If a restore fails (e.g. if it times out when we pg_ctl start) the PGDATA directory
could be left in an unclean state. Specifically, a postmaster.pid file can remain,
resulting in a pgBackRest error when the restore is subsequently attempted.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This update removes the postmaster.pid file, if it exists, from the PGDATA
directory before attempting a restore. This allows the restore to be tried
more than once without causing an error due to the presence of the file
in subsequent attempts or in scenarios where the file is otherwise present.


**Other Information**:
Issue: [sc-15157]