### PR TITLE
Make PGO backwards compatible with older crunchy-postgres-exporter im…

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,6 +112,12 @@ jobs:
       - name: Build executable
         run: PGO_VERSION='${{ github.sha }}' make build-postgres-operator
 
+      - name: Get pgMonitor files.
+        run: make get-pgmonitor
+        env:
+          PGMONITOR_DIR: "${{ github.workspace }}/hack/tools/pgmonitor"
+          QUERIES_CONFIG_DIR: "${{ github.workspace }}/hack/tools/queries" 
+
       # Start a Docker container with the working directory mounted.
       - name: Start PGO
         run: |
@@ -120,6 +126,7 @@ jobs:
           hack/create-kubeconfig.sh postgres-operator pgo
           docker run --detach --network host --read-only \
             --volume "$(pwd):/mnt" --workdir '/mnt' --env 'PATH=/mnt/bin' \
+            --env 'QUERIES_CONFIG_DIR=/mnt/hack/tools/queries' \
             --env 'KUBECONFIG=hack/.kube/postgres-operator/pgo' \
             --env 'RELATED_IMAGE_PGADMIN=registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-4.30-17' \
             --env 'RELATED_IMAGE_PGBACKREST=registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.47-0' \
@@ -133,6 +140,7 @@ jobs:
             --env 'PGO_FEATURE_GATES=TablespaceVolumes=true' \
             --name 'postgres-operator' ubuntu \
             postgres-operator
+
       - name: Install kuttl
         run: |
           curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.13.0/kubectl-kuttl_0.13.0_linux_x86_64

--- a/internal/pgmonitor/exporter.go
+++ b/internal/pgmonitor/exporter.go
@@ -122,16 +122,8 @@ func GenerateDefaultExporterQueries(ctx context.Context, cluster *v1beta1.Postgr
 // the source queries files.
 func ExporterStartCommand(commandFlags []string) []string {
 	script := strings.Join([]string{
-		// Check to see if the postgres_exporter command is successful. If it is, we are
-		// using an image that has the command on the PATH. If it isn't, we have an older
-		// image that does not have it on the PATH and we should find the directory that
-		// holds the postgres_exporter binary and add it to the PATH.
-		`rc=0`,
-		`postgres_exporter --version || rc=$?`,
-		`if [ $rc -ne 0 ]; then`,
-		`	dir=$(find /opt/cpm/bin/postgres_exporter* -type d)`,
-		`	export PATH=$PATH:$dir`,
-		`fi`,
+		// Older images do not have the command on the PATH.
+		`PATH="$PATH:$(echo /opt/cpm/bin/postgres_exporter-*)"`,
 
 		// Set up temporary file to hold postgres_exporter process id
 		`POSTGRES_EXPORTER_PIDFILE=/tmp/postgres_exporter.pid`,

--- a/internal/pgmonitor/exporter.go
+++ b/internal/pgmonitor/exporter.go
@@ -122,6 +122,17 @@ func GenerateDefaultExporterQueries(ctx context.Context, cluster *v1beta1.Postgr
 // the source queries files.
 func ExporterStartCommand(commandFlags []string) []string {
 	script := strings.Join([]string{
+		// Check to see if the postgres_exporter command is successful. If it is, we are
+		// using an image that has the command on the PATH. If it isn't, we have an older
+		// image that does not have it on the PATH and we should find the directory that
+		// holds the postgres_exporter binary and add it to the PATH.
+		`rc=0`,
+		`postgres_exporter --version || rc=$?`,
+		`if [ $rc -ne 0 ]; then`,
+		`	dir=$(find /opt/cpm/bin/postgres_exporter* -type d)`,
+		`	export PATH=$PATH:$dir`,
+		`fi`,
+
 		// Set up temporary file to hold postgres_exporter process id
 		`POSTGRES_EXPORTER_PIDFILE=/tmp/postgres_exporter.pid`,
 


### PR DESCRIPTION
…ages.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other


**What is the current behavior (link to any open issues here)?**
Currently, the latest changes to PGO are only compatible with `crunchy-postgres-exporter` images that will be built with the latest changes in that repo. This is because the new exporter images will have the `postgres_exporter` binary on the PATH and latest PGO now expect this. Older exporter images do not have `postgres_exporter` on the PATH and will therefore fail to run properly.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This PR makes it so PGO checks to see if the `postgres_exporter` command is available. If it is, it must be a newer image. If it isn't, it must be an older exporter image and PGO will find the directory that holds the binary and add that directory to the PATH.


**Other Information**:
