### PR TITLE
Tweak restart logic for exporter

### DIFF
--- a/internal/pgmonitor/exporter.go
+++ b/internal/pgmonitor/exporter.go
@@ -155,6 +155,9 @@ func ExporterStartCommand(builtinCollectors bool, commandFlags ...string) []stri
 		`  [ -e /proc/$! ] && echo $! > $POSTGRES_EXPORTER_PIDFILE`,
 		`}`,
 
+		// run function to combine queries files and start postgres_exporter
+		`start_postgres_exporter`,
+
 		// Create a file descriptor with a no-op process that will not get
 		// cleaned up
 		`exec {fd}<> <(:)`,
@@ -178,7 +181,7 @@ func ExporterStartCommand(builtinCollectors bool, commandFlags ...string) []stri
 
 		// If postgres_exporter is not running, restart it
 		// Use the recorded pid as a proxy for checking if postgres_exporter is running
-		`  if [ ! -e $POSTGRES_EXPORTER_PIDFILE ] || [ ! -e /proc/$(head -1 ${POSTGRES_EXPORTER_PIDFILE?}) ] ; then`,
+		`  if [ ! -e /proc/$(head -1 ${POSTGRES_EXPORTER_PIDFILE?}) ] ; then`,
 		`    start_postgres_exporter`,
 		`  fi`,
 		`done`,

--- a/internal/pgmonitor/exporter.go
+++ b/internal/pgmonitor/exporter.go
@@ -152,7 +152,7 @@ func ExporterStartCommand(builtinCollectors bool, commandFlags ...string) []stri
 		`  echo "Starting postgres_exporter with the following flags..."`,
 		`  echo "${postgres_exporter_flags[@]}"`,
 		`  postgres_exporter "${postgres_exporter_flags[@]}" &`,
-		`  [ -e /proc/$! ] && echo $! > $POSTGRES_EXPORTER_PIDFILE`,
+		`  echo $! > $POSTGRES_EXPORTER_PIDFILE`,
 		`}`,
 
 		// run function to combine queries files and start postgres_exporter


### PR DESCRIPTION
**Checklist:**
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Flakes in testing in one CI/CD environment.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This separates out the kill/restart logic for the exporter; previously, if a file changed, we would kill/restart. This led to some test flakes where the restart would happen too quickly (hypothesis) before the port was free. This PR separates the logic:

If the watched files change, kill the exporter;
If no exporter is running, start the exporter.

This also adds a check to the start_postgres_exporter func: save the PID to a file only if that proc is running.

**Other Information**:
Issue: [PGO-420]