### PR TITLE
Add constants for services registered with the IANA

### DIFF
--- a/internal/pgbackrest/iana.go
+++ b/internal/pgbackrest/iana.go
@@ -1,0 +1,27 @@
+/*
+ Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pgbackrest
+
+// The protocol used by pgBackRest is registered with the Internet Assigned
+// Numbers Authority (IANA).
+// - https://www.iana.org/assignments/service-names-port-numbers
+const (
+	// IANAPortNumber is the port assigned to pgBackRest at the IANA.
+	IANAPortNumber = 8432
+
+	// IANAServiceName is the name of the pgBackRest protocol at the IANA.
+	IANAServiceName = "pgbackrest"
+)

--- a/internal/postgres/iana.go
+++ b/internal/postgres/iana.go
@@ -1,0 +1,27 @@
+/*
+ Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package postgres
+
+// The protocol used by PostgreSQL is registered with the Internet Assigned
+// Numbers Authority (IANA).
+// - https://www.iana.org/assignments/service-names-port-numbers
+const (
+	// IANAPortNumber is the port assigned to PostgreSQL at the IANA.
+	IANAPortNumber = 5432
+
+	// IANAServiceName is the name of the PostgreSQL protocol at the IANA.
+	IANAServiceName = "postgresql"
+)


### PR DESCRIPTION
The PostgreSQL and pgBackRest protocols are both registered with the IANA according to RFC 6335.

See: https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=postgres

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other


**Other Information**:
 
Related: #3435