### PR TITLE
Get primary name after waiting for redeploy

### DIFF
--- a/testing/kuttl/e2e/exporter/13--check-exporter.yaml
+++ b/testing/kuttl/e2e/exporter/13--check-exporter.yaml
@@ -4,16 +4,16 @@ kind: TestStep
 commands:
   - script: |
       set -e
+      # Wait some time so that the instance pod is redeployed
+      # TODO: automate this wait
+      sleep 30
+      
       PRIMARY=$(
         kubectl get pod --namespace "${NAMESPACE}" \
           --output name --selector '
             postgres-operator.crunchydata.com/cluster=exporter-tls,
             postgres-operator.crunchydata.com/role=master'
       )
-
-      # Wait some time so that the instance pod is redeployed
-      # TODO: automate this wait
-      sleep 30
 
       {
         METRICS=$(kubectl exec --namespace "${NAMESPACE}" \


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
We grab the current primary name and wait for the pod to redeploy.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

With the change, we will wait for the redeploy, then grab the primary name. This helps ensure we have the most current info when running checks against the primary.

**Other Information**:
