### PR TITLE
Fix tests to work on macOS Ventura

### DIFF
--- a/internal/pki/pki_test.go
+++ b/internal/pki/pki_test.go
@@ -491,6 +491,9 @@ func strictOpenSSLVerify(t *testing.T, openssl string, root, leaf Certificate) {
 	if !strings.Contains(string(output), "-x509_strict") {
 		t.Skip(`requires "-x509_strict" flag`)
 	}
+	if !strings.Contains(string(output), "-no-CAfile") {
+		t.Skip(`requires a flag to ignore system certificates`)
+	}
 
 	verify := func(t testing.TB, args ...string) {
 		t.Helper()

--- a/internal/postgres/config_test.go
+++ b/internal/postgres/config_test.go
@@ -209,9 +209,11 @@ func TestBashRecreateDirectory(t *testing.T) {
 }
 
 func TestBashSafeLink(t *testing.T) {
-	// macOS lacks `realpath` which is part of GNU coreutils.
-	if _, err := exec.LookPath("realpath"); err != nil {
-		t.Skip(`requires "realpath" executable`)
+	// macOS `mv` takes different arguments than GNU coreutils.
+	if output, err := exec.Command("mv", "--help").CombinedOutput(); err != nil {
+		t.Skip(`requires "mv" executable`)
+	} else if !strings.Contains(string(output), "no-target-directory") {
+		t.Skip(`requires "mv" that overwrites a directory symlink`)
 	}
 
 	// execute calls the bash function with args.


### PR DESCRIPTION
Shell utilities included in Ventura do not behave the same as GNU core utilities, and OpenSSL has been replaced with LibreSSL.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

**What is the current behavior (link to any open issues here)?**

```
--- FAIL: TestLeafCertificate (0.05s)
    --- FAIL: TestLeafCertificate/OnlyCommonName (0.03s)
        --- FAIL: TestLeafCertificate/OnlyCommonName/OpenSSLVerify (0.03s)
            pki_test.go:277: using "/usr/bin/openssl"
                LibreSSL 3.3.6
```
```
--- FAIL: TestBashSafeLink (0.16s)
    --- FAIL: TestBashSafeLink/CurrentIsFullDirectory (0.07s)
        --- FAIL: TestBashSafeLink/CurrentIsFullDirectory/DesiredIsEmptyDirectory (0.02s)
            config_test.go:257: assertion failed: error is not nil: exit status 64:
                + mv --no-target-directory …/TestBashSafeLinkCurrentIsFullDirectoryDesiredIsEmptyDirectory3591910909/001/original …/TestBashSafeLinkCurrentIsFullDirectoryDesiredIsEmptyDirectory3591910909/001/desired
                mv: illegal option -- -
                usage: mv [-f | -i | -n] [-hv] source target
                       mv [-f | -i | -n] [-v] source ... directory
```

**What is the new behavior (if this is a feature change)?**

`make check check-envtest` passes.
