### PR TITLE
Update apply_test to handle changes for Kubernetes 1.28+

### DIFF
--- a/.github/actions/k3d/action.yaml
+++ b/.github/actions/k3d/action.yaml
@@ -53,7 +53,7 @@ runs:
       shell: bash
       run: |
         k3d cluster create --image '+${{ inputs.k3s-channel }}' --no-lb --timeout=2m --wait
-        kubectl version --short | awk '{ print "${tolower($1)}=${$3}" >> $GITHUB_OUTPUT }'
+        kubectl version | awk '{ print "${tolower($1)}=${$3}" >> $GITHUB_OUTPUT }'
 
         PAUSE_IMAGE=$(docker exec $(k3d node list --output json | jq --raw-output 'first.name') \
           k3s agent --help | awk '$1 == "--pause-image" {

--- a/internal/controller/postgrescluster/apply_test.go
+++ b/internal/controller/postgrescluster/apply_test.go
@@ -79,8 +79,19 @@ func TestServerSideApply(t *testing.T) {
 		after := constructor()
 		assert.NilError(t, cc.Patch(ctx, after, client.Apply, reconciler.Owner))
 		assert.Assert(t, after.GetResourceVersion() != "")
-		assert.Assert(t, after.GetResourceVersion() != before.GetResourceVersion(),
-			"expected https://github.com/kubernetes-sigs/controller-runtime/issues/1356")
+
+		switch {
+		// TODO(tjmoore4): The update currently impacts 1.28+ only, but may be
+		// backpatched in the future.
+		// - https://github.com/kubernetes/kubernetes/pull/116865
+		case serverVersion.LessThan(version.MustParseGeneric("1.28")):
+
+			assert.Assert(t, after.GetResourceVersion() != before.GetResourceVersion(),
+				"expected https://issue.k8s.io/116861")
+
+		default:
+			assert.Assert(t, after.GetResourceVersion() == before.GetResourceVersion())
+		}
 
 		// Our apply method generates the correct apply-patch.
 		again := constructor()


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Prior to 1.28.0, certain no-op server-side apply updates bumped the resourceVersion value. For new Kubernetes versions this behavior has been adjusted so that resourceVersion is not bumped.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This change adds an additional check for the server version to allow the correct test to be executed.


**Other Information**:
