### PR TITLE
Exporter tests overwrite annotation

### DIFF
--- a/testing/kuttl/e2e/exporter-custom-queries/00-assert.yaml
+++ b/testing/kuttl/e2e/exporter-custom-queries/00-assert.yaml
@@ -51,4 +51,4 @@ commands:
     }
 
     pid=$(kubectl exec ${pod} -n ${NAMESPACE} -c exporter -- cat /tmp/postgres_exporter.pid)
-    kubectl annotate -n ${NAMESPACE} ${pod} oldpid=${pid}
+    kubectl annotate --overwrite -n ${NAMESPACE} ${pod} oldpid=${pid}

--- a/testing/kuttl/e2e/exporter-password-change/01-assert.yaml
+++ b/testing/kuttl/e2e/exporter-password-change/01-assert.yaml
@@ -20,7 +20,7 @@ commands:
     }
 
     pid=$(kubectl exec ${pod} -n ${NAMESPACE} -c exporter -- cat /tmp/postgres_exporter.pid)
-    kubectl annotate -n ${NAMESPACE} ${pod} oldpid=${pid}
+    kubectl annotate --overwrite -n ${NAMESPACE} ${pod} oldpid=${pid}
 collectors:
 - type: pod
   selector: "postgres-operator.crunchydata.com/cluster=exporter-password-change,postgres-operator.crunchydata.com/crunchy-postgres-exporter=true"


### PR DESCRIPTION
As part of testing, Kuttl will add annotations to instances pods before and after a change. Kuttl tests will continue to loop through the script until various conditions are met. This means that the annotation may be run more than once. If this happens, kubectl will complain that the annotation is already set and needs to be overwritten. This change adds the overwrite flag to kubectl annotate commands.
