### PR TITLE
Add support for building docker images based on rocky8 and rocky9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,12 @@ ifeq ("$(PGO_BASEOS)", "rocky8")
     DOCKERBASEREGISTRY=docker.io/rockylinux/rockylinux:
     PACKAGER=dnf
 endif
+ifeq ("$(PGO_BASEOS)", "rocky9")
+    BASE_IMAGE_OS=9
+    DOCKERBASEREGISTRY=docker.io/rockylinux/rockylinux:
+    PACKAGER=dnf
+endif
+
 
 DEBUG_BUILD ?= false
 GO ?= go

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,11 @@ ifeq ("$(PGO_BASEOS)", "ubi8")
     DOCKERBASEREGISTRY=registry.access.redhat.com/
     PACKAGER=microdnf
 endif
+ifeq ("$(PGO_BASEOS)", "rocky8")
+    BASE_IMAGE_OS=8
+    DOCKERBASEREGISTRY=docker.io/rockylinux/rockylinux:
+    PACKAGER=dnf
+endif
 
 DEBUG_BUILD ?= false
 GO ?= go


### PR DESCRIPTION
Add support for building docker images based on rocky8.
