### PR TITLE
Start and stop upgrade-check using controller-runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ deploy-dev: build-postgres-operator createnamespaces
 	hack/create-kubeconfig.sh postgres-operator pgo
 	env \
 		CRUNCHY_DEBUG=true \
-		CHECK_FOR_UPGRADES=false \
+		CHECK_FOR_UPGRADES='$(if $(CHECK_FOR_UPGRADES),$(CHECK_FOR_UPGRADES),false)' \
 		KUBECONFIG=hack/.kube/postgres-operator/pgo \
 		$(shell $(PGO_KUBE_CLIENT) kustomize ./config/dev | \
 			sed -ne '/^kind: Deployment/,/^---/ { \

--- a/internal/upgradecheck/http_test.go
+++ b/internal/upgradecheck/http_test.go
@@ -113,24 +113,6 @@ func TestCheckForUpgrades(t *testing.T) {
 		checkData(t, header)
 	})
 
-	t.Run("recovers from panic", func(t *testing.T) {
-		var counter int
-		// A panicking call
-		funcFoo = func() (*http.Response, error) {
-			counter++
-			panic(fmt.Errorf("oh no!"))
-		}
-
-		res, header, err := checkForUpgrades(ctx, "", "4.7.3", backoff,
-			fakeClient, cfg, false)
-		// One call because of panic
-		assert.Equal(t, counter, 1)
-		assert.Equal(t, res, "")
-		assert.Equal(t, err.Error(), `oh no!`)
-		// no http response returned, so don't perform full check
-		assert.Assert(t, header == "")
-	})
-
 	t.Run("total failure, bad StatusCode", func(t *testing.T) {
 		var counter int
 		// A call returning bad StatusCode
@@ -213,7 +195,7 @@ func TestCheckForUpgradesScheduler(t *testing.T) {
 		// Sleeping leads to some non-deterministic results, but we expect at least 1 execution
 		// plus one log for the failure to apply the configmap
 		assert.Assert(t, len(calls) >= 2)
-		assert.Assert(t, cmp.Contains(calls[1], `could not complete upgrade check`))
+		assert.Assert(t, cmp.Contains(calls[1], `encountered panic in upgrade check`))
 	})
 
 	t.Run("cache sync fail leads to log and exit", func(t *testing.T) {

--- a/internal/upgradecheck/http_test.go
+++ b/internal/upgradecheck/http_test.go
@@ -1,5 +1,3 @@
-package upgradecheck
-
 /*
  Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package upgradecheck
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package upgradecheck
 
 import (
 	"context"
@@ -89,7 +89,7 @@ func TestCheckForUpgrades(t *testing.T) {
 			}, nil
 		}
 
-		res, header, err := checkForUpgrades(ctx, "4.7.3", backoff,
+		res, header, err := checkForUpgrades(ctx, "", "4.7.3", backoff,
 			fakeClient, cfg, false)
 		assert.NilError(t, err)
 		assert.Equal(t, res, `{"pgo_versions":[{"tag":"v5.0.4"},{"tag":"v5.0.3"},{"tag":"v5.0.2"},{"tag":"v5.0.1"},{"tag":"v5.0.0"}]}`)
@@ -104,7 +104,7 @@ func TestCheckForUpgrades(t *testing.T) {
 			return &http.Response{}, errors.New("whoops")
 		}
 
-		res, header, err := checkForUpgrades(ctx, "4.7.3", backoff,
+		res, header, err := checkForUpgrades(ctx, "", "4.7.3", backoff,
 			fakeClient, cfg, false)
 		// Two failed calls because of env var
 		assert.Equal(t, counter, 2)
@@ -121,7 +121,7 @@ func TestCheckForUpgrades(t *testing.T) {
 			panic(fmt.Errorf("oh no!"))
 		}
 
-		res, header, err := checkForUpgrades(ctx, "4.7.3", backoff,
+		res, header, err := checkForUpgrades(ctx, "", "4.7.3", backoff,
 			fakeClient, cfg, false)
 		// One call because of panic
 		assert.Equal(t, counter, 1)
@@ -142,7 +142,7 @@ func TestCheckForUpgrades(t *testing.T) {
 			}, nil
 		}
 
-		res, header, err := checkForUpgrades(ctx, "4.7.3", backoff,
+		res, header, err := checkForUpgrades(ctx, "", "4.7.3", backoff,
 			fakeClient, cfg, false)
 		assert.Equal(t, res, "")
 		// Two failed calls because of env var
@@ -171,7 +171,7 @@ func TestCheckForUpgrades(t *testing.T) {
 			}, nil
 		}
 
-		res, header, err := checkForUpgrades(ctx, "4.7.3", backoff,
+		res, header, err := checkForUpgrades(ctx, "", "4.7.3", backoff,
 			fakeClient, cfg, false)
 		assert.Equal(t, counter, 2)
 		assert.NilError(t, err)


### PR DESCRIPTION
[controller-runtime.Manager](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.3/pkg/manager#Manager) can start and stop a [manager.Runnable](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.3/pkg/manager#Runnable) at the right times.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other


**What is the current behavior (link to any open issues here)?**

The upgrade-check scheduler starts and stops concurrently with the one controller-runtime Manager using the same Context.

**What is the new behavior (if this is a feature change)?**

The one controller-runtime Manager starts and stops the upgrade-check scheduler in relation to cache syncs and Manager leader elections.