### PR TITLE
Update pgBackRest repo option logic

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -1011,7 +1011,9 @@ func (r *Reconciler) reconcileRestoreJob(ctx context.Context,
 	for _, opt := range options {
 		var msg string
 		switch {
-		case strings.Contains(opt, "--repo"):
+		// Since '--repo' can be set with or without an equals ('=') sign, we check for both
+		// usage patterns.
+		case strings.Contains(opt, "--repo=") || strings.Contains(opt, "--repo "):
 			msg = "Option '--repo' is not allowed: please use the 'repoName' field instead."
 		case strings.Contains(opt, "--stanza"):
 			msg = "Option '--stanza' is not allowed: the operator will automatically set this " +
@@ -2200,9 +2202,11 @@ func (r *Reconciler) reconcileManualBackup(ctx context.Context,
 	// and not using the "--repo" option in the "manual.options" field.  Therefore, record a
 	// warning event and return if a "--repo" option is found.  Reconciliation will then be
 	// reattempted when "--repo" is removed from "manual.options" and the spec is updated.
+	// Since '--repo' can be set with or without an equals ('=') sign, we check for both
+	// usage patterns.
 	backupOpts := postgresCluster.Spec.Backups.PGBackRest.Manual.Options
 	for _, opt := range backupOpts {
-		if strings.Contains(opt, "--repo") {
+		if strings.Contains(opt, "--repo=") || strings.Contains(opt, "--repo ") {
 			r.Recorder.Eventf(postgresCluster, corev1.EventTypeWarning, "InvalidManualBackup",
 				"Option '--repo' is not allowed: please use the 'repoName' field instead.",
 				repoName)

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -1831,13 +1831,27 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 				expectedClusterCondition: nil,
 			},
 		}, {
-			desc: "invalid option: repo",
+			desc: "invalid option: --repo=",
 			dataSource: &v1beta1.DataSource{PostgresCluster: &v1beta1.PostgresClusterDataSource{
-				ClusterName: "invalid-repo-option", RepoName: "repo1",
-				Options: []string{"--repo"},
+				ClusterName: "invalid-repo-option-equals", RepoName: "repo1",
+				Options: []string{"--repo="},
 			}},
 			clusterBootstrapped: false,
-			sourceClusterName:   "invalid-repo-option",
+			sourceClusterName:   "invalid-repo-option-equals",
+			sourceClusterRepos:  []v1beta1.PGBackRestRepo{{Name: "repo1"}},
+			result: testResult{
+				configCount: 1, jobCount: 0, pvcCount: 1,
+				invalidSourceRepo: false, invalidSourceCluster: false, invalidOptions: true,
+				expectedClusterCondition: nil,
+			},
+		}, {
+			desc: "invalid option: --repo ",
+			dataSource: &v1beta1.DataSource{PostgresCluster: &v1beta1.PostgresClusterDataSource{
+				ClusterName: "invalid-repo-option-space", RepoName: "repo1",
+				Options: []string{"--repo "},
+			}},
+			clusterBootstrapped: false,
+			sourceClusterName:   "invalid-repo-option-space",
 			sourceClusterRepos:  []v1beta1.PGBackRestRepo{{Name: "repo1"}},
 			result: testResult{
 				configCount: 1, jobCount: 0, pvcCount: 1,


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
When taking a backup, PGO tries to help by not allowing the user to pass the "--repo" option. However, the current method for catching this results in catching any option that begins with "--repo", which prevents users from passing in perfectly valid options.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This commit corrects the flag check to only block on exact matches of "--repo".



**Other Information**:
Issue: [sc-16128]