### PR TITLE
Set runAsNonRoot at the container-level only

### DIFF
--- a/internal/controller/postgrescluster/pgadmin_test.go
+++ b/internal/controller/postgrescluster/pgadmin_test.go
@@ -528,7 +528,6 @@ schedulerName: default-scheduler
 securityContext:
   fsGroup: 26
   fsGroupChangePolicy: OnRootMismatch
-  runAsNonRoot: true
 terminationGracePeriodSeconds: 30
 		`
 		if serverVersion.LessThan(version.MustParseGeneric("1.20")) {
@@ -541,7 +540,6 @@ restartPolicy: Always
 schedulerName: default-scheduler
 securityContext:
   fsGroup: 26
-  runAsNonRoot: true
 terminationGracePeriodSeconds: 30
 		`
 		}
@@ -668,7 +666,6 @@ schedulerName: default-scheduler
 securityContext:
   fsGroup: 26
   fsGroupChangePolicy: OnRootMismatch
-  runAsNonRoot: true
 terminationGracePeriodSeconds: 30
 tolerations:
 - key: sometoleration
@@ -704,7 +701,6 @@ restartPolicy: Always
 schedulerName: default-scheduler
 securityContext:
   fsGroup: 26
-  runAsNonRoot: true
 terminationGracePeriodSeconds: 30
 tolerations:
 - key: sometoleration

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -715,7 +715,7 @@ func generateBackupJobSpecIntent(postgresCluster *v1beta1.PostgresCluster,
 				// This will ensure the Job always has the latest configs mounted following a
 				// failure as needed to successfully verify config hashes and run the Job.
 				RestartPolicy:      corev1.RestartPolicyNever,
-				SecurityContext:    initialize.RestrictedPodSecurityContext(),
+				SecurityContext:    initialize.PodSecurityContext(),
 				ServiceAccountName: serviceAccountName,
 			},
 		},

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -344,7 +344,6 @@ restartPolicy: Always
 schedulerName: default-scheduler
 securityContext:
   fsGroup: 26
-  runAsNonRoot: true
 shareProcessNamespace: true
 terminationGracePeriodSeconds: 30
 tolerations:
@@ -2519,7 +2518,6 @@ enableServiceLinks: false
 restartPolicy: Never
 securityContext:
   fsGroupChangePolicy: OnRootMismatch
-  runAsNonRoot: true
 volumes:
 - name: pgbackrest-config
   projected:

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -447,7 +447,7 @@ func (r *Reconciler) generatePGBouncerDeployment(
 	// Do not add environment variables describing services in this namespace.
 	deploy.Spec.Template.Spec.EnableServiceLinks = initialize.Bool(false)
 
-	deploy.Spec.Template.Spec.SecurityContext = initialize.RestrictedPodSecurityContext()
+	deploy.Spec.Template.Spec.SecurityContext = initialize.PodSecurityContext()
 
 	// set the image pull secrets, if any exist
 	deploy.Spec.Template.Spec.ImagePullSecrets = cluster.Spec.ImagePullSecrets

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -470,7 +470,6 @@ enableServiceLinks: false
 restartPolicy: Always
 securityContext:
   fsGroupChangePolicy: OnRootMismatch
-  runAsNonRoot: true
 shareProcessNamespace: true
 topologySpreadConstraints:
 - labelSelector:

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -811,7 +811,6 @@ schedulerName: default-scheduler
 securityContext:
   fsGroup: 26
   fsGroupChangePolicy: OnRootMismatch
-  runAsNonRoot: true
 terminationGracePeriodSeconds: 30
 volumes:
 - name: postgres-data
@@ -860,7 +859,6 @@ restartPolicy: Never
 schedulerName: default-scheduler
 securityContext:
   fsGroup: 26
-  runAsNonRoot: true
 terminationGracePeriodSeconds: 30
 volumes:
 - name: postgres-data
@@ -924,7 +922,6 @@ schedulerName: default-scheduler
 securityContext:
   fsGroup: 26
   fsGroupChangePolicy: OnRootMismatch
-  runAsNonRoot: true
 terminationGracePeriodSeconds: 30
 volumes:
 - name: postgres-wal
@@ -972,7 +969,6 @@ restartPolicy: Never
 schedulerName: default-scheduler
 securityContext:
   fsGroup: 26
-  runAsNonRoot: true
 terminationGracePeriodSeconds: 30
 volumes:
 - name: postgres-wal
@@ -1038,7 +1034,6 @@ schedulerName: default-scheduler
 securityContext:
   fsGroup: 26
   fsGroupChangePolicy: OnRootMismatch
-  runAsNonRoot: true
 terminationGracePeriodSeconds: 30
 volumes:
 - name: pgbackrest-repo
@@ -1089,7 +1084,6 @@ restartPolicy: Never
 schedulerName: default-scheduler
 securityContext:
   fsGroup: 26
-  runAsNonRoot: true
 terminationGracePeriodSeconds: 30
 volumes:
 - name: pgbackrest-repo

--- a/internal/initialize/security.go
+++ b/internal/initialize/security.go
@@ -19,14 +19,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// RestrictedPodSecurityContext returns a v1.PodSecurityContext with safe defaults.
-// See https://docs.k8s.io/concepts/security/pod-security-standards/
-func RestrictedPodSecurityContext() *corev1.PodSecurityContext {
+// PodSecurityContext returns a v1.PodSecurityContext with some defaults.
+func PodSecurityContext() *corev1.PodSecurityContext {
 	onRootMismatch := corev1.FSGroupChangeOnRootMismatch
 	return &corev1.PodSecurityContext{
-		// Fail to start a container if its image runs as UID 0 (root).
-		RunAsNonRoot: Bool(true),
-
 		// If set to "OnRootMismatch", if the root of the volume already has
 		// the correct permissions, the recursive permission change can be skipped
 		FSGroupChangePolicy: &onRootMismatch,

--- a/internal/initialize/security_test.go
+++ b/internal/initialize/security_test.go
@@ -24,8 +24,12 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 )
 
-func TestRestrictedPodSecurityContext(t *testing.T) {
-	psc := initialize.RestrictedPodSecurityContext()
+func TestPodSecurityContext(t *testing.T) {
+	psc := initialize.PodSecurityContext()
+
+	if assert.Check(t, psc.FSGroupChangePolicy != nil) {
+		assert.Equal(t, string(*psc.FSGroupChangePolicy), "OnRootMismatch")
+	}
 
 	// Kubernetes describes recommended security profiles:
 	// - https://docs.k8s.io/concepts/security/pod-security-standards/
@@ -47,9 +51,9 @@ func TestRestrictedPodSecurityContext(t *testing.T) {
 	// > operators and developers of security-critical applications, as well as
 	// > lower-trust users.
 	t.Run("Restricted", func(t *testing.T) {
-		if assert.Check(t, psc.RunAsNonRoot != nil) {
-			assert.Assert(t, *psc.RunAsNonRoot == true,
-				"Containers must be required to run as non-root users.")
+		if assert.Check(t, psc.RunAsNonRoot == nil) {
+			assert.Assert(t, initialize.RestrictedSecurityContext().RunAsNonRoot != nil,
+				`RunAsNonRoot should be delegated to the container-level v1.SecurityContext`)
 		}
 
 		assert.Assert(t, psc.SeccompProfile == nil,

--- a/internal/postgres/reconcile.go
+++ b/internal/postgres/reconcile.go
@@ -262,7 +262,7 @@ func InstancePod(ctx context.Context,
 // PodSecurityContext returns a v1.PodSecurityContext for cluster that can write
 // to PersistentVolumes.
 func PodSecurityContext(cluster *v1beta1.PostgresCluster) *corev1.PodSecurityContext {
-	podSecurityContext := initialize.RestrictedPodSecurityContext()
+	podSecurityContext := initialize.PodSecurityContext()
 
 	// Use the specified supplementary groups except for root. The CRD has
 	// similar validation, but we should never emit a PodSpec with that group.

--- a/internal/postgres/reconcile_test.go
+++ b/internal/postgres/reconcile_test.go
@@ -604,25 +604,21 @@ func TestPodSecurityContext(t *testing.T) {
 	assert.Assert(t, marshalMatches(PodSecurityContext(cluster), `
 fsGroup: 26
 fsGroupChangePolicy: OnRootMismatch
-runAsNonRoot: true
 	`))
 
 	cluster.Spec.OpenShift = initialize.Bool(true)
 	assert.Assert(t, marshalMatches(PodSecurityContext(cluster), `
 fsGroupChangePolicy: OnRootMismatch
-runAsNonRoot: true
 	`))
 
 	cluster.Spec.SupplementalGroups = []int64{}
 	assert.Assert(t, marshalMatches(PodSecurityContext(cluster), `
 fsGroupChangePolicy: OnRootMismatch
-runAsNonRoot: true
 	`))
 
 	cluster.Spec.SupplementalGroups = []int64{999, 65000}
 	assert.Assert(t, marshalMatches(PodSecurityContext(cluster), `
 fsGroupChangePolicy: OnRootMismatch
-runAsNonRoot: true
 supplementalGroups:
 - 999
 - 65000
@@ -632,7 +628,6 @@ supplementalGroups:
 	assert.Assert(t, marshalMatches(PodSecurityContext(cluster), `
 fsGroup: 26
 fsGroupChangePolicy: OnRootMismatch
-runAsNonRoot: true
 supplementalGroups:
 - 999
 - 65000

--- a/testing/kuttl/e2e/security-context/10--kyverno.yaml
+++ b/testing/kuttl/e2e/security-context/10--kyverno.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      command -v kustomize || { echo Skipping... ; exit ; }
+      command -v kyverno || { echo Skipping... ; exit ; }
+
+      set -e
+      kustomize build ../../../../testing/policies/kyverno > policies.yaml
+      kyverno apply --cluster --namespace "${NAMESPACE}" policies.yaml

--- a/testing/policies/kyverno/kustomization.yaml
+++ b/testing/policies/kyverno/kustomization.yaml
@@ -1,0 +1,37 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - https://github.com/kyverno/policies/pod-security/restricted
+
+resources:
+  # CVE-2020-14386: https://cloud.google.com/anthos/clusters/docs/security-bulletins#gcp-2020-012
+  # CVE-2021-22555: https://cloud.google.com/anthos/clusters/docs/security-bulletins#gcp-2021-015
+  - https://raw.githubusercontent.com/kyverno/policies/main/best-practices/require_drop_all/require_drop_all.yaml
+  - https://raw.githubusercontent.com/kyverno/policies/main/best-practices/require_ro_rootfs/require_ro_rootfs.yaml
+
+  # CVE-2020-8554: https://cloud.google.com/anthos/clusters/docs/security-bulletins#gcp-2020-015
+  - https://raw.githubusercontent.com/kyverno/policies/main/best-practices/restrict-service-external-ips/restrict-service-external-ips.yaml
+
+patches:
+- target:
+    group: kyverno.io
+    kind: ClusterPolicy
+  patch: |-
+    # Ensure all policies "audit" rather than "enforce".
+    - { op: replace, path: /spec/validationFailureAction, value: audit }
+
+# Issue: [sc-11286]
+# OpenShift 4.10 forbids any/all seccomp profiles. Remove the policy for now.
+# - https://github.com/openshift/cluster-kube-apiserver-operator/issues/1325
+# - https://github.com/kyverno/policies/tree/main/pod-security/restricted/restrict-seccomp-strict
+- target:
+    group: kyverno.io
+    kind: ClusterPolicy
+    name: restrict-seccomp-strict
+  patch: |-
+    $patch: delete
+    apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    metadata:
+      name: restrict-seccomp-strict


### PR DESCRIPTION
We satisfy Kubernetes' Restricted Pod Security policy by setting `runAsNonRoot` for all our containers, so setting it on the pod is redundant.

A new step in `kuttl/e2e/security-context` verifies things using the [Require runAsNonRoot](https://kyverno.io/policies/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot/) Kyverno policy when the [Kyverno CLI](https://kyverno.io/docs/kyverno-cli/) is available.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

 - [x] Bug fix
 - [x] Testing enhancement


**What is the current behavior (link to any open issues here)?**

Sidecars that need to run as root cannot be injected into any of our Pods.


**What is the new behavior (if this is a feature change)?**

Sidecars can be added or injected with any privileges or security context settings.

**Other Information**:

- https://groups.google.com/a/crunchydata.com/g/postgres-operator/c/8Y3viamQ80w/m/eYbTKBb_CQAJ

Issue: [sc-15204]