### PR TITLE
Turn off JIT for only monitoring user's context

### DIFF
--- a/internal/controller/postgrescluster/pgmonitor_test.go
+++ b/internal/controller/postgrescluster/pgmonitor_test.go
@@ -437,7 +437,7 @@ func TestReconcilePGMonitorExporterStatus(t *testing.T) {
 		podExecCalled:   false,
 		// Status was generated manually for this test case
 		// TODO jmckulk: add code to generate status
-		status:                      v1beta1.MonitoringStatus{ExporterConfiguration: "8b589fd65"},
+		status:                      v1beta1.MonitoringStatus{ExporterConfiguration: "5f599686cf"},
 		statusChangedAfterReconcile: false,
 	}} {
 		t.Run(test.name, func(t *testing.T) {
@@ -504,9 +504,9 @@ func TestReconcilePGMonitorExporterStatus(t *testing.T) {
 
 			assert.NilError(t, reconciler.reconcilePGMonitorExporter(ctx,
 				cluster, observed, secret))
-			assert.Equal(t, called, test.podExecCalled)
 			assert.Assert(t, test.statusChangedAfterReconcile == (cluster.Status.Monitoring.ExporterConfiguration != test.status.ExporterConfiguration),
 				"got %v", cluster.Status.Monitoring.ExporterConfiguration)
+			assert.Equal(t, called, test.podExecCalled)
 		})
 	}
 }

--- a/internal/pgmonitor/postgres.go
+++ b/internal/pgmonitor/postgres.go
@@ -88,7 +88,7 @@ func DisableExporterInPostgreSQL(ctx context.Context, exec postgres.Executor) er
 // EnableExporterInPostgreSQL runs SQL setup commands in `database` to enable
 // the exporter to retrieve metrics. pgMonitor objects are created and expected
 // extensions are installed. We also ensure that the monitoring user has the
-// current password and can login.
+// current password, optimal config and can login.
 func EnableExporterInPostgreSQL(ctx context.Context, exec postgres.Executor,
 	monitoringSecret *corev1.Secret, database, setup string) error {
 	log := logging.FromContext(ctx)
@@ -134,6 +134,12 @@ func EnableExporterInPostgreSQL(ctx context.Context, exec postgres.Executor,
 				// password; update the password and ensure that the ROLE
 				// can login to the database
 				`ALTER ROLE :"username" LOGIN PASSWORD :'verifier';`,
+
+				// disable JIT for only ccp_monitoring user's context to prevent:
+				// - slow executing due unnecessary inlining, optimization and emission
+				// - memory leak due to re-creating struct types during inlining
+				// and allow to enable JIT for other database users transparently
+				`ALTER ROLE :"username" SET jit = off;`,
 			}, "\n"),
 			map[string]string{
 				"database": database,

--- a/testing/kuttl/e2e/exporter/01--check-exporter.yaml
+++ b/testing/kuttl/e2e/exporter/01--check-exporter.yaml
@@ -2,20 +2,27 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  # Ensure that the metrics endpoint is available from inside the exporter container
   - script: |
-      name=$(kubectl -n ${NAMESPACE} get pods --no-headers -o custom-columns="name:{metadata.name}" \
-        --selector='postgres-operator.crunchydata.com/cluster=exporter,postgres-operator.crunchydata.com/instance-set=instance1')
-      kubectl -n ${NAMESPACE} exec $name -it -c exporter -- curl http://localhost:9187/metrics
-  # Ensure that the ccp_monitoring user exists in the database
-  - script: |
-      name=$(kubectl -n ${NAMESPACE} get pods --no-headers -o custom-columns="name:{metadata.name}" \
-        --selector='postgres-operator.crunchydata.com/cluster=exporter,postgres-operator.crunchydata.com/instance-set=instance1')
-      kubectl -n ${NAMESPACE} exec $name -it -c database -- \
-        psql -c "DO \$\$
+      set -e
+      PRIMARY=$(
+        kubectl get pod --namespace "${NAMESPACE}" \
+          --output name --selector '
+            postgres-operator.crunchydata.com/cluster=exporter,
+            postgres-operator.crunchydata.com/role=master'
+      )
+
+      # Ensure that the metrics endpoint is available from inside the exporter container
+      kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -c exporter -- curl http://localhost:9187/metrics
+
+      # Ensure that the monitoring user exists and is configured.
+      kubectl exec --stdin --namespace "${NAMESPACE}" "${PRIMARY}" \
+        -- psql -qb --set ON_ERROR_STOP=1 --file=- <<'SQL'
+        DO $$
         DECLARE
-          result boolean;
+          result record;
         BEGIN
-          SELECT 1 from pg_roles where rolname='ccp_monitoring' INTO result;
-          ASSERT result = 't', 'ccp_monitor not found';
-        END \$\$;"
+          SELECT * INTO result FROM pg_catalog.pg_roles WHERE rolname = 'ccp_monitoring';
+          ASSERT FOUND, 'user not found';
+          ASSERT result.rolconfig @> '{jit=off}', format('got config: %L', result.rolconfig);
+        END $$
+      SQL


### PR DESCRIPTION
Dear, maintainers!

Thanks you for this operator and accumulation a lot of useful expertise around the best practices inside it. I bring a small improvement to the existing solution against memory leaks. Here it is.

---

It prevents issues related to monitoring queries:
- slow query executing due to unnecessary inlining, optimization and emission
- memory leak due to re-creating struct types during inlining 

related issues (CrunchyData/crunchy-containers#1381) (CrunchyData/pgmonitor#182)

On the other hand database is open to enabling JIT for other users

Signed-off-by: Kirill Petrov <chobostar85@gmail.com>

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [x] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

I believe that relevant discussions around JIT's memory leak is here: https://www.postgresql.org/message-id/20210417021602.7dilihkdc7oblrf7%40alap3.anarazel.de

The issue currently occurs atleast on Postgres 12.

Currently JIT is disabled in whole database: https://github.com/CrunchyData/crunchy-containers/pull/1309

It's not transparent for other database users and in the case of enabling JIT, one can face memory leaks and performance issues again.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Disabling JIT in ccp_monitoring's context is more explicit than current approach, thus I hope it safer for plain PGO users and obvious for PGO developers.

**Other Information**:
