### PR TITLE
Add name and version Labels to CRD during generation

### DIFF
--- a/build/crd/kustomization.yaml
+++ b/build/crd/kustomization.yaml
@@ -29,3 +29,14 @@ patchesJson6902:
     kind: CustomResourceDefinition
     name: postgresclusters.postgres-operator.crunchydata.com
   path: validation.yaml
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: postgresclusters.postgres-operator.crunchydata.com
+  patch: |-
+    - op: add
+      path: "/metadata/labels"
+      value:
+        app.kubernetes.io/name: pgo
+        app.kubernetes.io/version: 5.1.2

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -4,6 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: pgo
+    app.kubernetes.io/version: 5.1.2
   name: postgresclusters.postgres-operator.crunchydata.com
 spec:
   group: postgres-operator.crunchydata.com


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
Adds the name and version labels, i.e.

    app.kubernetes.io/name: pgo
    app.kubernetes.io/version: 5.1.2

to the PostgresCluster CRD generation process and update the
current CRD to match. This will align all of our CRDs across
install method.


**Other Information**:
