### PR TITLE
Update watchPods() behavior for Patroni role change

### DIFF
--- a/internal/controller/postgrescluster/watches.go
+++ b/internal/controller/postgrescluster/watches.go
@@ -57,6 +57,18 @@ func (*Reconciler) watchPods() handler.Funcs {
 				}})
 				return
 			}
+
+			// Queue an event to start applying changes if the PostgreSQL instance
+			// now has the "master" role.
+			if len(cluster) != 0 &&
+				!patroni.PodIsPrimary(e.ObjectOld) &&
+				patroni.PodIsPrimary(e.ObjectNew) {
+				q.Add(reconcile.Request{NamespacedName: client.ObjectKey{
+					Namespace: e.ObjectNew.GetNamespace(),
+					Name:      cluster,
+				}})
+				return
+			}
 		},
 	}
 }

--- a/internal/patroni/reconcile.go
+++ b/internal/patroni/reconcile.go
@@ -181,6 +181,24 @@ func instanceProbes(cluster *v1beta1.PostgresCluster, container *corev1.Containe
 	}
 }
 
+// PodIsPrimary returns whether or not pod is currently acting as the leader with
+// the "master" role. This role will be called "primary" in the future, see:
+// - https://github.com/zalando/patroni/blob/master/docs/releases.rst?plain=1#L213
+func PodIsPrimary(pod metav1.Object) bool {
+	if pod == nil {
+		return false
+	}
+
+	// TODO(cbandy): This works only when using Kubernetes for DCS.
+
+	// - https://github.com/zalando/patroni/blob/v3.1.1/patroni/ha.py#L296
+	// - https://github.com/zalando/patroni/blob/v3.1.1/patroni/ha.py#L583
+	// - https://github.com/zalando/patroni/blob/v3.1.1/patroni/ha.py#L782
+	// - https://github.com/zalando/patroni/blob/v3.1.1/patroni/ha.py#L1574
+	status := pod.GetAnnotations()["status"]
+	return strings.Contains(status, `"role":"master"`)
+}
+
 // PodIsStandbyLeader returns whether or not pod is currently acting as a "standby_leader".
 func PodIsStandbyLeader(pod metav1.Object) bool {
 	if pod == nil {

--- a/internal/patroni/reconcile_test.go
+++ b/internal/patroni/reconcile_test.go
@@ -231,6 +231,31 @@ volumes:
 	`))
 }
 
+func TestPodIsPrimary(t *testing.T) {
+	// No object
+	assert.Assert(t, !PodIsPrimary(nil))
+
+	// No annotations
+	pod := &corev1.Pod{}
+	assert.Assert(t, !PodIsPrimary(pod))
+
+	// No role
+	pod.Annotations = map[string]string{"status": `{}`}
+	assert.Assert(t, !PodIsPrimary(pod))
+
+	// Replica
+	pod.Annotations["status"] = `{"role":"replica"}`
+	assert.Assert(t, !PodIsPrimary(pod))
+
+	// Standby leader
+	pod.Annotations["status"] = `{"role":"standby_leader"}`
+	assert.Assert(t, !PodIsPrimary(pod))
+
+	// Primary
+	pod.Annotations["status"] = `{"role":"master"}`
+	assert.Assert(t, PodIsPrimary(pod))
+}
+
 func TestPodIsStandbyLeader(t *testing.T) {
 	// No object
 	assert.Assert(t, !PodIsStandbyLeader(nil))


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
In certain circumstances, another reconcile is needed after an instance role change, but there is nothing to trigger it.


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This change adds an additional check to the existing watchPods function to queue an event when an instance Pod is first given the 'master' role.

**Other Information**:
Issue: PGO-190