### PR TITLE
Add Crunchy Bridge Cluster adoption annotation logic.

### DIFF
--- a/internal/bridge/crunchybridgecluster/crunchybridgecluster_controller.go
+++ b/internal/bridge/crunchybridgecluster/crunchybridgecluster_controller.go
@@ -17,6 +17,7 @@ package crunchybridgecluster
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -38,6 +39,7 @@ import (
 
 	"github.com/crunchydata/postgres-operator/internal/bridge"
 	pgoRuntime "github.com/crunchydata/postgres-operator/internal/controller/runtime"
+	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -327,10 +329,38 @@ func (r *CrunchyBridgeClusterReconciler) Reconcile(ctx context.Context, req ctrl
 		}
 
 		for _, cluster := range clusters {
-			if crunchybridgecluster.Name == cluster.Name {
-				crunchybridgecluster.Status.ID = cluster.ID
-				// Requeue now that we have a cluster ID assigned
-				return ctrl.Result{Requeue: true}, nil
+			if crunchybridgecluster.Spec.ClusterName == cluster.Name {
+				// Cluster with the same name exists so check for adoption annotation
+				adoptionID, annotationExists := crunchybridgecluster.Annotations[naming.CrunchyBridgeClusterAdoptionAnnotation]
+				if annotationExists && strings.EqualFold(adoptionID, cluster.ID) {
+					// Annotation is present with correct ID value; adopt cluster by assigning ID to status.
+					crunchybridgecluster.Status.ID = cluster.ID
+					// Requeue now that we have a cluster ID assigned
+					return ctrl.Result{Requeue: true}, nil
+				}
+
+				// If we made it here, the adoption annotation either doesn't exist or its value is incorrect.
+				// The user must either add it or change the name on the CR.
+
+				// Set invalid status condition and create log message.
+				meta.SetStatusCondition(&crunchybridgecluster.Status.Conditions, metav1.Condition{
+					ObservedGeneration: crunchybridgecluster.GetGeneration(),
+					Type:               v1beta1.ConditionCreating,
+					Status:             metav1.ConditionFalse,
+					Reason:             "ClusterInvalid",
+					Message: fmt.Sprintf("A cluster with the same name already exists for this team (Team ID: %v). "+
+						"Give the CrunchyBridgeCluster CR a unique name, or if you would like to take control of the "+
+						"existing cluster, add the 'postgres-operator.crunchydata.com/adopt-bridge-cluster' "+
+						"annotation and set its value to the existing cluster's ID (Cluster ID: %v).", team, cluster.ID),
+				})
+
+				log.Info(fmt.Sprintf("A cluster with the same name already exists for this team (Team ID: %v). "+
+					"Give the CrunchyBridgeCluster CR a unique name, or if you would like to take control "+
+					"of the existing cluster, add the 'postgres-operator.crunchydata.com/adopt-bridge-cluster' "+
+					"annotation and set its value to the existing cluster's ID (Cluster ID: %v).", team, cluster.ID))
+
+				// We have an invalid cluster spec so we don't want to requeue
+				return ctrl.Result{}, nil
 			}
 		}
 

--- a/internal/naming/annotations.go
+++ b/internal/naming/annotations.go
@@ -63,4 +63,11 @@ const (
 	// not postgres_exporter default metrics, settings, and collectors are enabled. The value "None"
 	// disables all postgres_exporter defaults. Disabling the defaults may cause errors in dashboards.
 	PostgresExporterCollectorsAnnotation = annotationPrefix + "postgres-exporter-collectors"
+
+	// CrunchyBridgeClusterAdoptionAnnotation is an annotation used to allow users to "adopt" or take
+	// control over an existing Bridge Cluster with a CrunchyBridgeCluster CR. Essentially, if a
+	// CrunchyBridgeCluster CR does not have a status.ID, but the name matches the name of an existing
+	// bridge cluster, the user must add this annotation to the CR to allow the CR to take control of
+	// the Bridge Cluster. The Value assigned to the annotation must be the ID of existing cluster.
+	CrunchyBridgeClusterAdoptionAnnotation = annotationPrefix + "adopt-bridge-cluster"
 )

--- a/internal/naming/annotations_test.go
+++ b/internal/naming/annotations_test.go
@@ -31,4 +31,5 @@ func TestAnnotationsValid(t *testing.T) {
 	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestRestore))
 	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestIPVersion))
 	assert.Assert(t, nil == validation.IsQualifiedName(PostgresExporterCollectorsAnnotation))
+	assert.Assert(t, nil == validation.IsQualifiedName(CrunchyBridgeClusterAdoptionAnnotation))
 }


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Currently, a CrunchyBridgeCluster CR will automatically adopt an existing Bridge Cluster if they have the same name.

**What is the new behavior (if this is a feature change)?**
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Now, the CrunchyBridgeCluster CR will not adopt an existing Bridge Cluster with the same name unless a specific annotation is applied to the CR with the cluster ID as the value. Detailed conditions and log messages will be emitted if the proper annotation is not in place.


**Other Information**:
