### PR TITLE
Adds Sleep to Cluster Annotation Test [sc-15828]

### DIFF
--- a/testing/pgo_cli/cluster_annotation_test.go
+++ b/testing/pgo_cli/cluster_annotation_test.go
@@ -216,6 +216,9 @@ func TestClusterAnnotation(t *testing.T) {
 						requirePgBouncerReady(t, namespace(), test.testName, (2 * time.Minute))
 					}
 
+					// Allow pods time to reach ready status before running update.
+					time.Sleep(time.Minute + 30*time.Second)
+
 					updateCMD := []string{"update", "cluster", test.testName, "-n", namespace(), "--no-prompt"}
 					updateCMD = append(updateCMD, test.addFlags...)
 					output, err = pgo(updateCMD...).Exec(t)


### PR DESCRIPTION
The requireClusterReady helper in suite_helpers_test.go does not always wait until the cluster is truly ready. Consequently, 'on_update' in cluster_annotation_test.go flakes, attempting to run update on a pod that isn't ready.

[sc-15828]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
