### PR TITLE
Use Bash to assert on dropped caps in E2E tests

### DIFF
--- a/testing/kuttl/e2e/security-context/00-assert.yaml
+++ b/testing/kuttl/e2e/security-context/00-assert.yaml
@@ -32,7 +32,6 @@ spec:
   - name: pgbackrest
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -52,35 +51,30 @@ spec:
   - name: database
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: replication-cert-copy
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: pgbackrest
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: pgbackrest-config
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: exporter
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -88,14 +82,12 @@ spec:
   - name: postgres-startup
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: nss-wrapper-init
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -115,7 +107,6 @@ spec:
   - name: pgadmin
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -123,14 +114,12 @@ spec:
   - name: pgadmin-startup
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: nss-wrapper-init
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -147,14 +136,12 @@ spec:
   - name: pgbouncer
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: pgbouncer-config
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -175,14 +162,12 @@ spec:
   - name: pgbackrest
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: pgbackrest-config
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -190,14 +175,12 @@ spec:
   - name: pgbackrest-log-dir
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
   - name: nss-wrapper-init
     securityContext:
       allowPrivilegeEscalation: false
-      capabilities: { drop: [ALL] }
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true

--- a/testing/kuttl/e2e/security-context/01--security-context.yaml
+++ b/testing/kuttl/e2e/security-context/01--security-context.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      # Check that every container has the correct capabilities.
+
+      # Capture every container name alongside its list of dropped capabilities.
+      CONTAINERS_DROP_CAPS=$(
+        kubectl --namespace "${NAMESPACE}" get pods --output "jsonpath={\
+          range .items[*].spec.containers[*]\
+        }{ @.name }{'\t\t'}{ @.securityContext.capabilities.drop }{'\n'}{\
+          end\
+        }"
+      ) || exit
+
+      WRONG=$( ! echo "${CONTAINERS_DROP_CAPS}" | grep -Fv '"ALL"' ) || {
+        echo 'Not all containers have dropped "ALL" capabilities!'
+        echo "${WRONG}"
+        exit 1
+      }
+
+  - script: |
+      # Check that every Pod is assigned to the "restricted" SecurityContextConstraint
+      # in OpenShift.
+
+      SCC=$(
+        kubectl api-resources --cached |
+        grep -F 'security.openshift.io/v1' |
+        grep -F 'SecurityContextConstraint'
+      )
+
+      # Skip this check when the API has no notion of SecurityContextConstraint.
+      [ -z "${SCC}" ] && exit
+
+      PODS_SCC=$(
+        kubectl --namespace "${NAMESPACE}" get pods --no-headers \
+          --output "custom-columns=\
+            NAME:.metadata.name,\
+            SCC:.metadata.annotations['openshift\.io/scc']\
+          "
+      ) || exit
+
+      WRONG=$( ! echo "${PODS_SCC}" | grep -Ev '\<restricted$' ) || {
+        echo 'Found pods not assigned to the restricted security context constraint!'
+        echo "${PODS_SCC}"
+        exit 1
+      }


### PR DESCRIPTION
OpenShift appends to the list of dropped capabilities, and  KUTTL is unable to assert a subset of that list. Do the assertion ourselves in a script rather than create a copy of the test specifically for OpenShift.


**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

**What is the current behavior (link to any open issues here)?**

The `kuttl/e2e/security-context` test fails because containers drop `["ALL","KILL","MKNOD","SETGID","SETUID"]`.

**What is the new behavior (if this is a feature change)?**

The test passes in both Kubernetes and OpenShift.

**Other Information**:

Issue: [sc-15297]