### PR TITLE
Bind pgAdmin to every IPv4 address by default

### DIFF
--- a/internal/controller/standalone_pgadmin/configmap.go
+++ b/internal/controller/standalone_pgadmin/configmap.go
@@ -81,11 +81,19 @@ func configmap(pgadmin *v1beta1.PGAdmin,
 
 // generateConfig generates the config settings for the pgAdmin
 func generateConfig(pgadmin *v1beta1.PGAdmin) (string, error) {
-
-	settings := *pgadmin.Spec.Config.Settings.DeepCopy()
-	if settings == nil {
-		settings = make(map[string]interface{})
+	settings := map[string]any{
+		// Bind to all IPv4 addresses by default. "0.0.0.0" here represents INADDR_ANY.
+		// - https://flask.palletsprojects.com/en/2.2.x/api/#flask.Flask.run
+		// - https://flask.palletsprojects.com/en/2.3.x/api/#flask.Flask.run
+		"DEFAULT_SERVER": "0.0.0.0",
 	}
+
+	// Copy any specified settings over the defaults.
+	for k, v := range pgadmin.Spec.Config.Settings {
+		settings[k] = v
+	}
+
+	// Write mandatory settings over any specified ones.
 	// SERVER_MODE must always be enabled when running on a webserver.
 	// - https://github.com/pgadmin-org/pgadmin4/blob/REL-7_7/web/config.py#L110
 	settings["SERVER_MODE"] = true

--- a/testing/kuttl/e2e/standalone-pgadmin/README.md
+++ b/testing/kuttl/e2e/standalone-pgadmin/README.md
@@ -6,7 +6,7 @@ Note: due to the (random) namespace being part of the host, we cannot check the 
 
 * 00:
   * create a pgadmin with no server groups;
-  * check the correct existence of the secret, service, configmap, and pod.
+  * check the correct existence of the secret, configmap, and pod.
 * 01: dump the servers from pgAdmin and check that the list is empty.
 
 *Phase two*

--- a/testing/kuttl/e2e/standalone-pgadmin/files/00-pgadmin-check.yaml
+++ b/testing/kuttl/e2e/standalone-pgadmin/files/00-pgadmin-check.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,6 +8,7 @@ metadata:
 data:
   pgadmin-settings.json: |
     {
+      "DEFAULT_SERVER": "0.0.0.0",
       "SERVER_MODE": true,
       "UPGRADE_CHECK_ENABLED": false,
       "UPGRADE_CHECK_KEY": "",


### PR DESCRIPTION
The upstream default is "127.0.0.1", the IPv4 loopback address, which allows only local connections.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix

**What is the current behavior (link to any open issues here)?**

Cannot connect via Service because pgAdmin is binding to localhost.

- CrunchyData/postgres-operator#3809

**What is the new behavior (if this is a feature change)?**

Can connect via Service because pgAdmin is binding to all IPv4 addresses.

**Other Information**:

Fixes: CrunchyData/postgres-operator#3809