### PR TITLE
Adjust standalone pgadmin startup logic to support pgAdmin v8. Adjust…

### DIFF
--- a/internal/controller/standalone_pgadmin/pod_test.go
+++ b/internal/controller/standalone_pgadmin/pod_test.go
@@ -49,15 +49,18 @@ containers:
   - bash
   - -ceu
   - --
-  - "monitor() {\nPGADMIN_DIR=/usr/local/lib/python3.11/site-packages/pgadmin4\n\necho
-    \"Running pgAdmin4 Setup\"\npython3 ${PGADMIN_DIR}/setup.py\n\necho \"Starting
-    pgAdmin4\"\nPGADMIN4_PIDFILE=/tmp/pgadmin4.pid\npgadmin4 &\necho $! > $PGADMIN4_PIDFILE\n\npython3
-    ${PGADMIN_DIR}/setup.py --load-servers /etc/pgadmin/conf.d/~postgres-operator/pgadmin-shared-clusters.json
-    --user admin@pgadmin.postgres-operator.svc --replace\n\nexec {fd}<> <(:)\nwhile
-    read -r -t 5 -u \"${fd}\" || true; do\n\tif [ \"${cluster_file}\" -nt \"/proc/self/fd/${fd}\"
-    ] && python3 ${PGADMIN_DIR}/setup.py --load-servers /etc/pgadmin/conf.d/~postgres-operator/pgadmin-shared-clusters.json
-    --user admin@pgadmin.postgres-operator.svc --replace\n\tthen\n\t\texec {fd}>&-
-    && exec {fd}<> <(:)\n\t\tstat --format='Loaded shared servers dated %y' \"${cluster_file}\"\n\tfi\n\tif
+  - "monitor() {\nPGADMIN_DIR=/usr/local/lib/python3.11/site-packages/pgadmin4\nAPP_RELEASE=$(cd
+    $PGADMIN_DIR && python3 -c \"import config; print(config.APP_RELEASE)\")\n\necho
+    \"Running pgAdmin4 Setup\"\nif [ $APP_RELEASE -eq 7 ]; then\n\tpython3 ${PGADMIN_DIR}/setup.py\nelse\n\tpython3
+    ${PGADMIN_DIR}/setup.py setup-db\nfi\n\necho \"Starting pgAdmin4\"\nPGADMIN4_PIDFILE=/tmp/pgadmin4.pid\npgadmin4
+    &\necho $! > $PGADMIN4_PIDFILE\n\nloadServerCommand() {\n\tif [ $APP_RELEASE -eq
+    7 ]; then\n\t\tpython3 ${PGADMIN_DIR}/setup.py --load-servers /etc/pgadmin/conf.d/~postgres-operator/pgadmin-shared-clusters.json
+    --user admin@pgadmin.postgres-operator.svc --replace\n\telse\n\t\tpython3 ${PGADMIN_DIR}/setup.py
+    load-servers /etc/pgadmin/conf.d/~postgres-operator/pgadmin-shared-clusters.json
+    --user admin@pgadmin.postgres-operator.svc --replace\n\tfi\n}\nloadServerCommand\n\nexec
+    {fd}<> <(:)\nwhile read -r -t 5 -u \"${fd}\" || true; do\n\tif [ \"${cluster_file}\"
+    -nt \"/proc/self/fd/${fd}\" ] && loadServerCommand\n\tthen\n\t\texec {fd}>&- &&
+    exec {fd}<> <(:)\n\t\tstat --format='Loaded shared servers dated %y' \"${cluster_file}\"\n\tfi\n\tif
     [ ! -d /proc/$(cat $PGADMIN4_PIDFILE) ]\n\tthen\n\t\tpgadmin4 &\n\t\techo $! >
     $PGADMIN4_PIDFILE\n\t\techo \"Restarting pgAdmin4\"\n\tfi\ndone\n}; export cluster_file=\"$1\";
     export -f monitor; exec -a \"$0\" bash -ceu monitor"
@@ -178,15 +181,18 @@ containers:
   - bash
   - -ceu
   - --
-  - "monitor() {\nPGADMIN_DIR=/usr/local/lib/python3.11/site-packages/pgadmin4\n\necho
-    \"Running pgAdmin4 Setup\"\npython3 ${PGADMIN_DIR}/setup.py\n\necho \"Starting
-    pgAdmin4\"\nPGADMIN4_PIDFILE=/tmp/pgadmin4.pid\npgadmin4 &\necho $! > $PGADMIN4_PIDFILE\n\npython3
-    ${PGADMIN_DIR}/setup.py --load-servers /etc/pgadmin/conf.d/~postgres-operator/pgadmin-shared-clusters.json
-    --user admin@pgadmin.postgres-operator.svc --replace\n\nexec {fd}<> <(:)\nwhile
-    read -r -t 5 -u \"${fd}\" || true; do\n\tif [ \"${cluster_file}\" -nt \"/proc/self/fd/${fd}\"
-    ] && python3 ${PGADMIN_DIR}/setup.py --load-servers /etc/pgadmin/conf.d/~postgres-operator/pgadmin-shared-clusters.json
-    --user admin@pgadmin.postgres-operator.svc --replace\n\tthen\n\t\texec {fd}>&-
-    && exec {fd}<> <(:)\n\t\tstat --format='Loaded shared servers dated %y' \"${cluster_file}\"\n\tfi\n\tif
+  - "monitor() {\nPGADMIN_DIR=/usr/local/lib/python3.11/site-packages/pgadmin4\nAPP_RELEASE=$(cd
+    $PGADMIN_DIR && python3 -c \"import config; print(config.APP_RELEASE)\")\n\necho
+    \"Running pgAdmin4 Setup\"\nif [ $APP_RELEASE -eq 7 ]; then\n\tpython3 ${PGADMIN_DIR}/setup.py\nelse\n\tpython3
+    ${PGADMIN_DIR}/setup.py setup-db\nfi\n\necho \"Starting pgAdmin4\"\nPGADMIN4_PIDFILE=/tmp/pgadmin4.pid\npgadmin4
+    &\necho $! > $PGADMIN4_PIDFILE\n\nloadServerCommand() {\n\tif [ $APP_RELEASE -eq
+    7 ]; then\n\t\tpython3 ${PGADMIN_DIR}/setup.py --load-servers /etc/pgadmin/conf.d/~postgres-operator/pgadmin-shared-clusters.json
+    --user admin@pgadmin.postgres-operator.svc --replace\n\telse\n\t\tpython3 ${PGADMIN_DIR}/setup.py
+    load-servers /etc/pgadmin/conf.d/~postgres-operator/pgadmin-shared-clusters.json
+    --user admin@pgadmin.postgres-operator.svc --replace\n\tfi\n}\nloadServerCommand\n\nexec
+    {fd}<> <(:)\nwhile read -r -t 5 -u \"${fd}\" || true; do\n\tif [ \"${cluster_file}\"
+    -nt \"/proc/self/fd/${fd}\" ] && loadServerCommand\n\tthen\n\t\texec {fd}>&- &&
+    exec {fd}<> <(:)\n\t\tstat --format='Loaded shared servers dated %y' \"${cluster_file}\"\n\tfi\n\tif
     [ ! -d /proc/$(cat $PGADMIN4_PIDFILE) ]\n\tthen\n\t\tpgadmin4 &\n\t\techo $! >
     $PGADMIN4_PIDFILE\n\t\techo \"Restarting pgAdmin4\"\n\tfi\ndone\n}; export cluster_file=\"$1\";
     export -f monitor; exec -a \"$0\" bash -ceu monitor"


### PR DESCRIPTION
… unit tests accordingly.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Currently, we can only run pgAdmin v7 with the namespace-scoped pgAdmin API. 

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This PR adds logic to the namespace-scoped pgAdmin startup code that checks to see whether the pgAdmin version is v7 or not and then provides the appropriate commands. Unit tests for this code were adjusted as needed. 

**Other Information**:
