### PR TITLE
Update restore configuration file behavior

### DIFF
--- a/internal/pgbackrest/reconcile.go
+++ b/internal/pgbackrest/reconcile.go
@@ -206,16 +206,28 @@ func AddConfigToRestorePod(
 	sources := append([]corev1.VolumeProjection{},
 		cluster.Spec.Backups.PGBackRest.Configuration...)
 
-	if cluster.Spec.DataSource != nil &&
-		cluster.Spec.DataSource.PGBackRest != nil &&
-		cluster.Spec.DataSource.PGBackRest.Configuration != nil {
-		sources = append(sources, cluster.Spec.DataSource.PGBackRest.Configuration...)
-	}
-
 	// For a PostgresCluster restore, append all pgBackRest configuration from
-	// the source cluster for the restore
+	// the source cluster for the restore.
 	if sourceCluster != nil {
 		sources = append(sources, sourceCluster.Spec.Backups.PGBackRest.Configuration...)
+	}
+
+	// Currently the spec accepts a dataSource with both a PostgresCluster and
+	// a PGBackRest section. In that case only the PostgresCluster is honored (see
+	// internal/controller/postgrescluster/cluster.go, reconcileDataSource).
+	//
+	// `sourceCluster` is always nil for a cloud based restore (see
+	// internal/controller/postgrescluster/pgbackrest.go, reconcileCloudBasedDataSource).
+	//
+	// So, if `sourceCluster` is nil and `DataSource.PGBackRest` is not,
+	// this is a cloud based datasource restore and only the configuration from
+	// `dataSource.pgbackrest` section should be included.
+	if sourceCluster == nil &&
+		cluster.Spec.DataSource != nil &&
+		cluster.Spec.DataSource.PGBackRest != nil {
+
+		sources = append([]corev1.VolumeProjection{},
+			cluster.Spec.DataSource.PGBackRest.Configuration...)
 	}
 
 	addConfigVolumeAndMounts(pod, append(sources, configmap, secret))


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
Currently, the restore Pod will load both the pgBackRest configuration objects from `spec.datasource` and `spec.backups` sections. 


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This commit updates that behavior so that only the `datasource.pgbackrest.configuration` is loaded when performing a cloud based restore.


**Other Information**:
Issue: PGO-260