### PR TITLE
Bumping pgMonitor to v4.8.0.

### DIFF
--- a/bin/crunchy-postgres-exporter/start.sh
+++ b/bin/crunchy-postgres-exporter/start.sh
@@ -204,7 +204,7 @@ else
         else
           echo_warn "Query file queries_pg_stat_statements_reset_info.yml not loaded."
         fi
-    elif (( ${VERSION?} >= 140000 ))
+    elif (( ${VERSION?} >= 140000 )) && (( ${VERSION?} < 150000 ))
     then
         if [[ -f ${CONFIG_DIR?}/pg14/queries_general.yml ]]
         then
@@ -223,6 +223,28 @@ else
         if [[ -f ${CONFIG_DIR?}/pg14/queries_pg_stat_statements_reset_info.yml ]];
         then
           cat ${CONFIG_DIR?}/pg14/queries_pg_stat_statements_reset_info.yml >> /tmp/queries.yml
+        else
+          echo_warn "Query file queries_pg_stat_statements_reset_info.yml not loaded."
+        fi
+    elif (( ${VERSION?} >= 150000 ))
+    then
+        if [[ -f ${CONFIG_DIR?}/pg15/queries_general.yml ]]
+        then
+            cat ${CONFIG_DIR?}/pg15/queries_general.yml >> /tmp/queries.yml
+        else
+            echo_err "Query file queries_general.yml does not exist (it should).."
+        fi
+        if [[ -f ${CONFIG_DIR?}/pg15/queries_pg_stat_statements.yml ]]
+        then
+          cat ${CONFIG_DIR?}/pg15/queries_pg_stat_statements.yml >> /tmp/queries.yml
+        else
+          echo_warn "Query file queries_pg_stat_statements.yml not loaded."
+        fi
+        # queries_pg_stat_statements_reset is only available in PG12+. This may
+        # need to be updated based on a new path
+        if [[ -f ${CONFIG_DIR?}/pg15/queries_pg_stat_statements_reset_info.yml ]];
+        then
+          cat ${CONFIG_DIR?}/pg15/queries_pg_stat_statements_reset_info.yml >> /tmp/queries.yml
         else
           echo_warn "Query file queries_pg_stat_statements_reset_info.yml not loaded."
         fi

--- a/bin/get-pgmonitor.sh
+++ b/bin/get-pgmonitor.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 echo "Getting pgMonitor..."
-PGMONITOR_COMMIT='v4.7'
+PGMONITOR_COMMIT='v4.8.0'
 
 # pgMonitor Setup
 if [[ -d ${PGOROOT?}/tools/pgmonitor ]]

--- a/build/pgo-base/Dockerfile
+++ b/build/pgo-base/Dockerfile
@@ -35,6 +35,6 @@ RUN if [ "$BASEOS" = "ubi8" ] ; then \
 fi
 
 # Crunchy PostgreSQL repository
-ADD conf/RPM-GPG-KEY-crunchydata* /
+ADD conf/*KEY* /
 ADD conf/crunchypg${PGVERSION}.repo /etc/yum.repos.d/
-RUN rpm --import RPM-GPG-KEY-crunchydata*
+RUN rpm --import *GPG-KEY-crunchydata*

--- a/conf/.gitignore
+++ b/conf/.gitignore
@@ -1,4 +1,4 @@
 *.repo
 *.public
 *.private
-RPM-GPG-KEY-*
+*KEY*

--- a/hack/update-pgmonitor-installer.sh
+++ b/hack/update-pgmonitor-installer.sh
@@ -19,7 +19,7 @@
 directory=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 # The pgMonitor tag to use to refresh the current monitoring installer
-pgmonitor_tag=v4.7
+pgmonitor_tag=v4.8.0
 
 # Set the directory for the monitoring Kustomize installer
 pgo_examples_monitoring_dir="${directory}/../../postgres-operator-examples/kustomize/monitoring"


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [X] Other


**What is the current behavior (link to any open issues here)?**

The crunchy-postgres-exporter build currently uses pgMonitor 4.7 and the maximum Postgres version it is compatible with is 14.

[SC-16701]

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

With this update, postgres-exporter will use pgMonitor 4.8 and is compatible with PG 15.

**Other Information**:
