### PR TITLE
Add SessionAffinity to PGBouncer Service

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: pgo
@@ -995,12 +995,13 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: pgo
@@ -2645,8 +2645,8 @@ spec:
                                     constraint. - DoNotSchedule (default) tells the
                                     scheduler not to schedule it. - ScheduleAnyway
                                     tells the scheduler to schedule the pod in any
-                                    location, but giving higher precedence to topologies
-                                    that would help reduce the skew. A constraint
+                                    location,   but giving higher precedence to topologies
+                                    that would help reduce the   skew. A constraint
                                     is considered "Unsatisfiable" for an incoming
                                     pod if and only if every possible node assignment
                                     for that pod would violate "MaxSkew" on some topology.
@@ -2809,12 +2809,12 @@ spec:
                                         the other is non-empty. There are two important
                                         differences between DataSource and DataSourceRef:
                                         * While DataSource only allows two specific
-                                        types of objects, DataSourceRef allows any
+                                        types of objects, DataSourceRef   allows any
                                         non-core object, as well as PersistentVolumeClaim
                                         objects. * While DataSource ignores disallowed
-                                        values (dropping them), DataSourceRef preserves
+                                        values (dropping them), DataSourceRef   preserves
                                         all values, and generates an error if a disallowed
-                                        value is specified. (Beta) Using this field
+                                        value is   specified. (Beta) Using this field
                                         requires the AnyVolumeDataSource feature gate
                                         to be enabled.'
                                       properties:
@@ -5725,12 +5725,12 @@ spec:
                                       if one of them is empty and the other is non-empty.
                                       There are two important differences between
                                       DataSource and DataSourceRef: * While DataSource
-                                      only allows two specific types of objects, DataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim
+                                      only allows two specific types of objects, DataSourceRef   allows
+                                      any non-core object, as well as PersistentVolumeClaim
                                       objects. * While DataSource ignores disallowed
-                                      values (dropping them), DataSourceRef preserves
+                                      values (dropping them), DataSourceRef   preserves
                                       all values, and generates an error if a disallowed
-                                      value is specified. (Beta) Using this field
+                                      value is   specified. (Beta) Using this field
                                       requires the AnyVolumeDataSource feature gate
                                       to be enabled.'
                                     properties:
@@ -9231,11 +9231,11 @@ spec:
                             same value automatically if one of them is empty and the
                             other is non-empty. There are two important differences
                             between DataSource and DataSourceRef: * While DataSource
-                            only allows two specific types of objects, DataSourceRef
-                            allows any non-core object, as well as PersistentVolumeClaim
+                            only allows two specific types of objects, DataSourceRef   allows
+                            any non-core object, as well as PersistentVolumeClaim
                             objects. * While DataSource ignores disallowed values
-                            (dropping them), DataSourceRef preserves all values, and
-                            generates an error if a disallowed value is specified.
+                            (dropping them), DataSourceRef   preserves all values,
+                            and generates an error if a disallowed value is   specified.
                             (Beta) Using this field requires the AnyVolumeDataSource
                             feature gate to be enabled.'
                           properties:
@@ -9519,13 +9519,13 @@ spec:
                                   them is empty and the other is non-empty. There
                                   are two important differences between DataSource
                                   and DataSourceRef: * While DataSource only allows
-                                  two specific types of objects, DataSourceRef allows
+                                  two specific types of objects, DataSourceRef   allows
                                   any non-core object, as well as PersistentVolumeClaim
                                   objects. * While DataSource ignores disallowed values
-                                  (dropping them), DataSourceRef preserves all values,
-                                  and generates an error if a disallowed value is
-                                  specified. (Beta) Using this field requires the
-                                  AnyVolumeDataSource feature gate to be enabled.'
+                                  (dropping them), DataSourceRef   preserves all values,
+                                  and generates an error if a disallowed value is   specified.
+                                  (Beta) Using this field requires the AnyVolumeDataSource
+                                  feature gate to be enabled.'
                                 properties:
                                   apiGroup:
                                     description: APIGroup is the group for the resource
@@ -9820,15 +9820,15 @@ spec:
                               with a pod if it doesn''t satisfy the spread constraint.
                               - DoNotSchedule (default) tells the scheduler not to
                               schedule it. - ScheduleAnyway tells the scheduler to
-                              schedule the pod in any location, but giving higher
-                              precedence to topologies that would help reduce the
-                              skew. A constraint is considered "Unsatisfiable" for
-                              an incoming pod if and only if every possible node assignment
-                              for that pod would violate "MaxSkew" on some topology.
-                              For example, in a 3-zone cluster, MaxSkew is set to
-                              1, and pods with the same labelSelector spread as 3/1/1:
-                              | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
-                              If WhenUnsatisfiable is set to DoNotSchedule, incoming
+                              schedule the pod in any location,   but giving higher
+                              precedence to topologies that would help reduce the   skew.
+                              A constraint is considered "Unsatisfiable" for an incoming
+                              pod if and only if every possible node assignment for
+                              that pod would violate "MaxSkew" on some topology. For
+                              example, in a 3-zone cluster, MaxSkew is set to 1, and
+                              pods with the same labelSelector spread as 3/1/1: |
+                              zone1 | zone2 | zone3 | | P P P |   P   |   P   | If
+                              WhenUnsatisfiable is set to DoNotSchedule, incoming
                               pod can only be scheduled to zone2(zone3) to become
                               3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
                               MaxSkew(1). In other words, the cluster can still be
@@ -9893,11 +9893,11 @@ spec:
                             same value automatically if one of them is empty and the
                             other is non-empty. There are two important differences
                             between DataSource and DataSourceRef: * While DataSource
-                            only allows two specific types of objects, DataSourceRef
-                            allows any non-core object, as well as PersistentVolumeClaim
+                            only allows two specific types of objects, DataSourceRef   allows
+                            any non-core object, as well as PersistentVolumeClaim
                             objects. * While DataSource ignores disallowed values
-                            (dropping them), DataSourceRef preserves all values, and
-                            generates an error if a disallowed value is specified.
+                            (dropping them), DataSourceRef   preserves all values,
+                            and generates an error if a disallowed value is   specified.
                             (Beta) Using this field requires the AnyVolumeDataSource
                             feature gate to be enabled.'
                           properties:
@@ -13080,6 +13080,27 @@ spec:
                               requires one. - https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                             format: int32
                             type: integer
+                          sessionAffinity:
+                            description: Session Affinity Type string
+                            type: string
+                          sessionAffinityConfig:
+                            description: SessionAffinityConfig represents the configurations
+                              of session affinity.
+                            properties:
+                              clientIP:
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
+                                properties:
+                                  timeoutSeconds:
+                                    description: timeoutSeconds specifies the seconds
+                                      of ClientIP type session sticky time. The value
+                                      must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                      == "ClientIP". Default value is 10800(for 3
+                                      hours).
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
                           type:
                             default: ClusterIP
                             description: 'More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
@@ -13294,13 +13315,13 @@ spec:
                                 with a pod if it doesn''t satisfy the spread constraint.
                                 - DoNotSchedule (default) tells the scheduler not
                                 to schedule it. - ScheduleAnyway tells the scheduler
-                                to schedule the pod in any location, but giving higher
-                                precedence to topologies that would help reduce the
-                                skew. A constraint is considered "Unsatisfiable" for
-                                an incoming pod if and only if every possible node
-                                assignment for that pod would violate "MaxSkew" on
-                                some topology. For example, in a 3-zone cluster, MaxSkew
-                                is set to 1, and pods with the same labelSelector
+                                to schedule the pod in any location,   but giving
+                                higher precedence to topologies that would help reduce
+                                the   skew. A constraint is considered "Unsatisfiable"
+                                for an incoming pod if and only if every possible
+                                node assignment for that pod would violate "MaxSkew"
+                                on some topology. For example, in a 3-zone cluster,
+                                MaxSkew is set to 1, and pods with the same labelSelector
                                 spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P
                                 |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule,
                                 incoming pod can only be scheduled to zone2(zone3)
@@ -13342,6 +13363,26 @@ spec:
                       be allocated if this Service requires one. - https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                     format: int32
                     type: integer
+                  sessionAffinity:
+                    description: Session Affinity Type string
+                    type: string
+                  sessionAffinityConfig:
+                    description: SessionAffinityConfig represents the configurations
+                      of session affinity.
+                    properties:
+                      clientIP:
+                        description: clientIP contains the configurations of Client
+                          IP based session affinity.
+                        properties:
+                          timeoutSeconds:
+                            description: timeoutSeconds specifies the seconds of ClientIP
+                              type session sticky time. The value must be >0 && <=86400(for
+                              1 day) if ServiceAffinity == "ClientIP". Default value
+                              is 10800(for 3 hours).
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
                   type:
                     default: ClusterIP
                     description: 'More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
@@ -14618,12 +14659,12 @@ spec:
                               and the other is non-empty. There are two important
                               differences between DataSource and DataSourceRef: *
                               While DataSource only allows two specific types of objects,
-                              DataSourceRef allows any non-core object, as well as
-                              PersistentVolumeClaim objects. * While DataSource ignores
-                              disallowed values (dropping them), DataSourceRef preserves
+                              DataSourceRef   allows any non-core object, as well
+                              as PersistentVolumeClaim objects. * While DataSource
+                              ignores disallowed values (dropping them), DataSourceRef   preserves
                               all values, and generates an error if a disallowed value
-                              is specified. (Beta) Using this field requires the AnyVolumeDataSource
-                              feature gate to be enabled.'
+                              is   specified. (Beta) Using this field requires the
+                              AnyVolumeDataSource feature gate to be enabled.'
                             properties:
                               apiGroup:
                                 description: APIGroup is the group for the resource
@@ -14813,6 +14854,27 @@ spec:
                               requires one. - https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                             format: int32
                             type: integer
+                          sessionAffinity:
+                            description: Session Affinity Type string
+                            type: string
+                          sessionAffinityConfig:
+                            description: SessionAffinityConfig represents the configurations
+                              of session affinity.
+                            properties:
+                              clientIP:
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
+                                properties:
+                                  timeoutSeconds:
+                                    description: timeoutSeconds specifies the seconds
+                                      of ClientIP type session sticky time. The value
+                                      must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                      == "ClientIP". Default value is 10800(for 3
+                                      hours).
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
                           type:
                             default: ClusterIP
                             description: 'More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
@@ -14990,13 +15052,13 @@ spec:
                                 with a pod if it doesn''t satisfy the spread constraint.
                                 - DoNotSchedule (default) tells the scheduler not
                                 to schedule it. - ScheduleAnyway tells the scheduler
-                                to schedule the pod in any location, but giving higher
-                                precedence to topologies that would help reduce the
-                                skew. A constraint is considered "Unsatisfiable" for
-                                an incoming pod if and only if every possible node
-                                assignment for that pod would violate "MaxSkew" on
-                                some topology. For example, in a 3-zone cluster, MaxSkew
-                                is set to 1, and pods with the same labelSelector
+                                to schedule the pod in any location,   but giving
+                                higher precedence to topologies that would help reduce
+                                the   skew. A constraint is considered "Unsatisfiable"
+                                for an incoming pod if and only if every possible
+                                node assignment for that pod would violate "MaxSkew"
+                                on some topology. For example, in a 3-zone cluster,
+                                MaxSkew is set to 1, and pods with the same labelSelector
                                 spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P
                                 |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule,
                                 incoming pod can only be scheduled to zone2(zone3)

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -1515,8 +1515,8 @@ PGUpgradeStatus defines the observed state of PGUpgrade
 
 
 
-Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: "Available", "Progressing", and "Degraded" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` 
- // other fields }
+Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: "Available", "Progressing", and "Degraded"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` 
+     // other fields }
 
 <table>
     <thead>
@@ -2103,7 +2103,7 @@ Defines a PersistentVolumeClaim spec used to create and/or bind a volume
       </tr><tr>
         <td><b><a href="#postgresclusterspecbackupspgbackrestreposindexvolumevolumeclaimspecdatasourceref">dataSourceRef</a></b></td>
         <td>object</td>
-        <td>dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.</td>
+        <td>dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.</td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#postgresclusterspecbackupspgbackrestreposindexvolumevolumeclaimspecselector">selector</a></b></td>
@@ -2205,7 +2205,7 @@ dataSource field can be used to specify either: * An existing VolumeSnapshot obj
 
 
 
-dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
 
 <table>
     <thead>
@@ -5550,7 +5550,7 @@ TopologySpreadConstraint specifies how to spread matching pods among the given t
       </tr><tr>
         <td><b>whenUnsatisfiable</b></td>
         <td>string</td>
-        <td>WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.</td>
+        <td>WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,   but giving higher precedence to topologies that would help reduce the   skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.</td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#postgresclusterspecbackupspgbackrestrepohosttopologyspreadconstraintsindexlabelselector">labelSelector</a></b></td>
@@ -7249,7 +7249,7 @@ Defines a PersistentVolumeClaim for PostgreSQL data. More info: https://kubernet
       </tr><tr>
         <td><b><a href="#postgresclusterspecinstancesindexdatavolumeclaimspecdatasourceref">dataSourceRef</a></b></td>
         <td>object</td>
-        <td>dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.</td>
+        <td>dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.</td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#postgresclusterspecinstancesindexdatavolumeclaimspecselector">selector</a></b></td>
@@ -7351,7 +7351,7 @@ dataSource field can be used to specify either: * An existing VolumeSnapshot obj
 
 
 
-dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
 
 <table>
     <thead>
@@ -10805,7 +10805,7 @@ Defines a PersistentVolumeClaim for a tablespace. More info: https://kubernetes.
       </tr><tr>
         <td><b><a href="#postgresclusterspecinstancesindextablespacevolumesindexdatavolumeclaimspecdatasourceref">dataSourceRef</a></b></td>
         <td>object</td>
-        <td>dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.</td>
+        <td>dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.</td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#postgresclusterspecinstancesindextablespacevolumesindexdatavolumeclaimspecresources">resources</a></b></td>
@@ -10880,7 +10880,7 @@ dataSource field can be used to specify either: * An existing VolumeSnapshot obj
 
 
 
-dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
 
 <table>
     <thead>
@@ -11089,7 +11089,7 @@ TopologySpreadConstraint specifies how to spread matching pods among the given t
       </tr><tr>
         <td><b>whenUnsatisfiable</b></td>
         <td>string</td>
-        <td>WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.</td>
+        <td>WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,   but giving higher precedence to topologies that would help reduce the   skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.</td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#postgresclusterspecinstancesindextopologyspreadconstraintsindexlabelselector">labelSelector</a></b></td>
@@ -11212,7 +11212,7 @@ Defines a separate PersistentVolumeClaim for PostgreSQL's write-ahead log. More 
       </tr><tr>
         <td><b><a href="#postgresclusterspecinstancesindexwalvolumeclaimspecdatasourceref">dataSourceRef</a></b></td>
         <td>object</td>
-        <td>dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.</td>
+        <td>dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.</td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#postgresclusterspecinstancesindexwalvolumeclaimspecselector">selector</a></b></td>
@@ -11314,7 +11314,7 @@ dataSource field can be used to specify either: * An existing VolumeSnapshot obj
 
 
 
-dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
 
 <table>
     <thead>
@@ -12295,7 +12295,7 @@ Defines a PersistentVolumeClaim spec used to create and/or bind a volume
       </tr><tr>
         <td><b><a href="#postgresclusterspecdatasourcepgbackrestrepovolumevolumeclaimspecdatasourceref">dataSourceRef</a></b></td>
         <td>object</td>
-        <td>dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.</td>
+        <td>dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.</td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#postgresclusterspecdatasourcepgbackrestrepovolumevolumeclaimspecresources">resources</a></b></td>
@@ -12370,7 +12370,7 @@ dataSource field can be used to specify either: * An existing VolumeSnapshot obj
 
 
 
-dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
 
 <table>
     <thead>
@@ -20177,6 +20177,16 @@ Specification of the service that exposes PgBouncer.
         <td>The port on which this service is exposed when type is NodePort or LoadBalancer. Value must be in-range and not in use or the operation will fail. If unspecified, a port will be allocated if this Service requires one. - https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport</td>
         <td>false</td>
       </tr><tr>
+        <td><b>sessionAffinity</b></td>
+        <td>string</td>
+        <td>Session Affinity Type string</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecproxypgbouncerservicesessionaffinityconfig">sessionAffinityConfig</a></b></td>
+        <td>object</td>
+        <td>SessionAffinityConfig represents the configurations of session affinity.</td>
+        <td>false</td>
+      </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types</td>
@@ -20212,6 +20222,60 @@ Metadata contains metadata for custom resources
         <td><b>labels</b></td>
         <td>map[string]string</td>
         <td></td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecproxypgbouncerservicesessionaffinityconfig">
+  PostgresCluster.spec.proxy.pgBouncer.service.sessionAffinityConfig
+  <sup><sup><a href="#postgresclusterspecproxypgbouncerservice">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+SessionAffinityConfig represents the configurations of session affinity.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#postgresclusterspecproxypgbouncerservicesessionaffinityconfigclientip">clientIP</a></b></td>
+        <td>object</td>
+        <td>clientIP contains the configurations of Client IP based session affinity.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecproxypgbouncerservicesessionaffinityconfigclientip">
+  PostgresCluster.spec.proxy.pgBouncer.service.sessionAffinityConfig.clientIP
+  <sup><sup><a href="#postgresclusterspecproxypgbouncerservicesessionaffinityconfig">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+clientIP contains the configurations of Client IP based session affinity.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>timeoutSeconds</b></td>
+        <td>integer</td>
+        <td>timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).</td>
         <td>false</td>
       </tr></tbody>
 </table>
@@ -20381,7 +20445,7 @@ TopologySpreadConstraint specifies how to spread matching pods among the given t
       </tr><tr>
         <td><b>whenUnsatisfiable</b></td>
         <td>string</td>
-        <td>WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.</td>
+        <td>WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,   but giving higher precedence to topologies that would help reduce the   skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.</td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#postgresclusterspecproxypgbouncertopologyspreadconstraintsindexlabelselector">labelSelector</a></b></td>
@@ -20497,6 +20561,16 @@ Specification of the service that exposes the PostgreSQL primary instance.
         <td>The port on which this service is exposed when type is NodePort or LoadBalancer. Value must be in-range and not in use or the operation will fail. If unspecified, a port will be allocated if this Service requires one. - https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport</td>
         <td>false</td>
       </tr><tr>
+        <td><b>sessionAffinity</b></td>
+        <td>string</td>
+        <td>Session Affinity Type string</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecservicesessionaffinityconfig">sessionAffinityConfig</a></b></td>
+        <td>object</td>
+        <td>SessionAffinityConfig represents the configurations of session affinity.</td>
+        <td>false</td>
+      </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types</td>
@@ -20532,6 +20606,60 @@ Metadata contains metadata for custom resources
         <td><b>labels</b></td>
         <td>map[string]string</td>
         <td></td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecservicesessionaffinityconfig">
+  PostgresCluster.spec.service.sessionAffinityConfig
+  <sup><sup><a href="#postgresclusterspecservice">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+SessionAffinityConfig represents the configurations of session affinity.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#postgresclusterspecservicesessionaffinityconfigclientip">clientIP</a></b></td>
+        <td>object</td>
+        <td>clientIP contains the configurations of Client IP based session affinity.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecservicesessionaffinityconfigclientip">
+  PostgresCluster.spec.service.sessionAffinityConfig.clientIP
+  <sup><sup><a href="#postgresclusterspecservicesessionaffinityconfig">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+clientIP contains the configurations of Client IP based session affinity.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>timeoutSeconds</b></td>
+        <td>integer</td>
+        <td>timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).</td>
         <td>false</td>
       </tr></tbody>
 </table>
@@ -20714,7 +20842,7 @@ Defines a PersistentVolumeClaim for pgAdmin data. More info: https://kubernetes.
       </tr><tr>
         <td><b><a href="#postgresclusterspecuserinterfacepgadmindatavolumeclaimspecdatasourceref">dataSourceRef</a></b></td>
         <td>object</td>
-        <td>dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.</td>
+        <td>dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.</td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#postgresclusterspecuserinterfacepgadmindatavolumeclaimspecresources">resources</a></b></td>
@@ -20789,7 +20917,7 @@ dataSource field can be used to specify either: * An existing VolumeSnapshot obj
 
 
 
-dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
 
 <table>
     <thead>
@@ -22640,6 +22768,16 @@ Specification of the service that exposes pgAdmin.
         <td>The port on which this service is exposed when type is NodePort or LoadBalancer. Value must be in-range and not in use or the operation will fail. If unspecified, a port will be allocated if this Service requires one. - https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport</td>
         <td>false</td>
       </tr><tr>
+        <td><b>sessionAffinity</b></td>
+        <td>string</td>
+        <td>Session Affinity Type string</td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#postgresclusterspecuserinterfacepgadminservicesessionaffinityconfig">sessionAffinityConfig</a></b></td>
+        <td>object</td>
+        <td>SessionAffinityConfig represents the configurations of session affinity.</td>
+        <td>false</td>
+      </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types</td>
@@ -22675,6 +22813,60 @@ Metadata contains metadata for custom resources
         <td><b>labels</b></td>
         <td>map[string]string</td>
         <td></td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecuserinterfacepgadminservicesessionaffinityconfig">
+  PostgresCluster.spec.userInterface.pgAdmin.service.sessionAffinityConfig
+  <sup><sup><a href="#postgresclusterspecuserinterfacepgadminservice">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+SessionAffinityConfig represents the configurations of session affinity.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#postgresclusterspecuserinterfacepgadminservicesessionaffinityconfigclientip">clientIP</a></b></td>
+        <td>object</td>
+        <td>clientIP contains the configurations of Client IP based session affinity.</td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+<h3 id="postgresclusterspecuserinterfacepgadminservicesessionaffinityconfigclientip">
+  PostgresCluster.spec.userInterface.pgAdmin.service.sessionAffinityConfig.clientIP
+  <sup><sup><a href="#postgresclusterspecuserinterfacepgadminservicesessionaffinityconfig">↩ Parent</a></sup></sup>
+</h3>
+
+
+
+clientIP contains the configurations of Client IP based session affinity.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>timeoutSeconds</b></td>
+        <td>integer</td>
+        <td>timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).</td>
         <td>false</td>
       </tr></tbody>
 </table>
@@ -22758,7 +22950,7 @@ TopologySpreadConstraint specifies how to spread matching pods among the given t
       </tr><tr>
         <td><b>whenUnsatisfiable</b></td>
         <td>string</td>
-        <td>WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.</td>
+        <td>WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,   but giving higher precedence to topologies that would help reduce the   skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.</td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#postgresclusterspecuserinterfacepgadmintopologyspreadconstraintsindexlabelselector">labelSelector</a></b></td>

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -318,6 +318,9 @@ func (r *Reconciler) generatePGBouncerService(
 	}
 	service.Spec.Ports = []corev1.ServicePort{servicePort}
 
+	service.Spec.SessionAffinity = cluster.Spec.Proxy.PGBouncer.Service.SessionAffinity
+	service.Spec.SessionAffinityConfig = cluster.Spec.Proxy.PGBouncer.Service.SessionAffinityConfig
+
 	err := errors.WithStack(r.setControllerReference(cluster, service))
 
 	return service, true, err

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/shared_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/shared_types.go
@@ -55,6 +55,11 @@ type ServiceSpec struct {
 	// +kubebuilder:default=ClusterIP
 	// +kubebuilder:validation:Enum={ClusterIP,NodePort,LoadBalancer}
 	Type string `json:"type"`
+
+	// +optional
+	SessionAffinity corev1.ServiceAffinity `json:"sessionAffinity"`
+	// +optional
+	SessionAffinityConfig *corev1.SessionAffinityConfig `json:"sessionAffinityConfig"`
 }
 
 // Sidecar defines the configuration of a sidecar container


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

N/A

**What is the new behavior (if this is a feature change)?**

- It just adds a parameter to the PostgresCluster CRD so that we can set the sessionAffinity.


**Other Information**:
