### PR TITLE
Added namespace limiters to all client.List() calls in pgbackrest and…

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -789,6 +789,7 @@ func (r *Reconciler) observeRestoreEnv(ctx context.Context,
 
 	restoreJobs := &batchv1.JobList{}
 	if err := r.Client.List(ctx, restoreJobs, &client.ListOptions{
+		Namespace:     cluster.Namespace,
 		LabelSelector: naming.PGBackRestRestoreJobSelector(cluster.GetName()),
 	}); err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -836,8 +837,9 @@ func (r *Reconciler) observeRestoreEnv(ctx context.Context,
 			selector := naming.PGBackRestRestoreConfigSelector(cluster.GetName())
 			restoreConfigMaps := &corev1.ConfigMapList{}
 			if err := r.Client.List(ctx, restoreConfigMaps, &client.ListOptions{
+				Namespace:     cluster.Namespace,
 				LabelSelector: selector,
-			}, client.InNamespace(cluster.Namespace)); err != nil {
+			}); err != nil {
 				return nil, nil, errors.WithStack(err)
 			}
 			for i := range restoreConfigMaps.Items {
@@ -847,8 +849,9 @@ func (r *Reconciler) observeRestoreEnv(ctx context.Context,
 			}
 			restoreSecrets := &corev1.SecretList{}
 			if err := r.Client.List(ctx, restoreSecrets, &client.ListOptions{
+				Namespace:     cluster.Namespace,
 				LabelSelector: selector,
-			}, client.InNamespace(cluster.Namespace)); err != nil {
+			}); err != nil {
 				return nil, nil, errors.WithStack(err)
 			}
 			for i := range restoreSecrets.Items {

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -1371,6 +1371,7 @@ func TestReconcileManualBackup(t *testing.T) {
 
 					jobs := &batchv1.JobList{}
 					err := tClient.List(ctx, jobs, &client.ListOptions{
+						Namespace: postgresCluster.Namespace,
 						LabelSelector: naming.PGBackRestBackupJobSelector(clusterName,
 							tc.manual.RepoName, naming.BackupManual),
 					})
@@ -1417,6 +1418,7 @@ func TestReconcileManualBackup(t *testing.T) {
 					// just use a pgbackrest selector to check for the existence of any job since
 					// we might not have a repo name for tests within a manual backup defined
 					err := tClient.List(ctx, jobs, &client.ListOptions{
+						Namespace:     postgresCluster.Namespace,
 						LabelSelector: naming.PGBackRestSelector(clusterName),
 					})
 					assert.NilError(t, err)
@@ -3365,6 +3367,7 @@ func TestPrepareForRestore(t *testing.T) {
 
 				restoreJobs := &batchv1.JobList{}
 				assert.NilError(t, r.Client.List(ctx, restoreJobs, &client.ListOptions{
+					Namespace:     cluster.Namespace,
 					LabelSelector: naming.PGBackRestRestoreJobSelector(cluster.GetName()),
 				}))
 

--- a/internal/controller/postgrescluster/volumes.go
+++ b/internal/controller/postgrescluster/volumes.go
@@ -358,6 +358,7 @@ func (r *Reconciler) reconcileDirMoveJobs(ctx context.Context,
 
 		moveJobs := &batchv1.JobList{}
 		if err := r.Client.List(ctx, moveJobs, &client.ListOptions{
+			Namespace:     cluster.Namespace,
 			LabelSelector: naming.DirectoryMoveJobLabels(cluster.Name).AsSelector(),
 		}); err != nil {
 			return false, errors.WithStack(err)

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -747,6 +747,7 @@ func TestReconcileMoveDirectories(t *testing.T) {
 
 	moveJobs := &batchv1.JobList{}
 	err = r.Client.List(ctx, moveJobs, &client.ListOptions{
+		Namespace:     cluster.Namespace,
 		LabelSelector: naming.DirectoryMoveJobLabels(cluster.Name).AsSelector(),
 	})
 	assert.NilError(t, err)


### PR DESCRIPTION
… volumes files in the controller. This change was mandated by [sc-16139] and we believe the changes, particularly in `volumes.go`, should also solve the problem seen by the customer in [sc-13871]. 

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
A couple customers have seen issues when doing restores and volume moves with multiple clusters having the same name but being in different namespaces.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
Issue: [sc-16139] 
Issue: [sc-13871]
Issue: CrunchyData/postgres-operator#3364
Issue: CrunchyData/postgres-operator#3058
