### PR TITLE
Fix Patroni Dynamic Config Link

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -10396,7 +10396,7 @@ spec:
                     description: 'Patroni dynamic configuration settings. Changes
                       to this value will be automatically reloaded without validation.
                       Changes to certain PostgreSQL parameters cause PostgreSQL to
-                      restart. More info: https://patroni.readthedocs.io/en/latest/SETTINGS.html'
+                      restart. More info: https://patroni.readthedocs.io/en/latest/dynamic_configuration.html'
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   leaderLeaseDurationSeconds:

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/patroni_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/patroni_types.go
@@ -19,7 +19,7 @@ type PatroniSpec struct {
 	// Patroni dynamic configuration settings. Changes to this value will be
 	// automatically reloaded without validation. Changes to certain PostgreSQL
 	// parameters cause PostgreSQL to restart.
-	// More info: https://patroni.readthedocs.io/en/latest/SETTINGS.html
+	// More info: https://patroni.readthedocs.io/en/latest/dynamic_configuration.html
 	// +optional
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Schemaless


### PR DESCRIPTION
Fixes a broken link for Patroni dynamic configuration in the PostgresCluster spec.