### PR TITLE
Adding uniqueness to cluster names when testing service type changes …

### DIFF
--- a/internal/controller/postgrescluster/patroni_test.go
+++ b/internal/controller/postgrescluster/patroni_test.go
@@ -283,10 +283,21 @@ func TestReconcilePatroniLeaderLease(t *testing.T) {
 	// CRD validation looks only at the new/incoming value of fields. Confirm
 	// that each ServiceType can change to any other ServiceType. Forbidding
 	// certain transitions requires a validating webhook.
+	serviceTypeChangeClusterCounter := 0
 	for _, beforeType := range serviceTypes {
 		for _, changeType := range serviceTypes {
 			t.Run(beforeType+"To"+changeType, func(t *testing.T) {
-				cluster := cluster.DeepCopy()
+				// Creating fresh clusters for these tests
+				cluster := testCluster()
+				cluster.Namespace = ns.Name
+
+				// Note (dsessler): Adding a number to each cluster name to make cluster/service
+				// names unique to work around an intermittent race condition where a service
+				// from a prior test has not been deleted yet when the next test runs, causing
+				// the test to fail due to non-matching IP addresses.
+				cluster.Name += "-" + strconv.Itoa(serviceTypeChangeClusterCounter)
+				assert.NilError(t, cc.Create(ctx, cluster))
+
 				cluster.Spec.Service = &v1beta1.ServiceSpec{Type: beforeType}
 
 				before, err := reconciler.reconcilePatroniLeaderLease(ctx, cluster)
@@ -309,6 +320,7 @@ func TestReconcilePatroniLeaderLease(t *testing.T) {
 				assert.NilError(t, err, "\n%#v", errors.Unwrap(err))
 				assert.Equal(t, after.Spec.ClusterIP, before.Spec.ClusterIP,
 					"expected to keep the same ClusterIP")
+				serviceTypeChangeClusterCounter++
 			})
 		}
 	}

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -20,6 +20,7 @@ package postgrescluster
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -326,10 +327,27 @@ func TestReconcilePGBouncerService(t *testing.T) {
 	// CRD validation looks only at the new/incoming value of fields. Confirm
 	// that each ServiceType can change to any other ServiceType. Forbidding
 	// certain transitions requires a validating webhook.
+	serviceTypeChangeClusterCounter := 0
 	for _, beforeType := range serviceTypes {
 		for _, changeType := range serviceTypes {
 			t.Run(beforeType+"To"+changeType, func(t *testing.T) {
-				cluster := cluster.DeepCopy()
+				// Creating fresh clusters for these tests
+				clusterNamespace := cluster.Namespace
+				cluster := testCluster()
+				cluster.Namespace = clusterNamespace
+
+				// Note (dsessler): Adding a number to each cluster name to make cluster/service
+				// names unique to work around an intermittent race condition where a service
+				// from a prior test has not been deleted yet when the next test runs, causing
+				// the test to fail due to non-matching IP addresses.
+				cluster.Name += "-" + strconv.Itoa(serviceTypeChangeClusterCounter)
+				assert.NilError(t, cc.Create(ctx, cluster))
+
+				cluster.Spec.Proxy = &v1beta1.PostgresProxySpec{
+					PGBouncer: &v1beta1.PGBouncerPodSpec{
+						Port: initialize.Int32(19041),
+					},
+				}
 				cluster.Spec.Proxy.PGBouncer.Service = &v1beta1.ServiceSpec{Type: beforeType}
 
 				before, err := reconciler.reconcilePGBouncerService(ctx, cluster)
@@ -352,6 +370,7 @@ func TestReconcilePGBouncerService(t *testing.T) {
 				assert.NilError(t, err, "\n%#v", errors.Unwrap(err))
 				assert.Equal(t, after.Spec.ClusterIP, before.Spec.ClusterIP,
 					"expected to keep the same ClusterIP")
+				serviceTypeChangeClusterCounter++
 			})
 		}
 	}


### PR DESCRIPTION
…to work around race condition that is causing these tests to flake.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Currently, our tests for reconciling different services intermittently flake, specifically when testing changing the service type. This is due to a race condition where sometimes a service from a prior test has not yet been deleted when another test runs, causing the comparison of the "before" and "after" IP addresses to be misaligned. This fix makes each cluster/service name unique so that different services' IP addresses won't ever be compared.

[sc-16571]

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Tests should not flake due to this race condition anymore.

**Other Information**:
