### PR TITLE
Fix typos in the latest release notes

### DIFF
--- a/docs/content/releases/5.2.0.md
+++ b/docs/content/releases/5.2.0.md
@@ -22,10 +22,10 @@ for its release notes and more details.
 - Added the ability to customize and influence the scheduling of pgBackRest backup Jobs using `affinity` and `tolerations`.
 - You can now pause the reconciliation and rollout of changes to a PostgreSQL cluster using the `spec.paused` field.
 - Leaf certificates provisioned by PGO as part of a PostgreSQL cluster's TLS infrastructure are now automatically rotated prior to expiration.
-- PGO now has support for feature flags.
+- PGO now has support for feature gates.
 - You can now add custom sidecars to both PostgreSQL instance Pods and PgBouncer Pods using the `spec.instances.containers` and `spec.proxy.pgBouncer.containers` fields.
-- It is now possible to configured standby clusters to replicate from a remote primary using streaming replication.
-- Added the ability to provide a custom`nodePort` for the primary PostgreSQL, pgBouncer and pgAdmin services.
+- It is now possible to configure standby clusters to replicate from a remote primary using streaming replication.
+- Added the ability to provide a custom `nodePort` for the primary PostgreSQL, pgBouncer and pgAdmin services.
 - Added the ability to define custom labels and annotations for the primary PostgreSQL, pgBouncer and pgAdmin services.
 
 ## Changes
@@ -33,6 +33,7 @@ for its release notes and more details.
 - All containers are now run with the minimum capabilities required by the container runtime.
 - The PGO documentation now includes instructions for rotating the root TLS certificate.
 - A `fsGroupChangePolicy` of `OnRootMismatch` is now set on all Pods.
+- The `runAsNonRoot` security setting is on every container rather than every pod.
 
 ## Fixes
 


### PR DESCRIPTION
I noticed some other little things in the release notes.

- "feature gates" rather than "feature flags"
- Mention `runAsNonRoot`

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Documentation
