### PR TITLE
Update the minimum Kubernetes and OCP OLM versions

### DIFF
--- a/installers/olm/README.md
+++ b/installers/olm/README.md
@@ -76,6 +76,10 @@ and the kube minversion validation was in fact limiting the OCP version as well.
 be treated independently, but that was unfortunately not the case. The fix for this was to move this kube version to the
 1.19, despite its being released 3rd quarter of 2020 with 1 year of patch support.
 
+Following the lessons learned above, when bumping the Openshift supported version from v4.6 to v4.8, we will similarly
+keep the matching minimum Kubernetes version, i.e. 1.21.
+https://access.redhat.com/solutions/4870701
+
 ## Testing
 
 ### Setup

--- a/installers/olm/bundle.annotations.yaml
+++ b/installers/olm/bundle.annotations.yaml
@@ -29,10 +29,10 @@ annotations:
   operators.operatorframework.io.bundle.channels.v1: v5
   operators.operatorframework.io.bundle.channel.default.v1: v5
 
-  # OpenShift v4.6 is the first version to support CustomResourceDefinition v1.
+  # OpenShift v4.8 is the lowest version supported for v5.3.0+.
   # https://github.com/operator-framework/community-operators/blob/8a36a33/docs/packaging-required-criteria-ocp.md
   # https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
   com.redhat.delivery.operator.bundle: true
-  com.redhat.openshift.versions: 'v4.6'
+  com.redhat.openshift.versions: 'v4.8'
 
 ...

--- a/installers/olm/bundle.csv.yaml
+++ b/installers/olm/bundle.csv.yaml
@@ -56,7 +56,7 @@ spec:
 
   # https://olm.operatorframework.io/docs/best-practices/common/
   # Note: The minKubeVersion must correspond to the lowest supported OCP version
-  minKubeVersion: 1.19.0
+  minKubeVersion: 1.21.0
   maturity: stable
   # https://github.com/operator-framework/operator-lifecycle-manager/blob/v0.18.2/doc/design/how-to-update-operators.md#replaces--channels
   replaces: '' # generate.sh


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
PGO 5.3.0 will support, per the documentation, Kubernetes 1.22-1.25 and OpenShift 4.8-4.11. However, the OLM bundle minKubeVersion must match the minimum OCP's included Kubernetes version, which is 1.21 per https://access.redhat.com/solutions/4870701.

Therefore, this commit sets 'com.redhat.openshift.versions' to v4.8 and 'minKubeVersion' to 1.21.0 for our OLM bundle generation.

**Other Information**:
Issue: [sc-16943]