### PR TITLE
Adding fix for hugepages/restore issue.

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -1086,9 +1086,16 @@ func (r *Reconciler) reconcileRestoreJob(ctx context.Context,
 		}
 	}
 
+	// Check to see if huge pages have been requested in the spec. If they have, include 'huge_pages = try'
+	// in the restore command. If they haven't, include 'huge_pages = off'.
+	hugePagesSetting := "off"
+	if postgres.HugePagesRequested(cluster) {
+		hugePagesSetting = "try"
+	}
+
 	// NOTE (andrewlecuyer): Forcing users to put each argument separately might prevent the need
 	// to do any escaping or use eval.
-	cmd := pgbackrest.RestoreCommand(pgdata, pgtablespaceVolumes, strings.Join(opts, " "))
+	cmd := pgbackrest.RestoreCommand(pgdata, hugePagesSetting, pgtablespaceVolumes, strings.Join(opts, " "))
 
 	// create the volume resources required for the postgres data directory
 	dataVolumeMount := postgres.DataVolumeMount()

--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -177,7 +177,7 @@ func MakePGBackrestLogDir(template *corev1.PodTemplateSpec,
 //   - Renames the data directory as needed to bootstrap the cluster using the restored database.
 //     This ensures compatibility with the "existing" bootstrap method that is included in the
 //     Patroni config when bootstrapping a cluster using an existing data directory.
-func RestoreCommand(pgdata string, tablespaceVolumes []*corev1.PersistentVolumeClaim, args ...string) []string {
+func RestoreCommand(pgdata, hugePagesSetting string, tablespaceVolumes []*corev1.PersistentVolumeClaim, args ...string) []string {
 
 	// After pgBackRest restores files, PostgreSQL starts in recovery to finish
 	// replaying WAL files. "hot_standby" is "on" (by default) so we can detect
@@ -236,6 +236,7 @@ max_locks_per_transaction = '${max_lock}'
 max_prepared_transactions = '${max_ptxn}'
 max_worker_processes = '${max_work}'
 unix_socket_directories = '/tmp'
+huge_pages = ` + hugePagesSetting + `
 EOF
 if [ "$(< "${pgdata}/PG_VERSION")" -ge 12 ]; then
 read -r max_wals <<< "${control##*max_wal_senders setting:}"

--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -297,7 +297,7 @@ func TestRestoreCommand(t *testing.T) {
 	opts := []string{
 		"--stanza=" + DefaultStanzaName, "--pg1-path=" + pgdata,
 		"--repo=1"}
-	command := RestoreCommand(pgdata, nil, strings.Join(opts, " "))
+	command := RestoreCommand(pgdata, "try", nil, strings.Join(opts, " "))
 
 	assert.DeepEqual(t, command[:3], []string{"bash", "-ceu", "--"})
 	assert.Assert(t, len(command) > 3)
@@ -312,7 +312,7 @@ func TestRestoreCommand(t *testing.T) {
 }
 
 func TestRestoreCommandPrettyYAML(t *testing.T) {
-	b, err := yaml.Marshal(RestoreCommand("/dir", nil, "--options"))
+	b, err := yaml.Marshal(RestoreCommand("/dir", "try", nil, "--options"))
 	assert.NilError(t, err)
 	assert.Assert(t, strings.Contains(string(b), "\n- |"),
 		"expected literal block scalar, got:\n%s", b)

--- a/internal/postgres/huge_pages.go
+++ b/internal/postgres/huge_pages.go
@@ -28,7 +28,7 @@ import (
 // it sets the PostgreSQL parameter "huge_pages" to "try". If it doesn't find
 // one, it sets "huge_pages" to "off".
 func SetHugePages(cluster *v1beta1.PostgresCluster, pgParameters *Parameters) {
-	if hugePagesRequested(cluster) {
+	if HugePagesRequested(cluster) {
 		pgParameters.Default.Add("huge_pages", "try")
 	} else {
 		pgParameters.Default.Add("huge_pages", "off")
@@ -37,7 +37,7 @@ func SetHugePages(cluster *v1beta1.PostgresCluster, pgParameters *Parameters) {
 
 // This helper function checks to see if a huge_pages value greater than zero has
 // been set in any of the PostgresCluster's instances' resource specs
-func hugePagesRequested(cluster *v1beta1.PostgresCluster) bool {
+func HugePagesRequested(cluster *v1beta1.PostgresCluster) bool {
 	for _, instance := range cluster.Spec.InstanceSets {
 		for resourceName := range instance.Resources.Limits {
 			if strings.HasPrefix(resourceName.String(), corev1.ResourceHugePagesPrefix) {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Currently, a cluster restore will fail if the pods are scheduled to a node that has huge pages enabled and available but the postgrescluster is not requesting huge pages. This is due to our restore process creating a new `postgresql.conf` file that did not have the fix in place to workaround the previously addressed hugepages/kube issue.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Restores will now succeed regardless of hugepages settings on nodes/postgrescluster.

**Other Information**:
