### PR TITLE
Prevent 4.6 make build target from breaking check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ pgo-base-docker: pgo-base-build
 
 #======== Utility =======
 check:
+	rm -rf licenses/*/
 	PGOROOT=$(PGOROOT) go test ./...
 
 cli-docs:
@@ -211,6 +212,7 @@ cli-docs:
 	rm docs/content/pgo-client/reference/pgo.md
 
 clean: clean-deprecated
+	rm -rf licenses/*/
 	rm -f bin/apiserver
 	rm -f bin/postgres-operator
 	rm -f bin/pgo bin/pgo-mac bin/pgo.exe

--- a/internal/operator/cluster/standby.go
+++ b/internal/operator/cluster/standby.go
@@ -213,7 +213,7 @@ func EnableStandby(clientset kubernetes.Interface, cluster crv1.Pgcluster) error
 	// Delete the "leader" configMap
 	if err = clientset.CoreV1().ConfigMaps(namespace).Delete(ctx, leaderConfigMapName, metav1.DeleteOptions{}); err != nil &&
 		!kerrors.IsNotFound(err) {
-		log.Error("Unable to delete configMap %s while enabling standby mode for cluster "+
+		log.Errorf("Unable to delete configMap %s while enabling standby mode for cluster "+
 			"%s: %v", leaderConfigMapName, clusterName, err)
 		return err
 	}


### PR DESCRIPTION
Running make build breaks make check. Running make clean does not
resolve the problem. The break comes from the license target
pulling in Go files from packages installed on the system that are
unrelated to the operator project.
    
Now, make clean and make check will rm the licenses directory as
needed.
    
Issue: [sc-11938]
