### PR TITLE
document that wal files are not deleted

### DIFF
--- a/docs/content/guides/major-postgres-version-upgrade.md
+++ b/docs/content/guides/major-postgres-version-upgrade.md
@@ -152,7 +152,7 @@ rm -rf '/pgdata/pg{{< param fromPostgresVersion >}}'
 
 When you are satisfied with the upgrade, you can execute this command to remove the old data directory. Do so at your discretion.
 
-The script does not delete old WAL-files so these must be deleted manually.
+Note that the `delete_old_cluster.sh` script does not delete the old WAL files. These are typically found in `/pgdata/pg{{< param fromPostgresVersion >}}_wal`, although they can be stored elsewhere. If you would like to delete these files, this must be done manually.
 
 If you have extensions installed you may need to upgrade those as well. For example, for the `pgaudit` extension we recommend running the following to upgrade:
 

--- a/docs/content/guides/major-postgres-version-upgrade.md
+++ b/docs/content/guides/major-postgres-version-upgrade.md
@@ -147,7 +147,7 @@ If you are unable to exec into the Pod, you can run `ANALYZE` directly on each o
 `pg_upgrade` may also create a script called `delete_old_cluster.sh`, which contains the equivalent of
 
 ```
-rm -rf '/pgdata/{{< param fromPostgresVersion >}}'
+rm -rf '/pgdata/pg{{< param fromPostgresVersion >}}'
 ```
 
 When you are satisfied with the upgrade, you can execute this command to remove the old data directory. Do so at your discretion.

--- a/docs/content/guides/major-postgres-version-upgrade.md
+++ b/docs/content/guides/major-postgres-version-upgrade.md
@@ -152,6 +152,8 @@ rm -rf '/pgdata/{{< param fromPostgresVersion >}}'
 
 When you are satisfied with the upgrade, you can execute this command to remove the old data directory. Do so at your discretion.
 
+The script does not delete old WAL-files so these must be deleted manually.
+
 If you have extensions installed you may need to upgrade those as well. For example, for the `pgaudit` extension we recommend running the following to upgrade:
 
 ```sql


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [x] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

As I mentioned in issue #3623 the old wal files are not cleaned up on the primary instance after a major version pgupgrade. This is not mentioned in docs and can be a surprise if you're wondering what is taking up more space than normal.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Just mention it in the docs so people can delete it manually when they're happy with the upgrade.

**Other Information**:
