### PR TITLE
Reject invalid Postgres user specs

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -15080,8 +15080,14 @@ spec:
                     options:
                       description: 'ALTER ROLE options except for PASSWORD. This field
                         is ignored for the "postgres" user. More info: https://www.postgresql.org/docs/current/role-attributes.html'
+                      maxLength: 200
                       pattern: ^[^;]*$
                       type: string
+                      x-kubernetes-validations:
+                      - message: cannot assign password
+                        rule: '!self.matches("(?i:PASSWORD)")'
+                      - message: cannot contain comments
+                        rule: '!self.matches("(?:--|/[*]|[*]/)")'
                     password:
                       description: Properties of the password generated for this user.
                       properties:
@@ -15102,6 +15108,7 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/onsi/ginkgo/v2 v2.0.0
 	github.com/onsi/gomega v1.18.1
+	github.com/pganalyze/pg_query_go/v5 v5.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/xdg-go/stringprep v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -401,6 +401,8 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pganalyze/pg_query_go/v5 v5.1.0 h1:MlxQqHZnvA3cbRQYyIrjxEjzo560P6MyTgtlaf3pmXg=
+github.com/pganalyze/pg_query_go/v5 v5.1.0/go.mod h1:FsglvxidZsVN+Ltw3Ai6nTgPVcK2BPukH3jCDEqc1Ug=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -956,6 +958,7 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/internal/controller/postgrescluster/postgres_test.go
+++ b/internal/controller/postgrescluster/postgres_test.go
@@ -679,6 +679,8 @@ func TestValidatePostgresUsers(t *testing.T) {
 		assert.Equal(t, len(recorder.Events), 0)
 	})
 
+	// See [internal/testing/validation.TestPostgresUserOptions]
+
 	t.Run("NoComments", func(t *testing.T) {
 		cluster := v1beta1.NewPostgresCluster()
 		cluster.Name = "pg1"

--- a/internal/testing/validation/postgrescluster_test.go
+++ b/internal/testing/validation/postgrescluster_test.go
@@ -1,0 +1,136 @@
+/*
+ Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	"github.com/crunchydata/postgres-operator/internal/testing/cmp"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+)
+
+func TestPostgresUserOptions(t *testing.T) {
+	ctx := context.Background()
+	cc := require.Kubernetes(t)
+	t.Parallel()
+
+	namespace := require.Namespace(t, cc)
+	base := v1beta1.NewPostgresCluster()
+
+	// Start with a bunch of required fields.
+	assert.NilError(t, yaml.Unmarshal([]byte(`{
+		postgresVersion: 16,
+		backups: {
+			pgbackrest: {
+				repos: [{ name: repo1 }],
+			},
+		},
+		instances: [{
+			dataVolumeClaimSpec: {
+				accessModes: [ReadWriteOnce],
+				resources: { requests: { storage: 1Mi } },
+			},
+		}],
+	}`), &base.Spec))
+
+	base.Namespace = namespace.Name
+	base.Name = "postgres-user-options"
+
+	assert.NilError(t, cc.Create(ctx, base.DeepCopy(), client.DryRunAll),
+		"expected this base cluster to be valid")
+
+	// See [internal/controller/postgrescluster.TestValidatePostgresUsers]
+
+	t.Run("NoComments", func(t *testing.T) {
+		cluster := base.DeepCopy()
+		cluster.Spec.Users = []v1beta1.PostgresUserSpec{
+			{Name: "dashes", Options: "ANY -- comment"},
+			{Name: "block-open", Options: "/* asdf"},
+			{Name: "block-close", Options: " qw */ rt"},
+		}
+
+		err := cc.Create(ctx, cluster, client.DryRunAll)
+		assert.Assert(t, apierrors.IsInvalid(err))
+		assert.ErrorContains(t, err, "cannot contain comments")
+
+		//nolint:errorlint // This is a test, and a panic is unlikely.
+		status := err.(apierrors.APIStatus).Status()
+		assert.Assert(t, status.Details != nil)
+		assert.Equal(t, len(status.Details.Causes), 3)
+
+		for i, cause := range status.Details.Causes {
+			assert.Equal(t, cause.Field, fmt.Sprintf("spec.users[%d].options", i))
+			assert.Assert(t, cmp.Contains(cause.Message, "cannot contain comments"))
+		}
+	})
+
+	t.Run("NoPassword", func(t *testing.T) {
+		cluster := base.DeepCopy()
+		cluster.Spec.Users = []v1beta1.PostgresUserSpec{
+			{Name: "uppercase", Options: "SUPERUSER PASSWORD ''"},
+			{Name: "lowercase", Options: "password 'asdf'"},
+		}
+
+		err := cc.Create(ctx, cluster, client.DryRunAll)
+		assert.Assert(t, apierrors.IsInvalid(err))
+		assert.ErrorContains(t, err, "cannot assign password")
+
+		//nolint:errorlint // This is a test, and a panic is unlikely.
+		status := err.(apierrors.APIStatus).Status()
+		assert.Assert(t, status.Details != nil)
+		assert.Equal(t, len(status.Details.Causes), 2)
+
+		for i, cause := range status.Details.Causes {
+			assert.Equal(t, cause.Field, fmt.Sprintf("spec.users[%d].options", i))
+			assert.Assert(t, cmp.Contains(cause.Message, "cannot assign password"))
+		}
+	})
+
+	t.Run("NoTerminators", func(t *testing.T) {
+		cluster := base.DeepCopy()
+		cluster.Spec.Users = []v1beta1.PostgresUserSpec{
+			{Name: "semicolon", Options: "some ;where"},
+		}
+
+		err := cc.Create(ctx, cluster, client.DryRunAll)
+		assert.Assert(t, apierrors.IsInvalid(err))
+		assert.ErrorContains(t, err, "should match")
+
+		//nolint:errorlint // This is a test, and a panic is unlikely.
+		status := err.(apierrors.APIStatus).Status()
+		assert.Assert(t, status.Details != nil)
+		assert.Equal(t, len(status.Details.Causes), 1)
+		assert.Equal(t, status.Details.Causes[0].Field, "spec.users[0].options")
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		cluster := base.DeepCopy()
+		cluster.Spec.Users = []v1beta1.PostgresUserSpec{
+			{Name: "normal", Options: "CREATEDB valid until '2006-01-02'"},
+			{Name: "very-full", Options: "NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOLOGIN NOREPLICATION NOBYPASSRLS CONNECTION LIMIT 5"},
+		}
+
+		assert.NilError(t, cc.Create(ctx, cluster, client.DryRunAll))
+	})
+}

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgres_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgres_types.go
@@ -60,7 +60,10 @@ type PostgresUserSpec struct {
 	// ALTER ROLE options except for PASSWORD. This field is ignored for the
 	// "postgres" user.
 	// More info: https://www.postgresql.org/docs/current/role-attributes.html
+	// +kubebuilder:validation:MaxLength=200
 	// +kubebuilder:validation:Pattern=`^[^;]*$`
+	// +kubebuilder:validation:XValidation:rule=`!self.matches("(?i:PASSWORD)")`,message="cannot assign password"
+	// +kubebuilder:validation:XValidation:rule=`!self.matches("(?:--|/[*]|[*]/)")`,message="cannot contain comments"
 	// +optional
 	Options string `json:"options,omitempty"`
 

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -175,6 +175,7 @@ type PostgresClusterSpec struct {
 	// from this list does NOT drop the user nor revoke their access.
 	// +listType=map
 	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	Users []PostgresUserSpec `json:"users,omitempty"`
 


### PR DESCRIPTION
The PASSWORD option was never effective. CEL validation rules, available in beta since Kubernetes 1.25, can detect and reject values that the RE2 pattern validation of [github.com/go-openapi could not](https://pkg.go.dev/github.com/go-openapi/validate@v0.24.0#hdr-Known_limitations).

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix
 - [x] Testing enhancement

**What is the current behavior (link to any open issues here)?**

The PASSWORD option and SQL comments are accepted in Postgres user specs on the PostgresCluster object.


**What is the new behavior (if this is a feature change)?**
- [x] Breaking change (fix or feature that would cause existing functionality to change)

These values are now rejected at the Kubernetes API and removed before being sent to Postgres.

A new package checks CRD validation using envtest.

**Other Information**:

Issue: PGO-1094