### PR TITLE
When requested, load the "citus" library first

### DIFF
--- a/internal/patroni/config_test.go
+++ b/internal/patroni/config_test.go
@@ -394,7 +394,7 @@ func TestDynamicConfiguration(t *testing.T) {
 			},
 		},
 		{
-			name: "postgresql.parameters: mandatory shared_preload_libraries bad type",
+			name: "postgresql.parameters: mandatory shared_preload_libraries wrong-type is ignored",
 			input: map[string]any{
 				"postgresql": map[string]any{
 					"parameters": map[string]any{
@@ -413,6 +413,33 @@ func TestDynamicConfiguration(t *testing.T) {
 				"postgresql": map[string]any{
 					"parameters": map[string]any{
 						"shared_preload_libraries": "mandatory",
+					},
+					"pg_hba":        []string{},
+					"use_pg_rewind": true,
+					"use_slots":     false,
+				},
+			},
+		},
+		{
+			name: "postgresql.parameters: shared_preload_libraries order",
+			input: map[string]any{
+				"postgresql": map[string]any{
+					"parameters": map[string]any{
+						"shared_preload_libraries": "given, citus, more",
+					},
+				},
+			},
+			params: postgres.Parameters{
+				Mandatory: parameters(map[string]string{
+					"shared_preload_libraries": "mandatory",
+				}),
+			},
+			expected: map[string]any{
+				"loop_wait": int32(10),
+				"ttl":       int32(30),
+				"postgresql": map[string]any{
+					"parameters": map[string]any{
+						"shared_preload_libraries": "citus,mandatory,given, citus, more",
 					},
 					"pg_hba":        []string{},
 					"use_pg_rewind": true,

--- a/internal/pgaudit/postgres.go
+++ b/internal/pgaudit/postgres.go
@@ -17,7 +17,6 @@ package pgaudit
 
 import (
 	"context"
-	"strings"
 
 	"github.com/crunchydata/postgres-operator/internal/logging"
 	"github.com/crunchydata/postgres-operator/internal/postgres"
@@ -67,7 +66,5 @@ func PostgreSQLParameters(outParameters *postgres.Parameters) {
 	// PostgreSQL must be restarted when changing this value.
 	// - https://github.com/pgaudit/pgaudit#settings
 	// - https://www.postgresql.org/docs/current/runtime-config-client.html
-	shared := outParameters.Mandatory.Value("shared_preload_libraries")
-	outParameters.Mandatory.Add("shared_preload_libraries",
-		strings.TrimPrefix(shared+",pgaudit", ","))
+	outParameters.Mandatory.AppendToList("shared_preload_libraries", "pgaudit")
 }

--- a/internal/pgmonitor/postgres.go
+++ b/internal/pgmonitor/postgres.go
@@ -50,14 +50,7 @@ func PostgreSQLParameters(inCluster *v1beta1.PostgresCluster, outParameters *pos
 		// Exporter expects that shared_preload_libraries are installed
 		// pg_stat_statements: https://access.crunchydata.com/documentation/pgmonitor/latest/exporter/
 		// pgnodemx: https://github.com/CrunchyData/pgnodemx
-		libraries := []string{"pg_stat_statements", "pgnodemx"}
-
-		defined, found := outParameters.Mandatory.Get("shared_preload_libraries")
-		if found {
-			libraries = append(libraries, defined)
-		}
-
-		outParameters.Mandatory.Add("shared_preload_libraries", strings.Join(libraries, ","))
+		outParameters.Mandatory.AppendToList("shared_preload_libraries", "pg_stat_statements", "pgnodemx")
 		outParameters.Mandatory.Add("pgnodemx.kdapi_path",
 			postgres.DownwardAPIVolumeMount().MountPath)
 	}

--- a/internal/postgres/parameters.go
+++ b/internal/postgres/parameters.go
@@ -96,6 +96,22 @@ func (ps *ParameterSet) Add(name, value string) {
 	ps.values[ps.normalize(name)] = value
 }
 
+// AppendToList adds each value to the right-hand side of parameter name
+// as a comma-separated list without quoting.
+func (ps *ParameterSet) AppendToList(name string, value ...string) {
+	result := ps.Value(name)
+
+	if len(value) > 0 {
+		if len(result) > 0 {
+			result += "," + strings.Join(value, ",")
+		} else {
+			result = strings.Join(value, ",")
+		}
+	}
+
+	ps.Add(name, result)
+}
+
 // Get returns the value of parameter name and whether or not it was present in ps.
 func (ps ParameterSet) Get(name string) (string, bool) {
 	value, ok := ps.values[ps.normalize(name)]

--- a/internal/postgres/parameters_test.go
+++ b/internal/postgres/parameters_test.go
@@ -68,3 +68,26 @@ func TestParameterSet(t *testing.T) {
 	ps2.Add("x", "n")
 	assert.Assert(t, ps2.Value("x") != ps.Value("x"))
 }
+
+func TestParameterSetAppendToList(t *testing.T) {
+	ps := NewParameterSet()
+
+	ps.AppendToList("empty")
+	assert.Assert(t, ps.Has("empty"))
+	assert.Equal(t, ps.Value("empty"), "")
+
+	ps.AppendToList("empty")
+	assert.Equal(t, ps.Value("empty"), "", "expected no change")
+
+	ps.AppendToList("full", "a")
+	assert.Equal(t, ps.Value("full"), "a")
+
+	ps.AppendToList("full", "b")
+	assert.Equal(t, ps.Value("full"), "a,b")
+
+	ps.AppendToList("full")
+	assert.Equal(t, ps.Value("full"), "a,b", "expected no change")
+
+	ps.AppendToList("full", "a", "cd", `"e"`)
+	assert.Equal(t, ps.Value("full"), `a,b,a,cd,"e"`)
+}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature

**What is the current behavior (link to any open issues here)?**

User-defined libraries are loaded last. CrunchyData/postgres-operator#3194

**What is the new behavior (if this is a feature change)?**
- [x] Breaking change (fix or feature that would cause existing functionality to change)

When included in user-defined libraries, `citus` is loaded first.


**Other Information**:

Fixes: CrunchyData/postgres-operator#3194
Replaces: CrunchyData/postgres-operator#3530