### PR TITLE
Prevent 4.7 make build target from breaking check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,7 @@ pgo-base-docker: pgo-base-build
 
 #======== Utility =======
 check:
+	rm -rf licenses/*/
 	PGOROOT=$(PGOROOT) go test ./...
 
 cli-docs:
@@ -216,6 +217,7 @@ cli-docs:
 	rm docs/content/pgo-client/reference/pgo.md
 
 clean: clean-deprecated
+	rm -rf licenses/*/
 	rm -f bin/apiserver
 	rm -f bin/postgres-operator
 	rm -f bin/pgo bin/pgo-mac bin/pgo.exe


### PR DESCRIPTION
Running make build breaks make check. Running make clean does not resolve the problem. The break comes from the license target pulling in Go files from packages installed on the system that are unrelated to the operator project.

Now, make clean and make check will rm the licenses directory as needed.

Issue: [sc-11938]
