### PR TITLE
Add 'standalone-pgadmin-v8' KUTTL test

### DIFF
--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/00--create-pgadmin.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/00--create-pgadmin.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- files/00-pgadmin.yaml
+assert:
+- files/00-pgadmin-check.yaml

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/01-assert.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/01-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: |
+    contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+    
+    pod_name=$(kubectl get pod -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
+
+    clusters_actual=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py dump-servers /tmp/dumped.json --user admin@pgadmin.${NAMESPACE}.svc && cat /tmp/dumped.json")
+    
+    clusters_expected="\"Servers\": {}"
+    {
+      contains "${clusters_actual}" "${clusters_expected}"
+    } || {
+      echo "Wrong servers dumped: got ${clusters_actual}"
+      exit 1
+    }

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/02--create-cluster.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/02--create-cluster.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- files/02-cluster.yaml
+- files/02-pgadmin.yaml
+assert:
+- files/02-cluster-check.yaml

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/03-assert.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/03-assert.yaml
@@ -1,0 +1,76 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+# Check the configmap is updated;
+# Check the file is updated on the pod;
+# Check the server dump is accurate.
+# Because we have to wait for the configmap reload, make sure we have enough time.
+timeout: 120
+commands:
+- script: |
+    contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+    diff_comp() { bash -ceu 'diff <(echo "$1" ) <(echo "$2")' - "$@"; }
+    
+    data_expected='"pgadmin-shared-clusters.json": "{\n  \"Servers\": {\n    \"1\": {\n      \"Group\": \"groupOne\",\n      \"Host\": \"pgadmin1-primary.'${NAMESPACE}.svc'\",\n      \"MaintenanceDB\": \"postgres\",\n      \"Name\": \"pgadmin1\",\n      \"Port\": 5432,\n      \"SSLMode\": \"prefer\",\n      \"Shared\": true,\n      \"Username\": \"pgadmin1\"\n    }\n  }\n}\n"'
+
+    data_actual=$(kubectl get cm -l postgres-operator.crunchydata.com/pgadmin=pgadmin -n "${NAMESPACE}" -o json | jq .items[0].data)
+
+    {
+      contains "${data_actual}" "${data_expected}"
+    } || {
+      echo "Wrong configmap: got ${data_actual}"
+      exit 1
+    }
+
+    pod_name=$(kubectl get pod -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
+
+    config_updated=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c 'cat /etc/pgadmin/conf.d/~postgres-operator/pgadmin-shared-clusters.json')
+    config_expected='"Servers": {
+        "1": {
+          "Group": "groupOne",
+          "Host": "pgadmin1-primary.'${NAMESPACE}.svc'",
+          "MaintenanceDB": "postgres",
+          "Name": "pgadmin1",
+          "Port": 5432,
+          "SSLMode": "prefer",
+          "Shared": true,
+          "Username": "pgadmin1"
+        }
+      }'
+    {
+      contains "${config_updated}" "${config_expected}"
+    } || {
+      echo "Wrong file mounted: got ${config_updated}"
+      echo "Wrong file mounted: expected ${config_expected}"
+      sleep 10
+      exit 1
+    }
+
+    clusters_actual=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py dump-servers /tmp/dumped.json --user admin@pgadmin.${NAMESPACE}.svc && cat /tmp/dumped.json")
+    
+    clusters_expected='
+    {
+        "Servers": {
+            "1": {
+                "Name": "pgadmin1",
+                "Group": "groupOne",
+                "Host": "pgadmin1-primary.'${NAMESPACE}.svc'",
+                "Port": 5432,
+                "MaintenanceDB": "postgres",
+                "Username": "pgadmin1",
+                "Shared": true,
+                "TunnelPort": "22",
+                "KerberosAuthentication": false,
+                "ConnectionParameters": {
+                    "sslmode": "prefer"
+                }
+            }
+        }
+    }'
+    {
+      contains "${clusters_actual}" "${clusters_expected}"
+    } || {
+      echo "Wrong servers dumped: got ${clusters_actual}"
+      echo "Wrong servers dumped: expected ${clusters_expected}"
+      diff_comp "${clusters_actual}" "${clusters_expected}"
+      exit 1
+    }

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/04--create-cluster.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/04--create-cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- files/04-cluster.yaml
+assert:
+- files/04-cluster-check.yaml

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/05-assert.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/05-assert.yaml
@@ -1,0 +1,102 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+# Check the configmap is updated;
+# Check the file is updated on the pod;
+# Check the server dump is accurate.
+# Because we have to wait for the configmap reload, make sure we have enough time.
+timeout: 120
+commands:
+- script: |
+    contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+    diff_comp() { bash -ceu 'diff <(echo "$1" ) <(echo "$2")' - "$@"; }
+    
+    data_expected='"pgadmin-shared-clusters.json": "{\n  \"Servers\": {\n    \"1\": {\n      \"Group\": \"groupOne\",\n      \"Host\": \"pgadmin1-primary.'${NAMESPACE}.svc'\",\n      \"MaintenanceDB\": \"postgres\",\n      \"Name\": \"pgadmin1\",\n      \"Port\": 5432,\n      \"SSLMode\": \"prefer\",\n      \"Shared\": true,\n      \"Username\": \"pgadmin1\"\n    },\n    \"2\": {\n      \"Group\": \"groupOne\",\n      \"Host\": \"pgadmin2-primary.'${NAMESPACE}.svc'\",\n      \"MaintenanceDB\": \"postgres\",\n      \"Name\": \"pgadmin2\",\n      \"Port\": 5432,\n      \"SSLMode\": \"prefer\",\n      \"Shared\": true,\n      \"Username\": \"pgadmin2\"\n    }\n  }\n}\n"'
+
+    data_actual=$(kubectl get cm -l postgres-operator.crunchydata.com/pgadmin=pgadmin -n "${NAMESPACE}" -o json | jq .items[0].data)
+
+    {
+      contains "${data_actual}" "${data_expected}"
+    } || {
+      echo "Wrong configmap: got ${data_actual}"
+      diff_comp "${data_actual}" "${data_expected}"
+      exit 1
+    }
+
+    pod_name=$(kubectl get pod -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
+
+    config_updated=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c 'cat /etc/pgadmin/conf.d/~postgres-operator/pgadmin-shared-clusters.json')
+    config_expected='"Servers": {
+        "1": {
+          "Group": "groupOne",
+          "Host": "pgadmin1-primary.'${NAMESPACE}.svc'",
+          "MaintenanceDB": "postgres",
+          "Name": "pgadmin1",
+          "Port": 5432,
+          "SSLMode": "prefer",
+          "Shared": true,
+          "Username": "pgadmin1"
+        },
+        "2": {
+          "Group": "groupOne",
+          "Host": "pgadmin2-primary.'${NAMESPACE}.svc'",
+          "MaintenanceDB": "postgres",
+          "Name": "pgadmin2",
+          "Port": 5432,
+          "SSLMode": "prefer",
+          "Shared": true,
+          "Username": "pgadmin2"
+        }
+      }'
+    {
+      contains "${config_updated}" "${config_expected}"
+    } || {
+      echo "Wrong file mounted: got ${config_updated}"
+      echo "Wrong file mounted: expected ${config_expected}"
+      diff_comp  "${config_updated}" "${config_expected}"
+      sleep 10
+      exit 1
+    }
+
+    clusters_actual=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py dump-servers /tmp/dumped.json --user admin@pgadmin.${NAMESPACE}.svc && cat /tmp/dumped.json")
+    
+    clusters_expected='
+    {
+        "Servers": {
+            "1": {
+                "Name": "pgadmin1",
+                "Group": "groupOne",
+                "Host": "pgadmin1-primary.'${NAMESPACE}.svc'",
+                "Port": 5432,
+                "MaintenanceDB": "postgres",
+                "Username": "pgadmin1",
+                "Shared": true,
+                "TunnelPort": "22",
+                "KerberosAuthentication": false,
+                "ConnectionParameters": {
+                    "sslmode": "prefer"
+                }
+            },
+            "2": {
+                "Name": "pgadmin2",
+                "Group": "groupOne",
+                "Host": "pgadmin2-primary.'${NAMESPACE}.svc'",
+                "Port": 5432,
+                "MaintenanceDB": "postgres",
+                "Username": "pgadmin2",
+                "Shared": true,
+                "TunnelPort": "22",
+                "KerberosAuthentication": false,
+                "ConnectionParameters": {
+                    "sslmode": "prefer"
+                }
+            }
+        }
+    }'
+    {
+      contains "${clusters_actual}" "${clusters_expected}"
+    } || {
+      echo "Wrong servers dumped: got ${clusters_actual}"
+      echo "Wrong servers dumped: expected ${clusters_expected}"
+      diff_comp "${clusters_actual}" "${clusters_expected}"
+      exit 1
+    }

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/06--create-cluster.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/06--create-cluster.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- files/06-cluster.yaml
+- files/06-pgadmin.yaml
+assert:
+- files/06-cluster-check.yaml

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/07-assert.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/07-assert.yaml
@@ -1,0 +1,126 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+# Check the configmap is updated;
+# Check the file is updated on the pod;
+# Check the server dump is accurate.
+# Because we have to wait for the configmap reload, make sure we have enough time.
+timeout: 120
+commands:
+- script: |
+    contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+    diff_comp() { bash -ceu 'diff <(echo "$1" ) <(echo "$2")' - "$@"; }
+    
+    data_expected='"pgadmin-shared-clusters.json": "{\n  \"Servers\": {\n    \"1\": {\n      \"Group\": \"groupOne\",\n      \"Host\": \"pgadmin1-primary.'${NAMESPACE}.svc'\",\n      \"MaintenanceDB\": \"postgres\",\n      \"Name\": \"pgadmin1\",\n      \"Port\": 5432,\n      \"SSLMode\": \"prefer\",\n      \"Shared\": true,\n      \"Username\": \"pgadmin1\"\n    },\n    \"2\": {\n      \"Group\": \"groupOne\",\n      \"Host\": \"pgadmin2-primary.'${NAMESPACE}.svc'\",\n      \"MaintenanceDB\": \"postgres\",\n      \"Name\": \"pgadmin2\",\n      \"Port\": 5432,\n      \"SSLMode\": \"prefer\",\n      \"Shared\": true,\n      \"Username\": \"pgadmin2\"\n    },\n    \"3\": {\n      \"Group\": \"groupTwo\",\n      \"Host\": \"pgadmin3-primary.'${NAMESPACE}.svc'\",\n      \"MaintenanceDB\": \"postgres\",\n      \"Name\": \"pgadmin3\",\n      \"Port\": 5432,\n      \"SSLMode\": \"prefer\",\n      \"Shared\": true,\n      \"Username\": \"pgadmin3\"\n    }\n  }\n}\n"'
+
+    data_actual=$(kubectl get cm -l postgres-operator.crunchydata.com/pgadmin=pgadmin -n "${NAMESPACE}" -o json | jq .items[0].data)
+
+    {
+      contains "${data_actual}" "${data_expected}"
+    } || {
+      echo "Wrong configmap: got ${data_actual}"
+      diff_comp "${data_actual}" "${data_expected}"
+      exit 1
+    }
+
+    pod_name=$(kubectl get pod -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
+
+    config_updated=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c 'cat /etc/pgadmin/conf.d/~postgres-operator/pgadmin-shared-clusters.json')
+    config_expected='"Servers": {
+        "1": {
+          "Group": "groupOne",
+          "Host": "pgadmin1-primary.'${NAMESPACE}.svc'",
+          "MaintenanceDB": "postgres",
+          "Name": "pgadmin1",
+          "Port": 5432,
+          "SSLMode": "prefer",
+          "Shared": true,
+          "Username": "pgadmin1"
+        },
+        "2": {
+          "Group": "groupOne",
+          "Host": "pgadmin2-primary.'${NAMESPACE}.svc'",
+          "MaintenanceDB": "postgres",
+          "Name": "pgadmin2",
+          "Port": 5432,
+          "SSLMode": "prefer",
+          "Shared": true,
+          "Username": "pgadmin2"
+        },
+        "3": {
+          "Group": "groupTwo",
+          "Host": "pgadmin3-primary.'${NAMESPACE}.svc'",
+          "MaintenanceDB": "postgres",
+          "Name": "pgadmin3",
+          "Port": 5432,
+          "SSLMode": "prefer",
+          "Shared": true,
+          "Username": "pgadmin3"
+        }
+      }'
+    {
+      contains "${config_updated}" "${config_expected}"
+    } || {
+      echo "Wrong file mounted: got ${config_updated}"
+      echo "Wrong file mounted: expected ${config_expected}"
+      diff_comp  "${config_updated}" "${config_expected}"
+      sleep 10
+      exit 1
+    }
+
+    clusters_actual=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py dump-servers /tmp/dumped.json --user admin@pgadmin.${NAMESPACE}.svc && cat /tmp/dumped.json")
+    
+    clusters_expected='
+    {
+        "Servers": {
+            "1": {
+                "Name": "pgadmin1",
+                "Group": "groupOne",
+                "Host": "pgadmin1-primary.'${NAMESPACE}.svc'",
+                "Port": 5432,
+                "MaintenanceDB": "postgres",
+                "Username": "pgadmin1",
+                "Shared": true,
+                "TunnelPort": "22",
+                "KerberosAuthentication": false,
+                "ConnectionParameters": {
+                    "sslmode": "prefer"
+                }
+            },
+            "2": {
+                "Name": "pgadmin2",
+                "Group": "groupOne",
+                "Host": "pgadmin2-primary.'${NAMESPACE}.svc'",
+                "Port": 5432,
+                "MaintenanceDB": "postgres",
+                "Username": "pgadmin2",
+                "Shared": true,
+                "TunnelPort": "22",
+                "KerberosAuthentication": false,
+                "ConnectionParameters": {
+                    "sslmode": "prefer"
+                }
+            },
+            "3": {
+                "Name": "pgadmin3",
+                "Group": "groupTwo",
+                "Host": "pgadmin3-primary.'${NAMESPACE}.svc'",
+                "Port": 5432,
+                "MaintenanceDB": "postgres",
+                "Username": "pgadmin3",
+                "Shared": true,
+                "TunnelPort": "22",
+                "KerberosAuthentication": false,
+                "ConnectionParameters": {
+                    "sslmode": "prefer"
+                }
+            }
+        }
+    }'
+    {
+      contains "${clusters_actual}" "${clusters_expected}"
+    } || {
+      echo "Wrong servers dumped: got ${clusters_actual}"
+      echo "Wrong servers dumped: expected ${clusters_expected}"
+      diff_comp "${clusters_actual}" "${clusters_expected}"
+      exit 1
+    }

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/08--delete-cluster.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/08--delete-cluster.yaml
@@ -1,0 +1,8 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: postgres-operator.crunchydata.com/v1beta1
+    kind: PostgresCluster
+    name: pgadmin2
+error:
+- files/04-cluster-check.yaml

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/09-assert.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/09-assert.yaml
@@ -1,0 +1,102 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+# Check the configmap is updated;
+# Check the file is updated on the pod;
+# Check the server dump is accurate.
+# Because we have to wait for the configmap reload, make sure we have enough time.
+timeout: 120
+commands:
+- script: |
+    contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+    diff_comp() { bash -ceu 'diff <(echo "$1" ) <(echo "$2")' - "$@"; }
+    
+    data_expected='"pgadmin-shared-clusters.json": "{\n  \"Servers\": {\n    \"1\": {\n      \"Group\": \"groupOne\",\n      \"Host\": \"pgadmin1-primary.'${NAMESPACE}.svc'\",\n      \"MaintenanceDB\": \"postgres\",\n      \"Name\": \"pgadmin1\",\n      \"Port\": 5432,\n      \"SSLMode\": \"prefer\",\n      \"Shared\": true,\n      \"Username\": \"pgadmin1\"\n    },\n    \"2\": {\n      \"Group\": \"groupTwo\",\n      \"Host\": \"pgadmin3-primary.'${NAMESPACE}.svc'\",\n      \"MaintenanceDB\": \"postgres\",\n      \"Name\": \"pgadmin3\",\n      \"Port\": 5432,\n      \"SSLMode\": \"prefer\",\n      \"Shared\": true,\n      \"Username\": \"pgadmin3\"\n    }\n  }\n}\n"'
+
+    data_actual=$(kubectl get cm -l postgres-operator.crunchydata.com/pgadmin=pgadmin -n "${NAMESPACE}" -o json | jq .items[0].data)
+
+    {
+      contains "${data_actual}" "${data_expected}"
+    } || {
+      echo "Wrong configmap: got ${data_actual}"
+      diff_comp "${data_actual}" "${data_expected}"
+      exit 1
+    }
+
+    pod_name=$(kubectl get pod -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
+
+    config_updated=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c 'cat /etc/pgadmin/conf.d/~postgres-operator/pgadmin-shared-clusters.json')
+    config_expected='"Servers": {
+        "1": {
+          "Group": "groupOne",
+          "Host": "pgadmin1-primary.'${NAMESPACE}.svc'",
+          "MaintenanceDB": "postgres",
+          "Name": "pgadmin1",
+          "Port": 5432,
+          "SSLMode": "prefer",
+          "Shared": true,
+          "Username": "pgadmin1"
+        },
+        "2": {
+          "Group": "groupTwo",
+          "Host": "pgadmin3-primary.'${NAMESPACE}.svc'",
+          "MaintenanceDB": "postgres",
+          "Name": "pgadmin3",
+          "Port": 5432,
+          "SSLMode": "prefer",
+          "Shared": true,
+          "Username": "pgadmin3"
+        }
+      }'
+    {
+      contains "${config_updated}" "${config_expected}"
+    } || {
+      echo "Wrong file mounted: got ${config_updated}"
+      echo "Wrong file mounted: expected ${config_expected}"
+      diff_comp  "${config_updated}" "${config_expected}"
+      sleep 10
+      exit 1
+    }
+
+    clusters_actual=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py dump-servers /tmp/dumped.json --user admin@pgadmin.${NAMESPACE}.svc && cat /tmp/dumped.json")
+    
+    clusters_expected='
+    {
+        "Servers": {
+            "1": {
+                "Name": "pgadmin1",
+                "Group": "groupOne",
+                "Host": "pgadmin1-primary.'${NAMESPACE}.svc'",
+                "Port": 5432,
+                "MaintenanceDB": "postgres",
+                "Username": "pgadmin1",
+                "Shared": true,
+                "TunnelPort": "22",
+                "KerberosAuthentication": false,
+                "ConnectionParameters": {
+                    "sslmode": "prefer"
+                }
+            },
+            "2": {
+                "Name": "pgadmin3",
+                "Group": "groupTwo",
+                "Host": "pgadmin3-primary.'${NAMESPACE}.svc'",
+                "Port": 5432,
+                "MaintenanceDB": "postgres",
+                "Username": "pgadmin3",
+                "Shared": true,
+                "TunnelPort": "22",
+                "KerberosAuthentication": false,
+                "ConnectionParameters": {
+                    "sslmode": "prefer"
+                }
+            }
+        }
+    }'
+    {
+      contains "${clusters_actual}" "${clusters_expected}"
+    } || {
+      echo "Wrong servers dumped: got ${clusters_actual}"
+      echo "Wrong servers dumped: expected ${clusters_expected}"
+      diff_comp "${clusters_actual}" "${clusters_expected}"
+      exit 1
+    }

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/README.md
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/README.md
@@ -1,0 +1,64 @@
+** pgAdmin **
+
+(This test should replace `testing/kuttl/e2e/standalone-pgadmin` once pgAdmin4 v8 is released.)
+
+Note: due to the (random) namespace being part of the host, we cannot check the configmap using the usual assert/file pattern.
+
+*Phase one*
+
+* 00:
+  * create a pgadmin with no server groups;
+  * check the correct existence of the secret, configmap, and pod.
+* 01: dump the servers from pgAdmin and check that the list is empty.
+
+*Phase two*
+
+* 02:
+  * create a postgrescluster with a label;
+  * update the pgadmin with a selector;
+  * check the correct existence of the postgrescluster.
+* 03: 
+  * check that the configmap is updated in the pgadmin pod;
+  * dump the servers from pgAdmin and check that the list has the expected server.
+
+*Phase three*
+
+* 04:
+  * create a postgrescluster with the same label;
+  * check the correct existence of the postgrescluster.
+* 05:
+  * check that the configmap is updated in the pgadmin pod;
+  * dump the servers from pgAdmin and check that the list has the expected 2 servers.
+
+*Phase four*
+
+* 06:
+  * create a postgrescluster with the a different label;
+  * update the pgadmin with a second serverGroup;
+  * check the correct existence of the postgrescluster.
+* 07:
+  * check that the configmap is updated in the pgadmin pod;
+  * dump the servers from pgAdmin and check that the list has the expected 3 servers.
+
+*Phase five*
+
+* 08:
+  * delete a postgrescluster;
+  * update the pgadmin with a second serverGroup;
+  * check the correct existence of the postgrescluster.
+* 09:
+  * check that the configmap is updated in the pgadmin pod;
+  * dump the servers from pgAdmin and check that the list has the expected 2 servers
+
+pgAdmin v7 vs v8 Notes: 
+pgAdmin v8 includes updates to `setup.py` which alter how the `dump-servers` argument
+is called:
+- v7: https://github.com/pgadmin-org/pgadmin4/blob/REL-7_8/web/setup.py#L175
+- v8: https://github.com/pgadmin-org/pgadmin4/blob/REL-8_5/web/setup.py#L79
+
+You will also notice a difference in the `assert.yaml` files between the stored
+config and the config returned by the `dump-servers` command. The additional setting,
+`"TunnelPort": "22"`, is due to the new defaulting behavior added to pgAdmin for psycopg3.
+See
+- https://github.com/pgadmin-org/pgadmin4/commit/5e0daccf7655384db076512247733d7e73025d1b
+- https://github.com/pgadmin-org/pgadmin4/blob/REL-8_5/web/pgadmin/utils/driver/psycopg3/server_manager.py#L94

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/00-pgadmin-check.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/00-pgadmin-check.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/role: pgadmin
+    postgres-operator.crunchydata.com/pgadmin: pgadmin
+data:
+  pgadmin-settings.json: |
+    {
+      "DEFAULT_SERVER": "0.0.0.0",
+      "SERVER_MODE": true,
+      "UPGRADE_CHECK_ENABLED": false,
+      "UPGRADE_CHECK_KEY": "",
+      "UPGRADE_CHECK_URL": ""
+    }
+  pgadmin-shared-clusters.json: |
+    {
+      "Servers": {}
+    }
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/data: pgadmin
+    postgres-operator.crunchydata.com/role: pgadmin
+    postgres-operator.crunchydata.com/pgadmin: pgadmin
+status:
+  containerStatuses:
+  - name: pgadmin
+    ready: true
+    started: true
+  phase: Running
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/role: pgadmin
+    postgres-operator.crunchydata.com/pgadmin: pgadmin
+type: Opaque

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/00-pgadmin.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/00-pgadmin.yaml
@@ -1,0 +1,12 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGAdmin
+metadata:
+  name: pgadmin
+spec:
+  dataVolumeClaimSpec:
+    accessModes:
+    - "ReadWriteOnce"
+    resources:
+      requests:
+        storage: 1Gi
+  serverGroups: []

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/02-cluster-check.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/02-cluster-check.yaml
@@ -1,0 +1,6 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: pgadmin1
+  labels:
+    hello: world

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/02-cluster.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/02-cluster.yaml
@@ -1,0 +1,17 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: pgadmin1
+  labels:
+    hello: world
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/02-pgadmin.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/02-pgadmin.yaml
@@ -1,0 +1,17 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGAdmin
+metadata:
+  name: pgadmin
+spec:
+  adminUsername: admin@pgo.com
+  dataVolumeClaimSpec:
+    accessModes:
+    - "ReadWriteOnce"
+    resources:
+      requests:
+        storage: 1Gi
+  serverGroups:
+  - name: groupOne
+    postgresClusterSelector:
+      matchLabels:
+        hello: world

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/04-cluster-check.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/04-cluster-check.yaml
@@ -1,0 +1,6 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: pgadmin2
+  labels:
+    hello: world

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/04-cluster.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/04-cluster.yaml
@@ -1,0 +1,17 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: pgadmin2
+  labels:
+    hello: world
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/06-cluster-check.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/06-cluster-check.yaml
@@ -1,0 +1,6 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: pgadmin3
+  labels:
+    hello: world2

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/06-cluster.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/06-cluster.yaml
@@ -1,0 +1,17 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: pgadmin3
+  labels:
+    hello: world2
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }

--- a/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/06-pgadmin.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-v8/files/06-pgadmin.yaml
@@ -1,0 +1,20 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGAdmin
+metadata:
+  name: pgadmin
+spec:
+  dataVolumeClaimSpec:
+    accessModes:
+    - "ReadWriteOnce"
+    resources:
+      requests:
+        storage: 1Gi
+  serverGroups:
+  - name: groupOne
+    postgresClusterSelector:
+      matchLabels:
+        hello: world
+  - name: groupTwo
+    postgresClusterSelector:
+      matchLabels:
+        hello: world2


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Adds a KUTTL test for pgAdmin v8 in e2e-other. This test will replace the existing 'standalone-pgadmin' once the updated pgAdmin is released.


**Other Information**:
Issue: PGO-1145