### PR TITLE
Ipv6 workaround for pgbackrest issue #1841

### DIFF
--- a/docs/content/tutorial/backups.md
+++ b/docs/content/tutorial/backups.md
@@ -379,6 +379,19 @@ The full list of [pgBackRest configuration options](https://pgbackrest.org/confi
 
 [https://pgbackrest.org/configuration.html](https://pgbackrest.org/configuration.html)
 
+## IPv6 Support
+
+If you are running your cluster in an IPv6-only environment, you will need to add an annotation to your PostgresCluster so that PGO knows to set pgBackRest's `tls-server-address` to an IPv6 address. Otherwise, `tls-server-address` will be set to `0.0.0.0`, making pgBackRest inaccessible, and backups will not run. The annotation should be added as shown below:
+
+```yaml
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: hippo
+  annotations:
+    postgres-operator.crunchydata.com/pgbackrest-ip-version: IPv6
+```
+
 ## Next Steps
 
 We've now seen how to use PGO to get our backups and archives set up and safely stored. Now let's take a look at [backup management]({{< relref "./backup-management.md" >}}) and how we can do things such as set backup frequency, set retention policies, and even take one-off backups!

--- a/internal/naming/annotations.go
+++ b/internal/naming/annotations.go
@@ -50,4 +50,12 @@ const (
 	// timestamp), which will be stored in the PostgresCluster status to properly track completion
 	// of the Job.
 	PGBackRestRestore = annotationPrefix + "pgbackrest-restore"
+
+	// PGBackRestIPVersion is an annotation used to indicate whether an IPv6 wildcard address should be
+	// used for the pgBackRest "tls-server-address" or not. If the user wants to use IPv6, the value
+	// should be "IPv6". As of right now, if the annotation is not present or if the annotation's value
+	// is anything other than "IPv6", the "tls-server-address" will default to IPv4 (0.0.0.0). The need
+	// for this annotation is due to an issue in pgBackRest (#1841) where using a wildcard address to
+	// bind all addresses does not work in certain IPv6 environments.
+	PGBackRestIPVersion = annotationPrefix + "pgbackrest-ip-version"
 )

--- a/internal/naming/annotations_test.go
+++ b/internal/naming/annotations_test.go
@@ -29,4 +29,5 @@ func TestAnnotationsValid(t *testing.T) {
 	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestConfigHash))
 	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestCurrentConfig))
 	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestRestore))
+	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestIPVersion))
 }

--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -472,12 +472,8 @@ func serverConfig(cluster *v1beta1.PostgresCluster) iniSectionSet {
 	// going to workaround the issue by allowing the user to add an annotation to
 	// enable IPv6. We will check for that annotation here and override the
 	// "tls-server-address" setting accordingly.
-	annotations := cluster.GetAnnotations()
-	if annotations != nil {
-		if ipVersion, exists := annotations[naming.PGBackRestIPVersion]; exists &&
-			strings.ToLower(ipVersion) == "ipv6" {
-			global.Set("tls-server-address", "::")
-		}
+	if strings.ToLower(cluster.Annotations[naming.PGBackRestIPVersion]) == "ipv6" {
+		global.Set("tls-server-address", "::")
 	}
 
 	// The client certificate for this cluster is allowed to connect for any stanza.

--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -472,7 +472,7 @@ func serverConfig(cluster *v1beta1.PostgresCluster) iniSectionSet {
 	// going to workaround the issue by allowing the user to add an annotation to
 	// enable IPv6. We will check for that annotation here and override the
 	// "tls-server-address" setting accordingly.
-	if strings.ToLower(cluster.Annotations[naming.PGBackRestIPVersion]) == "ipv6" {
+	if strings.EqualFold(cluster.Annotations[naming.PGBackRestIPVersion], "ipv6") {
 		global.Set("tls-server-address", "::")
 	}
 

--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -341,9 +341,9 @@ log-timestamp = n
 func TestServerConfigIPv6(t *testing.T) {
 	cluster := &v1beta1.PostgresCluster{}
 	cluster.UID = "shoe"
-	annotations := map[string]string{}
-	annotations[naming.PGBackRestIPVersion] = "IPv6"
-	cluster.ObjectMeta.Annotations = annotations
+	cluster.Annotations = map[string]string{
+		naming.PGBackRestIPVersion: "IPv6",
+	}
 
 	assert.Equal(t, serverConfig(cluster).String(), `
 [global]

--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -337,3 +337,26 @@ log-level-stderr = error
 log-timestamp = n
 `)
 }
+
+func TestServerConfigIPv6(t *testing.T) {
+	cluster := &v1beta1.PostgresCluster{}
+	cluster.UID = "shoe"
+	annotations := map[string]string{}
+	annotations[naming.PGBackRestIPVersion] = "IPv6"
+	cluster.ObjectMeta.Annotations = annotations
+
+	assert.Equal(t, serverConfig(cluster).String(), `
+[global]
+tls-server-address = ::
+tls-server-auth = pgbackrest@shoe=*
+tls-server-ca-file = /etc/pgbackrest/conf.d/~postgres-operator/tls-ca.crt
+tls-server-cert-file = /etc/pgbackrest/server/server-tls.crt
+tls-server-key-file = /etc/pgbackrest/server/server-tls.key
+
+[global:server]
+log-level-console = detail
+log-level-file = off
+log-level-stderr = error
+log-timestamp = n
+`)
+}


### PR DESCRIPTION
These changes provide a workaround for an issue in pgBackRest that prevents it from working in an IPv6 environment. The workaround involves a user adding an annotation to the PostgresCluster. The changes in the code make the operator check for the existence of the annotation, and if present, set pgBackRest's `tls-server-address` to `::` rather than `0.0.0.0`.


**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
https://github.com/pgbackrest/pgbackrest/issues/1841
https://github.com/CrunchyData/postgres-operator/issues/3286

Currently, when PGO is used in an IPv6 environment, pgBackRest uses an IPv4 address, making it inaccessible and therefore cannot perform any backups.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

The operator now checks for the existence of a specific annotation on the PostgresCluster (`postgres-operator.crunchydata.com/pgbackrest-ip-version: IPv6`) and if it is present it will set the pgBackRest `tls-server-address` to `::`, allowing it to communicate with the rest of the cluster and perform backups as expected.


**Other Information**:

[sc-15736]