### PR TITLE
Limit the monitoring user to local connections

### DIFF
--- a/internal/pgmonitor/postgres_test.go
+++ b/internal/pgmonitor/postgres_test.go
@@ -46,8 +46,10 @@ func TestPostgreSQLHBA(t *testing.T) {
 		outHBAs := postgres.HBAs{}
 		PostgreSQLHBAs(inCluster, &outHBAs)
 
+		assert.Equal(t, len(outHBAs.Mandatory), 3)
 		assert.Equal(t, outHBAs.Mandatory[0].String(), `host all "ccp_monitoring" "127.0.0.0/8" scram-sha-256`)
 		assert.Equal(t, outHBAs.Mandatory[1].String(), `host all "ccp_monitoring" "::1/128" scram-sha-256`)
+		assert.Equal(t, outHBAs.Mandatory[2].String(), `host all "ccp_monitoring" all reject`)
 	})
 }
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other

**What is the current behavior (link to any open issues here)?**

The monitoring user is allowed to connect from anywhere on the network.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

The monitoring user is allowed to connect only from within the pod network namespace (localhost).

**Other Information**:

Issue: [sc-12218]