### PR TITLE
Integrate pg upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,7 @@ check-kuttl:
 		--config testing/kuttl/kuttl-test.yaml
 
 .PHONY: generate-kuttl
+generate-kuttl: export KUTTL_PG_UPGRADE_FROM_VERSION ?= 13
 generate-kuttl: export KUTTL_PG_VERSION ?= 14
 generate-kuttl: export KUTTL_POSTGIS_VERSION ?= 3.1
 generate-kuttl: export KUTTL_PSQL_IMAGE ?= registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.6-2
@@ -234,7 +235,7 @@ generate-kuttl:
 	12 ) export KUTTL_BITNAMI_IMAGE_TAG=12.12.0-debian-11-r40 ;; \
 	11 ) export KUTTL_BITNAMI_IMAGE_TAG=11.17.0-debian-11-r39 ;; \
 	esac; \
-	render() { envsubst '"'"'$$KUTTL_PG_VERSION $$KUTTL_POSTGIS_VERSION $$KUTTL_PSQL_IMAGE $$KUTTL_BITNAMI_IMAGE_TAG'"'"'; }; \
+	render() { envsubst '"'"'$$KUTTL_PG_UPGRADE_FROM_VERSION $$KUTTL_PG_VERSION $$KUTTL_POSTGIS_VERSION $$KUTTL_PSQL_IMAGE $$KUTTL_BITNAMI_IMAGE_TAG'"'"'; }; \
 	while [ $$# -gt 0 ]; do \
 		source="$${1}" target="$${1/e2e/e2e-generated}"; \
 		mkdir -p "$${target%/*}"; render < "$${source}" > "$${target}"; \

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+- bases/postgres-operator.crunchydata.com_pgupgrades.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,6 +44,8 @@ spec:
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.17-5"
         - name: RELATED_IMAGE_PGEXPORTER
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.3.0-0"
+        - name: RELATED_IMAGE_PGUPGRADE
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi8-5.3.0-0"        
         securityContext:
           allowPrivilegeEscalation: false
           capabilities: { drop: [ALL] }

--- a/config/rbac/cluster/role.yaml
+++ b/config/rbac/cluster/role.yaml
@@ -102,24 +102,34 @@ rules:
 - apiGroups:
   - postgres-operator.crunchydata.com
   resources:
-  - postgresclusters
+  - pgupgrades
   verbs:
   - get
   - list
-  - patch
   - watch
 - apiGroups:
   - postgres-operator.crunchydata.com
   resources:
+  - pgupgrades/finalizers
   - postgresclusters/finalizers
   verbs:
   - update
 - apiGroups:
   - postgres-operator.crunchydata.com
   resources:
+  - pgupgrades/status
   - postgresclusters/status
   verbs:
   - patch
+- apiGroups:
+  - postgres-operator.crunchydata.com
+  resources:
+  - postgresclusters
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/config/rbac/namespace/role.yaml
+++ b/config/rbac/namespace/role.yaml
@@ -102,24 +102,34 @@ rules:
 - apiGroups:
   - postgres-operator.crunchydata.com
   resources:
-  - postgresclusters
+  - pgupgrades
   verbs:
   - get
   - list
-  - patch
   - watch
 - apiGroups:
   - postgres-operator.crunchydata.com
   resources:
+  - pgupgrades/finalizers
   - postgresclusters/finalizers
   verbs:
   - update
 - apiGroups:
   - postgres-operator.crunchydata.com
   resources:
+  - pgupgrades/status
   - postgresclusters/status
   verbs:
   - patch
+- apiGroups:
+  - postgres-operator.crunchydata.com
+  resources:
+  - postgresclusters
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/internal/controller/pgupgrade/apply.go
+++ b/internal/controller/pgupgrade/apply.go
@@ -1,0 +1,164 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgupgrade
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// JSON6902 represents a JSON Patch according to RFC 6902; the same as
+// k8s.io/apimachinery/pkg/types.JSONPatchType.
+type JSON6902 []interface{}
+
+// NewJSONPatch creates a new JSON Patch according to RFC 6902; the same as
+// k8s.io/apimachinery/pkg/types.JSONPatchType.
+func NewJSONPatch() *JSON6902 { return &JSON6902{} }
+
+// escapeJSONPointer encodes '~' and '/' according to RFC 6901.
+var escapeJSONPointer = strings.NewReplacer(
+	"~", "~0",
+	"/", "~1",
+).Replace
+
+func (*JSON6902) pointer(tokens ...string) string {
+	var b strings.Builder
+
+	for _, t := range tokens {
+		_ = b.WriteByte('/')
+		_, _ = b.WriteString(escapeJSONPointer(t))
+	}
+
+	return b.String()
+}
+
+// Add appends an "add" operation to patch.
+//
+// > The "add" operation performs one of the following functions,
+// > depending upon what the target location references:
+// >
+// > o  If the target location specifies an array index, a new value is
+// >    inserted into the array at the specified index.
+// >
+// > o  If the target location specifies an object member that does not
+// >    already exist, a new member is added to the object.
+// >
+// > o  If the target location specifies an object member that does exist,
+// >    that member's value is replaced.
+//
+
+func (patch *JSON6902) Add(path ...string) func(value interface{}) *JSON6902 {
+	i := len(*patch)
+	f := func(value interface{}) *JSON6902 {
+		(*patch)[i] = map[string]interface{}{
+			"op":    "add",
+			"path":  patch.pointer(path...),
+			"value": value,
+		}
+		return patch
+	}
+
+	*patch = append(*patch, f)
+
+	return f
+}
+
+// Remove appends a "remove" operation to patch.
+//
+// > The "remove" operation removes the value at the target location.
+// >
+// > The target location MUST exist for the operation to be successful.
+//
+
+func (patch *JSON6902) Remove(path ...string) *JSON6902 {
+	*patch = append(*patch, map[string]interface{}{
+		"op":   "remove",
+		"path": patch.pointer(path...),
+	})
+
+	return patch
+}
+
+// Replace appends a "replace" operation to patch.
+//
+// > The "replace" operation replaces the value at the target location
+// > with a new value.
+// >
+// > The target location MUST exist for the operation to be successful.
+//
+
+func (patch *JSON6902) Replace(path ...string) func(value interface{}) *JSON6902 {
+	i := len(*patch)
+	f := func(value interface{}) *JSON6902 {
+		(*patch)[i] = map[string]interface{}{
+			"op":    "replace",
+			"path":  patch.pointer(path...),
+			"value": value,
+		}
+		return patch
+	}
+
+	*patch = append(*patch, f)
+
+	return f
+}
+
+// Bytes returns the JSON representation of patch.
+func (patch JSON6902) Bytes() ([]byte, error) { return patch.Data(nil) }
+
+// Data returns the JSON representation of patch.
+func (patch JSON6902) Data(client.Object) ([]byte, error) { return json.Marshal(patch) }
+
+// IsEmpty returns true when patch has no operations.
+func (patch JSON6902) IsEmpty() bool { return len(patch) == 0 }
+
+// Type returns k8s.io/apimachinery/pkg/types.JSONPatchType.
+func (patch JSON6902) Type() types.PatchType { return types.JSONPatchType }
+
+// patch sends patch to object's endpoint in the Kubernetes API and updates
+// object with any returned content. The fieldManager is set to r.Owner, but
+// can be overridden in options.
+// - https://docs.k8s.io/reference/using-api/server-side-apply/#managers
+func (r *PGUpgradeReconciler) patch(
+	ctx context.Context, object client.Object,
+	patch client.Patch, options ...client.PatchOption,
+) error {
+	options = append([]client.PatchOption{r.Owner}, options...)
+	return r.Client.Patch(ctx, object, patch, options...)
+}
+
+// apply sends an apply patch to object's endpoint in the Kubernetes API and
+// updates object with any returned content. The fieldManager is set to
+// r.Owner and the force parameter is true.
+// - https://docs.k8s.io/reference/using-api/server-side-apply/#managers
+// - https://docs.k8s.io/reference/using-api/server-side-apply/#conflicts
+func (r *PGUpgradeReconciler) apply(ctx context.Context, object client.Object) error {
+	// Generate an apply-patch by comparing the object to its zero value.
+	zero := reflect.New(reflect.TypeOf(object).Elem()).Interface()
+	data, err := client.MergeFrom(zero.(client.Object)).Data(object)
+	apply := client.RawPatch(client.Apply.Type(), data)
+
+	// Send the apply-patch with force=true.
+	if err == nil {
+		err = r.patch(ctx, object, apply, client.ForceOwnership)
+	}
+
+	return err
+}

--- a/internal/controller/pgupgrade/jobs.go
+++ b/internal/controller/pgupgrade/jobs.go
@@ -1,0 +1,340 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgupgrade
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/pointer"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+)
+
+// Upgrade job
+
+// pgUpgradeJob returns the ObjectMeta for the pg_upgrade Job utilized to
+// upgrade from one major PostgreSQL version to another
+func pgUpgradeJob(upgrade *v1beta1.PGUpgrade) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Namespace: upgrade.Namespace,
+		Name:      upgrade.Name + "-pgdata",
+	}
+}
+
+// upgradeCommand returns an entrypoint that prepares the filesystem for
+// and performs a PostgreSQL major version upgrade using pg_upgrade.
+func upgradeCommand(upgrade *v1beta1.PGUpgrade) []string {
+	oldVersion := fmt.Sprint(upgrade.Spec.FromPostgresVersion)
+	newVersion := fmt.Sprint(upgrade.Spec.ToPostgresVersion)
+
+	args := []string{oldVersion, newVersion}
+	script := strings.Join([]string{
+		`declare -r data_volume='/pgdata' old_version="$1" new_version="$2"`,
+		`printf 'Performing PostgreSQL upgrade from version "%s" to "%s" ...\n\n' "$@"`,
+
+		// Note: Rather than import the nss_wrapper init container, as we do in
+		// the main postgres-operator, this job does the required nss_wrapper
+		// settings here.
+
+		// Create a copy of the system group definitions, but remove the "postgres"
+		// group or any group with the current GID. Replace them with our own that
+		// has the current GID.
+		`gid=$(id -G); NSS_WRAPPER_GROUP=$(mktemp)`,
+		`(sed "/^postgres:x:/ d; /^[^:]*:x:${gid%% *}:/ d" /etc/group`,
+		`echo "postgres:x:${gid%% *}:") > "${NSS_WRAPPER_GROUP}"`,
+
+		// Create a copy of the system user definitions, but remove the "postgres"
+		// user or any user with the currrent UID. Replace them with our own that
+		// has the current UID and GID.
+		`uid=$(id -u); NSS_WRAPPER_PASSWD=$(mktemp)`,
+		`(sed "/^postgres:x:/ d; /^[^:]*:x:${uid}:/ d" /etc/passwd`,
+		`echo "postgres:x:${uid}:${gid%% *}::${data_volume}:") > "${NSS_WRAPPER_PASSWD}"`,
+
+		// Enable nss_wrapper so the current UID and GID resolve to "postgres".
+		// - https://cwrap.org/nss_wrapper.html
+		`export LD_PRELOAD='libnss_wrapper.so' NSS_WRAPPER_GROUP NSS_WRAPPER_PASSWD`,
+
+		// Below is the pg_upgrade script used to upgrade a PostgresCluster from
+		// one major verson to another. Additional information concerning the
+		// steps used and command flag specifics can be found in the documentation:
+		// - https://www.postgresql.org/docs/current/pgupgrade.html
+
+		// To begin, we first move to the mounted /pgdata directory and create a
+		// new version directory which is then initialized with the initdb command.
+		`cd /pgdata || exit`,
+		`echo -e "Step 1: Making new pgdata directory...\n"`,
+		`mkdir /pgdata/pg"${new_version}"`,
+		`echo -e "Step 2: Initializing new pgdata directory...\n"`,
+		`/usr/pgsql-"${new_version}"/bin/initdb -k -D /pgdata/pg"${new_version}"`,
+
+		// Before running the upgrade check, which ensures the clusters are compatible,
+		// proper permissions have to be set on the old pgdata directory and the
+		// preload library settings must be copied over.
+		`echo -e "\nStep 3: Setting the expected permissions on the old pgdata directory...\n"`,
+		`chmod 700 /pgdata/pg"${old_version}"`,
+		`echo -e "Step 4: Copying shared_preload_libraries setting to new postgresql.conf file...\n"`,
+		`echo "shared_preload_libraries = '$(/usr/pgsql-"""${old_version}"""/bin/postgres -D \`,
+		`/pgdata/pg"""${old_version}""" -C shared_preload_libraries)'" >> /pgdata/pg"${new_version}"/postgresql.conf`,
+
+		// Before the actual upgrade is run, we will run the upgrade --check to
+		// verify everything before actually changing any data.
+		`echo -e "Step 5: Running pg_upgrade check...\n"`,
+		`time /usr/pgsql-"${new_version}"/bin/pg_upgrade --old-bindir /usr/pgsql-"${old_version}"/bin \`,
+		`--new-bindir /usr/pgsql-"${new_version}"/bin --old-datadir /pgdata/pg"${old_version}"\`,
+		` --new-datadir /pgdata/pg"${new_version}" --link --check`,
+
+		// Assuming the check completes successfully, the pg_upgrade command will
+		// be run that actually prepares the upgraded pgdata directory.
+		`echo -e "\nStep 6: Running pg_upgrade...\n"`,
+		`time /usr/pgsql-"${new_version}"/bin/pg_upgrade --old-bindir /usr/pgsql-"${old_version}"/bin \`,
+		`--new-bindir /usr/pgsql-"${new_version}"/bin --old-datadir /pgdata/pg"${old_version}" \`,
+		`--new-datadir /pgdata/pg"${new_version}" --link`,
+
+		// Since we have cleared the Patroni cluster step by removing the EndPoints, we copy patroni.dynamic.json
+		// from the old data dir to help retain PostgreSQL parameters you had set before.
+		// - https://patroni.readthedocs.io/en/latest/existing_data.html#major-upgrade-of-postgresql-version
+		`echo -e "\nStep 7: Copying patroni.dynamic.json...\n"`,
+		`cp /pgdata/pg"${old_version}"/patroni.dynamic.json /pgdata/pg"${new_version}"`,
+
+		`echo -e "\npg_upgrade Job Complete!"`,
+	}, "\n")
+
+	return append([]string{"bash", "-ceu", "--", script, "upgrade"}, args...)
+}
+
+// generateUpgradeJob returns a Job that can upgrade the PostgreSQL data
+// directory of the startup instance.
+func (r *PGUpgradeReconciler) generateUpgradeJob(
+	_ context.Context, upgrade *v1beta1.PGUpgrade, startup *appsv1.StatefulSet,
+) *batchv1.Job {
+	job := &batchv1.Job{}
+	job.SetGroupVersionKind(batchv1.SchemeGroupVersion.WithKind("Job"))
+
+	job.Namespace = upgrade.Namespace
+	job.Name = pgUpgradeJob(upgrade).Name
+
+	job.Annotations = upgrade.Spec.Metadata.GetAnnotationsOrNil()
+	job.Labels = Merge(upgrade.Spec.Metadata.GetLabelsOrNil(),
+		commonLabels(pgUpgrade, upgrade), //FIXME role pgupgrade
+		map[string]string{
+			LabelVersion: fmt.Sprint(upgrade.Spec.ToPostgresVersion),
+		})
+
+	// Find the database container.
+	var database *corev1.Container
+	for i := range startup.Spec.Template.Spec.Containers {
+		container := startup.Spec.Template.Spec.Containers[i]
+		if container.Name == ContainerDatabase {
+			database = &container
+		}
+	}
+
+	// Copy the pod template from the startup instance StatefulSet. This includes
+	// the service account, volumes, DNS policies, and scheduling constraints.
+	startup.Spec.Template.DeepCopyInto(&job.Spec.Template)
+
+	// Use the same labels and annotations as the job.
+	job.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+		Annotations: job.Annotations,
+		Labels:      job.Labels,
+	}
+
+	// Use the image pull secrets specified for the upgrade image.
+	job.Spec.Template.Spec.ImagePullSecrets = upgrade.Spec.ImagePullSecrets
+
+	// Attempt the upgrade exactly once.
+	job.Spec.BackoffLimit = pointer.Int32Ptr(0)
+	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
+
+	// Replace all containers with one that does the upgrade.
+	job.Spec.Template.Spec.EphemeralContainers = nil
+	job.Spec.Template.Spec.InitContainers = nil
+	job.Spec.Template.Spec.Containers = []corev1.Container{{
+		// Copy volume mounts and the security context needed to access them
+		// from the database container. There is a downward API volume that
+		// refers back to the container by name, so use that same name here.
+		Name:            database.Name,
+		SecurityContext: database.SecurityContext,
+		VolumeMounts:    database.VolumeMounts,
+
+		// Use our upgrade command and the specified image and resources.
+		Command:         upgradeCommand(upgrade),
+		Image:           pgUpgradeContainerImage(upgrade),
+		ImagePullPolicy: upgrade.Spec.ImagePullPolicy,
+		Resources:       upgrade.Spec.Resources,
+	}}
+
+	// The following will set these fields to null if not set in the spec
+	job.Spec.Template.Spec.Affinity = upgrade.Spec.Affinity
+	job.Spec.Template.Spec.PriorityClassName = pointer.StringPtrDerefOr(
+		upgrade.Spec.PriorityClassName,
+		"")
+	job.Spec.Template.Spec.Tolerations = upgrade.Spec.Tolerations
+
+	r.setControllerReference(upgrade, job)
+	return job
+}
+
+// Remove data job
+
+// removeDataCommand returns an entrypoint that removes certain directories.
+// We currently target the `pgdata/pg{old_version}` and `pgdata/pg{old_version}_wal`
+// directories for removal.
+func removeDataCommand(upgrade *v1beta1.PGUpgrade) []string {
+	oldVersion := fmt.Sprint(upgrade.Spec.FromPostgresVersion)
+
+	// Before removing the directories (both data and wal), we check that
+	// the directory is not in use by running `pg_controldata` and making sure
+	// the server state is "shut down in recovery"
+	// TODO(benjaminjb): pg_controldata seems pretty stable, but might want to
+	// experiment with a few more versions.
+	args := []string{oldVersion}
+	script := strings.Join([]string{
+		`declare -r old_version="$1"`,
+		`printf 'Removing PostgreSQL data dir for pg%s...\n\n' "$@"`,
+		`echo -e "Checking the directory exists and isn't being used...\n"`,
+		`cd /pgdata || exit`,
+		// The string `shut down in recovery` is the dbstate that postgres sets from
+		// at least version 10 to 14 when a replica has been shut down.
+		// - https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/bin/pg_controldata/pg_controldata.c;h=f911f98d946d83f1191abf35239d9b4455c5f52a;hb=HEAD#l59
+		// Note: `pg_controldata` is actually used by `pg_upgrade` before upgrading
+		// to make sure that the server in question is shut down as a primary;
+		// that aligns with our use here, where we're making sure that the server in question
+		// was shut down as a replica.
+		// - https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/bin/pg_upgrade/controldata.c;h=41b8f69b8cbe4f40e6098ad84c2e8e987e24edaf;hb=HEAD#l122
+		`if [ "$(/usr/pgsql-"${old_version}"/bin/pg_controldata /pgdata/pg"${old_version}" | grep -c "shut down in recovery")" -ne 1 ]; then echo -e "Directory in use, cannot remove..."; exit 1; fi`,
+		`echo -e "Removing old pgdata directory...\n"`,
+		// When deleting the wal directory, use `realpath` to resolve the symlink from
+		// the pgdata directory. This is necessary because the wal directory can be
+		// mounted at different places depending on if an external wal PVC is used,
+		// i.e. `/pgdata/pg14_wal` vs `/pgwal/pg14_wal`
+		`rm -rf /pgdata/pg"${old_version}" "$(realpath /pgdata/pg${old_version}/pg_wal)"`,
+		`echo -e "Remove Data Job Complete!"`,
+	}, "\n")
+
+	return append([]string{"bash", "-ceu", "--", script, "remove"}, args...)
+}
+
+// generateRemoveDataJob returns a Job that can remove the data
+// on the given replica StatefulSet
+func (r *PGUpgradeReconciler) generateRemoveDataJob(
+	_ context.Context, upgrade *v1beta1.PGUpgrade, sts *appsv1.StatefulSet,
+) *batchv1.Job {
+	job := &batchv1.Job{}
+	job.SetGroupVersionKind(batchv1.SchemeGroupVersion.WithKind("Job"))
+
+	job.Namespace = upgrade.Namespace
+	job.Name = upgrade.Name + "-" + sts.Name
+
+	job.Annotations = upgrade.Spec.Metadata.GetAnnotationsOrNil()
+	job.Labels = labels.Merge(upgrade.Spec.Metadata.GetLabelsOrNil(),
+		commonLabels(removeData, upgrade)) //FIXME role removedata
+
+	// Find the database container.
+	var database *corev1.Container
+	for i := range sts.Spec.Template.Spec.Containers {
+		container := sts.Spec.Template.Spec.Containers[i]
+		if container.Name == ContainerDatabase {
+			database = &container
+		}
+	}
+
+	// Copy the pod template from the sts instance StatefulSet. This includes
+	// the service account, volumes, DNS policies, and scheduling constraints.
+	sts.Spec.Template.DeepCopyInto(&job.Spec.Template)
+
+	// Use the same labels and annotations as the job.
+	job.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+		Annotations: job.Annotations,
+		Labels:      job.Labels,
+	}
+
+	// Use the image pull secrets specified for the upgrade image.
+	job.Spec.Template.Spec.ImagePullSecrets = upgrade.Spec.ImagePullSecrets
+
+	// Attempt the removal exactly once.
+	job.Spec.BackoffLimit = pointer.Int32Ptr(0)
+	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
+
+	// Replace all containers with one that removes the data.
+	job.Spec.Template.Spec.EphemeralContainers = nil
+	job.Spec.Template.Spec.InitContainers = nil
+	job.Spec.Template.Spec.Containers = []corev1.Container{{
+		// Copy volume mounts and the security context needed to access them
+		// from the database container. There is a downward API volume that
+		// refers back to the container by name, so use that same name here.
+		// We are using a PG image in order to check that the PG server is down.
+		Name:            database.Name,
+		SecurityContext: database.SecurityContext,
+		VolumeMounts:    database.VolumeMounts,
+
+		// Use our remove command and the specified resources.
+		Command:         removeDataCommand(upgrade),
+		Image:           pgUpgradeContainerImage(upgrade),
+		ImagePullPolicy: upgrade.Spec.ImagePullPolicy,
+		Resources:       upgrade.Spec.Resources,
+	}}
+
+	// The following will set these fields to null if not set in the spec
+	job.Spec.Template.Spec.Affinity = upgrade.Spec.Affinity
+	job.Spec.Template.Spec.PriorityClassName = pointer.StringPtrDerefOr(
+		upgrade.Spec.PriorityClassName,
+		"")
+	job.Spec.Template.Spec.Tolerations = upgrade.Spec.Tolerations
+
+	r.setControllerReference(upgrade, job)
+	return job
+}
+
+// Util functions
+
+// pgUpgradeContainerImage returns the container image to use for pg_upgrade.
+func pgUpgradeContainerImage(upgrade *v1beta1.PGUpgrade) string {
+	var image string
+	if upgrade.Spec.Image != nil {
+		image = *upgrade.Spec.Image
+	}
+	return defaultFromEnv(image, "RELATED_IMAGE_PGUPGRADE")
+}
+
+// jobFailed returns "true" if the Job provided has failed.  Otherwise it returns "false".
+func jobFailed(job *batchv1.Job) bool {
+	conditions := job.Status.Conditions
+	for i := range conditions {
+		if conditions[i].Type == batchv1.JobFailed {
+			return (conditions[i].Status == corev1.ConditionTrue)
+		}
+	}
+	return false
+}
+
+// jobCompleted returns "true" if the Job provided completed successfully.  Otherwise it returns
+// "false".
+func jobCompleted(job *batchv1.Job) bool {
+	conditions := job.Status.Conditions
+	for i := range conditions {
+		if conditions[i].Type == batchv1.JobComplete {
+			return (conditions[i].Status == corev1.ConditionTrue)
+		}
+	}
+	return false
+}

--- a/internal/controller/pgupgrade/jobs_test.go
+++ b/internal/controller/pgupgrade/jobs_test.go
@@ -1,0 +1,266 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgupgrade
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/yaml"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+)
+
+// marshalMatches converts actual to YAML and compares that to expected.
+func marshalMatches(actual interface{}, expected string) cmp.Comparison {
+	b, err := yaml.Marshal(actual)
+	if err != nil {
+		return func() cmp.Result { return cmp.ResultFromError(err) }
+	}
+	return cmp.DeepEqual(string(b), strings.Trim(expected, "\t\n")+"\n")
+}
+
+func TestGenerateUpgradeJob(t *testing.T) {
+	ctx := context.Background()
+	reconciler := &PGUpgradeReconciler{}
+
+	upgrade := &v1beta1.PGUpgrade{}
+	upgrade.Namespace = "ns1"
+	upgrade.Name = "pgu2"
+	upgrade.UID = "uid3"
+	upgrade.Spec.Image = pointer.StringPtr("img4")
+	upgrade.Spec.PostgresClusterName = "pg5"
+	upgrade.Spec.FromPostgresVersion = 19
+	upgrade.Spec.ToPostgresVersion = 25
+	upgrade.Spec.Resources.Requests = corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("3.14"),
+	}
+
+	startup := &appsv1.StatefulSet{}
+	startup.Spec.Template.Spec = corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name: ContainerDatabase,
+
+			SecurityContext: &corev1.SecurityContext{Privileged: new(bool)},
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "vm1", MountPath: "/mnt/some/such"},
+			},
+		}},
+		Volumes: []corev1.Volume{
+			{
+				Name: "vol2",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: new(corev1.HostPathVolumeSource),
+				},
+			},
+		},
+	}
+
+	job := reconciler.generateUpgradeJob(ctx, upgrade, startup)
+	assert.Assert(t, marshalMatches(job, `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  creationTimestamp: null
+  labels:
+    postgres-operator.crunchydata.com/cluster: pg5
+    postgres-operator.crunchydata.com/pgupgrade: pgu2
+    postgres-operator.crunchydata.com/role: pgupgrade
+    postgres-operator.crunchydata.com/version: "25"
+  name: pgu2-pgdata
+  namespace: ns1
+  ownerReferences:
+  - apiVersion: postgres-operator.crunchydata.com/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PGUpgrade
+    name: pgu2
+    uid: uid3
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        postgres-operator.crunchydata.com/cluster: pg5
+        postgres-operator.crunchydata.com/pgupgrade: pgu2
+        postgres-operator.crunchydata.com/role: pgupgrade
+        postgres-operator.crunchydata.com/version: "25"
+    spec:
+      containers:
+      - command:
+        - bash
+        - -ceu
+        - --
+        - |-
+          declare -r data_volume='/pgdata' old_version="$1" new_version="$2"
+          printf 'Performing PostgreSQL upgrade from version "%s" to "%s" ...\n\n' "$@"
+          gid=$(id -G); NSS_WRAPPER_GROUP=$(mktemp)
+          (sed "/^postgres:x:/ d; /^[^:]*:x:${gid%% *}:/ d" /etc/group
+          echo "postgres:x:${gid%% *}:") > "${NSS_WRAPPER_GROUP}"
+          uid=$(id -u); NSS_WRAPPER_PASSWD=$(mktemp)
+          (sed "/^postgres:x:/ d; /^[^:]*:x:${uid}:/ d" /etc/passwd
+          echo "postgres:x:${uid}:${gid%% *}::${data_volume}:") > "${NSS_WRAPPER_PASSWD}"
+          export LD_PRELOAD='libnss_wrapper.so' NSS_WRAPPER_GROUP NSS_WRAPPER_PASSWD
+          cd /pgdata || exit
+          echo -e "Step 1: Making new pgdata directory...\n"
+          mkdir /pgdata/pg"${new_version}"
+          echo -e "Step 2: Initializing new pgdata directory...\n"
+          /usr/pgsql-"${new_version}"/bin/initdb -k -D /pgdata/pg"${new_version}"
+          echo -e "\nStep 3: Setting the expected permissions on the old pgdata directory...\n"
+          chmod 700 /pgdata/pg"${old_version}"
+          echo -e "Step 4: Copying shared_preload_libraries setting to new postgresql.conf file...\n"
+          echo "shared_preload_libraries = '$(/usr/pgsql-"""${old_version}"""/bin/postgres -D \
+          /pgdata/pg"""${old_version}""" -C shared_preload_libraries)'" >> /pgdata/pg"${new_version}"/postgresql.conf
+          echo -e "Step 5: Running pg_upgrade check...\n"
+          time /usr/pgsql-"${new_version}"/bin/pg_upgrade --old-bindir /usr/pgsql-"${old_version}"/bin \
+          --new-bindir /usr/pgsql-"${new_version}"/bin --old-datadir /pgdata/pg"${old_version}"\
+           --new-datadir /pgdata/pg"${new_version}" --link --check
+          echo -e "\nStep 6: Running pg_upgrade...\n"
+          time /usr/pgsql-"${new_version}"/bin/pg_upgrade --old-bindir /usr/pgsql-"${old_version}"/bin \
+          --new-bindir /usr/pgsql-"${new_version}"/bin --old-datadir /pgdata/pg"${old_version}" \
+          --new-datadir /pgdata/pg"${new_version}" --link
+          echo -e "\nStep 7: Copying patroni.dynamic.json...\n"
+          cp /pgdata/pg"${old_version}"/patroni.dynamic.json /pgdata/pg"${new_version}"
+          echo -e "\npg_upgrade Job Complete!"
+        - upgrade
+        - "19"
+        - "25"
+        image: img4
+        name: database
+        resources:
+          requests:
+            cpu: 3140m
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /mnt/some/such
+          name: vm1
+      restartPolicy: Never
+      volumes:
+      - hostPath:
+          path: ""
+        name: vol2
+status: {}
+	`))
+}
+
+func TestGenerateRemoveDataJob(t *testing.T) {
+	ctx := context.Background()
+	reconciler := &PGUpgradeReconciler{}
+
+	upgrade := &v1beta1.PGUpgrade{}
+	upgrade.Namespace = "ns1"
+	upgrade.Name = "pgu2"
+	upgrade.UID = "uid3"
+	upgrade.Spec.Image = pointer.StringPtr("img4")
+	upgrade.Spec.PostgresClusterName = "pg5"
+	upgrade.Spec.FromPostgresVersion = 19
+	upgrade.Spec.ToPostgresVersion = 25
+	upgrade.Spec.Resources.Requests = corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("3.14"),
+	}
+
+	sts := &appsv1.StatefulSet{}
+	sts.Name = "sts"
+	sts.Spec.Template.Spec = corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:            ContainerDatabase,
+			Image:           "img3",
+			SecurityContext: &corev1.SecurityContext{Privileged: new(bool)},
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "vm1", MountPath: "/mnt/some/such"},
+			},
+		}},
+		Volumes: []corev1.Volume{
+			{
+				Name: "vol2",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: new(corev1.HostPathVolumeSource),
+				},
+			},
+		},
+	}
+
+	job := reconciler.generateRemoveDataJob(ctx, upgrade, sts)
+	assert.Assert(t, marshalMatches(job, `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  creationTimestamp: null
+  labels:
+    postgres-operator.crunchydata.com/cluster: pg5
+    postgres-operator.crunchydata.com/pgupgrade: pgu2
+    postgres-operator.crunchydata.com/role: removedata
+  name: pgu2-sts
+  namespace: ns1
+  ownerReferences:
+  - apiVersion: postgres-operator.crunchydata.com/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PGUpgrade
+    name: pgu2
+    uid: uid3
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        postgres-operator.crunchydata.com/cluster: pg5
+        postgres-operator.crunchydata.com/pgupgrade: pgu2
+        postgres-operator.crunchydata.com/role: removedata
+    spec:
+      containers:
+      - command:
+        - bash
+        - -ceu
+        - --
+        - |-
+          declare -r old_version="$1"
+          printf 'Removing PostgreSQL data dir for pg%s...\n\n' "$@"
+          echo -e "Checking the directory exists and isn't being used...\n"
+          cd /pgdata || exit
+          if [ "$(/usr/pgsql-"${old_version}"/bin/pg_controldata /pgdata/pg"${old_version}" | grep -c "shut down in recovery")" -ne 1 ]; then echo -e "Directory in use, cannot remove..."; exit 1; fi
+          echo -e "Removing old pgdata directory...\n"
+          rm -rf /pgdata/pg"${old_version}" "$(realpath /pgdata/pg${old_version}/pg_wal)"
+          echo -e "Remove Data Job Complete!"
+        - remove
+        - "19"
+        image: img4
+        name: database
+        resources:
+          requests:
+            cpu: 3140m
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /mnt/some/such
+          name: vm1
+      restartPolicy: Never
+      volumes:
+      - hostPath:
+          path: ""
+        name: vol2
+status: {}
+	`))
+}

--- a/internal/controller/pgupgrade/labels.go
+++ b/internal/controller/pgupgrade/labels.go
@@ -1,0 +1,52 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgupgrade
+
+import (
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+)
+
+const (
+	// ConditionPGUpgradeProgressing is the type used in a condition to indicate that
+	// an Postgres major upgrade is in progress.
+	ConditionPGUpgradeProgressing = "Progressing"
+
+	// ConditionPGUpgradeSucceeded is the type used in a condition to indicate the
+	// status of a Postgres major upgrade.
+	ConditionPGUpgradeSucceeded = "Succeeded"
+
+	labelPrefix           = "postgres-operator.crunchydata.com/"
+	LabelPGUpgrade        = labelPrefix + "pgupgrade"
+	LabelCluster          = labelPrefix + "cluster"
+	LabelRole             = labelPrefix + "role"
+	LabelVersion          = labelPrefix + "version"
+	LabelPatroni          = labelPrefix + "patroni"
+	LabelPGBackRestBackup = labelPrefix + "pgbackrest-backup"
+	LabelInstance         = labelPrefix + "instance"
+
+	ReplicaCreate     = "replica-create"
+	ContainerDatabase = "database"
+
+	pgUpgrade  = "pgupgrade"
+	removeData = "removedata"
+)
+
+func commonLabels(role string, upgrade *v1beta1.PGUpgrade) map[string]string {
+	return map[string]string{
+		LabelPGUpgrade: upgrade.Name,
+		LabelCluster:   upgrade.Spec.PostgresClusterName,
+		LabelRole:      role,
+	}
+}

--- a/internal/controller/pgupgrade/pgupgrade_controller.go
+++ b/internal/controller/pgupgrade/pgupgrade_controller.go
@@ -1,0 +1,494 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgupgrade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+)
+
+const (
+	AnnotationAllowUpgrade = "postgres-operator.crunchydata.com/allow-upgrade"
+)
+
+// PGUpgradeReconciler reconciles a PGUpgrade object
+type PGUpgradeReconciler struct {
+	client.Client
+	Owner  client.FieldOwner
+	Scheme *runtime.Scheme
+
+	// For this iteration, we will only be setting conditions rather than
+	// setting conditions and emitting events. That may change in the future,
+	// so we're leaving this EventRecorder here for now.
+	// record.EventRecorder
+}
+
+//+kubebuilder:rbac:groups="batch",resources="jobs",verbs={list,watch}
+//+kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="pgupgrades",verbs={list,watch}
+//+kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="postgresclusters",verbs={list,watch}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *PGUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1beta1.PGUpgrade{}).
+		Owns(&batchv1.Job{}).
+		Watches(
+			&source.Kind{Type: v1beta1.NewPostgresCluster()},
+			r.watchPostgresClusters(),
+		).
+		Complete(r)
+}
+
+//+kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="pgupgrades",verbs={list}
+
+// findUpgradesForPostgresCluster returns PGUpgrades that target cluster.
+func (r *PGUpgradeReconciler) findUpgradesForPostgresCluster(
+	ctx context.Context, cluster client.ObjectKey,
+) []*v1beta1.PGUpgrade {
+	var matching []*v1beta1.PGUpgrade
+	var upgrades v1beta1.PGUpgradeList
+
+	// NOTE: If this becomes slow due to a large number of upgrades in a single
+	// namespace, we can configure the [ctrl.Manager] field indexer and pass a
+	// [fields.Selector] here.
+	// - https://book.kubebuilder.io/reference/watching-resources/externally-managed.html
+	if r.List(ctx, &upgrades, &client.ListOptions{
+		Namespace: cluster.Namespace,
+	}) == nil {
+		for i := range upgrades.Items {
+			if upgrades.Items[i].Spec.PostgresClusterName == cluster.Name {
+				matching = append(matching, &upgrades.Items[i])
+			}
+		}
+	}
+	return matching
+}
+
+// watchPostgresClusters returns a [handler.EventHandler] for PostgresClusters.
+func (r *PGUpgradeReconciler) watchPostgresClusters() handler.Funcs {
+	handle := func(cluster client.Object, q workqueue.RateLimitingInterface) {
+		ctx := context.Background()
+		key := client.ObjectKeyFromObject(cluster)
+
+		for _, upgrade := range r.findUpgradesForPostgresCluster(ctx, key) {
+			q.Add(ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(upgrade),
+			})
+		}
+	}
+
+	return handler.Funcs{
+		CreateFunc: func(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+			handle(e.Object, q)
+		},
+		UpdateFunc: func(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+			handle(e.ObjectNew, q)
+		},
+		DeleteFunc: func(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+			handle(e.Object, q)
+		},
+	}
+}
+
+//+kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="pgupgrades",verbs={get}
+//+kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="pgupgrades/status",verbs={patch}
+//+kubebuilder:rbac:groups="batch",resources="jobs",verbs={delete}
+//+kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="postgresclusters",verbs={get}
+//+kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="postgresclusters/status",verbs={patch}
+//+kubebuilder:rbac:groups="batch",resources="jobs",verbs={create,patch}
+//+kubebuilder:rbac:groups="batch",resources="jobs",verbs={list}
+//+kubebuilder:rbac:groups="",resources="endpoints",verbs={get}
+//+kubebuilder:rbac:groups="",resources="endpoints",verbs={delete}
+
+// Reconcile does the work to move the current state of the world toward the
+// desired state described in a [v1beta1.PGUpgrade] identified by req.
+func (r *PGUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Retrieve the upgrade from the client cache, if it exists. A deferred
+	// function below will send any changes to its Status field.
+	//
+	// NOTE: No DeepCopy is necessary here because controller-runtime makes a
+	// copy before returning from its cache.
+	// - https://github.com/kubernetes-sigs/controller-runtime/issues/1235
+	upgrade := &v1beta1.PGUpgrade{}
+	err = r.Get(ctx, req.NamespacedName, upgrade)
+
+	if err == nil {
+		// Write any changes to the upgrade status on the way out.
+		before := upgrade.DeepCopy()
+		defer func() {
+			if !equality.Semantic.DeepEqual(before.Status, upgrade.Status) {
+				status := r.Status().Patch(ctx, upgrade, client.MergeFrom(before), r.Owner)
+
+				if err == nil && status != nil {
+					err = status
+				} else if status != nil {
+					log.Error(status, "Patching PGUpgrade status")
+				}
+			}
+		}()
+	} else {
+		// NotFound cannot be fixed by requeuing so ignore it. During background
+		// deletion, we receive delete events from upgrade's dependents after
+		// upgrade is deleted.
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Validate the remainder of the upgrade specification. These can likely
+	// move to CEL rules or a webhook when supported.
+
+	// Exit if upgrade success condition has already been reached.
+	// If a cluster needs multiple upgrades, it is currently only possible to delete and
+	// create a new pgupgrade rather than edit an existing succeeded upgrade.
+	// This controller may be changed in the future to allow multiple uses of
+	// a single pgupgrade; if that is the case, it will probably need to reset
+	// the succeeded condition and remove upgrade and removedata jobs.
+	succeeded := meta.FindStatusCondition(upgrade.Status.Conditions,
+		ConditionPGUpgradeSucceeded)
+	if succeeded != nil && succeeded.Reason == "PGUpgradeSucceeded" {
+		return
+	}
+
+	// Set progressing condition to true if it doesn't exist already
+	setStatusToProgressingIfReasonWas("", upgrade)
+
+	// The "from" version must be smaller than the "to" version.
+	// An invalid PGUpgrade should not be requeued.
+	if upgrade.Spec.FromPostgresVersion >= upgrade.Spec.ToPostgresVersion {
+
+		meta.SetStatusCondition(&upgrade.Status.Conditions, metav1.Condition{
+			ObservedGeneration: upgrade.GetGeneration(),
+			Type:               ConditionPGUpgradeProgressing,
+			Status:             metav1.ConditionFalse,
+			Reason:             "PGUpgradeInvalid",
+			Message: fmt.Sprintf(
+				"Cannot upgrade from postgres version %d to %d",
+				upgrade.Spec.FromPostgresVersion, upgrade.Spec.ToPostgresVersion),
+		})
+
+		return ctrl.Result{}, nil
+	}
+
+	setStatusToProgressingIfReasonWas("PGUpgradeInvalid", upgrade)
+
+	// Observations and cluster validation
+	//
+	// First, read everything we need from the API. Compare the state of the
+	// world to the upgrade specification, perform any remaining validation.
+	world, err := r.observeWorld(ctx, upgrade)
+	// If `observeWorld` returns an error, then exit early.
+	// If we do no exit here, err is assume nil
+	if err != nil {
+		meta.SetStatusCondition(&upgrade.Status.Conditions, metav1.Condition{
+			ObservedGeneration: upgrade.Generation,
+			Type:               ConditionPGUpgradeProgressing,
+			Status:             metav1.ConditionFalse,
+			Reason:             "PGClusterErrorWhenObservingWorld",
+			Message:            err.Error(),
+		})
+
+		return // FIXME
+	}
+
+	setStatusToProgressingIfReasonWas("PGClusterErrorWhenObservingWorld", upgrade)
+
+	// ClusterNotFound cannot be fixed by requeuing. We will reconcile again when
+	// a matching PostgresCluster is created. Set a condition about our
+	// inability to proceed.
+	if world.ClusterNotFound != nil {
+
+		meta.SetStatusCondition(&upgrade.Status.Conditions, metav1.Condition{
+			ObservedGeneration: upgrade.Generation,
+			Type:               ConditionPGUpgradeProgressing,
+			Status:             metav1.ConditionFalse,
+			Reason:             "PGClusterNotFound",
+			Message:            world.ClusterNotFound.Error(),
+		})
+
+		return ctrl.Result{}, nil
+	}
+
+	setStatusToProgressingIfReasonWas("PGClusterNotFound", upgrade)
+
+	// Get the spec version to check if this cluster is at the requested version
+	version := int64(world.Cluster.Spec.PostgresVersion)
+
+	// Get the status version and check the jobs to see if this upgrade has completed
+	statusVersion := int64(world.Cluster.Status.PostgresVersion)
+	upgradeJob := world.Jobs[pgUpgradeJob(upgrade).Name]
+	upgradeJobComplete := upgradeJob != nil &&
+		jobCompleted(upgradeJob)
+	upgradeJobFailed := upgradeJob != nil &&
+		jobFailed(upgradeJob)
+
+	var removeDataJobsFailed bool
+	var removeDataJobsCompleted []*batchv1.Job
+	for _, job := range world.Jobs {
+		if job.GetLabels()[LabelRole] == removeData {
+			if jobCompleted(job) {
+				removeDataJobsCompleted = append(removeDataJobsCompleted, job)
+			} else if jobFailed(job) {
+				removeDataJobsFailed = true
+				break
+			}
+		}
+	}
+	removeDataJobsComplete := len(removeDataJobsCompleted) == world.ReplicasExpected
+
+	// If the PostgresCluster is already set to the desired version, but the upgradejob has
+	// not completed successfully, the operator assumes that the cluster is already
+	// running the desired version. We consider this a no-op rather than a successful upgrade.
+	// Documentation should make it clear that the PostgresCluster postgresVersion
+	// should be updated _after_ the upgrade is considered successful.
+	if version == int64(upgrade.Spec.ToPostgresVersion) && !upgradeJobComplete {
+		meta.SetStatusCondition(&upgrade.Status.Conditions, metav1.Condition{
+			ObservedGeneration: upgrade.Generation,
+			Type:               ConditionPGUpgradeProgressing,
+			Status:             metav1.ConditionFalse,
+			Reason:             "PGUpgradeResolved",
+			Message: fmt.Sprintf(
+				"PostgresCluster %s is already running version %d",
+				upgrade.Spec.PostgresClusterName, upgrade.Spec.ToPostgresVersion),
+		})
+
+		return ctrl.Result{}, nil
+	}
+
+	// This condition is unlikely to ever need to be changed, but is added just in case.
+	setStatusToProgressingIfReasonWas("PGUpgradeResolved", upgrade)
+
+	if statusVersion == int64(upgrade.Spec.ToPostgresVersion) {
+		meta.SetStatusCondition(&upgrade.Status.Conditions, metav1.Condition{
+			ObservedGeneration: upgrade.Generation,
+			Type:               ConditionPGUpgradeProgressing,
+			Status:             metav1.ConditionFalse,
+			Reason:             "PGUpgradeCompleted",
+			Message: fmt.Sprintf(
+				"PostgresCluster %s is running version %d",
+				upgrade.Spec.PostgresClusterName, upgrade.Spec.ToPostgresVersion),
+		})
+
+		if upgradeJobComplete && removeDataJobsComplete {
+			meta.SetStatusCondition(&upgrade.Status.Conditions, metav1.Condition{
+				ObservedGeneration: upgrade.Generation,
+				Type:               ConditionPGUpgradeSucceeded,
+				Status:             metav1.ConditionTrue,
+				Reason:             "PGUpgradeSucceeded",
+				Message: fmt.Sprintf(
+					"PostgresCluster %s is ready to complete upgrade to version %d",
+					upgrade.Spec.PostgresClusterName, upgrade.Spec.ToPostgresVersion),
+			})
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// The upgrade needs to manipulate the data directory of the primary while
+	// Postgres is stopped. Wait until all instances are gone and the primary
+	// is identified.
+	//
+	// Requiring the cluster be shutdown also provides some assurance that the
+	// user understands downtime requirement of upgrading
+	if !world.ClusterShutdown || world.ClusterPrimary == nil {
+		meta.SetStatusCondition(&upgrade.Status.Conditions, metav1.Condition{
+			ObservedGeneration: upgrade.Generation,
+			Type:               ConditionPGUpgradeProgressing,
+			Status:             metav1.ConditionFalse,
+			Reason:             "PGClusterNotShutdown",
+			Message:            "PostgresCluster instances still running",
+		})
+
+		return ctrl.Result{}, nil
+	}
+
+	setStatusToProgressingIfReasonWas("PGClusterNotShutdown", upgrade)
+
+	if version != int64(upgrade.Spec.FromPostgresVersion) &&
+		statusVersion != int64(upgrade.Spec.ToPostgresVersion) {
+		meta.SetStatusCondition(&upgrade.Status.Conditions, metav1.Condition{
+			ObservedGeneration: upgrade.Generation,
+			Type:               ConditionPGUpgradeProgressing,
+			Status:             metav1.ConditionFalse,
+			Reason:             "PGUpgradeInvalidForCluster",
+			Message: fmt.Sprintf(
+				"Current postgres version is %d, but upgrade expected %d",
+				version, upgrade.Spec.FromPostgresVersion),
+		})
+
+		return ctrl.Result{}, nil
+	}
+
+	setStatusToProgressingIfReasonWas("PGUpgradeInvalidForCluster", upgrade)
+
+	// Each upgrade can specify one cluster, but we also want to ensure that
+	// each cluster is managed by at most one upgrade. Check that the specified
+	// cluster is annotated with the name of *this* upgrade.
+	//
+	// Having an annotation on the cluster also provides some assurance that
+	// the user that created the upgrade also has authority to create or edit
+	// the cluster.
+
+	if allowed := world.Cluster.GetAnnotations()[AnnotationAllowUpgrade] == upgrade.Name; !allowed {
+		meta.SetStatusCondition(&upgrade.Status.Conditions, metav1.Condition{
+			ObservedGeneration: upgrade.Generation,
+			Type:               ConditionPGUpgradeProgressing,
+			Status:             metav1.ConditionFalse,
+			Reason:             "PGClusterMissingRequiredAnnotation",
+			Message: fmt.Sprintf(
+				"PostgresCluster %s lacks annotation for upgrade %s",
+				upgrade.Spec.PostgresClusterName, upgrade.GetName()),
+		})
+
+		return ctrl.Result{}, nil
+	}
+
+	setStatusToProgressingIfReasonWas("PGClusterMissingRequiredAnnotation", upgrade)
+
+	// Currently our jobs are set to only run once, so if any job has failed, the
+	// upgrade has failed.
+	if upgradeJobFailed || removeDataJobsFailed {
+		meta.SetStatusCondition(&upgrade.Status.Conditions, metav1.Condition{
+			ObservedGeneration: upgrade.Generation,
+			Type:               ConditionPGUpgradeSucceeded,
+			Status:             metav1.ConditionFalse,
+			Reason:             "PGUpgradeFailed",
+			Message:            "Upgrade jobs failed, please check individual pod logs",
+		})
+
+		return ctrl.Result{}, nil
+	}
+
+	// If we have reached this point, all preconditions for upgrade are satisfied.
+	// If the jobs have already run to completion
+	// - delete the replica-create jobs to kick off a backup
+	// - delete the PostgresCluster.Status.Repos to kick off a reconcile
+	if upgradeJobComplete && removeDataJobsComplete &&
+		statusVersion != int64(upgrade.Spec.ToPostgresVersion) {
+
+		// Patroni will try to recreate replicas using pgBackRest. Convince PGO to
+		// take a recent backup by deleting its "replica-create" jobs.
+		for _, object := range world.Jobs {
+			if backup := object.Labels[LabelPGBackRestBackup]; err == nil &&
+				backup == ReplicaCreate {
+
+				uid := object.GetUID()
+				version := object.GetResourceVersion()
+				exactly := client.Preconditions{UID: &uid, ResourceVersion: &version}
+				// Jobs default to an `orphanDependents` policy, orphaning pods after deletion.
+				// We don't want that, so we set the delete policy explicitly.
+				// - https://kubernetes.io/docs/concepts/workloads/controllers/job/
+				// - https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/batch/job/strategy.go#L58
+				propagate := client.PropagationPolicy(metav1.DeletePropagationBackground)
+				err = client.IgnoreNotFound(r.Client.Delete(ctx, object, exactly, propagate))
+			}
+		}
+
+		if err == nil {
+			patch := world.Cluster.DeepCopy()
+
+			// Set the cluster status when we know the upgrade has completed successfully.
+			// This will serve to help the user see that the upgrade has completed if they
+			// are only watching the PostgresCluster
+			patch.Status.PostgresVersion = upgrade.Spec.ToPostgresVersion
+
+			// Set the pgBackRest status for bootstrapping
+			patch.Status.PGBackRest.Repos = []v1beta1.RepoStatus{}
+
+			err = r.Status().Patch(ctx, patch, client.MergeFrom(world.Cluster), r.Owner)
+		}
+
+		return ctrl.Result{}, err
+	}
+
+	// TODO: error from apply could mean that the job exists with a different spec.
+	if err == nil && !upgradeJobComplete {
+		err = errors.WithStack(r.apply(ctx,
+			r.generateUpgradeJob(ctx, upgrade, world.ClusterPrimary)))
+	}
+
+	// Create the jobs to remove the data from the replicas, as long as
+	// the upgrade job has completed.
+	// (When the cluster is not shutdown, the `world.ClusterReplicas` will be [],
+	// so there should be no danger of accidentally targeting the primary.)
+	if err == nil && upgradeJobComplete && !removeDataJobsComplete {
+		for _, sts := range world.ClusterReplicas {
+			if err == nil {
+				err = r.apply(ctx, r.generateRemoveDataJob(ctx, upgrade, sts))
+			}
+		}
+	}
+
+	// The upgrade job generates a new system identifier for this cluster.
+	// Clear the old identifier from Patroni by deleting its DCS Endpoints.
+	// This is safe to do this when all Patroni processes are stopped
+	// (ClusterShutdown) and PGO has identified a leader to start first
+	// (ClusterPrimary).
+	// - https://github.com/zalando/patroni/blob/v2.1.2/docs/existing_data.rst
+	//
+	// TODO(cbandy): This works only when using Kubernetes Endpoints for DCS.
+	if len(world.PatroniEndpoints) > 0 {
+		for _, object := range world.PatroniEndpoints {
+			uid := object.GetUID()
+			version := object.GetResourceVersion()
+			exactly := client.Preconditions{UID: &uid, ResourceVersion: &version}
+			err = client.IgnoreNotFound(r.Client.Delete(ctx, object, exactly))
+		}
+
+		// Requeue to verify that Patroni endpoints are deleted
+		return ctrl.Result{Requeue: true}, err // FIXME
+	}
+
+	// TODO: write upgradeJob back to world? No, we will wake and see it when it
+	// has some progress. OTOH, whatever we just wrote has the latest metadata.generation.
+	// TODO: consider what it means to "re-use" the same PGUpgrade for more than
+	// one postgres version. Should the job name include the version number?
+
+	log.Info("Reconciled", "requeue", err != nil ||
+		result.Requeue ||
+		result.RequeueAfter > 0)
+	return
+}
+
+func setStatusToProgressingIfReasonWas(reason string, upgrade *v1beta1.PGUpgrade) {
+	progressing := meta.FindStatusCondition(upgrade.Status.Conditions,
+		ConditionPGUpgradeProgressing)
+	if progressing == nil || (progressing != nil && progressing.Reason == reason) {
+		meta.SetStatusCondition(&upgrade.Status.Conditions, metav1.Condition{
+			ObservedGeneration: upgrade.GetGeneration(),
+			Type:               ConditionPGUpgradeProgressing,
+			Status:             metav1.ConditionTrue,
+			Reason:             "PGUpgradeProgressing",
+			Message: fmt.Sprintf(
+				"Upgrade progressing for cluster %s",
+				upgrade.Spec.PostgresClusterName),
+		})
+	}
+}

--- a/internal/controller/pgupgrade/utils.go
+++ b/internal/controller/pgupgrade/utils.go
@@ -1,0 +1,74 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgupgrade
+
+import (
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+)
+
+// The owner reference created by controllerutil.SetControllerReference blocks
+// deletion. The OwnerReferencesPermissionEnforcement plugin requires that the
+// creator of such a reference have either "delete" permission on the owner or
+// "update" permission on the owner's "finalizers" subresource.
+// - https://docs.k8s.io/reference/access-authn-authz/admission-controllers/
+// +kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="pgupgrades/finalizers",verbs={update}
+
+// setControllerReference sets owner as a Controller OwnerReference on controlled.
+// It panics if another controller is already set.
+func (r *PGUpgradeReconciler) setControllerReference(
+	owner *v1beta1.PGUpgrade, controlled client.Object,
+) {
+	if metav1.GetControllerOf(controlled) != nil {
+		panic(controllerutil.SetControllerReference(owner, controlled, r.Client.Scheme()))
+	}
+
+	controlled.SetOwnerReferences(append(
+		controlled.GetOwnerReferences(),
+		metav1.OwnerReference{
+			APIVersion:         v1beta1.GroupVersion.String(),
+			Kind:               "PGUpgrade",
+			Name:               owner.GetName(),
+			UID:                owner.GetUID(),
+			BlockOwnerDeletion: pointer.BoolPtr(true),
+			Controller:         pointer.BoolPtr(true),
+		},
+	))
+}
+
+// Merge takes sets of labels and merges them. The last set
+// provided will win in case of conflicts.
+func Merge(sets ...map[string]string) labels.Set {
+	merged := labels.Set{}
+	for _, set := range sets {
+		merged = labels.Merge(merged, set)
+	}
+	return merged
+}
+
+// defaultFromEnv reads the environment variable key when value is empty.
+func defaultFromEnv(value, key string) string {
+	if value == "" {
+		return os.Getenv(key)
+	}
+	return value
+}

--- a/internal/controller/pgupgrade/world.go
+++ b/internal/controller/pgupgrade/world.go
@@ -1,0 +1,185 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgupgrade
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+)
+
+// The client used by the controller sets up a cache and an informer for any GVK
+// that it GETs. That informer needs the "watch" permission.
+// - https://github.com/kubernetes-sigs/controller-runtime/issues/1249
+// - https://github.com/kubernetes-sigs/controller-runtime/issues/1454
+//+kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="postgresclusters",verbs={get,watch}
+//+kubebuilder:rbac:groups="",resources="endpoints",verbs={list,watch}
+//+kubebuilder:rbac:groups="batch",resources="jobs",verbs={list,watch}
+//+kubebuilder:rbac:groups="apps",resources="statefulsets",verbs={list,watch}
+
+func (r *PGUpgradeReconciler) observeWorld(
+	ctx context.Context, upgrade *v1beta1.PGUpgrade,
+) (*World, error) {
+	selectCluster := labels.SelectorFromSet(labels.Set{
+		LabelCluster: upgrade.Spec.PostgresClusterName,
+	})
+
+	world := NewWorld()
+	world.Upgrade = upgrade
+
+	cluster := v1beta1.NewPostgresCluster()
+	err := errors.WithStack(
+		r.Get(ctx, client.ObjectKey{
+			Namespace: upgrade.Namespace,
+			Name:      upgrade.Spec.PostgresClusterName,
+		}, cluster))
+	err = world.populateCluster(cluster, err)
+
+	if err == nil {
+		var endpoints corev1.EndpointsList
+		err = errors.WithStack(
+			r.List(ctx, &endpoints,
+				client.InNamespace(upgrade.Namespace),
+				client.MatchingLabelsSelector{Selector: selectCluster},
+			))
+		world.populatePatroniEndpoints(endpoints.Items)
+	}
+
+	if err == nil {
+		var jobs batchv1.JobList
+		err = errors.WithStack(
+			r.List(ctx, &jobs,
+				client.InNamespace(upgrade.Namespace),
+				client.MatchingLabelsSelector{Selector: selectCluster},
+			))
+		for i := range jobs.Items {
+			world.Jobs[jobs.Items[i].Name] = &jobs.Items[i]
+		}
+	}
+
+	if err == nil {
+		var statefulsets appsv1.StatefulSetList
+		err = errors.WithStack(
+			r.List(ctx, &statefulsets,
+				client.InNamespace(upgrade.Namespace),
+				client.MatchingLabelsSelector{Selector: selectCluster},
+			))
+		world.populateStatefulSets(statefulsets.Items)
+	}
+
+	if err == nil {
+		world.populateShutdown()
+	}
+
+	return world, err
+}
+
+func (w *World) populateCluster(cluster *v1beta1.PostgresCluster, err error) error {
+	if err == nil {
+		w.Cluster = cluster
+		w.ClusterNotFound = nil
+
+	} else if apierrors.IsNotFound(err) {
+		w.Cluster = nil
+		w.ClusterNotFound = err
+		err = nil
+	}
+	return err
+}
+
+func (w *World) populatePatroniEndpoints(endpoints []corev1.Endpoints) {
+	for index, endpoint := range endpoints {
+		if endpoint.Labels[LabelPatroni] != "" {
+			w.PatroniEndpoints = append(w.PatroniEndpoints, &endpoints[index])
+		}
+	}
+}
+
+// populateStatefulSets assigns
+// a) the expected number of replicas -- the number of StatefulSets that have the expected
+// LabelInstance label, minus 1 (for the primary)
+// b) the primary StatefulSet and replica StatefulSets if the cluster is shutdown.
+// When the cluster is not shutdown, we cannot verify which StatefulSet is the primary.
+func (w *World) populateStatefulSets(statefulSets []appsv1.StatefulSet) {
+	w.ReplicasExpected = -1
+	if w.Cluster != nil {
+		startup := w.Cluster.Status.StartupInstance
+		for index, sts := range statefulSets {
+			if sts.Labels[LabelInstance] != "" {
+				w.ReplicasExpected++
+				if startup != "" {
+					switch sts.Name {
+					case startup:
+						w.ClusterPrimary = &statefulSets[index]
+					default:
+						w.ClusterReplicas = append(w.ClusterReplicas, &statefulSets[index])
+					}
+				}
+			}
+		}
+	}
+}
+
+func (w *World) populateShutdown() {
+	if w.Cluster != nil {
+		status := w.Cluster.Status
+		generation := status.ObservedGeneration
+
+		// The cluster is "shutdown" only when it is specified *and* the status
+		// indicates all instances are stopped.
+		shutdownValue := w.Cluster.Spec.Shutdown
+		if shutdownValue != nil {
+			w.ClusterShutdown = *shutdownValue
+		} else {
+			w.ClusterShutdown = false
+		}
+		w.ClusterShutdown = w.ClusterShutdown && generation == w.Cluster.GetGeneration()
+
+		sets := status.InstanceSets
+		for _, set := range sets {
+			if n := set.Replicas; n != 0 {
+				w.ClusterShutdown = false
+			}
+		}
+	}
+}
+
+type World struct {
+	Cluster *v1beta1.PostgresCluster
+	Upgrade *v1beta1.PGUpgrade
+
+	ClusterNotFound  error
+	ClusterPrimary   *appsv1.StatefulSet
+	ClusterReplicas  []*appsv1.StatefulSet
+	ClusterShutdown  bool
+	ReplicasExpected int
+
+	PatroniEndpoints []*corev1.Endpoints
+	Jobs             map[string]*batchv1.Job
+}
+
+func NewWorld() *World {
+	return &World{
+		Jobs: make(map[string]*batchv1.Job),
+	}
+}

--- a/internal/controller/pgupgrade/world_test.go
+++ b/internal/controller/pgupgrade/world_test.go
@@ -1,0 +1,240 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgupgrade
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/crunchydata/postgres-operator/internal/initialize"
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+)
+
+func TestPopulateCluster(t *testing.T) {
+	t.Run("Found", func(t *testing.T) {
+		cluster := v1beta1.NewPostgresCluster()
+		cluster.SetName("cluster")
+
+		world := NewWorld()
+		err := world.populateCluster(cluster, nil)
+
+		assert.NilError(t, err)
+		assert.Equal(t, world.Cluster, cluster)
+		assert.Assert(t, world.ClusterNotFound == nil)
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		cluster := v1beta1.NewPostgresCluster()
+		expected := apierrors.NewNotFound(schema.GroupResource{}, "name")
+
+		world := NewWorld()
+		err := world.populateCluster(cluster, expected)
+
+		assert.NilError(t, err, "NotFound is handled")
+		assert.Assert(t, world.Cluster == nil)
+		assert.Equal(t, world.ClusterNotFound, expected)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		cluster := v1beta1.NewPostgresCluster()
+		expected := fmt.Errorf("danger")
+
+		world := NewWorld()
+		err := world.populateCluster(cluster, expected)
+
+		assert.Equal(t, err, expected)
+		assert.Assert(t, world.Cluster == nil)
+		assert.Assert(t, world.ClusterNotFound == nil)
+	})
+}
+
+func TestPopulatePatroniEndpoint(t *testing.T) {
+	endpoints := []corev1.Endpoints{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					LabelPatroni: "west",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					LabelPatroni: "east",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"different-label": "north",
+				},
+			},
+		},
+	}
+
+	world := NewWorld()
+	world.populatePatroniEndpoints(endpoints)
+
+	// The first two have the correct labels.
+	assert.DeepEqual(t, world.PatroniEndpoints, []*corev1.Endpoints{
+		&endpoints[0],
+		&endpoints[1],
+	})
+}
+
+func TestPopulateShutdown(t *testing.T) {
+	t.Run("NoCluster", func(t *testing.T) {
+		world := NewWorld()
+
+		world.populateShutdown()
+		assert.Assert(t, !world.ClusterShutdown)
+	})
+
+	t.Run("NotShutdown", func(t *testing.T) {
+		cluster := v1beta1.NewPostgresCluster()
+		cluster.Spec.Shutdown = initialize.Bool(false)
+
+		world := NewWorld()
+		world.Cluster = cluster
+
+		world.populateShutdown()
+		assert.Assert(t, !world.ClusterShutdown)
+	})
+
+	t.Run("OldStatus", func(t *testing.T) {
+		cluster := v1beta1.NewPostgresCluster()
+		cluster.SetGeneration(99)
+		cluster.Spec.Shutdown = initialize.Bool(true)
+		cluster.Status.ObservedGeneration = 21
+
+		world := NewWorld()
+		world.Cluster = cluster
+
+		world.populateShutdown()
+		assert.Assert(t, !world.ClusterShutdown)
+	})
+
+	t.Run("InstancesRunning", func(t *testing.T) {
+		cluster := v1beta1.NewPostgresCluster()
+		cluster.SetGeneration(99)
+		cluster.Spec.Shutdown = initialize.Bool(true)
+		cluster.Status.ObservedGeneration = 99
+		cluster.Status.InstanceSets = []v1beta1.PostgresInstanceSetStatus{{Replicas: 2}}
+
+		world := NewWorld()
+		world.Cluster = cluster
+
+		world.populateShutdown()
+		assert.Assert(t, !world.ClusterShutdown)
+	})
+
+	t.Run("InstancesStopped", func(t *testing.T) {
+		cluster := v1beta1.NewPostgresCluster()
+		cluster.SetGeneration(99)
+		cluster.Spec.Shutdown = initialize.Bool(true)
+		cluster.Status.ObservedGeneration = 99
+		cluster.Status.InstanceSets = []v1beta1.PostgresInstanceSetStatus{{Replicas: 0}}
+
+		world := NewWorld()
+		world.Cluster = cluster
+
+		world.populateShutdown()
+		assert.Assert(t, world.ClusterShutdown)
+	})
+}
+
+func TestPopulateStatefulSets(t *testing.T) {
+	t.Run("NoPopulatesWithoutStartupGiven", func(t *testing.T) {
+		cluster := v1beta1.NewPostgresCluster()
+		world := NewWorld()
+		world.Cluster = cluster
+
+		primary := appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "the-one",
+				Labels: map[string]string{
+					LabelInstance: "whatever",
+				},
+			},
+		}
+		replica := appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "something-else",
+				Labels: map[string]string{
+					LabelInstance: "whatever",
+				},
+			},
+		}
+		other := appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "repo-host",
+				Labels: map[string]string{
+					"other-label": "other",
+				},
+			},
+		}
+		world.populateStatefulSets([]appsv1.StatefulSet{primary, replica, other})
+
+		assert.Assert(t, world.ClusterPrimary == nil)
+		assert.Assert(t, world.ClusterReplicas == nil)
+		assert.Assert(t, world.ReplicasExpected == 1)
+	})
+
+	t.Run("PopulatesWithStartupGiven", func(t *testing.T) {
+		cluster := v1beta1.NewPostgresCluster()
+		cluster.Status.StartupInstance = "the-one"
+
+		world := NewWorld()
+		world.Cluster = cluster
+
+		primary := appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "the-one",
+				Labels: map[string]string{
+					LabelInstance: "whatever",
+				},
+			},
+		}
+		replica := appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "something-else",
+				Labels: map[string]string{
+					LabelInstance: "whatever",
+				},
+			},
+		}
+		other := appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "repo-host",
+				Labels: map[string]string{
+					"other-label": "other",
+				},
+			},
+		}
+		world.populateStatefulSets([]appsv1.StatefulSet{primary, replica, other})
+
+		assert.DeepEqual(t, world.ClusterPrimary, &primary)
+		assert.DeepEqual(t, world.ClusterReplicas, []*appsv1.StatefulSet{&replica})
+		assert.Assert(t, world.ReplicasExpected == 1)
+	})
+}

--- a/internal/postgres/config_test.go
+++ b/internal/postgres/config_test.go
@@ -175,7 +175,9 @@ func TestBashRecreateDirectory(t *testing.T) {
 	cmd.Args = append(cmd.Args, "-ceu", "--",
 		bashRecreateDirectory+` recreate "$@"`, "-",
 		filepath.Join(dir, "d"), "0740")
-
+	// The assertion below expects alphabetically sorted filenames.
+	// Set an empty environment to always use the default/standard locale.
+	cmd.Env = []string{}
 	output, err := cmd.CombinedOutput()
 	assert.NilError(t, err, string(output))
 	assert.Assert(t, cmp.Regexp(`^`+

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -673,3 +673,9 @@ type ExporterSpec struct {
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 }
+
+func NewPostgresCluster() *PostgresCluster {
+	cluster := &PostgresCluster{}
+	cluster.SetGroupVersionKind(GroupVersion.WithKind("PostgresCluster"))
+	return cluster
+}

--- a/testing/kuttl/e2e/major-upgrade/01--invalid-pgupgrade.yaml
+++ b/testing/kuttl/e2e/major-upgrade/01--invalid-pgupgrade.yaml
@@ -1,0 +1,10 @@
+---
+# This pgupgrade is invalid and should get that condition (even with no cluster)
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: major-upgrade-do-it
+spec:
+  fromPostgresVersion: ${KUTTL_PG_VERSION}
+  toPostgresVersion: ${KUTTL_PG_VERSION}
+  postgresClusterName: major-upgrade

--- a/testing/kuttl/e2e/major-upgrade/01-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/01-assert.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: major-upgrade-do-it
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+    reason: "PGUpgradeInvalid"

--- a/testing/kuttl/e2e/major-upgrade/02--valid-upgrade.yaml
+++ b/testing/kuttl/e2e/major-upgrade/02--valid-upgrade.yaml
@@ -1,0 +1,10 @@
+---
+# This upgrade is valid, but has no pgcluster to work on and should get that condition
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: major-upgrade-do-it
+spec:
+  fromPostgresVersion: ${KUTTL_PG_UPGRADE_FROM_VERSION}
+  toPostgresVersion: ${KUTTL_PG_VERSION}
+  postgresClusterName: major-upgrade

--- a/testing/kuttl/e2e/major-upgrade/02-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/02-assert.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: major-upgrade-do-it
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+    reason: "PGClusterNotFound"

--- a/testing/kuttl/e2e/major-upgrade/10--already-updated-cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade/10--already-updated-cluster.yaml
@@ -1,0 +1,16 @@
+---
+# Create a cluster that is already at the correct version
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+  backups:
+    pgbackrest:
+      repos:
+        - name: repo1
+          volume:
+            volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }

--- a/testing/kuttl/e2e/major-upgrade/10-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/10-assert.yaml
@@ -1,0 +1,11 @@
+---
+# pgupgrade should exit since the cluster is already at the requested version
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: major-upgrade-do-it
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+    reason: "PGUpgradeResolved"

--- a/testing/kuttl/e2e/major-upgrade/11-delete-cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade/11-delete-cluster.yaml
@@ -1,0 +1,8 @@
+---
+# Delete the existing cluster.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: postgres-operator.crunchydata.com/v1beta1
+    kind: PostgresCluster
+    name: major-upgrade

--- a/testing/kuttl/e2e/major-upgrade/20--cluster-with-invalid-version.yaml
+++ b/testing/kuttl/e2e/major-upgrade/20--cluster-with-invalid-version.yaml
@@ -1,0 +1,18 @@
+---
+# Create a cluster where the version does not match the pgupgrade's `from`
+# TODO(benjaminjb): this isn't quite working out
+# apiVersion: postgres-operator.crunchydata.com/v1beta1
+# kind: PostgresCluster
+# metadata:
+#   name: major-upgrade
+# spec:
+#   shutdown: true
+#   postgresVersion: ${KUTTL_PG_UPGRADE_TOO_EARLY_FROM_VERSION}
+#   instances:
+#     - dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+#   backups:
+#     pgbackrest:
+#       repos:
+#         - name: repo1
+#           volume:
+#             volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }

--- a/testing/kuttl/e2e/major-upgrade/20-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/20-assert.yaml
@@ -1,0 +1,11 @@
+---
+# # pgupgrade should exit since the cluster is already at the requested version
+# apiVersion: postgres-operator.crunchydata.com/v1beta1
+# kind: PGUpgrade
+# metadata:
+#   name: major-upgrade-do-it
+# status:
+#   conditions:
+#   - type:   "Progressing"
+#     status: "False"
+#     reason: "PGUpgradeInvalidForCluster"

--- a/testing/kuttl/e2e/major-upgrade/21-delete-cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade/21-delete-cluster.yaml
@@ -1,0 +1,8 @@
+---
+# # Delete the existing cluster.
+# apiVersion: kuttl.dev/v1beta1
+# kind: TestStep
+# delete:
+#   - apiVersion: postgres-operator.crunchydata.com/v1beta1
+#     kind: PostgresCluster
+#     name: major-upgrade

--- a/testing/kuttl/e2e/major-upgrade/30--cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade/30--cluster.yaml
@@ -1,0 +1,22 @@
+---
+# Create the cluster we will do an actual upgrade on
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade
+spec:
+  postgresVersion: ${KUTTL_PG_UPGRADE_FROM_VERSION}
+  patroni:
+    dynamicConfiguration:
+      postgresql:
+        parameters:
+          shared_preload_libraries: pgaudit, set_user, pg_stat_statements, pgnodemx, pg_cron
+  instances:
+    - dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+      replicas: 3
+  backups:
+    pgbackrest:
+      repos:
+        - name: repo1
+          volume:
+            volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }

--- a/testing/kuttl/e2e/major-upgrade/30-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/30-assert.yaml
@@ -1,0 +1,31 @@
+---
+# Wait for the instances to be ready and the replica backup to complete
+# by waiting for the status to signal pods ready and pgbackrest stanza created
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade
+spec:
+  postgresVersion: ${KUTTL_PG_UPGRADE_FROM_VERSION}
+status:
+  instances:
+    - name: '00'
+      replicas: 3
+      readyReplicas: 3
+      updatedReplicas: 3
+  pgbackrest:
+    repos:
+    - name: repo1
+      replicaCreateBackupComplete: true
+      stanzaCreated: true
+---
+# Even when the cluster exists, the pgupgrade is not progressing because the cluster is not shutdown
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: major-upgrade-do-it
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+    reason: "PGClusterNotShutdown"

--- a/testing/kuttl/e2e/major-upgrade/31--create-data.yaml
+++ b/testing/kuttl/e2e/major-upgrade/31--create-data.yaml
@@ -1,0 +1,93 @@
+---
+# Check the version reported by PostgreSQL and create some data.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: major-upgrade-before
+  labels: { postgres-operator-test: kuttl }
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels: { postgres-operator-test: kuttl }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: psql
+          image: ${KUTTL_PSQL_IMAGE}
+          env:
+            - name: PGURI
+              valueFrom: { secretKeyRef: { name: major-upgrade-pguser-major-upgrade, key: uri } }
+
+            # Do not wait indefinitely.
+            - { name: PGCONNECT_TIMEOUT, value: '5' }
+
+          # Note: the `$$$$` is reduced to `$$` by Kubernetes.
+          # - https://kubernetes.io/docs/tasks/inject-data-application/
+          command:
+            - psql
+            - $(PGURI)
+            - --quiet
+            - --echo-errors
+            - --set=ON_ERROR_STOP=1
+            - --command
+            - |
+              DO $$$$
+              BEGIN
+                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_UPGRADE_FROM_VERSION}%',
+                  format('got %L', current_setting('server_version_num'));
+              END $$$$;
+            - --command
+            - |
+              CREATE TABLE important (data) AS VALUES ('treasure');
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: major-upgrade-before-replica
+  labels: { postgres-operator-test: kuttl }
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels: { postgres-operator-test: kuttl }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: psql
+          image: ${KUTTL_PSQL_IMAGE}
+          env:
+          # The Replica svc is not held in the user secret, so we hard-code the Service address
+          # (using the downstream API for the namespace)
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PGHOST
+            value: "major-upgrade-replicas.$(NAMESPACE).svc"
+          - name: PGPORT
+            valueFrom: { secretKeyRef: { name: major-upgrade-pguser-major-upgrade, key: port } }
+          - name: PGDATABASE
+            valueFrom: { secretKeyRef: { name: major-upgrade-pguser-major-upgrade, key: dbname } }
+          - name: PGUSER
+            valueFrom: { secretKeyRef: { name: major-upgrade-pguser-major-upgrade, key: user } }
+          - name: PGPASSWORD
+            valueFrom: { secretKeyRef: { name: major-upgrade-pguser-major-upgrade, key: password } }
+          
+          # Do not wait indefinitely.
+          - { name: PGCONNECT_TIMEOUT, value: '5' }
+
+          # Note: the `$$$$` is reduced to `$$` by Kubernetes.
+          # - https://kubernetes.io/docs/tasks/inject-data-application/
+          command:
+            - psql
+            - --quiet
+            - --echo-errors
+            - --set=ON_ERROR_STOP=1
+            - --command
+            - |
+              DO $$$$
+              BEGIN
+                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_UPGRADE_FROM_VERSION}%',
+                  format('got %L', current_setting('server_version_num'));
+              END $$$$;

--- a/testing/kuttl/e2e/major-upgrade/31-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/31-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: major-upgrade-before
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: major-upgrade-before-replica
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/major-upgrade/32--shutdown-cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade/32--shutdown-cluster.yaml
@@ -1,0 +1,8 @@
+---
+# Shutdown the cluster -- but without the annotation.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade
+spec:
+  shutdown: true

--- a/testing/kuttl/e2e/major-upgrade/32-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/32-assert.yaml
@@ -1,0 +1,11 @@
+---
+# Since the cluster is missing the annotation, we get this condition
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: major-upgrade-do-it
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+    reason: "PGClusterMissingRequiredAnnotation"

--- a/testing/kuttl/e2e/major-upgrade/33--annotate-cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade/33--annotate-cluster.yaml
@@ -1,0 +1,8 @@
+---
+# Annotate the cluster for an upgrade.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade
+  annotations:
+    postgres-operator.crunchydata.com/allow-upgrade: major-upgrade-do-it

--- a/testing/kuttl/e2e/major-upgrade/33-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/33-assert.yaml
@@ -1,0 +1,22 @@
+---
+# Now that the postgres cluster is shut down and annotated, the pgupgrade
+# can finish reconciling. We know the reconciling is complete when
+# the pgupgrade status is succeeded and the postgres cluster status
+# has the updated version.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: major-upgrade-do-it
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+  - type:   "Succeeded"
+    status: "True"
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade
+status:
+  postgresVersion: ${KUTTL_PG_VERSION}

--- a/testing/kuttl/e2e/major-upgrade/34--restart-cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade/34--restart-cluster.yaml
@@ -1,0 +1,10 @@
+---
+# Once the pgupgrade is finished, update the version and set shutdown to false
+# in the postgres cluster
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  shutdown: false

--- a/testing/kuttl/e2e/major-upgrade/34-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/34-assert.yaml
@@ -1,0 +1,18 @@
+---
+# Wait for the instances to be ready with the target Postgres version.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade
+status:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: '00'
+      replicas: 3
+      readyReplicas: 3
+      updatedReplicas: 3
+  pgbackrest:
+    repos:
+    - name: repo1
+      replicaCreateBackupComplete: true
+      stanzaCreated: true

--- a/testing/kuttl/e2e/major-upgrade/35-check-pgbackrest-and-replica.yaml
+++ b/testing/kuttl/e2e/major-upgrade/35-check-pgbackrest-and-replica.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# Check that the pgbackrest setup has successfully completed
+- script: |
+    kubectl -n "${NAMESPACE}" exec "statefulset.apps/major-upgrade-repo-host" -c pgbackrest -- pgbackrest check --stanza=db
+# Check that the replica data dir has been successfully cleaned
+- script: |
+    # Check that the old pg folders do not exist on the replica
+    REPLICA=$(kubectl get pod -l=postgres-operator.crunchydata.com/role=replica -n "${NAMESPACE}" -o=jsonpath='{ .items[0].metadata.name }')
+    kubectl -n "${NAMESPACE}" exec "${REPLICA}" -c database -- [ ! -d "pgdata/pg${KUTTL_PG_UPGRADE_FROM_VERSION}" ]

--- a/testing/kuttl/e2e/major-upgrade/36--check-data-and-version.yaml
+++ b/testing/kuttl/e2e/major-upgrade/36--check-data-and-version.yaml
@@ -1,0 +1,108 @@
+---
+# Check the version reported by PostgreSQL and confirm that data was upgraded.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: major-upgrade-after
+  labels: { postgres-operator-test: kuttl }
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels: { postgres-operator-test: kuttl }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: psql
+          image: ${KUTTL_PSQL_IMAGE}
+          env:
+            - name: PGURI
+              valueFrom: { secretKeyRef: { name: major-upgrade-pguser-major-upgrade, key: uri } }
+
+            # Do not wait indefinitely.
+            - { name: PGCONNECT_TIMEOUT, value: '5' }
+
+          # Note: the `$$$$` is reduced to `$$` by Kubernetes.
+          # - https://kubernetes.io/docs/tasks/inject-data-application/
+          command:
+            - psql
+            - $(PGURI)
+            - --quiet
+            - --echo-errors
+            - --set=ON_ERROR_STOP=1
+            - --command
+            - |
+              DO $$$$
+              BEGIN
+                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_VERSION}%',
+                  format('got %L', current_setting('server_version_num'));
+              END $$$$;
+            - --command
+            - |
+              DO $$$$
+              DECLARE
+                everything jsonb;
+              BEGIN
+                SELECT jsonb_agg(important) INTO everything FROM important;
+                ASSERT everything = '[{"data":"treasure"}]', format('got %L', everything);
+              END $$$$;
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: major-upgrade-after-replica
+  labels: { postgres-operator-test: kuttl }
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels: { postgres-operator-test: kuttl }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: psql
+          image: ${KUTTL_PSQL_IMAGE}
+          env:
+          # The Replica svc is not held in the user secret, so we hard-code the Service address
+          # (using the downstream API for the namespace)
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PGHOST
+            value: "major-upgrade-replicas.$(NAMESPACE).svc"
+          - name: PGPORT
+            valueFrom: { secretKeyRef: { name: major-upgrade-pguser-major-upgrade, key: port } }
+          - name: PGDATABASE
+            valueFrom: { secretKeyRef: { name: major-upgrade-pguser-major-upgrade, key: dbname } }
+          - name: PGUSER
+            valueFrom: { secretKeyRef: { name: major-upgrade-pguser-major-upgrade, key: user } }
+          - name: PGPASSWORD
+            valueFrom: { secretKeyRef: { name: major-upgrade-pguser-major-upgrade, key: password } }
+          
+          # Do not wait indefinitely.
+          - { name: PGCONNECT_TIMEOUT, value: '5' }
+
+          # Note: the `$$$$` is reduced to `$$` by Kubernetes.
+          # - https://kubernetes.io/docs/tasks/inject-data-application/
+          command:
+            - psql
+            - --quiet
+            - --echo-errors
+            - --set=ON_ERROR_STOP=1
+            - --command
+            - |
+              DO $$$$
+              BEGIN
+                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_VERSION}%',
+                  format('got %L', current_setting('server_version_num'));
+              END $$$$;
+            - --command
+            - |
+              DO $$$$
+              DECLARE
+                everything jsonb;
+              BEGIN
+                SELECT jsonb_agg(important) INTO everything FROM important;
+                ASSERT everything = '[{"data":"treasure"}]', format('got %L', everything);
+              END $$$$;

--- a/testing/kuttl/e2e/major-upgrade/36-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/36-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: major-upgrade-after
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: major-upgrade-after-replica
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/00--create-resources.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/00--create-resources.yaml
@@ -1,0 +1,28 @@
+---
+# Create the cluster we will do an actual upgrade on
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: wal-pvc-pgupgrade
+spec:
+  postgresVersion: ${KUTTL_PG_UPGRADE_FROM_VERSION}
+  instances:
+    - dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+      walVolumeClaimSpec: { accessModes: ["ReadWriteOnce"], resources: { requests: { storage: 1Gi } } }
+      replicas: 3
+  backups:
+    pgbackrest:
+      repos:
+        - name: repo1
+          volume:
+            volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+---
+# This upgrade is valid, but has no pgcluster to work on and should get that condition
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: wal-pvc-pgupgrade-do-it
+spec:
+  fromPostgresVersion: ${KUTTL_PG_UPGRADE_FROM_VERSION}
+  toPostgresVersion: ${KUTTL_PG_VERSION}
+  postgresClusterName: wal-pvc-pgupgrade

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/00-assert.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/00-assert.yaml
@@ -1,0 +1,31 @@
+---
+# Wait for the instances to be ready and the replica backup to complete
+# by waiting for the status to signal pods ready and pgbackrest stanza created
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: wal-pvc-pgupgrade
+spec:
+  postgresVersion: ${KUTTL_PG_UPGRADE_FROM_VERSION}
+status:
+  instances:
+    - name: '00'
+      replicas: 3
+      readyReplicas: 3
+      updatedReplicas: 3
+  pgbackrest:
+    repos:
+    - name: repo1
+      replicaCreateBackupComplete: true
+      stanzaCreated: true
+---
+# Even when the cluster exists, the pgupgrade is not progressing because the cluster is not shutdown
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: wal-pvc-pgupgrade-do-it
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+    reason: "PGClusterNotShutdown"

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/01--create-data.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/01--create-data.yaml
@@ -1,0 +1,93 @@
+---
+# Check the version reported by PostgreSQL and create some data.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wal-pvc-pgupgrade-before
+  labels: { postgres-operator-test: kuttl }
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels: { postgres-operator-test: kuttl }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: psql
+          image: ${KUTTL_PSQL_IMAGE}
+          env:
+            - name: PGURI
+              valueFrom: { secretKeyRef: { name: wal-pvc-pgupgrade-pguser-wal-pvc-pgupgrade, key: uri } }
+
+            # Do not wait indefinitely.
+            - { name: PGCONNECT_TIMEOUT, value: '5' }
+
+          # Note: the `$$$$` is reduced to `$$` by Kubernetes.
+          # - https://kubernetes.io/docs/tasks/inject-data-application/
+          command:
+            - psql
+            - $(PGURI)
+            - --quiet
+            - --echo-errors
+            - --set=ON_ERROR_STOP=1
+            - --command
+            - |
+              DO $$$$
+              BEGIN
+                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_UPGRADE_FROM_VERSION}%',
+                  format('got %L', current_setting('server_version_num'));
+              END $$$$;
+            - --command
+            - |
+              CREATE TABLE important (data) AS VALUES ('treasure');
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wal-pvc-pgupgrade-before-replica
+  labels: { postgres-operator-test: kuttl }
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels: { postgres-operator-test: kuttl }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: psql
+          image: ${KUTTL_PSQL_IMAGE}
+          env:
+          # The Replica svc is not held in the user secret, so we hard-code the Service address
+          # (using the downstream API for the namespace)
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PGHOST
+            value: "wal-pvc-pgupgrade-replicas.$(NAMESPACE).svc"
+          - name: PGPORT
+            valueFrom: { secretKeyRef: { name: wal-pvc-pgupgrade-pguser-wal-pvc-pgupgrade, key: port } }
+          - name: PGDATABASE
+            valueFrom: { secretKeyRef: { name: wal-pvc-pgupgrade-pguser-wal-pvc-pgupgrade, key: dbname } }
+          - name: PGUSER
+            valueFrom: { secretKeyRef: { name: wal-pvc-pgupgrade-pguser-wal-pvc-pgupgrade, key: user } }
+          - name: PGPASSWORD
+            valueFrom: { secretKeyRef: { name: wal-pvc-pgupgrade-pguser-wal-pvc-pgupgrade, key: password } }
+          
+          # Do not wait indefinitely.
+          - { name: PGCONNECT_TIMEOUT, value: '5' }
+
+          # Note: the `$$$$` is reduced to `$$` by Kubernetes.
+          # - https://kubernetes.io/docs/tasks/inject-data-application/
+          command:
+            - psql
+            - --quiet
+            - --echo-errors
+            - --set=ON_ERROR_STOP=1
+            - --command
+            - |
+              DO $$$$
+              BEGIN
+                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_UPGRADE_FROM_VERSION}%',
+                  format('got %L', current_setting('server_version_num'));
+              END $$$$;

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/01-assert.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/01-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wal-pvc-pgupgrade-before
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wal-pvc-pgupgrade-before-replica
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/02--shutdown-cluster.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/02--shutdown-cluster.yaml
@@ -1,0 +1,8 @@
+---
+# Shutdown the cluster -- but without the annotation.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: wal-pvc-pgupgrade
+spec:
+  shutdown: true

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/02-assert.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/02-assert.yaml
@@ -1,0 +1,11 @@
+---
+# Since the cluster is missing the annotation, we get this condition
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: wal-pvc-pgupgrade-do-it
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+    reason: "PGClusterMissingRequiredAnnotation"

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/03--annotate-cluster.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/03--annotate-cluster.yaml
@@ -1,0 +1,8 @@
+---
+# Annotate the cluster for an upgrade.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: wal-pvc-pgupgrade
+  annotations:
+    postgres-operator.crunchydata.com/allow-upgrade: wal-pvc-pgupgrade-do-it

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/03-assert.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/03-assert.yaml
@@ -1,0 +1,22 @@
+---
+# Now that the postgres cluster is shut down and annotated, the pgupgrade
+# can finish reconciling. We know the reconciling is complete when
+# the pgupgrade status is succeeded and the postgres cluster status
+# has the updated version.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: wal-pvc-pgupgrade-do-it
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+  - type:   "Succeeded"
+    status: "True"
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: wal-pvc-pgupgrade
+status:
+  postgresVersion: ${KUTTL_PG_VERSION}

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/04--restart-cluster.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/04--restart-cluster.yaml
@@ -1,0 +1,10 @@
+---
+# Once the pgupgrade is finished, update the version and set shutdown to false
+# in the postgres cluster
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: wal-pvc-pgupgrade
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  shutdown: false

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/04-assert.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/04-assert.yaml
@@ -1,0 +1,18 @@
+---
+# Wait for the instances to be ready with the target Postgres version.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: wal-pvc-pgupgrade
+status:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: '00'
+      replicas: 3
+      readyReplicas: 3
+      updatedReplicas: 3
+  pgbackrest:
+    repos:
+    - name: repo1
+      replicaCreateBackupComplete: true
+      stanzaCreated: true

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/05-check-pgbackrest-and-replica.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/05-check-pgbackrest-and-replica.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# Check that the pgbackrest setup has successfully completed
+- script: |
+    kubectl -n "${NAMESPACE}" exec "statefulset.apps/wal-pvc-pgupgrade-repo-host" -c pgbackrest -- pgbackrest check --stanza=db
+# Check that the replica data dir has been successfully cleaned
+- script: |
+    # Check that the old pg folders do not exist on the replica
+    REPLICA=$(kubectl get pod -l=postgres-operator.crunchydata.com/role=replica -n "${NAMESPACE}" -o=jsonpath='{ .items[0].metadata.name }')
+    kubectl -n "${NAMESPACE}" exec "${REPLICA}" -c database -- [ ! -d "pgdata/pg${KUTTL_PG_UPGRADE_FROM_VERSION}" ]

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/06--check-data-and-version.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/06--check-data-and-version.yaml
@@ -1,0 +1,108 @@
+---
+# Check the version reported by PostgreSQL and confirm that data was upgraded.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wal-pvc-pgupgrade-after
+  labels: { postgres-operator-test: kuttl }
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels: { postgres-operator-test: kuttl }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: psql
+          image: ${KUTTL_PSQL_IMAGE}
+          env:
+            - name: PGURI
+              valueFrom: { secretKeyRef: { name: wal-pvc-pgupgrade-pguser-wal-pvc-pgupgrade, key: uri } }
+
+            # Do not wait indefinitely.
+            - { name: PGCONNECT_TIMEOUT, value: '5' }
+
+          # Note: the `$$$$` is reduced to `$$` by Kubernetes.
+          # - https://kubernetes.io/docs/tasks/inject-data-application/
+          command:
+            - psql
+            - $(PGURI)
+            - --quiet
+            - --echo-errors
+            - --set=ON_ERROR_STOP=1
+            - --command
+            - |
+              DO $$$$
+              BEGIN
+                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_VERSION}%',
+                  format('got %L', current_setting('server_version_num'));
+              END $$$$;
+            - --command
+            - |
+              DO $$$$
+              DECLARE
+                everything jsonb;
+              BEGIN
+                SELECT jsonb_agg(important) INTO everything FROM important;
+                ASSERT everything = '[{"data":"treasure"}]', format('got %L', everything);
+              END $$$$;
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wal-pvc-pgupgrade-after-replica
+  labels: { postgres-operator-test: kuttl }
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels: { postgres-operator-test: kuttl }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: psql
+          image: ${KUTTL_PSQL_IMAGE}
+          env:
+          # The Replica svc is not held in the user secret, so we hard-code the Service address
+          # (using the downstream API for the namespace)
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PGHOST
+            value: "wal-pvc-pgupgrade-replicas.$(NAMESPACE).svc"
+          - name: PGPORT
+            valueFrom: { secretKeyRef: { name: wal-pvc-pgupgrade-pguser-wal-pvc-pgupgrade, key: port } }
+          - name: PGDATABASE
+            valueFrom: { secretKeyRef: { name: wal-pvc-pgupgrade-pguser-wal-pvc-pgupgrade, key: dbname } }
+          - name: PGUSER
+            valueFrom: { secretKeyRef: { name: wal-pvc-pgupgrade-pguser-wal-pvc-pgupgrade, key: user } }
+          - name: PGPASSWORD
+            valueFrom: { secretKeyRef: { name: wal-pvc-pgupgrade-pguser-wal-pvc-pgupgrade, key: password } }
+          
+          # Do not wait indefinitely.
+          - { name: PGCONNECT_TIMEOUT, value: '5' }
+
+          # Note: the `$$$$` is reduced to `$$` by Kubernetes.
+          # - https://kubernetes.io/docs/tasks/inject-data-application/
+          command:
+            - psql
+            - --quiet
+            - --echo-errors
+            - --set=ON_ERROR_STOP=1
+            - --command
+            - |
+              DO $$$$
+              BEGIN
+                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_VERSION}%',
+                  format('got %L', current_setting('server_version_num'));
+              END $$$$;
+            - --command
+            - |
+              DO $$$$
+              DECLARE
+                everything jsonb;
+              BEGIN
+                SELECT jsonb_agg(important) INTO everything FROM important;
+                ASSERT everything = '[{"data":"treasure"}]', format('got %L', everything);
+              END $$$$;

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/06-assert.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/06-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wal-pvc-pgupgrade-after
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wal-pvc-pgupgrade-after-replica
+status:
+  succeeded: 1


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other


**What is the current behavior (link to any open issues here)?**

Currently, the PGUpgrades controller runs in its own image.

[sc-16348]

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

With this change, a single postgres-operator binary will run/manage the controllers for both the PostgresCluster and PGUpgrade APIs.

**Other Information**:
