### PR TITLE
Update depguard configuration for golangci-lint v1.53

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,17 +21,25 @@ linters:
 
 linters-settings:
   depguard:
-    include-go-root: true
-    packages-with-error-message:
-      - io/ioutil: >
-          Use the "io" and "os" packages instead.
-          See https://go.dev/doc/go1.16#ioutil
+    rules:
+      everything:
+        deny:
+          - pkg: io/ioutil
+            desc: >
+              Use the "io" and "os" packages instead.
+              See https://go.dev/doc/go1.16#ioutil
 
-      - net/http/httptest: Should be used only in tests.
-      - testing/*: The "testing" packages should be used only in tests.
+      not-tests:
+        files: ['!$test']
+        deny:
+          - pkg: net/http/httptest
+            desc: Should be used only in tests.
 
-      - github.com/crunchydata/postgres-operator/internal/testing/*: >
-          The "internal/testing" packages should be used only in tests.
+          - pkg: testing/*
+            desc: The "testing" packages should be used only in tests.
+
+          - pkg: github.com/crunchydata/postgres-operator/internal/testing/*
+            desc: The "internal/testing" packages should be used only in tests.
 
   exhaustive:
     default-signifies-exhaustive: true
@@ -59,14 +67,6 @@ linters-settings:
       - pkg: k8s.io/apimachinery/pkg/api/errors
         alias: apierrors
     no-unaliased: true
-
-issues:
-  exclude-rules:
-    # These testing packages are allowed in test files. The packages are
-    # disallowed everywhere then ignored here because that is how depguard works.
-    - linters: [depguard]
-      path: _test[.]go$
-      text: \`(net/http/httptest|[^`]*testing[^`]*)`
 
 run:
   build-tags:


### PR DESCRIPTION
The depguard v2 linter allows different rules to be applied to different sets of files. We can remove the path-based exclusion from the golangci-lint configuration.

See: https://github.com/OpenPeeDeeP/depguard#config
See: https://golangci-lint.run/usage/linters/#depguard

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other


**What is the current behavior (link to any open issues here)?**

When no rulesets are configured, a default "Main" ruleset rejects everything except stdlib. Lint checks are failing with:

```
  Error: import 'k8s.io/apimachinery/pkg/util/intstr' is not allowed from list 'Main' (depguard)
```

**What is the new behavior (if this is a feature change)?**

Lint checks are passing.

**Other Information**:
