### PR TITLE
Normalize our kustomize files and get rid of deprecation warnings.

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,10 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 namespace: postgres-operator
 
-commonLabels:
-  # Note: this label differs from the label set in postgres-operator-examples
-  postgres-operator.crunchydata.com/control-plane: postgres-operator
+labels:
+- includeSelectors: true
+  pairs:
+    # Note: this label differs from the label set in postgres-operator-examples
+    postgres-operator.crunchydata.com/control-plane: postgres-operator
 
-bases:
+resources:
 - ../crd
 - ../rbac/cluster
 - ../manager

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
 - ../default
 
 patches:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - manager.yaml

--- a/config/namespace/kustomization.yaml
+++ b/config/namespace/kustomization.yaml
@@ -1,2 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - namespace.yaml

--- a/config/rbac/cluster/kustomization.yaml
+++ b/config/rbac/cluster/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - service_account.yaml
 - role.yaml

--- a/config/rbac/namespace/kustomization.yaml
+++ b/config/rbac/namespace/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - service_account.yaml
 - role.yaml

--- a/config/singlenamespace/kustomization.yaml
+++ b/config/singlenamespace/kustomization.yaml
@@ -1,17 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 namespace: postgres-operator
 
-commonLabels:
-  postgres-operator.crunchydata.com/control-plane: postgres-operator
+labels:
+- includeSelectors: true
+  pairs:
+    postgres-operator.crunchydata.com/control-plane: postgres-operator
 
-bases:
+resources:
 - ../crd
 - ../rbac/namespace
 - ../manager
-
-patches:
-- path: manager-target.yaml
 
 images:
 - name: postgres-operator
   newName: registry.developers.crunchydata.com/crunchydata/postgres-operator
   newTag: latest
+
+patches:
+- path: manager-target.yaml

--- a/examples/pgadmin/kustomization.yaml
+++ b/examples/pgadmin/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 namespace: postgres-operator
 
 resources:

--- a/examples/postgrescluster/kustomization.yaml
+++ b/examples/postgrescluster/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 namespace: postgres-operator
 
 resources:


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other


**What is the current behavior (link to any open issues here)?**
Currently, when using certain kustomize installers there will be warnings about using deprecated features. Some of the files are also not formatted according to kustomize's standards.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This change gets rid of the deprecation warnings and normalizes our kustomize files' formatting.


**Other Information**:
