### PR TITLE
Do not configure JIT for the monitoring user

### DIFF
--- a/internal/controller/postgrescluster/pgmonitor_test.go
+++ b/internal/controller/postgrescluster/pgmonitor_test.go
@@ -441,7 +441,7 @@ func TestReconcilePGMonitorExporterStatus(t *testing.T) {
 		podExecCalled:   false,
 		// Status was generated manually for this test case
 		// TODO jmckulk: add code to generate status
-		status:                      v1beta1.MonitoringStatus{ExporterConfiguration: "5dbc557689"},
+		status:                      v1beta1.MonitoringStatus{ExporterConfiguration: "74476b9895"},
 		statusChangedAfterReconcile: false,
 	}} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/pgmonitor/postgres.go
+++ b/internal/pgmonitor/postgres.go
@@ -86,7 +86,7 @@ func DisableExporterInPostgreSQL(ctx context.Context, exec postgres.Executor) er
 // EnableExporterInPostgreSQL runs SQL setup commands in `database` to enable
 // the exporter to retrieve metrics. pgMonitor objects are created and expected
 // extensions are installed. We also ensure that the monitoring user has the
-// current password, optimal config and can login.
+// current password and can login.
 func EnableExporterInPostgreSQL(ctx context.Context, exec postgres.Executor,
 	monitoringSecret *corev1.Secret, database, setup string) error {
 	log := logging.FromContext(ctx)
@@ -138,12 +138,6 @@ func EnableExporterInPostgreSQL(ctx context.Context, exec postgres.Executor,
 				// password; update the password and ensure that the ROLE
 				// can login to the database
 				`ALTER ROLE :"username" LOGIN PASSWORD :'verifier';`,
-
-				// disable JIT for only ccp_monitoring user's context to prevent:
-				// - slow executing due unnecessary inlining, optimization and emission
-				// - memory leak due to re-creating struct types during inlining
-				// and allow to enable JIT for other database users transparently
-				`ALTER ROLE :"username" SET jit = off;`,
 			}, "\n"),
 			map[string]string{
 				"database": database,

--- a/testing/kuttl/e2e/exporter/01--check-exporter.yaml
+++ b/testing/kuttl/e2e/exporter/01--check-exporter.yaml
@@ -41,6 +41,5 @@ commands:
         BEGIN
           SELECT * INTO result FROM pg_catalog.pg_roles WHERE rolname = 'ccp_monitoring';
           ASSERT FOUND, 'user not found';
-          ASSERT result.rolconfig @> '{jit=off}', format('got config: %L', result.rolconfig);
         END $$
       SQL

--- a/testing/kuttl/e2e/exporter/11--check-exporter-tls.yaml
+++ b/testing/kuttl/e2e/exporter/11--check-exporter-tls.yaml
@@ -41,6 +41,5 @@ commands:
         BEGIN
           SELECT * INTO result FROM pg_catalog.pg_roles WHERE rolname = 'ccp_monitoring';
           ASSERT FOUND, 'user not found';
-          ASSERT result.rolconfig @> '{jit=off}', format('got config: %L', result.rolconfig);
         END $$
       SQL


### PR DESCRIPTION
PostgreSQL 10 does not have a `jit` parameter. The current release of pgMonitor includes this fix and correctly applies it to specific versions of PostgreSQL.

This partially reverts commit df492f1361a569690062c6ea350cdc733390be1d.