### PR TITLE
Remove backup assertions from some KUTTL tests

### DIFF
--- a/testing/kuttl/e2e/exporter/00-assert.yaml
+++ b/testing/kuttl/e2e/exporter/00-assert.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
@@ -8,17 +9,3 @@ status:
       readyReplicas: 1
       replicas: 1
       updatedReplicas: 1
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  labels:
-    postgres-operator.crunchydata.com/cluster: exporter
-    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
-status:
-  succeeded: 1
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: exporter-primary

--- a/testing/kuttl/e2e/exporter/01--check-exporter.yaml
+++ b/testing/kuttl/e2e/exporter/01--check-exporter.yaml
@@ -11,6 +11,13 @@ commands:
             postgres-operator.crunchydata.com/role=master'
       )
 
+      # TODO: We have no notion of exporter readiness.
+      for _ in $(seq 10); do
+        kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -c exporter \
+          -- curl --head --silent 'http://localhost:9187/metrics' && break
+        sleep 1
+      done
+
       # Ensure that the metrics endpoint is available from inside the exporter container
       {
         METRICS=$(kubectl exec --namespace "${NAMESPACE}" \

--- a/testing/kuttl/e2e/exporter/10-assert.yaml
+++ b/testing/kuttl/e2e/exporter/10-assert.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
@@ -8,20 +9,6 @@ status:
       readyReplicas: 1
       replicas: 1
       updatedReplicas: 1
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  labels:
-    postgres-operator.crunchydata.com/cluster: exporter-tls
-    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
-status:
-  succeeded: 1
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: exporter-tls-primary
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/testing/kuttl/e2e/exporter/11--check-exporter-tls.yaml
+++ b/testing/kuttl/e2e/exporter/11--check-exporter-tls.yaml
@@ -11,6 +11,13 @@ commands:
             postgres-operator.crunchydata.com/role=master'
       )
 
+      # TODO: We have no notion of exporter readiness.
+      for _ in $(seq 10); do
+        kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -c exporter \
+          -- curl --insecure --head --silent 'https://localhost:9187/metrics' && break
+        sleep 1
+      done
+
       # Ensure that the metrics endpoint is available from inside the exporter container
       {
         METRICS=$(kubectl exec --namespace "${NAMESPACE}" \

--- a/testing/kuttl/e2e/streaming-standby/01-assert.yaml
+++ b/testing/kuttl/e2e/streaming-standby/01-assert.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
@@ -9,21 +10,7 @@ status:
       replicas: 1
       updatedReplicas: 1
 ---
-apiVersion: batch/v1
-kind: Job
-metadata:
-  labels:
-    postgres-operator.crunchydata.com/cluster: primary-cluster
-    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
-status:
-  succeeded: 1
----
 apiVersion: v1
 kind: Service
 metadata:
   name: primary-cluster-primary
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: primary-cluster-ha

--- a/testing/kuttl/e2e/streaming-standby/03-assert.yaml
+++ b/testing/kuttl/e2e/streaming-standby/03-assert.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:


### PR DESCRIPTION
Postgres 15 changed the way it handles `CREATE DATABASE` which slows down the initial backup we take. These changes speed up the test suite for me locally.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

**What is the current behavior (link to any open issues here)?**

```
--- Postgres 14
        --- PASS: kuttl/harness/exporter (129.71s)
        --- PASS: kuttl/harness/streaming-standby (96.56s)
--- Postgres 15
        --- PASS: kuttl/harness/exporter (384.46s)
        --- PASS: kuttl/harness/streaming-standby (247.31s)
```

**What is the new behavior (if this is a feature change)?**

```
--- Postgres 14
        --- PASS: kuttl/harness/exporter (43.33s)
        --- PASS: kuttl/harness/streaming-standby (52.48s)
--- Postgres 15
        --- PASS: kuttl/harness/exporter (43.95s)
        --- PASS: kuttl/harness/streaming-standby (136.34s)
```

**Other Information**:

Issue: [sc-17016]