### PR TITLE
Hide the progress bar when calling curl in tests

### DIFF
--- a/testing/kuttl/e2e/exporter/01--check-exporter.yaml
+++ b/testing/kuttl/e2e/exporter/01--check-exporter.yaml
@@ -15,7 +15,7 @@ commands:
       {
         METRICS=$(kubectl exec --namespace "${NAMESPACE}" \
           "${PRIMARY}" -c exporter \
-          -- curl http://localhost:9187/metrics)
+          -- curl --show-error --silent 'http://localhost:9187/metrics')
       } || {
         echo >&2 'curl metrics endpoint returned error'
         echo "${METRICS}"

--- a/testing/kuttl/e2e/exporter/11--check-exporter-tls.yaml
+++ b/testing/kuttl/e2e/exporter/11--check-exporter-tls.yaml
@@ -15,7 +15,7 @@ commands:
       {
         METRICS=$(kubectl exec --namespace "${NAMESPACE}" \
           "${PRIMARY}" -c exporter \
-          -- curl -k https://localhost:9187/metrics)
+          -- curl --insecure --show-error --silent 'https://localhost:9187/metrics')
       } || {
         echo >&2 'curl metrics endpoint returned error'
         echo "${METRICS}"

--- a/testing/kuttl/e2e/exporter/13--check-exporter.yaml
+++ b/testing/kuttl/e2e/exporter/13--check-exporter.yaml
@@ -18,7 +18,7 @@ commands:
       {
         METRICS=$(kubectl exec --namespace "${NAMESPACE}" \
           "${PRIMARY}" -c exporter \
-          -- curl http://localhost:9187/metrics)
+          -- curl --show-error --silent 'http://localhost:9187/metrics')
       } || {
         echo >&2 'curl metrics endpoint returned error'
         echo "${METRICS}"


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

**What is the current behavior (link to any open issues here)?**

Exporter KUTTL tests print some noise:

```
    logger.go:42: 07:47:12 | exporter/1-01--check-exporter |   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    logger.go:42: 07:47:12 | exporter/1-01--check-exporter |                                  Dload  Upload   Total   Spent    Left  Speed
    logger.go:42: 07:47:12 | exporter/1-01--check-exporter | 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  134k    0  134k    0     0  1104k      0 --:--:-- --:--:-- --:--:-- 1104k
    logger.go:42: 07:47:14 | exporter/1-01--check-exporter | test step completed 1-01--check-exporter
```

**What is the new behavior (if this is a feature change)?**

No progress bar when the assertions succeed. Error messages when the assertions fail.
