### PR TITLE
Bumping min OCP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ For more information about which versions of the PostgreSQL Operator include whi
 PGO, the Postgres Operator from Crunchy Data, is tested on the following platforms:
 
 - Kubernetes 1.22-1.25
-- OpenShift 4.8-4.11
+- OpenShift 4.9-4.11
 - Rancher
 - Google Kubernetes Engine (GKE), including Anthos
 - Amazon EKS

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -25,7 +25,7 @@ PGO is developed with many years of production experience in automating Postgres
 PGO, the Postgres Operator from Crunchy Data, is tested on the following platforms:
 
 - Kubernetes 1.22-1.25
-- OpenShift 4.8-4.11
+- OpenShift 4.9-4.11
 - Rancher
 - Google Kubernetes Engine (GKE), including Anthos
 - Amazon EKS

--- a/docs/content/references/components.md
+++ b/docs/content/references/components.md
@@ -10,7 +10,7 @@ weight: 110
 PGO, the Postgres Operator from Crunchy Data, is tested on the following platforms:
 
 - Kubernetes 1.22-1.25
-- OpenShift 4.8-4.11
+- OpenShift 4.9-4.11
 - Rancher
 - Google Kubernetes Engine (GKE), including Anthos
 - Amazon EKS

--- a/installers/olm/bundle.annotations.yaml
+++ b/installers/olm/bundle.annotations.yaml
@@ -29,10 +29,10 @@ annotations:
   operators.operatorframework.io.bundle.channels.v1: v5
   operators.operatorframework.io.bundle.channel.default.v1: v5
 
-  # OpenShift v4.8 is the lowest version supported for v5.3.0+.
+  # OpenShift v4.9 is the lowest version supported for v5.3.0+.
   # https://github.com/operator-framework/community-operators/blob/8a36a33/docs/packaging-required-criteria-ocp.md
   # https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
   com.redhat.delivery.operator.bundle: true
-  com.redhat.openshift.versions: 'v4.8'
+  com.redhat.openshift.versions: 'v4.9'
 
 ...


### PR DESCRIPTION
**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

The operator works on 4.8, but due to the extract command used there, we cannot install on 4.8 using OperatorHub. (The bundle ends up being too big and 4.8 doesn't offer the gzip option that 4.9 does.)

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Update min in docs

**Other Information**:
