### PR TITLE
Remove pki NoNames test

### DIFF
--- a/internal/pki/pki_test.go
+++ b/internal/pki/pki_test.go
@@ -226,12 +226,6 @@ func TestLeafCertificate(t *testing.T) {
 		dnsNames   []string
 	}{
 		{
-			test: "NoNames",
-
-			// This is a valid certificate according to OpenSSL, in which name
-			// verification is entirely optional.
-		},
-		{
 			test: "OnlyCommonName", commonName: "some-cn",
 		},
 		{


### PR DESCRIPTION
OpenSSL 3.x returns an error when the subject name is empty on a cert. This cert is no longer valid, so we don't need the test.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
