### PR TITLE
Refactor Delete Namespace test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,7 @@ generate-kuttl: export KUTTL_PG_UPGRADE_TO_VERSION ?= 15
 generate-kuttl: export KUTTL_PG_VERSION ?= 15
 generate-kuttl: export KUTTL_POSTGIS_VERSION ?= 3.3
 generate-kuttl: export KUTTL_PSQL_IMAGE ?= registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.3-2
+generate-kuttl: export KUTTL_TEST_DELETE_NAMESPACE ?= kuttl-test-delete-namespace
 generate-kuttl: ## Generate kuttl tests
 	[ ! -d testing/kuttl/e2e-generated ] || rm -r testing/kuttl/e2e-generated
 	[ ! -d testing/kuttl/e2e-generated-other ] || rm -r testing/kuttl/e2e-generated-other
@@ -285,7 +286,10 @@ generate-kuttl: ## Generate kuttl tests
 	12 ) export KUTTL_BITNAMI_IMAGE_TAG=12.12.0-debian-11-r40 ;; \
 	11 ) export KUTTL_BITNAMI_IMAGE_TAG=11.17.0-debian-11-r39 ;; \
 	esac; \
-	render() { envsubst '"'"'$$KUTTL_PG_UPGRADE_FROM_VERSION $$KUTTL_PG_UPGRADE_TO_VERSION $$KUTTL_PG_VERSION $$KUTTL_POSTGIS_VERSION $$KUTTL_PSQL_IMAGE $$KUTTL_BITNAMI_IMAGE_TAG'"'"'; }; \
+	render() { envsubst '"'"' \
+		$$KUTTL_PG_UPGRADE_FROM_VERSION $$KUTTL_PG_UPGRADE_TO_VERSION \
+		$$KUTTL_PG_VERSION $$KUTTL_POSTGIS_VERSION $$KUTTL_PSQL_IMAGE \
+		$$KUTTL_BITNAMI_IMAGE_TAG $$KUTTL_TEST_DELETE_NAMESPACE'"'"'; }; \
 	while [ $$# -gt 0 ]; do \
 		source="$${1}" target="$${1/e2e/e2e-generated}"; \
 		mkdir -p "$${target%/*}"; render < "$${source}" > "$${target}"; \

--- a/testing/kuttl/e2e/delete-namespace/00--namespace.yaml
+++ b/testing/kuttl/e2e/delete-namespace/00--namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kuttl-test-delete-namespace
+  name: ${KUTTL_TEST_DELETE_NAMESPACE}

--- a/testing/kuttl/e2e/delete-namespace/01--cluster.yaml
+++ b/testing/kuttl/e2e/delete-namespace/01--cluster.yaml
@@ -3,26 +3,16 @@ apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
   name: delete-namespace
-  namespace: kuttl-test-delete-namespace
+  namespace: ${KUTTL_TEST_DELETE_NAMESPACE}
 spec:
   postgresVersion: ${KUTTL_PG_VERSION}
   instances:
     - name: instance1
-      replicas: 2
-      dataVolumeClaimSpec:
-        accessModes:
-        - "ReadWriteOnce"
-        resources:
-          requests:
-            storage: 1Gi
+      replicas: 1
+      dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
   backups:
     pgbackrest:
       repos:
       - name: repo1
         volume:
-          volumeClaimSpec:
-            accessModes:
-            - "ReadWriteOnce"
-            resources:
-              requests:
-                storage: 1Gi
+          volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }

--- a/testing/kuttl/e2e/delete-namespace/01-assert.yaml
+++ b/testing/kuttl/e2e/delete-namespace/01-assert.yaml
@@ -3,18 +3,18 @@ apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
   name: delete-namespace
-  namespace: kuttl-test-delete-namespace
+  namespace: ${KUTTL_TEST_DELETE_NAMESPACE}
 status:
   instances:
     - name: instance1
-      readyReplicas: 2
-      replicas: 2
-      updatedReplicas: 2
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  namespace: kuttl-test-delete-namespace
+  namespace: ${KUTTL_TEST_DELETE_NAMESPACE}
   labels:
     postgres-operator.crunchydata.com/cluster: delete-namespace
     postgres-operator.crunchydata.com/pgbackrest-backup: replica-create

--- a/testing/kuttl/e2e/delete-namespace/02--delete-namespace.yaml
+++ b/testing/kuttl/e2e/delete-namespace/02--delete-namespace.yaml
@@ -5,4 +5,4 @@ kind: TestStep
 delete:
   - apiVersion: v1
     kind: Namespace
-    name: kuttl-test-delete-namespace
+    name: ${KUTTL_TEST_DELETE_NAMESPACE}

--- a/testing/kuttl/e2e/delete-namespace/02-errors.yaml
+++ b/testing/kuttl/e2e/delete-namespace/02-errors.yaml
@@ -2,13 +2,13 @@
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
-  namespace: kuttl-test-delete-namespace
+  namespace: ${KUTTL_TEST_DELETE_NAMESPACE}
   name: delete-namespace
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  namespace: kuttl-test-delete-namespace
+  namespace: ${KUTTL_TEST_DELETE_NAMESPACE}
   labels:
     postgres-operator.crunchydata.com/cluster: delete-namespace
 ---
@@ -16,34 +16,34 @@ metadata:
 apiVersion: v1
 kind: Endpoints
 metadata:
-  namespace: kuttl-test-delete-namespace
+  namespace: ${KUTTL_TEST_DELETE_NAMESPACE}
   labels:
     postgres-operator.crunchydata.com/cluster: delete-namespace
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: kuttl-test-delete-namespace
+  namespace: ${KUTTL_TEST_DELETE_NAMESPACE}
   labels:
     postgres-operator.crunchydata.com/cluster: delete-namespace
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: kuttl-test-delete-namespace
+  namespace: ${KUTTL_TEST_DELETE_NAMESPACE}
   labels:
     postgres-operator.crunchydata.com/cluster: delete-namespace
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  namespace: kuttl-test-delete-namespace
+  namespace: ${KUTTL_TEST_DELETE_NAMESPACE}
   labels:
     postgres-operator.crunchydata.com/cluster: delete-namespace
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: kuttl-test-delete-namespace
+  namespace: ${KUTTL_TEST_DELETE_NAMESPACE}
   labels:
     postgres-operator.crunchydata.com/cluster: delete-namespace

--- a/testing/kuttl/e2e/delete-namespace/README.md
+++ b/testing/kuttl/e2e/delete-namespace/README.md
@@ -7,4 +7,5 @@
 
 Note: KUTTL provides a `$NAMESPACE` var that can be used in scripts/commands,
 but which cannot be used in object definition yamls (like `01--cluster.yaml`).
-Therefore, we use a given, non-random namespace: `kuttl-test-delete-namespace`.
+Therefore, we use a given, non-random namespace that is defined in the makefile
+and generated with `generate-kuttl`.


### PR DESCRIPTION
- Allow runner to define a namespace to delete through the Makefile. This will be useful if two sets of Kuttl tests are running in the same env
- Move from 2 replicas to 1 to speed up the test
- Use single line volume claim specs

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
