### PR TITLE
Skip some pgMonitor tests when not configured

### DIFF
--- a/internal/controller/postgrescluster/pgmonitor_test.go
+++ b/internal/controller/postgrescluster/pgmonitor_test.go
@@ -346,6 +346,10 @@ name: exporter-config
 // reacts when the kubernetes resources are in different states (e.g., checks
 // what happens when the database pod is terminating)
 func TestReconcilePGMonitorExporterSetupErrors(t *testing.T) {
+	if os.Getenv("QUERIES_CONFIG_DIR") == "" {
+		t.Skip("QUERIES_CONFIG_DIR must be set")
+	}
+
 	for _, test := range []struct {
 		name          string
 		podExecCalled bool
@@ -570,6 +574,10 @@ func TestReconcilePGMonitorExporter(t *testing.T) {
 // when it should be. Because the status updated when we update the setup sql from
 // pgmonitor (by using podExec), we check if podExec is called when a change is needed.
 func TestReconcilePGMonitorExporterStatus(t *testing.T) {
+	if os.Getenv("QUERIES_CONFIG_DIR") == "" {
+		t.Skip("QUERIES_CONFIG_DIR must be set")
+	}
+
 	for _, test := range []struct {
 		name                        string
 		exporterEnabled             bool

--- a/internal/pgmonitor/exporter_test.go
+++ b/internal/pgmonitor/exporter_test.go
@@ -17,6 +17,7 @@ package pgmonitor
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -28,6 +29,10 @@ import (
 )
 
 func TestGenerateDefaultExporterQueries(t *testing.T) {
+	if os.Getenv("QUERIES_CONFIG_DIR") == "" {
+		t.Skip("QUERIES_CONFIG_DIR must be set")
+	}
+
 	ctx := context.Background()
 	cluster := &v1beta1.PostgresCluster{}
 


### PR DESCRIPTION
My editor can run individual Go tests, but I don't have it configured with every variable in the Makefile. With this, <code>go&nbsp;test&nbsp;./...</code> passes in a minimal environment.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
