### PR TITLE
adding Postgres primary & replica cert to Secret

### DIFF
--- a/internal/controller/postgrescluster/cluster.go
+++ b/internal/controller/postgrescluster/cluster.go
@@ -238,13 +238,13 @@ func (r *Reconciler) generateClusterReplicaService(
 // replica instances.
 func (r *Reconciler) reconcileClusterReplicaService(
 	ctx context.Context, cluster *v1beta1.PostgresCluster,
-) error {
+) (*corev1.Service, error) {
 	service, err := r.generateClusterReplicaService(cluster)
 
 	if err == nil {
 		err = errors.WithStack(r.apply(ctx, service))
 	}
-	return err
+	return service, err
 }
 
 // reconcileDataSource is responsible for reconciling the data source for a PostgreSQL cluster.

--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -169,6 +169,7 @@ func (r *Reconciler) Reconcile(
 		patroniLeaderService     *corev1.Service
 		primaryCertificate       *corev1.SecretProjection
 		primaryService           *corev1.Service
+		replicaService           *corev1.Service
 		rootCA                   *pki.RootCertificateAuthority
 		monitoringSecret         *corev1.Secret
 		exporterWebConfig        *corev1.ConfigMap
@@ -291,10 +292,10 @@ func (r *Reconciler) Reconcile(
 		primaryService, err = r.reconcileClusterPrimaryService(ctx, cluster, patroniLeaderService)
 	}
 	if err == nil {
-		err = r.reconcileClusterReplicaService(ctx, cluster)
+		replicaService, err = r.reconcileClusterReplicaService(ctx, cluster)
 	}
 	if err == nil {
-		primaryCertificate, err = r.reconcileClusterCertificate(ctx, rootCA, cluster, primaryService)
+		primaryCertificate, err = r.reconcileClusterCertificate(ctx, rootCA, cluster, primaryService, replicaService)
 	}
 	if err == nil {
 		err = r.reconcilePatroniDistributedConfiguration(ctx, cluster)

--- a/internal/controller/postgrescluster/pki.go
+++ b/internal/controller/postgrescluster/pki.go
@@ -118,6 +118,7 @@ func (r *Reconciler) reconcileRootCertificate(
 func (r *Reconciler) reconcileClusterCertificate(
 	ctx context.Context, root *pki.RootCertificateAuthority,
 	cluster *v1beta1.PostgresCluster, primaryService *corev1.Service,
+	replicaService *corev1.Service,
 ) (
 	*corev1.SecretProjection, error,
 ) {
@@ -133,7 +134,7 @@ func (r *Reconciler) reconcileClusterCertificate(
 		r.Client.Get(ctx, client.ObjectKeyFromObject(existing), existing)))
 
 	leaf := &pki.LeafCertificate{}
-	dnsNames := naming.ServiceDNSNames(ctx, primaryService)
+	dnsNames := append(naming.ServiceDNSNames(ctx, primaryService), naming.ServiceDNSNames(ctx, replicaService)...)
 	dnsFQDN := dnsNames[0]
 
 	if err == nil {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Add replica service SAN to TLS cert used, such that it's possible to perform SSL connections between pgBouncer directly to the read-replica(s): #3446 


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Adding all DNS names for the replica service to the TLS cert generated for the PostgresCluster


**Other Information**:

With this change, it'd be possible to deploy a dedicated deployment that points directly to the Postgres replicas for read-only queries; such that you can segment read/write queries by pointing to a different service.