### PR TITLE
Stop PostgresCluster reconciliation when required image not set and update PGUpgrade logic

### DIFF
--- a/internal/controller/pgupgrade/jobs.go
+++ b/internal/controller/pgupgrade/jobs.go
@@ -314,6 +314,15 @@ func pgUpgradeContainerImage(upgrade *v1beta1.PGUpgrade) string {
 	return defaultFromEnv(image, "RELATED_IMAGE_PGUPGRADE")
 }
 
+// verifyUpgradeImageValue checks that the upgrade container image required by the
+// spec is defined. If it is undefined, an error is returned.
+func verifyUpgradeImageValue(upgrade *v1beta1.PGUpgrade) error {
+	if pgUpgradeContainerImage(upgrade) == "" {
+		return fmt.Errorf("Missing crunchy-upgrade image")
+	}
+	return nil
+}
+
 // jobFailed returns "true" if the Job provided has failed.  Otherwise it returns "false".
 func jobFailed(job *batchv1.Job) bool {
 	conditions := job.Status.Conditions

--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/crunchydata/postgres-operator/internal/config"
 	"github.com/crunchydata/postgres-operator/internal/logging"
 	"github.com/crunchydata/postgres-operator/internal/pgaudit"
 	"github.com/crunchydata/postgres-operator/internal/pgbackrest"
@@ -145,6 +146,13 @@ func (r *Reconciler) Reconcile(
 	// Perform initial validation on a cluster
 	// TODO: Move this to a defaulting (mutating admission) webhook
 	// to leverage regular validation.
+
+	if err := config.VerifyImageValues(cluster); err != nil {
+		r.Recorder.Event(cluster, corev1.EventTypeWarning, "MissingRequiredImage",
+			err.Error())
+		return result, err
+	}
+
 	if cluster.Spec.Standby != nil &&
 		cluster.Spec.Standby.Enabled &&
 		cluster.Spec.Standby.Host == "" &&

--- a/internal/controller/postgrescluster/controller_test.go
+++ b/internal/controller/postgrescluster/controller_test.go
@@ -173,6 +173,7 @@ metadata:
   name: carlos
 spec:
   postgresVersion: 13
+  image: postgres
   instances:
   - name: samba
     dataVolumeClaimSpec:
@@ -183,6 +184,7 @@ spec:
           storage: 1Gi
   backups:
     pgbackrest:
+      image: pgbackrest
       repos:
       - name: repo1
         volume:
@@ -376,6 +378,7 @@ metadata:
   name: carlos
 spec:
   postgresVersion: 13
+  image: postgres
   instances:
   - name: samba
     dataVolumeClaimSpec:
@@ -386,6 +389,7 @@ spec:
           storage: 1Gi
   backups:
     pgbackrest:
+      image: pgbackrest
       repos:
       - name: repo1
         volume:

--- a/testing/kuttl/e2e/major-upgrade-missing-image/01--valid-upgrade.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/01--valid-upgrade.yaml
@@ -1,0 +1,11 @@
+---
+# This upgrade is valid, but has no pgcluster to work on and should get that condition
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: empty-image-upgrade
+spec:
+  # postgres version that is no longer available
+  fromPostgresVersion: 10
+  toPostgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}
+  postgresClusterName: major-upgrade-empty-image

--- a/testing/kuttl/e2e/major-upgrade-missing-image/01-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/01-assert.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: empty-image-upgrade
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+    reason: "PGClusterNotFound"

--- a/testing/kuttl/e2e/major-upgrade-missing-image/10--cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/10--cluster.yaml
@@ -1,0 +1,23 @@
+---
+# Create the cluster we will do an actual upgrade on, but set the postgres version
+# to '10' to force a missing image scenario
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade-empty-image
+spec:
+  # postgres version that is no longer available
+  postgresVersion: 10
+  patroni:
+    dynamicConfiguration:
+      postgresql:
+        parameters:
+          shared_preload_libraries: pgaudit, set_user, pg_stat_statements, pgnodemx, pg_cron
+  instances:
+    - dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+  backups:
+    pgbackrest:
+      repos:
+        - name: repo1
+          volume:
+            volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }

--- a/testing/kuttl/e2e/major-upgrade-missing-image/10-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/10-assert.yaml
@@ -1,0 +1,12 @@
+---
+# The cluster is not running due to the missing image, not due to a proper
+# shutdown status.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: empty-image-upgrade
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+    reason: "PGClusterNotShutdown"

--- a/testing/kuttl/e2e/major-upgrade-missing-image/11--shutdown-cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/11--shutdown-cluster.yaml
@@ -1,0 +1,8 @@
+---
+# Shutdown the cluster -- but without the annotation.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade-empty-image
+spec:
+  shutdown: true

--- a/testing/kuttl/e2e/major-upgrade-missing-image/11-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/11-assert.yaml
@@ -1,0 +1,11 @@
+---
+# Since the cluster is missing the annotation, we get this condition
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: empty-image-upgrade
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+    reason: "PGClusterPrimaryNotIdentified"

--- a/testing/kuttl/e2e/major-upgrade-missing-image/12--start-and-update-version.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/12--start-and-update-version.yaml
@@ -1,0 +1,17 @@
+---
+# Update the postgres version and restart the cluster.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade-empty-image
+spec:
+  shutdown: false
+  postgresVersion: ${KUTTL_PG_UPGRADE_FROM_VERSION}
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: empty-image-upgrade
+spec:
+  # update postgres version
+  fromPostgresVersion: ${KUTTL_PG_UPGRADE_FROM_VERSION}

--- a/testing/kuttl/e2e/major-upgrade-missing-image/12-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/12-assert.yaml
@@ -1,0 +1,31 @@
+---
+# Wait for the instances to be ready and the replica backup to complete
+# by waiting for the status to signal pods ready and pgbackrest stanza created
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade-empty-image
+spec:
+  postgresVersion: ${KUTTL_PG_UPGRADE_FROM_VERSION}
+status:
+  instances:
+    - name: '00'
+      replicas: 1
+      readyReplicas: 1
+      updatedReplicas: 1
+  pgbackrest:
+    repos:
+    - name: repo1
+      replicaCreateBackupComplete: true
+      stanzaCreated: true
+---
+# Even when the cluster exists, the pgupgrade is not progressing because the cluster is not shutdown
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: empty-image-upgrade
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+    reason: "PGClusterNotShutdown"

--- a/testing/kuttl/e2e/major-upgrade-missing-image/13--shutdown-cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/13--shutdown-cluster.yaml
@@ -1,0 +1,8 @@
+---
+# Shutdown the cluster -- but without the annotation.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade-empty-image
+spec:
+  shutdown: true

--- a/testing/kuttl/e2e/major-upgrade-missing-image/13-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/13-assert.yaml
@@ -1,0 +1,11 @@
+---
+# Since the cluster is missing the annotation, we get this condition
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: empty-image-upgrade
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+    reason: "PGClusterMissingRequiredAnnotation"

--- a/testing/kuttl/e2e/major-upgrade-missing-image/14--annotate-cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/14--annotate-cluster.yaml
@@ -1,0 +1,8 @@
+---
+# Annotate the cluster for an upgrade.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade-empty-image
+  annotations:
+    postgres-operator.crunchydata.com/allow-upgrade: empty-image-upgrade

--- a/testing/kuttl/e2e/major-upgrade-missing-image/14-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/14-assert.yaml
@@ -1,0 +1,22 @@
+---
+# Now that the postgres cluster is shut down and annotated, the pgupgrade
+# can finish reconciling. We know the reconciliation is complete when
+# the pgupgrade status is succeeded and the postgres cluster status
+# has the updated version.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: empty-image-upgrade
+status:
+  conditions:
+  - type:   "Progressing"
+    status: "False"
+  - type:   "Succeeded"
+    status: "True"
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade-empty-image
+status:
+  postgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}

--- a/testing/kuttl/e2e/major-upgrade-missing-image/15--start-cluster.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/15--start-cluster.yaml
@@ -1,0 +1,10 @@
+---
+# Once the pgupgrade is finished, update the version and set shutdown to false
+# in the postgres cluster
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade-empty-image
+spec:
+  postgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}
+  shutdown: false

--- a/testing/kuttl/e2e/major-upgrade-missing-image/15-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/15-assert.yaml
@@ -1,0 +1,18 @@
+---
+# Wait for the instances to be ready with the target Postgres version.
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: major-upgrade-empty-image
+status:
+  postgresVersion: ${KUTTL_PG_UPGRADE_TO_VERSION}
+  instances:
+    - name: '00'
+      replicas: 1
+      readyReplicas: 1
+      updatedReplicas: 1
+  pgbackrest:
+    repos:
+    - name: repo1
+      replicaCreateBackupComplete: true
+      stanzaCreated: true

--- a/testing/kuttl/e2e/major-upgrade-missing-image/16-check-pgbackrest.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/16-check-pgbackrest.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# Check that the pgbackrest setup has successfully completed
+- script: |
+    kubectl -n "${NAMESPACE}" exec "statefulset.apps/major-upgrade-empty-image-repo-host" -c pgbackrest -- pgbackrest check --stanza=db

--- a/testing/kuttl/e2e/major-upgrade-missing-image/17--check-version.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/17--check-version.yaml
@@ -1,0 +1,39 @@
+---
+# Check the version reported by PostgreSQL
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: major-upgrade-empty-image-after
+  labels: { postgres-operator-test: kuttl }
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels: { postgres-operator-test: kuttl }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: psql
+          image: ${KUTTL_PSQL_IMAGE}
+          env:
+            - name: PGURI
+              valueFrom: { secretKeyRef: { name: major-upgrade-empty-image-pguser-major-upgrade-empty-image, key: uri } }
+
+            # Do not wait indefinitely.
+            - { name: PGCONNECT_TIMEOUT, value: '5' }
+
+          # Note: the `$$$$` is reduced to `$$` by Kubernetes.
+          # - https://kubernetes.io/docs/tasks/inject-data-application/
+          command:
+            - psql
+            - $(PGURI)
+            - --quiet
+            - --echo-errors
+            - --set=ON_ERROR_STOP=1
+            - --command
+            - |
+              DO $$$$
+              BEGIN
+                ASSERT current_setting('server_version_num') LIKE '${KUTTL_PG_UPGRADE_TO_VERSION}%',
+                  format('got %L', current_setting('server_version_num'));
+              END $$$$;

--- a/testing/kuttl/e2e/major-upgrade-missing-image/17-assert.yaml
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/17-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: major-upgrade-empty-image-after
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/major-upgrade-missing-image/README.md
+++ b/testing/kuttl/e2e/major-upgrade-missing-image/README.md
@@ -1,0 +1,36 @@
+## Major upgrade missing image tests
+
+This is a variation derived from our major upgrade KUTTL tests designed to
+test scenarios where required container images are not defined in either the
+PostgresCluster spec or via the RELATED_IMAGES environment variables.
+
+### Basic PGUpgrade controller and CRD instance validation
+
+* 01--valid-upgrade: create a valid PGUpgrade instance
+* 01-assert: check that the PGUpgrade instance exists and has the expected status
+
+### Verify new statuses for missing required container images
+
+* 10--cluster: create the cluster with an unavailable image (i.e. Postgres 10)
+* 10-assert: check that the PGUpgrade instance has the expected reason: "PGClusterNotShutdown"
+* 11-shutdown-cluster: set the spec.shutdown value to 'true' as required for upgrade
+* 11-assert: check that the new reason is set, "PGClusterPrimaryNotIdentified"
+
+### Update to an available Postgres version, start and upgrade PostgresCluster
+
+* 12--start-and-update-version: update the Postgres version on both CRD instances and set 'shutdown' to false
+* 12-assert: verify that the cluster is running and the PGUpgrade instance now has the new status info with reason: "PGClusterNotShutdown"
+* 13--shutdown-cluster: set spec.shutdown to 'true'
+* 13-assert: check that the PGUpgrade instance has the expected reason: "PGClusterMissingRequiredAnnotation"
+* 14--annotate-cluster: set the required annotation
+* 14-assert: verify that the upgrade succeeded and the new Postgres version shows in the cluster's status
+* 15--start-cluster: set the new Postgres version and spec.shutdown to 'false'
+
+### Verify upgraded PostgresCluster
+
+* 15-assert: verify that the cluster is running
+* 16-check-pgbackrest: check that the pgbackrest setup has successfully completed
+* 17--check-version: check the version reported by PostgreSQL
+* 17-assert: assert the Job from the previous step succeeded
+
+


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
In certain scenarios, an empty `image:` field can result in a failure to properly reconcile a PostgresCluster as described in #3690.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This update prevents empty image values from impacting the reconciliation of a PostgresCluster. With this change, the impacted cluster will not be updated until the necessary images are defined and a corresponding warning event will be created. PostgresClusters with images properly defined will reconcile normally.

Also adjusts the PGUpgrade logic to allow for easier recovery from a
missing image scenario. Specific Conditions are more clearly defined
and checking is added for the 'crunchy-upgrade' image.

Finally, a Kuttl test scenario is added.


**Other Information**:
Issue: [sc-21130]