### PR TITLE
Document Postgres 15 recovery_target_action behavior

### DIFF
--- a/internal/pgbackrest/restore.md
+++ b/internal/pgbackrest/restore.md
@@ -28,11 +28,6 @@ For PostgreSQL 9.5 through 15,
    of `pause` will act the same as `shutdown`," but that cannot be configured
    through pgBackRest.
 
- - The pgBackRest documentation seems to state that `--target-action` has no
-   effect when `hot_standby=off`, but that is not the case.
-
-   See: https://github.com/pgbackrest/pgbackrest/issues/987
-
 The default value of `hot_standby` is `off` prior to PostgreSQL 10 and `on` since.
 
 ### PostgreSQL 15, 14, 13, 12

--- a/internal/pgbackrest/restore.md
+++ b/internal/pgbackrest/restore.md
@@ -19,7 +19,7 @@ The `--target-action` option of `pgbackrest restore` almost translates to the
 PostgreSQL `recovery_target_action` parameter but not exactly. The behavior of
 that parameter also depends on the PostgreSQL version and on other parameters.
 
-For PostgreSQL 9.5 through 14,
+For PostgreSQL 9.5 through 15,
 
  - The PostgreSQL documentation states that for `recovery_target_action`
    "the default is `pause`," but that is only the case when `hot_standby=on`.
@@ -35,7 +35,7 @@ For PostgreSQL 9.5 through 14,
 
 The default value of `hot_standby` is `off` prior to PostgreSQL 10 and `on` since.
 
-### PostgreSQL 14, 13, 12
+### PostgreSQL 15, 14, 13, 12
 
 [12]: https://www.postgresql.org/docs/12/runtime-config-wal.html
 [commit]: https://git.postgresql.org/gitweb/?p=postgresql.git;h=2dedf4d9a899b36d1a8ed29be5efbd1b31a8fe85


### PR DESCRIPTION
I ran the steps at the bottom of this doc and confirmed that Postgres 15 behaves the same as Postgres 14.

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other
