### PR TITLE
Custom queries

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  QUERIES_CONFIG_DIR: "${{ github.workspace }}/hack/tools/queries" 
-
 jobs:
   go-test:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,8 @@ check-envtest: SHELL = bash
 check-envtest: get-pgmonitor
 	GOBIN='$(CURDIR)/hack/tools' $(GO) install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 	@$(ENVTEST_USE) --print=overview && echo
-	source <($(ENVTEST_USE) --print=env) && PGO_NAMESPACE="postgres-operator" $(GO_TEST) -count=1 -cover -tags=envtest ./...
+	source <($(ENVTEST_USE) --print=env) && PGO_NAMESPACE="postgres-operator" QUERIES_CONFIG_DIR="$(CURDIR)/${QUERIES_CONFIG_DIR}" \
+		$(GO_TEST) -count=1 -cover -tags=envtest ./...
 
 # The "PGO_TEST_TIMEOUT_SCALE" environment variable (default: 1) can be set to a
 # positive number that extends test timeouts. The following runs tests with 
@@ -209,7 +210,8 @@ check-envtest-existing: ## Run check using envtest and an existing kube api
 check-envtest-existing: get-pgmonitor
 check-envtest-existing: createnamespaces
 	kubectl apply --server-side -k ./config/dev
-	USE_EXISTING_CLUSTER=true PGO_NAMESPACE="postgres-operator" $(GO_TEST) -count=1 -cover -p=1 -tags=envtest ./...
+	USE_EXISTING_CLUSTER=true PGO_NAMESPACE="postgres-operator" QUERIES_CONFIG_DIR="$(CURDIR)/${QUERIES_CONFIG_DIR}" \
+		$(GO_TEST) -count=1 -cover -p=1 -tags=envtest ./...
 	kubectl delete -k ./config/dev
 
 # Expects operator to be running

--- a/internal/pgmonitor/exporter.go
+++ b/internal/pgmonitor/exporter.go
@@ -1,0 +1,168 @@
+/*
+ Copyright 2021 - 2023 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pgmonitor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/crunchydata/postgres-operator/internal/logging"
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+)
+
+const (
+	ExporterPort = int32(9187)
+
+	// TODO: With the current implementation of the crunchy-postgres-exporter
+	// it makes sense to hard-code the database. When moving away from the
+	// crunchy-postgres-exporter start.sh script we should re-evaluate always
+	// setting the exporter database to `postgres`.
+	ExporterDB = "postgres"
+
+	// The exporter connects to all databases over loopback using a password.
+	// Kubernetes guarantees localhost resolves to loopback:
+	// https://kubernetes.io/docs/concepts/cluster-administration/networking/
+	// https://releases.k8s.io/v1.21.0/pkg/kubelet/kubelet_pods.go#L343
+	ExporterHost = "localhost"
+)
+
+// postgres_exporter command flags
+var (
+	ExporterExtendQueryPathFlag  = "--extend.query-path=/tmp/queries.yml"
+	ExporterWebListenAddressFlag = fmt.Sprintf("--web.listen-address=:%d", ExporterPort)
+	ExporterWebConfigFileFlag    = "--web.config.file=/web-config/web-config.yml"
+)
+
+// Defaults for certain values used in queries.yml
+// TODO(dsessler7): make these values configurable via spec
+var DefaultValuesForQueries = map[string]string{
+	"PGBACKREST_INFO_THROTTLE_MINUTES":    "10",
+	"PG_STAT_STATEMENTS_LIMIT":            "20",
+	"PG_STAT_STATEMENTS_THROTTLE_MINUTES": "-1",
+}
+
+// GenerateDefaultExporterQueries generates the default queries used by exporter
+func GenerateDefaultExporterQueries(ctx context.Context, cluster *v1beta1.PostgresCluster) string {
+	log := logging.FromContext(ctx)
+	var queries string
+	baseQueries := []string{"backrest", "global", "per_db", "nodemx"}
+	queriesConfigDir := GetQueriesConfigDir(ctx)
+
+	// TODO: When we add pgbouncer support we will do something like the following:
+	// if pgbouncerEnabled() {
+	// 	baseQueries = append(baseQueries, "pgbouncer")
+	// }
+
+	for _, queryType := range baseQueries {
+		queriesContents, err := os.ReadFile(fmt.Sprintf("%s/queries_%s.yml", queriesConfigDir, queryType))
+		if err != nil {
+			// log an error, but continue to next iteration
+			log.Error(err, fmt.Sprintf("Query file queries_%s.yml does not exist (it should)...", queryType))
+			continue
+		}
+		queries += string(queriesContents) + "\n"
+	}
+
+	// Add general queries for specific postgres version
+	queriesGeneral, err := os.ReadFile(fmt.Sprintf("%s/pg%d/queries_general.yml", queriesConfigDir, cluster.Spec.PostgresVersion))
+	if err != nil {
+		// log an error, but continue
+		log.Error(err, fmt.Sprintf("Query file %s/pg%d/queries_general.yml does not exist (it should)...", queriesConfigDir, cluster.Spec.PostgresVersion))
+	} else {
+		queries += string(queriesGeneral) + "\n"
+	}
+
+	// Add pg_stat_statement queries for specific postgres version
+	queriesPgStatStatements, err := os.ReadFile(fmt.Sprintf("%s/pg%d/queries_pg_stat_statements.yml", queriesConfigDir, cluster.Spec.PostgresVersion))
+	if err != nil {
+		// log an error, but continue
+		log.Error(err, fmt.Sprintf("Query file %s/pg%d/queries_pg_stat_statements.yml not loaded.", queriesConfigDir, cluster.Spec.PostgresVersion))
+	} else {
+		queries += string(queriesPgStatStatements) + "\n"
+	}
+
+	// If postgres version >= 12, add pg_stat_statements_reset queries
+	if cluster.Spec.PostgresVersion >= 12 {
+		queriesPgStatStatementsReset, err := os.ReadFile(fmt.Sprintf("%s/pg%d/queries_pg_stat_statements_reset_info.yml", queriesConfigDir, cluster.Spec.PostgresVersion))
+		if err != nil {
+			// log an error, but continue
+			log.Error(err, fmt.Sprintf("Query file %s/pg%d/queries_pg_stat_statements_reset_info.yml not loaded.", queriesConfigDir, cluster.Spec.PostgresVersion))
+		} else {
+			queries += string(queriesPgStatStatementsReset) + "\n"
+		}
+	}
+
+	// Find and replace default values in queries
+	for k, v := range DefaultValuesForQueries {
+		queries = strings.ReplaceAll(queries, fmt.Sprintf("#%s#", k), v)
+	}
+
+	// TODO: Add ability to exclude certain user-specified queries
+
+	return queries
+}
+
+// ExporterStartCommand generates an entrypoint that will create a master queries file and
+// start the postgres_exporter. It will repeat those steps if it notices a change in
+// the source queries files.
+func ExporterStartCommand(commandFlags []string) []string {
+	script := strings.Join([]string{
+		// Set up temporary file to hold postgres_exporter process id
+		`POSTGRES_EXPORTER_PIDFILE=/tmp/postgres_exporter.pid`,
+
+		// declare function that will combine custom queries file and default
+		// queries and start the postgres_exporter
+		`start_postgres_exporter() {`,
+		`	cat /conf/* > /tmp/queries.yml`,
+		`	echo "Starting postgres_exporter with the following flags..."`,
+		`	echo "$@"`,
+		`	postgres_exporter "$@" &`,
+		`	echo $! > $POSTGRES_EXPORTER_PIDFILE`,
+		`}`,
+
+		// run function to combine queries files and start postgres_exporter
+		`start_postgres_exporter "$@"`,
+
+		// set directory to watch
+		`declare -r directory=/conf`,
+
+		// Create a file descriptor with a no-op process that will not get
+		// cleaned up
+		`exec {fd}<> <(:)`,
+
+		// Set up loop. Use read's timeout setting instead of sleep,
+		// which uses up a lot of memory
+		`while read -r -t 3 -u "${fd}" || true; do`,
+
+		// If the directory's modify time is newer than our file descriptor's,
+		// something must have changed, so kill the postgres_exporter and rerun
+		// the function to combine queries files and start postgres_exporter
+		`  if [ "${directory}" -nt "/proc/self/fd/${fd}" ] && echo "Something changed..." &&`,
+		`    kill $(head -1 ${POSTGRES_EXPORTER_PIDFILE?}) && start_postgres_exporter "$@"`,
+
+		// We then want to get rid of the old file descriptor, get a fresh one
+		// and restart the loop
+		`  then`,
+		`    exec {fd}>&- && exec {fd}<> <(:)`,
+		`    stat --format='Latest queries file dated %%y' "${directory}"`,
+		`  fi`,
+		`done`,
+	}, "\n")
+
+	return append([]string{"bash", "-ceu", "--", script, "postgres_exporter_watcher"}, commandFlags...)
+}

--- a/internal/pgmonitor/exporter_test.go
+++ b/internal/pgmonitor/exporter_test.go
@@ -1,0 +1,62 @@
+//go:build envtest
+// +build envtest
+
+/*
+ Copyright 2021 - 2023 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pgmonitor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+)
+
+func TestGenerateDefaultExporterQueries(t *testing.T) {
+	ctx := context.Background()
+	cluster := &v1beta1.PostgresCluster{}
+
+	t.Run("PG<=11", func(t *testing.T) {
+		cluster.Spec.PostgresVersion = 11
+		queries := GenerateDefaultExporterQueries(ctx, cluster)
+		assert.Assert(t, !strings.Contains(queries, "ccp_pg_stat_statements_reset"),
+			"Queries contain 'ccp_pg_stat_statements_reset' query when they should not.")
+	})
+
+	t.Run("PG>=12", func(t *testing.T) {
+		cluster.Spec.PostgresVersion = 12
+		queries := GenerateDefaultExporterQueries(ctx, cluster)
+		assert.Assert(t, strings.Contains(queries, "ccp_pg_stat_statements_reset"),
+			"Queries do not contain 'ccp_pg_stat_statements_reset' query when they should.")
+	})
+}
+
+func TestExporterStartCommand(t *testing.T) {
+	t.Run("OneFlag", func(t *testing.T) {
+		commandSlice := ExporterStartCommand([]string{"--testFlag"})
+		assert.DeepEqual(t, commandSlice[:3], []string{"bash", "-ceu", "--"})
+		assert.DeepEqual(t, commandSlice[4:], []string{"postgres_exporter_watcher", "--testFlag"})
+	})
+
+	t.Run("MultipleFlags", func(t *testing.T) {
+		commandSlice := ExporterStartCommand([]string{"--firstTestFlag", "--secondTestFlag"})
+		assert.DeepEqual(t, commandSlice[:3], []string{"bash", "-ceu", "--"})
+		assert.DeepEqual(t, commandSlice[4:], []string{"postgres_exporter_watcher", "--firstTestFlag", "--secondTestFlag"})
+	})
+}

--- a/internal/util/features.go
+++ b/internal/util/features.go
@@ -32,6 +32,9 @@ const (
 	// Feature gates should be listed in alphabetical, case-sensitive
 	// (upper before any lower case character) order.
 	//
+	// Enables support of appending custom queries to default PGMonitor queries
+	AppendCustomQueries featuregate.Feature = "AppendCustomQueries"
+	//
 	BridgeIdentifiers featuregate.Feature = "BridgeIdentifiers"
 	//
 	// Enables support of custom sidecars for PostgreSQL instance Pods
@@ -52,10 +55,11 @@ const (
 //
 // - https://releases.k8s.io/v1.20.0/pkg/features/kube_features.go#L729-732
 var pgoFeatures = map[featuregate.Feature]featuregate.FeatureSpec{
-	BridgeIdentifiers: {Default: false, PreRelease: featuregate.Alpha},
-	InstanceSidecars:  {Default: false, PreRelease: featuregate.Alpha},
-	PGBouncerSidecars: {Default: false, PreRelease: featuregate.Alpha},
-	TablespaceVolumes: {Default: false, PreRelease: featuregate.Alpha},
+	AppendCustomQueries: {Default: false, PreRelease: featuregate.Alpha},
+	BridgeIdentifiers:   {Default: false, PreRelease: featuregate.Alpha},
+	InstanceSidecars:    {Default: false, PreRelease: featuregate.Alpha},
+	PGBouncerSidecars:   {Default: false, PreRelease: featuregate.Alpha},
+	TablespaceVolumes:   {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // DefaultMutableFeatureGate is a mutable, shared global FeatureGate.

--- a/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/00--cluster.yaml
+++ b/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/00--cluster.yaml
@@ -1,0 +1,28 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: exporter
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi
+  monitoring:
+    pgmonitor:
+      exporter: {}

--- a/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/00-assert.yaml
+++ b/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/00-assert.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: exporter
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exporter-exporter-queries-config

--- a/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/01--check-exporter.yaml
+++ b/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/01--check-exporter.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      set -e
+      PRIMARY=$(
+        kubectl get pod --namespace "${NAMESPACE}" \
+          --output name --selector '
+            postgres-operator.crunchydata.com/cluster=exporter,
+            postgres-operator.crunchydata.com/role=master'
+      )
+
+      # TODO: We have no notion of exporter readiness.
+      for _ in $(seq 10); do
+        kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -c exporter \
+          -- curl --head --silent 'http://localhost:9187/metrics' && break
+        sleep 1
+      done
+
+      # Ensure that the metrics endpoint is available from inside the exporter container
+      {
+        METRICS=$(kubectl exec --namespace "${NAMESPACE}" \
+          "${PRIMARY}" -c exporter \
+          -- curl --show-error --silent 'http://localhost:9187/metrics')
+      } || {
+        echo >&2 'curl metrics endpoint returned error'
+        echo "${METRICS}"
+        exit 1
+      }
+
+      LOGS=$(kubectl logs --namespace "${NAMESPACE}" "${PRIMARY}" -c exporter)
+      contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+      {
+        contains "${LOGS}" 'TLS is disabled'
+      } || {
+        echo >&2 'tls is enabled'
+        echo "${LOGS}"
+        exit 1
+      }
+
+      # Ensure that the monitoring user exists and is configured.
+      kubectl exec --stdin --namespace "${NAMESPACE}" "${PRIMARY}" -c database \
+        -- psql -qb --set ON_ERROR_STOP=1 --file=- <<'SQL'
+        DO $$
+        DECLARE
+          result record;
+        BEGIN
+          SELECT * INTO result FROM pg_catalog.pg_roles WHERE rolname = 'ccp_monitoring';
+          ASSERT FOUND, 'user not found';
+        END $$
+      SQL

--- a/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/02--custom-config-append-enabled.yaml
+++ b/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/02--custom-config-append-enabled.yaml
@@ -1,0 +1,38 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: exporter-custom-queries
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi
+  monitoring:
+    pgmonitor:
+      exporter:
+        configuration:
+          - configMap:
+              name: custom-queries-test
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-queries-test
+data:
+  queries.yml: "# This is a test."

--- a/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/02-assert.yaml
+++ b/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/02-assert.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: exporter-custom-queries
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exporter-custom-queries-exporter-queries-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-queries-test

--- a/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/03--check-queries.yaml
+++ b/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/03--check-queries.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      set -e
+      PRIMARY=$(
+        kubectl get pod --namespace "${NAMESPACE}" \
+          --output name --selector '
+            postgres-operator.crunchydata.com/cluster=exporter-custom-queries,
+            postgres-operator.crunchydata.com/role=master'
+      )
+
+      # TODO: We have no notion of exporter readiness.
+      for _ in $(seq 10); do
+        kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -c exporter \
+          -- curl --head --silent 'http://localhost:9187/metrics' && break
+        sleep 1
+      done
+      
+      QUERIES_FILES=$(
+        kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -c exporter \
+          -- ls /conf
+      )
+
+      contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+      {
+        contains "${QUERIES_FILES}" "queries.yml" &&
+        contains "${QUERIES_FILES}" "defaultQueries.yml"
+      } || {
+        echo >&2 'The /conf directory should contain queries.yml and defaultQueries.yml. Instead it has:'
+        echo "${QUERIES_FILES}"
+        exit 1
+      }
+
+      MASTER_QUERIES_CONTENTS=$(
+        kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -c exporter \
+          -- cat /tmp/queries.yml
+      )
+
+      {
+        contains "${MASTER_QUERIES_CONTENTS}" "# This is a test." &&
+        contains "${MASTER_QUERIES_CONTENTS}" "ccp_postgresql_version"
+      } || {
+        echo >&2 'The master queries.yml file should contain the contents of both defaultQueries.yml and the custom queries.yml file. Instead it contains:'
+        echo "${MASTER_QUERIES_CONTENTS}"
+        exit 1
+      }

--- a/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/README.md
+++ b/testing/kuttl/e2e-other/exporter-append-custom-queries-enabled/README.md
@@ -1,0 +1,5 @@
+# Exporter - AppendCustomQueries Enabled
+
+**Note**: This series of tests depends on PGO being deployed with the `AppendCustomQueries` feature gate ON. There is a separate set of tests in `e2e` that tests exporter functionality without the `AppendCustomQueries` feature.
+
+When running this test, make sure that the `PGO_FEATURE_GATES` environment variable is set to "AppendCustomQueries=true" on the PGO Deployment.

--- a/testing/kuttl/e2e/exporter/02--custom-config-append-disabled.yaml
+++ b/testing/kuttl/e2e/exporter/02--custom-config-append-disabled.yaml
@@ -1,0 +1,38 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: exporter-custom-queries
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi
+  monitoring:
+    pgmonitor:
+      exporter:
+        configuration:
+          - configMap:
+              name: custom-queries-test
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-queries-test
+data:
+  queries.yml: "# This is a test."

--- a/testing/kuttl/e2e/exporter/02-assert.yaml
+++ b/testing/kuttl/e2e/exporter/02-assert.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: exporter-custom-queries
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exporter-custom-queries-exporter-queries-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-queries-test

--- a/testing/kuttl/e2e/exporter/03--check-queries.yaml
+++ b/testing/kuttl/e2e/exporter/03--check-queries.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      set -e
+      PRIMARY=$(
+        kubectl get pod --namespace "${NAMESPACE}" \
+          --output name --selector '
+            postgres-operator.crunchydata.com/cluster=exporter-custom-queries,
+            postgres-operator.crunchydata.com/role=master'
+      )
+
+      # TODO: We have no notion of exporter readiness.
+      for _ in $(seq 10); do
+        kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -c exporter \
+          -- curl --head --silent 'http://localhost:9187/metrics' && break
+        sleep 1
+      done
+      
+      QUERIES_FILES=$(
+        kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -c exporter \
+          -- ls /conf
+      )
+
+      contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+      {
+        contains "${QUERIES_FILES}" "queries.yml" &&
+        !(contains "${QUERIES_FILES}" "defaultQueries.yml")
+      } || {
+        echo >&2 'The /conf directory should contain the queries.yml file. Instead it has:'
+        echo "${QUERIES_FILES}"
+        exit 1
+      }
+
+      MASTER_QUERIES_CONTENTS=$(
+        kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -c exporter \
+          -- cat /tmp/queries.yml
+      )
+
+      {
+        contains "${MASTER_QUERIES_CONTENTS}" "# This is a test." &&
+        !(contains "${MASTER_QUERIES_CONTENTS}" "ccp_postgresql_version")
+      } || {
+        echo >&2 'The master queries.yml file should only contain the contents of the custom queries.yml file. Instead it contains:'
+        echo "${MASTER_QUERIES_CONTENTS}"
+        exit 1
+      }

--- a/testing/kuttl/e2e/exporter/README.md
+++ b/testing/kuttl/e2e/exporter/README.md
@@ -1,0 +1,4 @@
+# Exporter
+
+**Note**: This series of tests depends on PGO being deployed with the `AppendCustomQueries` feature gate OFF. There is a separate set of tests in `e2e-other` that tests the `AppendCustomQueries` functionality.
+


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
Currently, the only way that users can provide custom queries to the exporter is by providing a file that will be used instead of the default queries file. This means that if the user wants to keep the defaults, they have to copy the default queries into the custom queries file they provide.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This PR introduces the ability to simply append custom queries to the existing default queries. This ability is feature gated, so it is not a breaking change.


**Other Information**:
