### PR TITLE
Fix compatibility with Kubernetes 1.25

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.24, v1.20]
+        kubernetes: [v1.24, v1.21]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.24, v1.21]
+        kubernetes: [latest, v1.21]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/internal/controller/postgrescluster/cluster_test.go
+++ b/internal/controller/postgrescluster/cluster_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,8 +60,8 @@ var gvks = []schema.GroupVersionKind{{
 	Version: appsv1.SchemeGroupVersion.Version,
 	Kind:    "DeploymentList",
 }, {
-	Group:   batchv1beta1.SchemeGroupVersion.Group,
-	Version: batchv1beta1.SchemeGroupVersion.Version,
+	Group:   batchv1.SchemeGroupVersion.Group,
+	Version: batchv1.SchemeGroupVersion.Version,
 	Kind:    "CronJobList",
 }, {
 	Group:   corev1.SchemeGroupVersion.Group,
@@ -139,7 +139,7 @@ func TestCustomLabels(t *testing.T) {
 				labels["resource"] = resource.GetLabels()
 				labels["podTemplate"] = resource.Spec.Template.GetLabels()
 			case "CronJob":
-				var resource batchv1beta1.CronJob
+				var resource batchv1.CronJob
 				err = runtime.DefaultUnstructuredConverter.
 					FromUnstructured(u.UnstructuredContent(), &resource)
 				labels["resource"] = resource.GetLabels()
@@ -392,7 +392,7 @@ func TestCustomAnnotations(t *testing.T) {
 				annotations["resource"] = resource.GetAnnotations()
 				annotations["podTemplate"] = resource.Spec.Template.GetAnnotations()
 			case "CronJob":
-				var resource batchv1beta1.CronJob
+				var resource batchv1.CronJob
 				err = runtime.DefaultUnstructuredConverter.
 					FromUnstructured(u.UnstructuredContent(), &resource)
 				annotations["resource"] = resource.GetAnnotations()

--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -26,9 +26,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -453,8 +452,8 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 		Owns(&batchv1.Job{}).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
-		Owns(&batchv1beta1.CronJob{}).
-		Owns(&policyv1beta1.PodDisruptionBudget{}).
+		Owns(&batchv1.CronJob{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Watches(&source.Kind{Type: &corev1.Pod{}}, r.watchPods()).
 		Watches(&source.Kind{Type: &appsv1.StatefulSet{}},
 			r.controllerRefHandlerFuncs()). // watch all StatefulSets

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -581,7 +581,7 @@ func (r *Reconciler) cleanupPodDisruptionBudgets(
 ) error {
 	selector, err := naming.AsSelector(naming.ClusterInstanceSets(cluster.Name))
 
-	pdbList := &policyv1beta1.PodDisruptionBudgetList{}
+	pdbList := &policyv1.PodDisruptionBudgetList{}
 	if err == nil {
 		err = r.Client.List(ctx, pdbList,
 			client.InNamespace(cluster.Namespace), client.MatchingLabelsSelector{

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -33,7 +33,7 @@ import (
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1733,7 +1733,7 @@ func TestReconcileInstanceSetPodDisruptionBudget(t *testing.T) {
 		cluster *v1beta1.PostgresCluster,
 		spec *v1beta1.PostgresInstanceSetSpec,
 	) bool {
-		got := &policyv1beta1.PodDisruptionBudget{}
+		got := &policyv1.PodDisruptionBudget{}
 		err := r.Client.Get(ctx,
 			naming.AsObjectKey(naming.InstanceSet(cluster, spec)),
 			got)
@@ -1854,7 +1854,7 @@ func TestCleanupDisruptionBudgets(t *testing.T) {
 		cluster *v1beta1.PostgresCluster,
 		spec *v1beta1.PostgresInstanceSetSpec,
 		minAvailable *intstr.IntOrString,
-	) *policyv1beta1.PodDisruptionBudget {
+	) *policyv1.PodDisruptionBudget {
 		meta := naming.InstanceSet(cluster, spec)
 		meta.Labels = map[string]string{
 			naming.LabelCluster:     cluster.Name,
@@ -1871,17 +1871,17 @@ func TestCleanupDisruptionBudgets(t *testing.T) {
 	}
 
 	createPDB := func(
-		pdb *policyv1beta1.PodDisruptionBudget,
+		pdb *policyv1.PodDisruptionBudget,
 	) error {
 		return r.Client.Create(ctx, pdb)
 	}
 
 	foundPDB := func(
-		pdb *policyv1beta1.PodDisruptionBudget,
+		pdb *policyv1.PodDisruptionBudget,
 	) bool {
 		return !apierrors.IsNotFound(
 			r.Client.Get(ctx, client.ObjectKeyFromObject(pdb),
-				&policyv1beta1.PodDisruptionBudget{}))
+				&policyv1.PodDisruptionBudget{}))
 	}
 
 	t.Run("pdbs not found", func(t *testing.T) {

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -118,7 +117,7 @@ var regexRepoIndex = regexp.MustCompile(`\d+`)
 // RepoResources is used to store various resources for pgBackRest repositories and
 // repository hosts
 type RepoResources struct {
-	cronjobs                []*batchv1beta1.CronJob
+	cronjobs                []*batchv1.CronJob
 	manualBackupJobs        []*batchv1.Job
 	replicaCreateBackupJobs []*batchv1.Job
 	hosts                   []*appsv1.StatefulSet
@@ -202,8 +201,8 @@ func (r *Reconciler) getPGBackRestResources(ctx context.Context,
 		Version: appsv1.SchemeGroupVersion.Version,
 		Kind:    "StatefulSetList",
 	}, {
-		Group:   batchv1beta1.SchemeGroupVersion.Group,
-		Version: batchv1beta1.SchemeGroupVersion.Version,
+		Group:   batchv1.SchemeGroupVersion.Group,
+		Version: batchv1.SchemeGroupVersion.Version,
 		Kind:    "CronJobList",
 	}}
 
@@ -400,7 +399,7 @@ func unstructuredToRepoResources(kind string, repoResources *RepoResources,
 			repoResources.hosts = append(repoResources.hosts, &stsList.Items[i])
 		}
 	case "CronJobList":
-		var cronList batchv1beta1.CronJobList
+		var cronList batchv1.CronJobList
 		if err := runtime.DefaultUnstructuredConverter.
 			FromUnstructured(uList.UnstructuredContent(), &cronList); err != nil {
 			return errors.WithStack(err)
@@ -2739,7 +2738,7 @@ func getRepoVolumeStatus(repoStatus []v1beta1.RepoStatus, repoVolumes []*corev1.
 // schedules configured in the cluster definition
 func (r *Reconciler) reconcileScheduledBackups(
 	ctx context.Context, cluster *v1beta1.PostgresCluster, sa *corev1.ServiceAccount,
-	cronjobs []*batchv1beta1.CronJob,
+	cronjobs []*batchv1.CronJob,
 ) bool {
 	log := logging.FromContext(ctx).WithValues("reconcileResource", "repoCronJob")
 	// requeue if there is an error during creation
@@ -2783,7 +2782,7 @@ func (r *Reconciler) reconcileScheduledBackups(
 func (r *Reconciler) reconcilePGBackRestCronJob(
 	ctx context.Context, cluster *v1beta1.PostgresCluster, repo v1beta1.PGBackRestRepo,
 	backupType string, schedule *string, serviceAccount *corev1.ServiceAccount,
-	cronjobs []*batchv1beta1.CronJob,
+	cronjobs []*batchv1.CronJob,
 ) error {
 
 	log := logging.FromContext(ctx).WithValues("reconcileResource", "repoCronJob")
@@ -2871,12 +2870,12 @@ func (r *Reconciler) reconcilePGBackRestCronJob(
 	suspend := (cluster.Spec.Shutdown != nil && *cluster.Spec.Shutdown) ||
 		(cluster.Spec.Standby != nil && cluster.Spec.Standby.Enabled)
 
-	pgBackRestCronJob := &batchv1beta1.CronJob{
+	pgBackRestCronJob := &batchv1.CronJob{
 		ObjectMeta: objectmeta,
-		Spec: batchv1beta1.CronJobSpec{
+		Spec: batchv1.CronJobSpec{
 			Schedule: *schedule,
 			Suspend:  &suspend,
-			JobTemplate: batchv1beta1.JobTemplateSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: annotations,
 					Labels:      labels,
@@ -2894,7 +2893,7 @@ func (r *Reconciler) reconcilePGBackRestCronJob(
 		cluster.Spec.ImagePullSecrets
 
 	// set metadata
-	pgBackRestCronJob.SetGroupVersionKind(batchv1beta1.SchemeGroupVersion.WithKind("CronJob"))
+	pgBackRestCronJob.SetGroupVersionKind(batchv1.SchemeGroupVersion.WithKind("CronJob"))
 	err = errors.WithStack(r.setControllerReference(cluster, pgBackRestCronJob))
 
 	if err == nil {

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -33,7 +33,6 @@ import (
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -173,8 +172,8 @@ func fakePostgresCluster(clusterName, namespace, clusterUID string,
 	return postgresCluster
 }
 
-func fakeObservedCronJobs() []*batchv1beta1.CronJob {
-	return []*batchv1beta1.CronJob{
+func fakeObservedCronJobs() []*batchv1.CronJob {
+	return []*batchv1.CronJob{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "fake-cronjob",
@@ -518,7 +517,7 @@ topologySpreadConstraints:
 		requeue := r.reconcileScheduledBackups(ctx, postgresCluster, serviceAccount, fakeObservedCronJobs())
 		assert.Assert(t, !requeue)
 
-		returnedCronJob := &batchv1beta1.CronJob{}
+		returnedCronJob := &batchv1.CronJob{}
 		if err := tClient.Get(ctx, types.NamespacedName{
 			Name:      postgresCluster.Name + "-repo1-full",
 			Namespace: postgresCluster.GetNamespace(),
@@ -564,7 +563,7 @@ topologySpreadConstraints:
 
 	t.Run("pgbackrest schedule suspended status", func(t *testing.T) {
 
-		returnedCronJob := &batchv1beta1.CronJob{}
+		returnedCronJob := &batchv1.CronJob{}
 		if err := tClient.Get(ctx, types.NamespacedName{
 			Name:      postgresCluster.Name + "-repo1-full",
 			Namespace: postgresCluster.GetNamespace(),
@@ -3539,7 +3538,7 @@ func TestReconcileScheduledBackups(t *testing.T) {
 
 				var requeue bool
 				if tc.cronJobs {
-					existingCronJobs := []*batchv1beta1.CronJob{
+					existingCronJobs := []*batchv1.CronJob{
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "existingcronjob-repo1-full",
@@ -3614,7 +3613,7 @@ func TestReconcileScheduledBackups(t *testing.T) {
 							cronJobName = postgresCluster.Name + "-repo1-" + backupType
 						}
 
-						returnedCronJob := &batchv1beta1.CronJob{}
+						returnedCronJob := &batchv1.CronJob{}
 						if err := tClient.Get(ctx, types.NamespacedName{
 							Name:      cronJobName,
 							Namespace: postgresCluster.GetNamespace(),

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -531,7 +531,7 @@ func (r *Reconciler) reconcilePGBouncerPodDisruptionBudget(
 	cluster *v1beta1.PostgresCluster,
 ) error {
 	deleteExistingPDB := func(cluster *v1beta1.PostgresCluster) error {
-		existing := &policyv1beta1.PodDisruptionBudget{ObjectMeta: naming.ClusterPGBouncer(cluster)}
+		existing := &policyv1.PodDisruptionBudget{ObjectMeta: naming.ClusterPGBouncer(cluster)}
 		err := errors.WithStack(r.Client.Get(ctx, client.ObjectKeyFromObject(existing), existing))
 		if err == nil {
 			err = errors.WithStack(r.deleteControlled(ctx, cluster, existing))
@@ -569,7 +569,7 @@ func (r *Reconciler) reconcilePGBouncerPodDisruptionBudget(
 		cluster.Spec.Proxy.PGBouncer.Metadata.GetAnnotationsOrNil())
 
 	selector := naming.ClusterPGBouncerSelector(cluster)
-	pdb := &policyv1beta1.PodDisruptionBudget{}
+	pdb := &policyv1.PodDisruptionBudget{}
 	if err == nil {
 		pdb, err = r.generatePodDisruptionBudget(cluster, meta, minAvailable, selector)
 	}

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -515,7 +515,7 @@ func TestReconcilePGBouncerDisruptionBudget(t *testing.T) {
 	foundPDB := func(
 		cluster *v1beta1.PostgresCluster,
 	) bool {
-		got := &policyv1beta1.PodDisruptionBudget{}
+		got := &policyv1.PodDisruptionBudget{}
 		err := r.Client.Get(ctx,
 			naming.AsObjectKey(naming.ClusterPGBouncer(cluster)),
 			got)

--- a/internal/controller/postgrescluster/pod_disruption_budget.go
+++ b/internal/controller/postgrescluster/pod_disruption_budget.go
@@ -22,7 +22,7 @@ package postgrescluster
 // https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
 import (
 	"github.com/pkg/errors"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -37,15 +37,15 @@ func (r *Reconciler) generatePodDisruptionBudget(
 	meta metav1.ObjectMeta,
 	minAvailable *intstr.IntOrString,
 	selector metav1.LabelSelector,
-) (*policyv1beta1.PodDisruptionBudget, error) {
-	pdb := &policyv1beta1.PodDisruptionBudget{
+) (*policyv1.PodDisruptionBudget, error) {
+	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: meta,
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MinAvailable: minAvailable,
 			Selector:     &selector,
 		},
 	}
-	pdb.SetGroupVersionKind(policyv1beta1.SchemeGroupVersion.WithKind("PodDisruptionBudget"))
+	pdb.SetGroupVersionKind(policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget"))
 	err := errors.WithStack(r.setControllerReference(cluster, pdb))
 	return pdb, err
 }


### PR DESCRIPTION
Add support for Kubernetes 1.25. 

Move to CRDs removed in Kubernetes 1.25:
* policyv1beta1.PodDisruptionBudget => policyv1.PodDisruptionBudget
* batchv1beta1.CronJob => batchv1.CronJob

Issue: #3365 