### PR TITLE
Remove envtest build tags and add logic to skip envtests when running…

### DIFF
--- a/.golangci.next.yaml
+++ b/.golangci.next.yaml
@@ -38,7 +38,3 @@ linters-settings:
     # https://github.com/kulti/thelper/issues/27
     tb:   { begin: true, first: true }
     test: { begin: true, first: true, name: true }
-
-run:
-  build-tags:
-    - envtest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -69,7 +69,5 @@ linters-settings:
     no-unaliased: true
 
 run:
-  build-tags:
-    - envtest
   skip-dirs:
     - pkg/generated

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,8 @@ build-postgres-operator-image: build/postgres-operator/Dockerfile
 ##@ Test
 .PHONY: check
 check: ## Run basic go tests with coverage output
-	$(GO_TEST) -cover ./...
+check: get-pgmonitor
+	QUERIES_CONFIG_DIR="$(CURDIR)/${QUERIES_CONFIG_DIR}" $(GO_TEST) -cover ./...
 
 # Available versions: curl -s 'https://storage.googleapis.com/kubebuilder-tools/' | grep -o '<Key>[^<]*</Key>'
 # - KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT=true
@@ -199,7 +200,7 @@ check-envtest: get-pgmonitor
 	GOBIN='$(CURDIR)/hack/tools' $(GO) install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 	@$(ENVTEST_USE) --print=overview && echo
 	source <($(ENVTEST_USE) --print=env) && PGO_NAMESPACE="postgres-operator" QUERIES_CONFIG_DIR="$(CURDIR)/${QUERIES_CONFIG_DIR}" \
-		$(GO_TEST) -count=1 -cover -tags=envtest ./...
+		$(GO_TEST) -count=1 -cover ./...
 
 # The "PGO_TEST_TIMEOUT_SCALE" environment variable (default: 1) can be set to a
 # positive number that extends test timeouts. The following runs tests with 
@@ -211,7 +212,7 @@ check-envtest-existing: get-pgmonitor
 check-envtest-existing: createnamespaces
 	kubectl apply --server-side -k ./config/dev
 	USE_EXISTING_CLUSTER=true PGO_NAMESPACE="postgres-operator" QUERIES_CONFIG_DIR="$(CURDIR)/${QUERIES_CONFIG_DIR}" \
-		$(GO_TEST) -count=1 -cover -p=1 -tags=envtest ./...
+		$(GO_TEST) -count=1 -cover -p=1 ./...
 	kubectl delete -k ./config/dev
 
 # Expects operator to be running

--- a/internal/bridge/crunchybridgecluster/apply.go
+++ b/internal/bridge/crunchybridgecluster/apply.go
@@ -1,16 +1,17 @@
-// Copyright 2021 - 2023 Crunchy Data Solutions, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 package crunchybridgecluster
 

--- a/internal/bridge/crunchybridgecluster/crunchybridgecluster_controller.go
+++ b/internal/bridge/crunchybridgecluster/crunchybridgecluster_controller.go
@@ -1,16 +1,17 @@
-// Copyright 2021 - 2023 Crunchy Data Solutions, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 package crunchybridgecluster
 

--- a/internal/bridge/crunchybridgecluster/crunchybridgecluster_controller_test.go
+++ b/internal/bridge/crunchybridgecluster/crunchybridgecluster_controller_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/bridge/crunchybridgecluster/delete.go
+++ b/internal/bridge/crunchybridgecluster/delete.go
@@ -1,16 +1,17 @@
-// Copyright 2021 - 2023 Crunchy Data Solutions, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 package crunchybridgecluster
 

--- a/internal/bridge/crunchybridgecluster/delete_test.go
+++ b/internal/bridge/crunchybridgecluster/delete_test.go
@@ -1,19 +1,17 @@
-//go:build envtest
-// +build envtest
+/*
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-// Copyright 2021 - 2023 Crunchy Data Solutions, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 package crunchybridgecluster
 

--- a/internal/bridge/crunchybridgecluster/helpers_test.go
+++ b/internal/bridge/crunchybridgecluster/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -77,6 +78,9 @@ var kubernetes struct {
 //nolint:unparam
 func setupKubernetes(t testing.TB) (*envtest.Environment, client.Client) {
 	t.Helper()
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" && !strings.EqualFold(os.Getenv("USE_EXISTING_CLUSTER"), "true") {
+		t.SkipNow()
+	}
 
 	kubernetes.Lock()
 	defer kubernetes.Unlock()

--- a/internal/bridge/crunchybridgecluster/postgres.go
+++ b/internal/bridge/crunchybridgecluster/postgres.go
@@ -1,16 +1,17 @@
-// Copyright 2021 - 2023 Crunchy Data Solutions, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 package crunchybridgecluster
 

--- a/internal/bridge/crunchybridgecluster/postgres_test.go
+++ b/internal/bridge/crunchybridgecluster/postgres_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/bridge/crunchybridgecluster/watches.go
+++ b/internal/bridge/crunchybridgecluster/watches.go
@@ -1,16 +1,17 @@
-// Copyright 2021 - 2023 Crunchy Data Solutions, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 package crunchybridgecluster
 

--- a/internal/bridge/crunchybridgecluster/watches_test.go
+++ b/internal/bridge/crunchybridgecluster/watches_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/bridge/quantity.go
+++ b/internal/bridge/quantity.go
@@ -1,9 +1,11 @@
 /*
- Copyright 2024 Crunchy Data Solutions, Inc.
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
+
  http://www.apache.org/licenses/LICENSE-2.0
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/internal/bridge/quantity_test.go
+++ b/internal/bridge/quantity_test.go
@@ -1,9 +1,11 @@
 /*
- Copyright 2024 Crunchy Data Solutions, Inc.
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
+
  http://www.apache.org/licenses/LICENSE-2.0
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/internal/controller/postgrescluster/apply_test.go
+++ b/internal/controller/postgrescluster/apply_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/controller/postgrescluster/cluster_test.go
+++ b/internal/controller/postgrescluster/cluster_test.go
@@ -1,8 +1,3 @@
-//go:build envtest
-// +build envtest
-
-package postgrescluster
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +12,8 @@ package postgrescluster
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package postgrescluster
 
 import (
 	"context"

--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -1,19 +1,19 @@
-package postgrescluster
-
 /*
-Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 */
+
+package postgrescluster
 
 import (
 	"context"

--- a/internal/controller/postgrescluster/controller_ref_manager.go
+++ b/internal/controller/postgrescluster/controller_ref_manager.go
@@ -1,5 +1,3 @@
-package postgrescluster
-
 /*
 Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+package postgrescluster
 
 import (
 	"context"

--- a/internal/controller/postgrescluster/controller_ref_manager_test.go
+++ b/internal/controller/postgrescluster/controller_ref_manager_test.go
@@ -1,8 +1,3 @@
-//go:build envtest
-// +build envtest
-
-package postgrescluster
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +12,8 @@ package postgrescluster
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package postgrescluster
 
 import (
 	"context"

--- a/internal/controller/postgrescluster/controller_test.go
+++ b/internal/controller/postgrescluster/controller_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/controller/postgrescluster/helpers_test.go
+++ b/internal/controller/postgrescluster/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -85,6 +86,9 @@ var kubernetes struct {
 // It deletes CRDs and stops the local API using t.Cleanup.
 func setupKubernetes(t testing.TB) (*envtest.Environment, client.Client) {
 	t.Helper()
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" && !strings.EqualFold(os.Getenv("USE_EXISTING_CLUSTER"), "true") {
+		t.SkipNow()
+	}
 
 	kubernetes.Lock()
 	defer kubernetes.Unlock()

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/controller/postgrescluster/olm_registration.go
+++ b/internal/controller/postgrescluster/olm_registration.go
@@ -1,3 +1,18 @@
+/*
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 package postgrescluster
 
 import (

--- a/internal/controller/postgrescluster/patroni_test.go
+++ b/internal/controller/postgrescluster/patroni_test.go
@@ -1,8 +1,3 @@
-//go:build envtest
-// +build envtest
-
-package postgrescluster
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +12,8 @@ package postgrescluster
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package postgrescluster
 
 import (
 	"context"

--- a/internal/controller/postgrescluster/pgadmin_test.go
+++ b/internal/controller/postgrescluster/pgadmin_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -1,5 +1,3 @@
-package postgrescluster
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package postgrescluster
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package postgrescluster
 
 import (
 	"context"

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -1,8 +1,3 @@
-//go:build envtest
-// +build envtest
-
-package postgrescluster
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +12,8 @@ package postgrescluster
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package postgrescluster
 
 import (
 	"context"

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/controller/postgrescluster/pgmonitor_test.go
+++ b/internal/controller/postgrescluster/pgmonitor_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/controller/postgrescluster/pki_test.go
+++ b/internal/controller/postgrescluster/pki_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/controller/postgrescluster/pod_disruption_budget_test.go
+++ b/internal/controller/postgrescluster/pod_disruption_budget_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/controller/postgrescluster/postgres_test.go
+++ b/internal/controller/postgrescluster/postgres_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/controller/postgrescluster/util.go
+++ b/internal/controller/postgrescluster/util.go
@@ -1,5 +1,3 @@
-package postgrescluster
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package postgrescluster
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package postgrescluster
 
 import (
 	"fmt"

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/controller/runtime/runtime.go
+++ b/internal/controller/runtime/runtime.go
@@ -1,5 +1,3 @@
-package runtime
-
 /*
 Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+package runtime
 
 import (
 	"time"

--- a/internal/controller/standalone_pgadmin/helpers_test.go
+++ b/internal/controller/standalone_pgadmin/helpers_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 // Copyright 2023 - 2024 Crunchy Data Solutions, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -71,6 +69,9 @@ var kubernetes struct {
 // TODO(tjmoore4): This function is duplicated from a version that takes a PostgresCluster object.
 func setupKubernetes(t testing.TB) client.Client {
 	t.Helper()
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" && !strings.EqualFold(os.Getenv("USE_EXISTING_CLUSTER"), "true") {
+		t.SkipNow()
+	}
 
 	kubernetes.Lock()
 	defer kubernetes.Unlock()

--- a/internal/controller/standalone_pgadmin/statefulset_test.go
+++ b/internal/controller/standalone_pgadmin/statefulset_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 // Copyright 2023 - 2024 Crunchy Data Solutions, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/controller/standalone_pgadmin/volume_test.go
+++ b/internal/controller/standalone_pgadmin/volume_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 // Copyright 2023 - 2024 Crunchy Data Solutions, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/kubeapi/patch.go
+++ b/internal/kubeapi/patch.go
@@ -1,5 +1,3 @@
-package kubeapi
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package kubeapi
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package kubeapi
 
 import (
 	"strings"

--- a/internal/kubeapi/patch_test.go
+++ b/internal/kubeapi/patch_test.go
@@ -1,5 +1,3 @@
-package kubeapi
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package kubeapi
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package kubeapi
 
 import (
 	"encoding/json"

--- a/internal/pgadmin/config_test.go
+++ b/internal/pgadmin/config_test.go
@@ -1,3 +1,18 @@
+/*
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 package pgadmin
 
 import (

--- a/internal/pgmonitor/exporter_test.go
+++ b/internal/pgmonitor/exporter_test.go
@@ -1,6 +1,3 @@
-//go:build envtest
-// +build envtest
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/postgres/doc.go
+++ b/internal/postgres/doc.go
@@ -1,8 +1,3 @@
-// Package postgres is a collection of resources that interact with PostgreSQL
-// or provide functionality that makes it easier for other resources to interact
-// with PostgreSQL.
-package postgres
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,3 +12,8 @@ package postgres
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+// Package postgres is a collection of resources that interact with PostgreSQL
+// or provide functionality that makes it easier for other resources to interact
+// with PostgreSQL.
+package postgres

--- a/internal/postgres/password/doc.go
+++ b/internal/postgres/password/doc.go
@@ -1,8 +1,3 @@
-// package password lets one create the appropriate password hashes and
-// verifiers that are used for adding the information into PostgreSQL
-
-package password
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,3 +12,7 @@ package password
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+// package password lets one create the appropriate password hashes and
+// verifiers that are used for adding the information into PostgreSQL
+package password

--- a/internal/postgres/password/md5.go
+++ b/internal/postgres/password/md5.go
@@ -1,5 +1,3 @@
-package password
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package password
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package password
 
 import (
 

--- a/internal/postgres/password/md5_test.go
+++ b/internal/postgres/password/md5_test.go
@@ -1,5 +1,3 @@
-package password
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package password
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package password
 
 import (
 	"fmt"

--- a/internal/postgres/password/password.go
+++ b/internal/postgres/password/password.go
@@ -1,5 +1,3 @@
-package password
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package password
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package password
 
 import (
 	"errors"

--- a/internal/postgres/password/password_test.go
+++ b/internal/postgres/password/password_test.go
@@ -1,5 +1,3 @@
-package password
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package password
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package password
 
 import (
 	"errors"

--- a/internal/postgres/password/scram.go
+++ b/internal/postgres/password/scram.go
@@ -1,5 +1,3 @@
-package password
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package password
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package password
 
 import (
 	"crypto/hmac"

--- a/internal/postgres/password/scram_test.go
+++ b/internal/postgres/password/scram_test.go
@@ -1,5 +1,3 @@
-package password
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package password
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package password
 
 import (
 	"bytes"

--- a/internal/upgradecheck/header.go
+++ b/internal/upgradecheck/header.go
@@ -1,5 +1,3 @@
-package upgradecheck
-
 /*
  Copyright 2017 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package upgradecheck
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package upgradecheck
 
 import (
 	"context"

--- a/internal/upgradecheck/header_test.go
+++ b/internal/upgradecheck/header_test.go
@@ -1,8 +1,3 @@
-//go:build envtest
-// +build envtest
-
-package upgradecheck
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,11 +13,15 @@ package upgradecheck
  limitations under the License.
 */
 
+package upgradecheck
+
 import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -44,6 +43,10 @@ import (
 )
 
 func TestGenerateHeader(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" && !strings.EqualFold(os.Getenv("USE_EXISTING_CLUSTER"), "true") {
+		t.SkipNow()
+	}
+
 	setupDeploymentID(t)
 	ctx := context.Background()
 	env := &envtest.Environment{
@@ -140,6 +143,10 @@ func TestGenerateHeader(t *testing.T) {
 }
 
 func TestEnsureID(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" && !strings.EqualFold(os.Getenv("USE_EXISTING_CLUSTER"), "true") {
+		t.SkipNow()
+	}
+
 	ctx := context.Background()
 	env := &envtest.Environment{}
 	config, err := env.Start()
@@ -283,6 +290,10 @@ func TestEnsureID(t *testing.T) {
 }
 
 func TestManageUpgradeCheckConfigMap(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" && !strings.EqualFold(os.Getenv("USE_EXISTING_CLUSTER"), "true") {
+		t.SkipNow()
+	}
+
 	ctx := context.Background()
 	env := &envtest.Environment{}
 	config, err := env.Start()
@@ -416,6 +427,10 @@ func TestManageUpgradeCheckConfigMap(t *testing.T) {
 }
 
 func TestApplyConfigMap(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" && !strings.EqualFold(os.Getenv("USE_EXISTING_CLUSTER"), "true") {
+		t.SkipNow()
+	}
+
 	ctx := context.Background()
 	env := &envtest.Environment{}
 	config, err := env.Start()

--- a/internal/upgradecheck/helpers_test.go
+++ b/internal/upgradecheck/helpers_test.go
@@ -1,5 +1,3 @@
-package upgradecheck
-
 /*
  Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package upgradecheck
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package upgradecheck
 
 import (
 	"context"

--- a/internal/util/registration.go
+++ b/internal/util/registration.go
@@ -1,3 +1,18 @@
+/*
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 package util
 
 import (

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,5 +1,3 @@
-package util
-
 /*
  Copyright 2017 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@ package util
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+package util
 
 import (
 	"regexp"

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/crunchy_bridgecluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/crunchy_bridgecluster_types.go
@@ -1,5 +1,5 @@
 /*
- Copyright 2021 - 2023 Crunchy Data Solutions, Inc.
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at


### PR DESCRIPTION
… standard go tests. This increases our "make check" code coverage. Also, clean up licenses and package declarations.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Currently, `make check` only runs on files that do not have an `envtest` tag.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

The `make check` tests will now run over the entire codebase and will skip tests that require envtest when appropriate. This increases the code coverage of the `make check` target.

**Other Information**:
