### PR TITLE
Cleanup EnvTest binaries more aggressively

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
-        with: { go-version: 1.x }
+        with: { go-version: 1.21 }
       - run: go mod download
       - run: ENVTEST_K8S_VERSION="${KUBERNETES#default}" make check-envtest
         env:
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
-        with: { go-version: 1.x }
+        with: { go-version: 1.21 }
 
       - name: Start k3s
         uses: ./.github/actions/k3d

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.x
+          go-version: 1.21
       - run: make check
       - run: make check-generate
 

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,8 @@ clean: clean-deprecated
 	[ ! -d testing/kuttl/e2e-generated ] || rm -r testing/kuttl/e2e-generated
 	[ ! -d testing/kuttl/e2e-generated-other ] || rm -r testing/kuttl/e2e-generated-other
 	rm -rf build/crd/generated build/crd/*/generated
-	[ ! -f hack/tools/setup-envtest ] || hack/tools/setup-envtest --bin-dir=hack/tools/envtest cleanup
 	[ ! -f hack/tools/setup-envtest ] || rm hack/tools/setup-envtest
-	[ ! -d hack/tools/envtest ] || rm -r hack/tools/envtest
+	[ ! -d hack/tools/envtest ] || { chmod -R u+w hack/tools/envtest && rm -r hack/tools/envtest; }
 	[ ! -d hack/tools/pgmonitor ] || rm -rf hack/tools/pgmonitor
 	[ ! -n "$$(ls hack/tools)" ] || rm -r hack/tools/*
 	[ ! -d hack/.kube ] || rm -r hack/.kube


### PR DESCRIPTION
I had trouble running "make clean" while switching between Linux and macOS in the same working directory.