### PR TITLE
feat: generate postgres user secret with r2dbc uris

### DIFF
--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -128,6 +128,14 @@ func (r *Reconciler) generatePostgresUserSecret(
 			Path:     database,
 			RawQuery: query.Encode(),
 		}).String())
+		// The R2DBC driver requires a different URI scheme than the JDBC driver
+		// - https://r2dbc.io/spec/1.0.0.RELEASE/spec/html/#overview.connection.url
+		intent.Data["r2dbc-uri"] = []byte((&url.URL{
+			Scheme:   "r2dbc:postgresql",
+			Host:     net.JoinHostPort(hostname, port),
+			Path:     database,
+			RawQuery: query.Encode(),
+		}).String())
 	}
 
 	// When PgBouncer is enabled, include values for connecting through it.
@@ -160,6 +168,12 @@ func (r *Reconciler) generatePostgresUserSecret(
 			query.Set("prepareThreshold", "0")
 			intent.Data["pgbouncer-jdbc-uri"] = []byte((&url.URL{
 				Scheme:   "jdbc:postgresql",
+				Host:     net.JoinHostPort(hostname, port),
+				Path:     database,
+				RawQuery: query.Encode(),
+			}).String())
+			intent.Data["pgbouncer-r2dbc-uri"] = []byte((&url.URL{
+				Scheme:   "r2dbc:postgresql",
 				Host:     net.JoinHostPort(hostname, port),
 				Path:     database,
 				RawQuery: query.Encode(),

--- a/internal/controller/postgrescluster/postgres_test.go
+++ b/internal/controller/postgrescluster/postgres_test.go
@@ -183,6 +183,10 @@ func TestGeneratePostgresUserSecret(t *testing.T) {
 				`^jdbc:postgresql://hippo2-primary.ns1.svc:9999/db1`+
 					`[?]password=[^&]+&user=some-user-name$`,
 				string(secret.Data["jdbc-uri"])))
+			assert.Assert(t, cmp.Regexp(
+				`^r2dbc:postgresql://hippo2-primary.ns1.svc:9999/db1`+
+					`[?]password=[^&]+&user=some-user-name$`,
+				string(secret.Data["r2dbc-uri"])))
 		}
 
 		// Only the first in the list.
@@ -199,7 +203,9 @@ func TestGeneratePostgresUserSecret(t *testing.T) {
 			assert.Assert(t, cmp.Regexp(
 				`^jdbc:postgresql://hippo2-primary.ns1.svc:9999/first[?].+$`,
 				string(secret.Data["jdbc-uri"])))
-
+			assert.Assert(t, cmp.Regexp(
+				`^r2dbc:postgresql://hippo2-primary.ns1.svc:9999/first[?].+$`,
+				string(secret.Data["r2dbc-uri"])))
 		}
 	})
 
@@ -233,6 +239,10 @@ func TestGeneratePostgresUserSecret(t *testing.T) {
 				`^jdbc:postgresql://hippo2-pgbouncer.ns1.svc:10220/yes`+
 					`[?]password=[^&]+&prepareThreshold=0&user=some-user-name$`,
 				string(secret.Data["pgbouncer-jdbc-uri"])))
+			assert.Assert(t, cmp.Regexp(
+				`^r2dbc:postgresql://hippo2-pgbouncer.ns1.svc:10220/yes`+
+					`[?]password=[^&]+&prepareThreshold=0&user=some-user-name$`,
+				string(secret.Data["pgbouncer-r2dbc-uri"])))
 		}
 	})
 }


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other


**What is the current behavior (link to any open issues here)?**

The operator generates user secrets. For example if you use a r2dbc based application you cannot reference the jdbc-uri key from the secret.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

r2dbc-uri keys are added to the secrets starting with `r2dbc:postgresql://....`

**Other Information**:
