### PR TITLE
add initial changes for PG16 compatibility and pgMonitor 4.10.0 bump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PGO_IMAGE_URL ?= https://www.crunchydata.com/products/crunchy-postgresql-for-kub
 PGO_IMAGE_PREFIX ?= localhost
 
 PGMONITOR_DIR ?= hack/tools/pgmonitor
-PGMONITOR_VERSION ?= v4.9.0
+PGMONITOR_VERSION ?= v4.10.0
 QUERIES_CONFIG_DIR ?= hack/tools/queries
 
 # Buildah's "build" used to be "bud". Use the alias to be compatible for a while.
@@ -233,6 +233,7 @@ generate-kuttl: ## Generate kuttl tests
 	[ ! -d testing/kuttl/e2e-generated-other ] || rm -r testing/kuttl/e2e-generated-other
 	bash -ceu ' \
 	case $(KUTTL_PG_VERSION) in \
+	16 ) export KUTTL_BITNAMI_IMAGE_TAG=16.0.0-debian-11-r3 ;; \
 	15 ) export KUTTL_BITNAMI_IMAGE_TAG=15.0.0-debian-11-r4 ;; \
 	14 ) export KUTTL_BITNAMI_IMAGE_TAG=14.5.0-debian-11-r37 ;; \
 	13 ) export KUTTL_BITNAMI_IMAGE_TAG=13.8.0-debian-11-r39 ;; \

--- a/config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml
@@ -857,7 +857,7 @@ spec:
                 type: object
               fromPostgresVersion:
                 description: The major version of PostgreSQL before the upgrade.
-                maximum: 15
+                maximum: 16
                 minimum: 10
                 type: integer
               image:
@@ -937,7 +937,7 @@ spec:
                 type: string
               toPostgresVersion:
                 description: The major version of PostgreSQL to be upgraded to.
-                maximum: 15
+                maximum: 16
                 minimum: 10
                 type: integer
               tolerations:

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -10471,7 +10471,7 @@ spec:
               postgresVersion:
                 description: The major version of PostgreSQL installed in the PostgreSQL
                   image
-                maximum: 15
+                maximum: 16
                 minimum: 10
                 type: integer
               proxy:

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgupgrade_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgupgrade_types.go
@@ -59,7 +59,7 @@ type PGUpgradeSpec struct {
 	// The major version of PostgreSQL before the upgrade.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=10
-	// +kubebuilder:validation:Maximum=15
+	// +kubebuilder:validation:Maximum=16
 	FromPostgresVersion int `json:"fromPostgresVersion"`
 
 	// TODO(benjaminjb): define webhook validation to make sure
@@ -70,7 +70,7 @@ type PGUpgradeSpec struct {
 	// The major version of PostgreSQL to be upgraded to.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=10
-	// +kubebuilder:validation:Maximum=15
+	// +kubebuilder:validation:Maximum=16
 	ToPostgresVersion int `json:"toPostgresVersion"`
 
 	// The image name to use for PostgreSQL containers after upgrade.

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -123,7 +123,7 @@ type PostgresClusterSpec struct {
 	// The major version of PostgreSQL installed in the PostgreSQL image
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=10
-	// +kubebuilder:validation:Maximum=15
+	// +kubebuilder:validation:Maximum=16
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	PostgresVersion int `json:"postgresVersion"`
 

--- a/testing/kuttl/e2e/major-upgrade/31--create-data.yaml
+++ b/testing/kuttl/e2e/major-upgrade/31--create-data.yaml
@@ -39,7 +39,8 @@ spec:
               END $$$$;
             - --command
             - |
-              CREATE TABLE important (data) AS VALUES ('treasure');
+              CREATE SCHEMA very;
+              CREATE TABLE very.important (data) AS VALUES ('treasure');
 ---
 apiVersion: batch/v1
 kind: Job

--- a/testing/kuttl/e2e/major-upgrade/36--check-data-and-version.yaml
+++ b/testing/kuttl/e2e/major-upgrade/36--check-data-and-version.yaml
@@ -43,7 +43,7 @@ spec:
               DECLARE
                 everything jsonb;
               BEGIN
-                SELECT jsonb_agg(important) INTO everything FROM important;
+                SELECT jsonb_agg(important) INTO everything FROM very.important;
                 ASSERT everything = '[{"data":"treasure"}]', format('got %L', everything);
               END $$$$;
 ---
@@ -103,6 +103,6 @@ spec:
               DECLARE
                 everything jsonb;
               BEGIN
-                SELECT jsonb_agg(important) INTO everything FROM important;
+                SELECT jsonb_agg(important) INTO everything FROM very.important;
                 ASSERT everything = '[{"data":"treasure"}]', format('got %L', everything);
               END $$$$;

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/01--create-data.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/01--create-data.yaml
@@ -39,7 +39,8 @@ spec:
               END $$$$;
             - --command
             - |
-              CREATE TABLE important (data) AS VALUES ('treasure');
+              CREATE SCHEMA very;
+              CREATE TABLE very.important (data) AS VALUES ('treasure');
 ---
 apiVersion: batch/v1
 kind: Job

--- a/testing/kuttl/e2e/wal-pvc-pgupgrade/06--check-data-and-version.yaml
+++ b/testing/kuttl/e2e/wal-pvc-pgupgrade/06--check-data-and-version.yaml
@@ -43,7 +43,7 @@ spec:
               DECLARE
                 everything jsonb;
               BEGIN
-                SELECT jsonb_agg(important) INTO everything FROM important;
+                SELECT jsonb_agg(important) INTO everything FROM very.important;
                 ASSERT everything = '[{"data":"treasure"}]', format('got %L', everything);
               END $$$$;
 ---
@@ -103,6 +103,6 @@ spec:
               DECLARE
                 everything jsonb;
               BEGIN
-                SELECT jsonb_agg(important) INTO everything FROM important;
+                SELECT jsonb_agg(important) INTO everything FROM very.important;
                 ASSERT everything = '[{"data":"treasure"}]', format('got %L', everything);
               END $$$$;


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other


**What is the current behavior (link to any open issues here)?**
The max postgres version that `postgres-operator` is currently compatible with is 15. Also, it is set to use pgMonitor 4.9.0. 


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This change will change the max postgres version that `postgres-operator` can use to 16. Will also be setup to pgMonitor 4.10.0.


**Other Information**:
