### PR TITLE
Allow disabling of postgres_exporter defaults

### DIFF
--- a/internal/controller/postgrescluster/pgmonitor.go
+++ b/internal/controller/postgrescluster/pgmonitor.go
@@ -305,7 +305,6 @@ func addPGMonitorExporterToInstancePodSpec(
 			},
 		},
 	}
-	template.Spec.Volumes = append(template.Spec.Volumes, passwordVolume)
 
 	// add custom exporter config volume
 	configVolume := corev1.Volume{
@@ -316,7 +315,7 @@ func addPGMonitorExporterToInstancePodSpec(
 			},
 		},
 	}
-	template.Spec.Volumes = append(template.Spec.Volumes, configVolume)
+	template.Spec.Volumes = append(template.Spec.Volumes, configVolume, passwordVolume)
 
 	// The original "custom queries" ability allowed users to provide a file with custom queries;
 	// however, it would turn off the default queries. The new "custom queries" ability allows

--- a/internal/controller/postgrescluster/pgmonitor.go
+++ b/internal/controller/postgrescluster/pgmonitor.go
@@ -269,9 +269,7 @@ func addPGMonitorExporterToInstancePodSpec(
 		Image:           config.PGExporterContainerImage(cluster),
 		ImagePullPolicy: cluster.Spec.ImagePullPolicy,
 		Resources:       cluster.Spec.Monitoring.PGMonitor.Exporter.Resources,
-		Command: pgmonitor.ExporterStartCommand([]string{
-			pgmonitor.ExporterExtendQueryPathFlag, pgmonitor.ExporterWebListenAddressFlag,
-		}),
+		Command:         pgmonitor.ExporterStartCommand(),
 		Env: []corev1.EnvVar{
 			{Name: "DATA_SOURCE_URI", Value: fmt.Sprintf("%s:%d/%s", pgmonitor.ExporterHost, *cluster.Spec.Port, pgmonitor.ExporterDB)},
 			{Name: "DATA_SOURCE_USER", Value: pgmonitor.MonitoringUser},
@@ -400,9 +398,7 @@ func configureExporterTLS(cluster *v1beta1.PostgresCluster, template *corev1.Pod
 		}}
 
 		exporterContainer.VolumeMounts = append(exporterContainer.VolumeMounts, mounts...)
-		exporterContainer.Command = pgmonitor.ExporterStartCommand([]string{
-			pgmonitor.ExporterExtendQueryPathFlag, pgmonitor.ExporterWebListenAddressFlag, pgmonitor.ExporterWebConfigFileFlag,
-		})
+		exporterContainer.Command = pgmonitor.ExporterStartCommand(pgmonitor.ExporterWebConfigFileFlag)
 	}
 }
 

--- a/internal/naming/annotations.go
+++ b/internal/naming/annotations.go
@@ -58,4 +58,9 @@ const (
 	// for this annotation is due to an issue in pgBackRest (#1841) where using a wildcard address to
 	// bind all addresses does not work in certain IPv6 environments.
 	PGBackRestIPVersion = annotationPrefix + "pgbackrest-ip-version"
+
+	// PostgresExporterCollectorsAnnotation is an annotation used to allow users to control whether or
+	// not postgres_exporter default metrics, settings, and collectors are enabled. The value "None"
+	// disables all postgres_exporter defaults. Disabling the defaults may cause errors in dashboards.
+	PostgresExporterCollectorsAnnotation = annotationPrefix + "postgres-exporter-collectors"
 )

--- a/internal/naming/annotations_test.go
+++ b/internal/naming/annotations_test.go
@@ -30,4 +30,5 @@ func TestAnnotationsValid(t *testing.T) {
 	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestCurrentConfig))
 	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestRestore))
 	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestIPVersion))
+	assert.Assert(t, nil == validation.IsQualifiedName(PostgresExporterCollectorsAnnotation))
 }


### PR DESCRIPTION
postgres_exporter provides default metrics, settings, and collectors. This change creates an annotation to allow disabling all of the postgres_exporter defaults.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
