### PR TITLE
Allow users to configure CONFIG_DATABASE_URI setting in a Secret

### DIFF
--- a/build/crd/pgadmins/todos.yaml
+++ b/build/crd/pgadmins/todos.yaml
@@ -16,5 +16,8 @@
 - op: copy
   from: /work
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/users/items/properties/passwordRef/properties/name/description
+- op: copy
+  from: /work
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/config/properties/configDatabaseURI/properties/name/description
 - op: remove
   path: /work

--- a/config/crd/bases/postgres-operator.crunchydata.com_pgadmins.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_pgadmins.yaml
@@ -860,6 +860,24 @@ spec:
                   to any of these values will be loaded without validation. Be careful,
                   as you may put pgAdmin into an unusable state.
                 properties:
+                  configDatabaseURI:
+                    description: 'A Secret containing the value for the CONFIG_DATABASE_URI
+                      setting. More info: https://www.pgadmin.org/docs/pgadmin4/latest/external_database.html'
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
                   files:
                     description: Files allows the user to mount projected volumes
                       into the pgAdmin container so that files can be referenced by

--- a/internal/controller/standalone_pgadmin/pod_test.go
+++ b/internal/controller/standalone_pgadmin/pod_test.go
@@ -157,6 +157,9 @@ initContainers:
     if os.path.isfile('/etc/pgadmin/conf.d/~postgres-operator/ldap-bind-password'):
         with open('/etc/pgadmin/conf.d/~postgres-operator/ldap-bind-password') as _f:
             LDAP_BIND_PASSWORD = _f.read()
+    if os.path.isfile('/etc/pgadmin/conf.d/~postgres-operator/config-database-uri'):
+        with open('/etc/pgadmin/conf.d/~postgres-operator/config-database-uri') as _f:
+            CONFIG_DATABASE_URI = _f.read()
   - |
     import json, re
     with open('/etc/pgadmin/conf.d/~postgres-operator/gunicorn-config.json') as _f:
@@ -336,6 +339,9 @@ initContainers:
     if os.path.isfile('/etc/pgadmin/conf.d/~postgres-operator/ldap-bind-password'):
         with open('/etc/pgadmin/conf.d/~postgres-operator/ldap-bind-password') as _f:
             LDAP_BIND_PASSWORD = _f.read()
+    if os.path.isfile('/etc/pgadmin/conf.d/~postgres-operator/config-database-uri'):
+        with open('/etc/pgadmin/conf.d/~postgres-operator/config-database-uri') as _f:
+            CONFIG_DATABASE_URI = _f.read()
   - |
     import json, re
     with open('/etc/pgadmin/conf.d/~postgres-operator/gunicorn-config.json') as _f:

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/standalone_pgadmin_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/standalone_pgadmin_types.go
@@ -26,6 +26,11 @@ type StandalonePGAdminConfiguration struct {
 	// +optional
 	Files []corev1.VolumeProjection `json:"files,omitempty"`
 
+	// A Secret containing the value for the CONFIG_DATABASE_URI setting.
+	// More info: https://www.pgadmin.org/docs/pgadmin4/latest/external_database.html
+	// +optional
+	ConfigDatabaseURI *corev1.SecretKeySelector `json:"configDatabaseURI,omitempty"`
+
 	// Settings for the gunicorn server.
 	// More info: https://docs.gunicorn.org/en/latest/settings.html
 	// +optional

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
@@ -2224,6 +2224,11 @@ func (in *StandalonePGAdminConfiguration) DeepCopyInto(out *StandalonePGAdminCon
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ConfigDatabaseURI != nil {
+		in, out := &in.ConfigDatabaseURI, &out.ConfigDatabaseURI
+		*out = new(corev1.SecretKeySelector)
+		(*in).DeepCopyInto(*out)
+	}
 	in.Gunicorn.DeepCopyInto(&out.Gunicorn)
 	if in.LDAPBindPassword != nil {
 		in, out := &in.LDAPBindPassword, &out.LDAPBindPassword

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/00--create-cluster.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/00--create-cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- files/00-cluster.yaml
+assert:
+- files/00-cluster-check.yaml

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/01--user-schema.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/01--user-schema.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# ensure the user schema is created for pgAdmin to use
+  - script: |
+      PRIMARY=$(
+        kubectl get pod --namespace "${NAMESPACE}" \
+          --output name --selector '
+            postgres-operator.crunchydata.com/cluster=elephant,
+            postgres-operator.crunchydata.com/role=master'
+      )
+      kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" \
+        -- psql -qAt -d elephant --command 'CREATE SCHEMA elephant AUTHORIZATION elephant'

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/02--create-pgadmin.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/02--create-pgadmin.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- files/02-pgadmin.yaml
+assert:
+- files/02-pgadmin-check.yaml

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/03-assert.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/03-assert.yaml
@@ -1,0 +1,21 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: |
+      PRIMARY=$(
+        kubectl get pod --namespace "${NAMESPACE}" \
+          --output name --selector '
+            postgres-operator.crunchydata.com/cluster=elephant,
+            postgres-operator.crunchydata.com/role=master'
+      )
+
+      NUM_USERS=$(
+      kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -- \
+        psql -qAt -d elephant --command 'select count(*) from elephant.user' \
+      )
+
+      if [[ ${NUM_USERS} != 1 ]]; then
+          echo >&2 'Expected 1 user'
+          echo "got ${NUM_USERS}"
+          exit 1
+      fi

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/04--update-pgadmin.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/04--update-pgadmin.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- files/04-pgadmin.yaml
+assert:
+- files/04-pgadmin-check.yaml

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/05-assert.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/05-assert.yaml
@@ -1,0 +1,36 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+# timeout: 120
+commands:
+- script: |
+    PRIMARY=$(
+      kubectl get pod --namespace "${NAMESPACE}" \
+        --output name --selector '
+          postgres-operator.crunchydata.com/cluster=elephant,
+          postgres-operator.crunchydata.com/role=master'
+    )
+
+    NUM_USERS=$(
+    kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -- \
+      psql -qAt -d elephant --command 'select count(*) from elephant.user' \
+    )
+
+    if [[ ${NUM_USERS} != 2 ]]; then
+        echo >&2 'Expected 2 user'
+        echo "got ${NUM_USERS}"
+        exit 1
+    fi
+
+    contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+    USER_LIST=$(
+    kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -- \
+      psql -qAt -d elephant --command 'select email from elephant.user;' \
+    )      
+
+    {
+      contains "${USER_LIST}" "john.doe@example.com"
+    } || {
+      echo >&2 'User john.doe@example.com not found. Got:'
+      echo "${USER_LIST}"
+      exit 1
+    }

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/README.md
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/README.md
@@ -1,0 +1,26 @@
+# pgAdmin external database tests
+
+Notes: 
+- Due to the (random) namespace being part of the host, we cannot check the configmap using the usual assert/file pattern.
+- These tests will only work with pgAdmin version v8 and higher
+
+## create postgrescluster and add user schema
+* 00:
+  * create a postgrescluster with a label;
+  * check that the cluster has the label and that the expected user secret is created.
+* 01: 
+  * create the user schema for pgAdmin to use
+
+ ## create pgadmin and verify connection to database
+* 02:
+  * create a pgadmin with a selector for the existing cluster's label;
+  * check the correct existence of the secret, configmap, and pod.
+* 03: 
+  * check that pgAdmin only has one user
+
+ ## add a pgadmin user and verify it in the database
+* 04:
+  * update pgadmin with a new user;
+  * check that the pod is still running as expected.
+* 05:
+  * check that pgAdmin now has two users and that the defined user is present.

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/files/00-cluster-check.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/files/00-cluster-check.yaml
@@ -1,0 +1,31 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: elephant
+  labels:
+    sometest: test1
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: elephant
+    postgres-operator.crunchydata.com/pguser: elephant
+    postgres-operator.crunchydata.com/role: pguser
+type: Opaque
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: elephant
+    postgres-operator.crunchydata.com/instance-set: instance1
+    postgres-operator.crunchydata.com/role: master
+status:
+  phase: Running

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/files/00-cluster.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/files/00-cluster.yaml
@@ -1,0 +1,17 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: elephant
+  labels:
+    sometest: test1
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/files/02-pgadmin-check.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/files/02-pgadmin-check.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/role: pgadmin
+    postgres-operator.crunchydata.com/pgadmin: pgadmin1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/data: pgadmin
+    postgres-operator.crunchydata.com/role: pgadmin
+    postgres-operator.crunchydata.com/pgadmin: pgadmin1
+status:
+  containerStatuses:
+  - name: pgadmin
+    ready: true
+    started: true
+  phase: Running
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/role: pgadmin
+    postgres-operator.crunchydata.com/pgadmin: pgadmin1
+type: Opaque

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/files/02-pgadmin.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/files/02-pgadmin.yaml
@@ -1,0 +1,20 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGAdmin
+metadata:
+  name: pgadmin1
+spec:
+  config:
+    configDatabaseURI:
+      name: elephant-pguser-elephant
+      key: uri
+  dataVolumeClaimSpec:
+    accessModes:
+    - "ReadWriteOnce"
+    resources:
+      requests:
+        storage: 1Gi
+  serverGroups:
+    - name: kuttl-test
+      postgresClusterSelector:
+        matchLabels:
+          sometest: test1

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/files/04-pgadmin-check.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/files/04-pgadmin-check.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/data: pgadmin
+    postgres-operator.crunchydata.com/role: pgadmin
+    postgres-operator.crunchydata.com/pgadmin: pgadmin1
+status:
+  containerStatuses:
+  - name: pgadmin
+    ready: true
+    started: true
+  phase: Running

--- a/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/files/04-pgadmin.yaml
+++ b/testing/kuttl/e2e-other/standalone-pgadmin-db-uri/files/04-pgadmin.yaml
@@ -1,0 +1,33 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGAdmin
+metadata:
+  name: pgadmin1
+spec:
+  users:
+    - username: "john.doe@example.com"
+      passwordRef:
+        name: john-doe-password
+        key: password
+  config:
+    configDatabaseURI:
+      name: elephant-pguser-elephant
+      key: uri
+  dataVolumeClaimSpec:
+    accessModes:
+    - "ReadWriteOnce"
+    resources:
+      requests:
+        storage: 1Gi
+  serverGroups:
+    - name: kuttl-test
+      postgresClusterSelector:
+        matchLabels:
+          sometest: test1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: john-doe-password
+type: Opaque
+stringData:
+  password: password


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This update allows users to configure the CONFIG_DATABASE_URI setting using a Secret rather than in plaintext in the PGAdmin manifest.

- https://www.pgadmin.org/docs/pgadmin4/latest/external_database.html


**Other Information**:
Issue: PGO-1130