### PR TITLE
Remove 'postgresVersion10' from Docs

### DIFF
--- a/docs/content/advanced/crunchy-postgres-exporter.md
+++ b/docs/content/advanced/crunchy-postgres-exporter.md
@@ -23,7 +23,7 @@ can be specified for the API to collect. For an example of a queries.yml file, s
 
 The crunchy-postgres-exporter Docker image contains the following packages (versions vary depending on PostgreSQL version):
 
-* PostgreSQL ({{< param postgresVersion13 >}}, {{< param postgresVersion12 >}}, {{< param postgresVersion11 >}}, and {{< param postgresVersion10 >}}
+* PostgreSQL ({{< param postgresVersion13 >}}, {{< param postgresVersion12 >}}, and {{< param postgresVersion11 >}}
 * CentOS 8 - publicly available
 * UBI 7, UBI 8  - customers only
 * [PostgreSQL Exporter](https://github.com/wrouesnel/postgres_exporter)


### PR DESCRIPTION
Removes all use of `postgresVersion10` in the Docs.