### PR TITLE
Add Postgres 15 RELATED_IMAGE environment variable

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,6 +32,8 @@ spec:
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.6-3.2-2"
         - name: RELATED_IMAGE_POSTGRES_14_GIS_3.3
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.6-3.3-0"
+        - name: RELATED_IMAGE_POSTGRES_15
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.0-0"
         - name: RELATED_IMAGE_POSTGRES_15_GIS_3.3
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-15.0-3.3-0"
         - name: RELATED_IMAGE_PGADMIN


### PR DESCRIPTION
This commit adds the Postgres 15 RELATED_IMAGE environment variable to manager.yaml

**Other Information**:

Issue: [sc-16943]