### PR TITLE
Fix e2e-other/postgis-cluster KUTTL

### DIFF
--- a/testing/kuttl/e2e-other/postgis-cluster/01--psql-connect.yaml
+++ b/testing/kuttl/e2e-other/postgis-cluster/01--psql-connect.yaml
@@ -122,8 +122,8 @@ spec:
               DECLARE
                result text;
               BEGIN
-               SELECT ST_AsText(ST_AsGeoJSON('SRID=4326;POINT(-118.4079 33.9434)'::geography)) INTO result;
-               ASSERT result = 'POINT(-118.4079 33.9434)', 'GeoJSON check failed';
+               SELECT ST_AsGeoJSON('SRID=4326;POINT(-118.4079 33.9434)'::geography) INTO result;
+               ASSERT result = '{\"type\":\"Point\",\"coordinates\":[-118.4079,33.9434]}', FORMAT('GeoJSON check failed, got %L', result);
               END \$\$;" 2>&1)
               
               if [[ "$RESULT" == *"ERROR"* ]]; then


### PR DESCRIPTION
**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Problem: PostGIS < v3.1 had trouble parsing result from ST_AsGeoJSON with ST_AsText function.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Solution: Remove ST_AsText and check JSON directly

**Other Information**:
Issue: [sc-18159]
