### PR TITLE
Allow to control the order of shared_preload_libraries (citus)

### DIFF
--- a/internal/patroni/config_test.go
+++ b/internal/patroni/config_test.go
@@ -421,17 +421,17 @@ func TestDynamicConfiguration(t *testing.T) {
 				},
 			},
 			{
-				name: "postgresql.parameters: mandatory shared_preload_libraries shared_preload_libraries first",
+				name: "postgresql.parameters: mandatory shared_preload_libraries containing a mandatory",
 				input: map[string]interface{}{
 					"postgresql": map[string]interface{}{
 						"parameters": map[string]interface{}{
-							"shared_preload_libraries": "given",
+							"shared_preload_libraries": "given1, mandatory1, given2",
 						},
 					},
 				},
 				params: postgres.Parameters{
 					Mandatory: parameters(map[string]string{
-						"shared_preload_libraries": "mandatory",
+						"shared_preload_libraries": "mandatory1, mandatory2, mandatory3",
 					}),
 				},
 				expected: map[string]interface{}{
@@ -439,7 +439,7 @@ func TestDynamicConfiguration(t *testing.T) {
 					"ttl":       int32(30),
 					"postgresql": map[string]interface{}{
 						"parameters": map[string]interface{}{
-							"shared_preload_libraries": "given, mandatory",
+							"shared_preload_libraries": "mandatory2, mandatory3, given1, mandatory1, given2",
 						},
 						"pg_hba":        []string{},
 						"use_pg_rewind": true,
@@ -452,13 +452,13 @@ func TestDynamicConfiguration(t *testing.T) {
 				input: map[string]interface{}{
 					"postgresql": map[string]interface{}{
 						"parameters": map[string]interface{}{
-							"shared_preload_libraries": "mandatory2, given1, mandatory1, given2",
+							"shared_preload_libraries": "mandatory2, mandatory3, mandatory1",
 						},
 					},
 				},
 				params: postgres.Parameters{
 					Mandatory: parameters(map[string]string{
-						"shared_preload_libraries": "mandatory1, mandatory3, mandatory2",
+						"shared_preload_libraries": "mandatory1, mandatory2, mandatory3",
 					}),
 				},
 				expected: map[string]interface{}{
@@ -466,7 +466,7 @@ func TestDynamicConfiguration(t *testing.T) {
 					"ttl":       int32(30),
 					"postgresql": map[string]interface{}{
 						"parameters": map[string]interface{}{
-							"shared_preload_libraries": "mandatory2, given1, mandatory1, given2, mandatory3",
+							"shared_preload_libraries": "mandatory2, mandatory3, mandatory1",
 						},
 						"pg_hba":        []string{},
 						"use_pg_rewind": true,

--- a/internal/patroni/config_test.go
+++ b/internal/patroni/config_test.go
@@ -420,6 +420,60 @@ func TestDynamicConfiguration(t *testing.T) {
 					"use_slots":     false,
 				},
 			},
+			{
+				name: "postgresql.parameters: mandatory shared_preload_libraries shared_preload_libraries first",
+				input: map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"parameters": map[string]interface{}{
+							"shared_preload_libraries": "given",
+						},
+					},
+				},
+				params: postgres.Parameters{
+					Mandatory: parameters(map[string]string{
+						"shared_preload_libraries": "mandatory",
+					}),
+				},
+				expected: map[string]interface{}{
+					"loop_wait": int32(10),
+					"ttl":       int32(30),
+					"postgresql": map[string]interface{}{
+						"parameters": map[string]interface{}{
+							"shared_preload_libraries": "given, mandatory",
+						},
+						"pg_hba":        []string{},
+						"use_pg_rewind": true,
+						"use_slots":     false,
+					},
+				},
+			},
+			{
+				name: "postgresql.parameters: mandatory shared_preload_libraries order from shared_preload_libraries, no duplicates",
+				input: map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"parameters": map[string]interface{}{
+							"shared_preload_libraries": "mandatory2, given1, mandatory1, given2",
+						},
+					},
+				},
+				params: postgres.Parameters{
+					Mandatory: parameters(map[string]string{
+						"shared_preload_libraries": "mandatory1, mandatory3, mandatory2",
+					}),
+				},
+				expected: map[string]interface{}{
+					"loop_wait": int32(10),
+					"ttl":       int32(30),
+					"postgresql": map[string]interface{}{
+						"parameters": map[string]interface{}{
+							"shared_preload_libraries": "mandatory2, given1, mandatory1, given2, mandatory3",
+						},
+						"pg_hba":        []string{},
+						"use_pg_rewind": true,
+						"use_slots":     false,
+					},
+				},
+			},		
 		},
 		{
 			name: "postgresql.pg_hba: wrong-type is ignored",

--- a/internal/pgbackrest/restore.md
+++ b/internal/pgbackrest/restore.md
@@ -28,11 +28,6 @@ For PostgreSQL 9.5 through 15,
    of `pause` will act the same as `shutdown`," but that cannot be configured
    through pgBackRest.
 
- - The pgBackRest documentation seems to state that `--target-action` has no
-   effect when `hot_standby=off`, but that is not the case.
-
-   See: https://github.com/pgbackrest/pgbackrest/issues/987
-
 The default value of `hot_standby` is `off` prior to PostgreSQL 10 and `on` since.
 
 ### PostgreSQL 15, 14, 13, 12


### PR DESCRIPTION
The citus extension needs to be loaded first when bringing up a cluster. The current implementation allows customising the extensions loaded, but extensions provided by the resource definition will be loaded after any internal ones.

Therefore, we updated the implementation such that the extension list order will be driven by the shared_preload_libraries list when present.

When your definition has a shared_preload_libraries list containing one of the internally loaded libraries, the extension order will change to take the order from the shared_preload_libraries list. ***This may change the behaviour of existing definitions when the shared_preload_libraries contains one of the internally loaded libraries***.

When there shared_preload_libraries list contains one or more or the internal extensions, the duplicate internal extensions will be ignored, which allows the user to fully define the order of loading of extensions.

Issue: https://github.com/CrunchyData/postgres-operator/issues/3194