### PR TITLE
Allow configuration of replica service through spec

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -13319,6 +13319,38 @@ spec:
                 required:
                 - pgBouncer
                 type: object
+              replicaService:
+                description: Specification of the service that exposes PostgreSQL
+                  replica instances
+                properties:
+                  metadata:
+                    description: Metadata contains metadata for custom resources
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  nodePort:
+                    description: The port on which this service is exposed when type
+                      is NodePort or LoadBalancer. Value must be in-range and not
+                      in use or the operation will fail. If unspecified, a port will
+                      be allocated if this Service requires one. - https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+                    format: int32
+                    type: integer
+                  type:
+                    default: ClusterIP
+                    description: 'More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                    enum:
+                    - ClusterIP
+                    - NodePort
+                    - LoadBalancer
+                    type: string
+                type: object
               service:
                 description: Specification of the service that exposes the PostgreSQL
                   primary instance.

--- a/internal/controller/postgrescluster/cluster.go
+++ b/internal/controller/postgrescluster/cluster.go
@@ -17,6 +17,7 @@ package postgrescluster
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -199,33 +200,64 @@ func (r *Reconciler) generateClusterReplicaService(
 	service := &corev1.Service{ObjectMeta: naming.ClusterReplicaService(cluster)}
 	service.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
 
-	service.Annotations = naming.Merge(
-		cluster.Spec.Metadata.GetAnnotationsOrNil())
+	service.Annotations = cluster.Spec.Metadata.GetAnnotationsOrNil()
+	service.Labels = cluster.Spec.Metadata.GetLabelsOrNil()
+
+	if spec := cluster.Spec.ReplicaService; spec != nil {
+		service.Annotations = naming.Merge(service.Annotations,
+			spec.Metadata.GetAnnotationsOrNil())
+		service.Labels = naming.Merge(service.Labels,
+			spec.Metadata.GetLabelsOrNil())
+	}
+
+	// add our labels last so they aren't overwritten
 	service.Labels = naming.Merge(
-		cluster.Spec.Metadata.GetLabelsOrNil(),
+		service.Labels,
 		map[string]string{
 			naming.LabelCluster: cluster.Name,
 			naming.LabelRole:    naming.RoleReplica,
 		})
 
-	// Allocate an IP address and let Kubernetes manage the Endpoints by
-	// selecting Pods with the Patroni replica role.
-	// - https://docs.k8s.io/concepts/services-networking/service/#defining-a-service
-	service.Spec.Type = corev1.ServiceTypeClusterIP
-	service.Spec.Selector = map[string]string{
-		naming.LabelCluster: cluster.Name,
-		naming.LabelRole:    naming.RolePatroniReplica,
-	}
-
 	// The TargetPort must be the name (not the number) of the PostgreSQL
 	// ContainerPort. This name allows the port number to differ between Pods,
 	// which can happen during a rolling update.
-	service.Spec.Ports = []corev1.ServicePort{{
+	servicePort := corev1.ServicePort{
 		Name:       naming.PortPostgreSQL,
 		Port:       *cluster.Spec.Port,
 		Protocol:   corev1.ProtocolTCP,
 		TargetPort: intstr.FromString(naming.PortPostgreSQL),
-	}}
+	}
+
+	// Default to a service type of ClusterIP
+	service.Spec.Type = corev1.ServiceTypeClusterIP
+
+	// Check user provided spec for a specified type
+	if spec := cluster.Spec.ReplicaService; spec != nil {
+		service.Spec.Type = corev1.ServiceType(spec.Type)
+		if spec.NodePort != nil {
+			if service.Spec.Type == corev1.ServiceTypeClusterIP {
+				// The NodePort can only be set when the Service type is NodePort or
+				// LoadBalancer. However, due to a known issue prior to Kubernetes
+				// 1.20, we clear these errors during our apply. To preserve the
+				// appropriate behavior, we log an Event and return an error.
+				// TODO(tjmoore4): Once Validation Rules are available, this check
+				// and event could potentially be removed in favor of that validation
+				r.Recorder.Eventf(cluster, corev1.EventTypeWarning, "MisconfiguredClusterIP",
+					"NodePort cannot be set with type ClusterIP on Service %q", service.Name)
+				return nil, fmt.Errorf("NodePort cannot be set with type ClusterIP on Service %q", service.Name)
+			}
+			servicePort.NodePort = *spec.NodePort
+		}
+	}
+	service.Spec.Ports = []corev1.ServicePort{servicePort}
+
+	// Allocate an IP address and let Kubernetes manage the Endpoints by
+	// selecting Pods with the Patroni replica role.
+	// - https://docs.k8s.io/concepts/services-networking/service/#defining-a-service
+	service.Spec.Selector = map[string]string{
+		naming.LabelCluster: cluster.Name,
+		naming.LabelRole:    naming.RolePatroniReplica,
+	}
 
 	err := errors.WithStack(r.setControllerReference(cluster, service))
 

--- a/internal/controller/postgrescluster/cluster_test.go
+++ b/internal/controller/postgrescluster/cluster_test.go
@@ -732,11 +732,12 @@ func TestGenerateClusterReplicaServiceIntent(t *testing.T) {
 	service, err := reconciler.generateClusterReplicaService(cluster)
 	assert.NilError(t, err)
 
-	assert.Assert(t, marshalMatches(service.TypeMeta, `
+	alwaysExpect := func(t testing.TB, service *corev1.Service) {
+		assert.Assert(t, marshalMatches(service.TypeMeta, `
 apiVersion: v1
 kind: Service
-	`))
-	assert.Assert(t, marshalMatches(service.ObjectMeta, `
+		`))
+		assert.Assert(t, marshalMatches(service.ObjectMeta, `
 creationTimestamp: null
 labels:
   postgres-operator.crunchydata.com/cluster: pg2
@@ -750,7 +751,10 @@ ownerReferences:
   kind: PostgresCluster
   name: pg2
   uid: ""
-	`))
+		`))
+	}
+
+	alwaysExpect(t, service)
 	assert.Assert(t, marshalMatches(service.Spec, `
 ports:
 - name: postgres
@@ -762,6 +766,39 @@ selector:
   postgres-operator.crunchydata.com/role: replica
 type: ClusterIP
 	`))
+
+	types := []struct {
+		Type   string
+		Expect func(testing.TB, *corev1.Service)
+	}{
+		{Type: "ClusterIP", Expect: func(t testing.TB, service *corev1.Service) {
+			assert.Equal(t, service.Spec.Type, corev1.ServiceTypeClusterIP)
+		}},
+		{Type: "NodePort", Expect: func(t testing.TB, service *corev1.Service) {
+			assert.Equal(t, service.Spec.Type, corev1.ServiceTypeNodePort)
+		}},
+		{Type: "LoadBalancer", Expect: func(t testing.TB, service *corev1.Service) {
+			assert.Equal(t, service.Spec.Type, corev1.ServiceTypeLoadBalancer)
+		}},
+	}
+
+	for _, test := range types {
+		t.Run(test.Type, func(t *testing.T) {
+			cluster := cluster.DeepCopy()
+			cluster.Spec.ReplicaService = &v1beta1.ServiceSpec{Type: test.Type}
+
+			service, err := reconciler.generateClusterReplicaService(cluster)
+			assert.NilError(t, err)
+			alwaysExpect(t, service)
+			test.Expect(t, service)
+			assert.Assert(t, marshalMatches(service.Spec.Ports, `
+- name: postgres
+  port: 9876
+  protocol: TCP
+  targetPort: postgres
+	`))
+		})
+	}
 
 	t.Run("AnnotationsLabels", func(t *testing.T) {
 		cluster := cluster.DeepCopy()

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -148,6 +148,10 @@ type PostgresClusterSpec struct {
 	// +optional
 	Service *ServiceSpec `json:"service,omitempty"`
 
+	// Specification of the service that exposes PostgreSQL replica instances
+	// +optional
+	ReplicaService *ServiceSpec `json:"replicaService,omitempty"`
+
 	// Whether or not the PostgreSQL cluster should be stopped.
 	// When this is true, workloads are scaled to zero and CronJobs
 	// are suspended.

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
@@ -1683,6 +1683,11 @@ func (in *PostgresClusterSpec) DeepCopyInto(out *PostgresClusterSpec) {
 		*out = new(ServiceSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ReplicaService != nil {
+		in, out := &in.ReplicaService, &out.ReplicaService
+		*out = new(ServiceSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Shutdown != nil {
 		in, out := &in.Shutdown, &out.Shutdown
 		*out = new(bool)

--- a/testing/kuttl/e2e/replica-service/00-base-cluster.yaml
+++ b/testing/kuttl/e2e/replica-service/00-base-cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- files/base-cluster.yaml
+assert:
+- files/base-check.yaml

--- a/testing/kuttl/e2e/replica-service/01-node-port.yaml
+++ b/testing/kuttl/e2e/replica-service/01-node-port.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- files/np-cluster.yaml
+assert:
+- files/np-check.yaml

--- a/testing/kuttl/e2e/replica-service/02-loadbalancer.yaml
+++ b/testing/kuttl/e2e/replica-service/02-loadbalancer.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- files/lb-cluster.yaml
+assert:
+- files/lb-check.yaml

--- a/testing/kuttl/e2e/replica-service/03-cluster-ip.yaml
+++ b/testing/kuttl/e2e/replica-service/03-cluster-ip.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- files/cip-cluster.yaml
+assert:
+- files/cip-check.yaml

--- a/testing/kuttl/e2e/replica-service/files/base-check.yaml
+++ b/testing/kuttl/e2e/replica-service/files/base-check.yaml
@@ -1,0 +1,15 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: service
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 2
+      replicas: 2
+      updatedReplicas: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-replicas

--- a/testing/kuttl/e2e/replica-service/files/base-cluster.yaml
+++ b/testing/kuttl/e2e/replica-service/files/base-cluster.yaml
@@ -1,0 +1,28 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: service
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  replicaService:
+    type: ClusterIP
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 0.5Gi
+      replicas: 2
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 0.5Gi

--- a/testing/kuttl/e2e/replica-service/files/cip-check.yaml
+++ b/testing/kuttl/e2e/replica-service/files/cip-check.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-replicas
+spec:
+  type: ClusterIP
+  selector:
+    postgres-operator.crunchydata.com/cluster: service
+    postgres-operator.crunchydata.com/role: replica

--- a/testing/kuttl/e2e/replica-service/files/cip-cluster.yaml
+++ b/testing/kuttl/e2e/replica-service/files/cip-cluster.yaml
@@ -1,0 +1,8 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: service
+spec:
+  replicaService:
+    type: ClusterIP
+    nodePort: null

--- a/testing/kuttl/e2e/replica-service/files/lb-check.yaml
+++ b/testing/kuttl/e2e/replica-service/files/lb-check.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-replicas
+spec:
+  type: LoadBalancer
+  selector:
+    postgres-operator.crunchydata.com/cluster: service
+    postgres-operator.crunchydata.com/role: replica

--- a/testing/kuttl/e2e/replica-service/files/lb-cluster.yaml
+++ b/testing/kuttl/e2e/replica-service/files/lb-cluster.yaml
@@ -1,0 +1,8 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: service
+spec:
+  replicaService:
+    type: LoadBalancer
+    nodePort: null

--- a/testing/kuttl/e2e/replica-service/files/np-check.yaml
+++ b/testing/kuttl/e2e/replica-service/files/np-check.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-replicas
+spec:
+  type: NodePort
+  ports:
+  - name: postgres
+    nodePort: 30789
+    port: 5432
+    protocol: TCP
+    targetPort: postgres
+  selector:
+    postgres-operator.crunchydata.com/cluster: service
+    postgres-operator.crunchydata.com/role: replica

--- a/testing/kuttl/e2e/replica-service/files/np-cluster.yaml
+++ b/testing/kuttl/e2e/replica-service/files/np-cluster.yaml
@@ -1,0 +1,8 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: service
+spec:
+  replicaService:
+    type: NodePort
+    nodePort: 30789


### PR DESCRIPTION
This change adds the `ReplicaService` field to the spec that gives users the same configuration options as other services (primary and pgbouncer).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
Currently, the replica service defaults to a `ServiceType` of `ClusterIP` without the ability to change the type.


**What is the new behavior (if this is a feature change)?**
With this change, users can change the replica service `ServiceType` using the `spec.ReplicaService` field.

- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:

We check that the service type is configured correctly using both kuttl and go tests. In the future, I would like to see more kuttl test steps added that check connection to the different service types. This type of testing would require environment-specific details and configurations (thinking load balancer). 
