### PR TITLE
Adds KUTTL_PG_UPGRADE_TO_VERSION parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ check-kuttl:
 
 .PHONY: generate-kuttl
 generate-kuttl: export KUTTL_PG_UPGRADE_FROM_VERSION ?= 13
+generate-kuttl: export KUTTL_PG_UPGRADE_TO_VERSION ?= 14
 generate-kuttl: export KUTTL_PG_VERSION ?= 14
 generate-kuttl: export KUTTL_POSTGIS_VERSION ?= 3.1
 generate-kuttl: export KUTTL_PSQL_IMAGE ?= registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.6-2
@@ -235,7 +236,7 @@ generate-kuttl:
 	12 ) export KUTTL_BITNAMI_IMAGE_TAG=12.12.0-debian-11-r40 ;; \
 	11 ) export KUTTL_BITNAMI_IMAGE_TAG=11.17.0-debian-11-r39 ;; \
 	esac; \
-	render() { envsubst '"'"'$$KUTTL_PG_UPGRADE_FROM_VERSION $$KUTTL_PG_VERSION $$KUTTL_POSTGIS_VERSION $$KUTTL_PSQL_IMAGE $$KUTTL_BITNAMI_IMAGE_TAG'"'"'; }; \
+	render() { envsubst '"'"'$$KUTTL_PG_UPGRADE_FROM_VERSION $$KUTTL_PG_UPGRADE_TO_VERSION $$KUTTL_PG_VERSION $$KUTTL_POSTGIS_VERSION $$KUTTL_PSQL_IMAGE $$KUTTL_BITNAMI_IMAGE_TAG'"'"'; }; \
 	while [ $$# -gt 0 ]; do \
 		source="$${1}" target="$${1/e2e/e2e-generated}"; \
 		mkdir -p "$${target%/*}"; render < "$${source}" > "$${target}"; \

--- a/testing/kuttl/e2e/major-upgrade/02--valid-upgrade.yaml
+++ b/testing/kuttl/e2e/major-upgrade/02--valid-upgrade.yaml
@@ -6,5 +6,5 @@ metadata:
   name: major-upgrade-do-it
 spec:
   fromPostgresVersion: ${KUTTL_PG_UPGRADE_FROM_VERSION}
-  toPostgresVersion: ${KUTTL_PG_VERSION}
+  toPostgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}
   postgresClusterName: major-upgrade

--- a/testing/kuttl/e2e/major-upgrade/10--already-updated-cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade/10--already-updated-cluster.yaml
@@ -5,7 +5,7 @@ kind: PostgresCluster
 metadata:
   name: major-upgrade
 spec:
-  postgresVersion: ${KUTTL_PG_VERSION}
+  postgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}
   instances:
     - dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
   backups:

--- a/testing/kuttl/e2e/major-upgrade/33-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/33-assert.yaml
@@ -19,4 +19,4 @@ kind: PostgresCluster
 metadata:
   name: major-upgrade
 status:
-  postgresVersion: ${KUTTL_PG_VERSION}
+  postgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}

--- a/testing/kuttl/e2e/major-upgrade/34--restart-cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade/34--restart-cluster.yaml
@@ -6,5 +6,5 @@ kind: PostgresCluster
 metadata:
   name: major-upgrade
 spec:
-  postgresVersion: ${KUTTL_PG_VERSION}
+  postgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}
   shutdown: false

--- a/testing/kuttl/e2e/major-upgrade/34-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade/34-assert.yaml
@@ -5,7 +5,7 @@ kind: PostgresCluster
 metadata:
   name: major-upgrade
 status:
-  postgresVersion: ${KUTTL_PG_VERSION}
+  postgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}
   instances:
     - name: '00'
       replicas: 3

--- a/testing/kuttl/e2e/major-upgrade/36--check-data-and-version.yaml
+++ b/testing/kuttl/e2e/major-upgrade/36--check-data-and-version.yaml
@@ -34,7 +34,7 @@ spec:
             - |
               DO $$$$
               BEGIN
-                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_VERSION}%',
+                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_UPGRADE_TO_VERSION}%',
                   format('got %L', current_setting('server_version_num'));
               END $$$$;
             - --command
@@ -94,7 +94,7 @@ spec:
             - |
               DO $$$$
               BEGIN
-                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_VERSION}%',
+              ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_UPGRADE_TO_VERSION}%',
                   format('got %L', current_setting('server_version_num'));
               END $$$$;
             - --command

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/00--create-resources.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/00--create-resources.yaml
@@ -24,5 +24,5 @@ metadata:
   name: wal-pvc-pgupgrade-do-it
 spec:
   fromPostgresVersion: ${KUTTL_PG_UPGRADE_FROM_VERSION}
-  toPostgresVersion: ${KUTTL_PG_VERSION}
+  toPostgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}
   postgresClusterName: wal-pvc-pgupgrade

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/03-assert.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/03-assert.yaml
@@ -19,4 +19,4 @@ kind: PostgresCluster
 metadata:
   name: wal-pvc-pgupgrade
 status:
-  postgresVersion: ${KUTTL_PG_VERSION}
+  postgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/04--restart-cluster.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/04--restart-cluster.yaml
@@ -6,5 +6,5 @@ kind: PostgresCluster
 metadata:
   name: wal-pvc-pgupgrade
 spec:
-  postgresVersion: ${KUTTL_PG_VERSION}
+  postgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}
   shutdown: false

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/04-assert.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/04-assert.yaml
@@ -5,7 +5,7 @@ kind: PostgresCluster
 metadata:
   name: wal-pvc-pgupgrade
 status:
-  postgresVersion: ${KUTTL_PG_VERSION}
+  postgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}
   instances:
     - name: '00'
       replicas: 3

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/06--check-data-and-version.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/06--check-data-and-version.yaml
@@ -34,7 +34,7 @@ spec:
             - |
               DO $$$$
               BEGIN
-                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_VERSION}%',
+                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_UPGRADE_TO_VERSION}%',
                   format('got %L', current_setting('server_version_num'));
               END $$$$;
             - --command
@@ -94,7 +94,7 @@ spec:
             - |
               DO $$$$
               BEGIN
-                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_VERSION}%',
+                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_UPGRADE_TO_VERSION}%',
                   format('got %L', current_setting('server_version_num'));
               END $$$$;
             - --command


### PR DESCRIPTION

Issue: [sc-17416]

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
 - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Kuttl tests for upgrades will fail when running a matrix of PG versions.

**What is the new behavior (if this is a feature change)?**
A new parameter is added to decouple settings between operator tests and upgrade tests.

