### PR TITLE
Update k3d and k3s URLs

### DIFF
--- a/.github/actions/k3d/action.yaml
+++ b/.github/actions/k3d/action.yaml
@@ -5,12 +5,12 @@ inputs:
     default: latest
     required: true
     description: >
-      Git tag from https://github.com/rancher/k3d/releases or "latest"
+      Git tag from https://github.com/k3d-io/k3d/releases or "latest"
   k3s-channel:
     default: latest
     required: true
     description: >
-      https://rancher.com/docs/k3s/latest/en/upgrades/basic/#release-channels
+      https://docs.k3s.io/upgrades/manual#release-channels
   prefetch-images:
     required: true
     description: >
@@ -44,7 +44,7 @@ runs:
       env:
         K3D_TAG: ${{ inputs.k3d-tag }}
       run: |
-        curl --fail --silent https://raw.githubusercontent.com/rancher/k3d/main/install.sh |
+        curl --fail --silent https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh |
           TAG="${K3D_TAG#latest}" bash
         k3d version | awk '{ print "${tolower($1)}=${$3}" >> $GITHUB_OUTPUT }'
 


### PR DESCRIPTION
I noticed these URLs redirect away from the Rancher domain and organization. The k3d install script is identical, so everything behaves the same.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Documentation
 - [x] Testing enhancement
