### PR TITLE
Create schemas for users in granted databases

### DIFF
--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -534,7 +534,7 @@ func (r *Reconciler) reconcilePostgresUsersInPostgreSQL(
 	}
 
 	write := func(ctx context.Context, exec postgres.Executor) error {
-		return postgres.WriteUsersInPostgreSQL(ctx, exec, specUsers, verifiers)
+		return postgres.WriteUsersInPostgreSQL(ctx, cluster, exec, specUsers, verifiers)
 	}
 
 	revision, err := safeHash32(func(hasher io.Writer) error {

--- a/internal/naming/annotations.go
+++ b/internal/naming/annotations.go
@@ -71,7 +71,8 @@ const (
 	// the Bridge Cluster. The Value assigned to the annotation must be the ID of existing cluster.
 	CrunchyBridgeClusterAdoptionAnnotation = annotationPrefix + "adopt-bridge-cluster"
 
-	// Starting with a true/false, but possibly change to a list of users?
-	// Doing this because changes to spec are worse to handle
+	// AutoCreateUserSchemaAnnotation is an annotation used to allow users to control whether the cluster
+	// has schemas automatically created for the users defined in `spec.users` for all of the databases
+	// listed for that user.
 	AutoCreateUserSchemaAnnotation = annotationPrefix + "autoCreateUserSchema"
 )

--- a/internal/naming/annotations.go
+++ b/internal/naming/annotations.go
@@ -70,4 +70,8 @@ const (
 	// bridge cluster, the user must add this annotation to the CR to allow the CR to take control of
 	// the Bridge Cluster. The Value assigned to the annotation must be the ID of existing cluster.
 	CrunchyBridgeClusterAdoptionAnnotation = annotationPrefix + "adopt-bridge-cluster"
+
+	// Starting with a true/false, but possibly change to a list of users?
+	// Doing this because changes to spec are worse to handle
+	AutoCreateUserSchemaAnnotation = annotationPrefix + "autoCreateUserSchema"
 )

--- a/internal/postgres/users.go
+++ b/internal/postgres/users.go
@@ -174,7 +174,8 @@ SELECT pg_catalog.format('GRANT ALL PRIVILEGES ON DATABASE %I TO %I',
 	// 	* the feature gate is enabled and
 	// 	* the cluster is annotated.
 	if util.DefaultMutableFeatureGate.Enabled(util.AutoCreateUserSchema) {
-		if _, annotationExists := cluster.Annotations[naming.AutoCreateUserSchemaAnnotation]; annotationExists {
+		autoCreateUserSchemaAnnotationValue, annotationExists := cluster.Annotations[naming.AutoCreateUserSchemaAnnotation]
+		if annotationExists && strings.EqualFold(autoCreateUserSchemaAnnotationValue, "true") {
 			log.V(1).Info("Writing schemas for users.")
 			err = WriteUsersSchemasInPostgreSQL(ctx, exec, users)
 		}

--- a/internal/postgres/users.go
+++ b/internal/postgres/users.go
@@ -30,7 +30,7 @@ import (
 )
 
 var RESERVED_SCHEMA_NAMES = map[string]bool{
-	"public":    true,
+	"public":    true, // This is here for documentation; Postgres will reject a role named `public` as reserved
 	"pgbouncer": true,
 	"monitor":   true,
 }

--- a/internal/postgres/users_test.go
+++ b/internal/postgres/users_test.go
@@ -213,10 +213,10 @@ func TestWriteUsersSchemasInPostgreSQL(t *testing.T) {
 
 			// The command strings will contain either of two possibilities, depending on the user called.
 			commands := strings.Join(command, ",")
-			re := regexp.MustCompile("--set=databases=db1,--set=username=user-single-db|--set=databases=db1, db2,--set=username=user-multi-dbs")
+			re := regexp.MustCompile("--set=databases=\\[\"db1\"\\],--set=username=user-single-db|--set=databases=\\[\"db1\",\"db2\"\\],--set=username=user-multi-db")
 			assert.Assert(t, cmp.Regexp(re, commands))
 
-			assert.Assert(t, cmp.Contains(string(b), `CREATE SCHEMA IF NOT EXISTS AUTHORIZATION :username;`))
+			assert.Assert(t, cmp.Contains(string(b), `CREATE SCHEMA IF NOT EXISTS :"username" AUTHORIZATION :"username";`))
 			return nil
 		}
 

--- a/internal/postgres/users_test.go
+++ b/internal/postgres/users_test.go
@@ -59,7 +59,8 @@ func TestWriteUsersInPostgreSQL(t *testing.T) {
 			return expected
 		}
 
-		assert.Equal(t, expected, WriteUsersInPostgreSQL(ctx, exec, nil, nil))
+		cluster := new(v1beta1.PostgresCluster)
+		assert.Equal(t, expected, WriteUsersInPostgreSQL(ctx, cluster, exec, nil, nil))
 	})
 
 	t.Run("Empty", func(t *testing.T) {
@@ -104,17 +105,19 @@ COMMIT;`))
 			return nil
 		}
 
-		assert.NilError(t, WriteUsersInPostgreSQL(ctx, exec, nil, nil))
+		cluster := new(v1beta1.PostgresCluster)
+		assert.NilError(t, WriteUsersInPostgreSQL(ctx, cluster, exec, nil, nil))
 		assert.Equal(t, calls, 1)
 
-		assert.NilError(t, WriteUsersInPostgreSQL(ctx, exec, []v1beta1.PostgresUserSpec{}, nil))
+		assert.NilError(t, WriteUsersInPostgreSQL(ctx, cluster, exec, []v1beta1.PostgresUserSpec{}, nil))
 		assert.Equal(t, calls, 2)
 
-		assert.NilError(t, WriteUsersInPostgreSQL(ctx, exec, nil, map[string]string{}))
+		assert.NilError(t, WriteUsersInPostgreSQL(ctx, cluster, exec, nil, map[string]string{}))
 		assert.Equal(t, calls, 3)
 	})
 
 	t.Run("OptionalFields", func(t *testing.T) {
+		cluster := new(v1beta1.PostgresCluster)
 		calls := 0
 		exec := func(
 			_ context.Context, stdin io.Reader, _, _ io.Writer, command ...string,
@@ -134,7 +137,7 @@ COMMIT;`))
 			return nil
 		}
 
-		assert.NilError(t, WriteUsersInPostgreSQL(ctx, exec,
+		assert.NilError(t, WriteUsersInPostgreSQL(ctx, cluster, exec,
 			[]v1beta1.PostgresUserSpec{
 				{
 					Name:      "user-no-options",
@@ -162,6 +165,7 @@ COMMIT;`))
 
 	t.Run("PostgresSuperuser", func(t *testing.T) {
 		calls := 0
+		cluster := new(v1beta1.PostgresCluster)
 		exec := func(
 			_ context.Context, stdin io.Reader, _, _ io.Writer, command ...string,
 		) error {
@@ -177,7 +181,7 @@ COMMIT;`))
 			return nil
 		}
 
-		assert.NilError(t, WriteUsersInPostgreSQL(ctx, exec,
+		assert.NilError(t, WriteUsersInPostgreSQL(ctx, cluster, exec,
 			[]v1beta1.PostgresUserSpec{
 				{
 					Name:      "postgres",

--- a/internal/util/features.go
+++ b/internal/util/features.go
@@ -35,6 +35,9 @@ const (
 	// Enables support of appending custom queries to default PGMonitor queries
 	AppendCustomQueries featuregate.Feature = "AppendCustomQueries"
 	//
+	// Enables automatic creation of user schema
+	AutoCreateUserSchema featuregate.Feature = "AutoCreateUserSchema"
+	//
 	// Enables support of auto-grow volumes
 	AutoGrowVolumes featuregate.Feature = "AutoGrowVolumes"
 	//
@@ -58,12 +61,13 @@ const (
 //
 // - https://releases.k8s.io/v1.20.0/pkg/features/kube_features.go#L729-732
 var pgoFeatures = map[featuregate.Feature]featuregate.FeatureSpec{
-	AppendCustomQueries: {Default: false, PreRelease: featuregate.Alpha},
-	AutoGrowVolumes:     {Default: false, PreRelease: featuregate.Alpha},
-	BridgeIdentifiers:   {Default: false, PreRelease: featuregate.Alpha},
-	InstanceSidecars:    {Default: false, PreRelease: featuregate.Alpha},
-	PGBouncerSidecars:   {Default: false, PreRelease: featuregate.Alpha},
-	TablespaceVolumes:   {Default: false, PreRelease: featuregate.Alpha},
+	AppendCustomQueries:  {Default: false, PreRelease: featuregate.Alpha},
+	AutoCreateUserSchema: {Default: false, PreRelease: featuregate.Alpha},
+	AutoGrowVolumes:      {Default: false, PreRelease: featuregate.Alpha},
+	BridgeIdentifiers:    {Default: false, PreRelease: featuregate.Alpha},
+	InstanceSidecars:     {Default: false, PreRelease: featuregate.Alpha},
+	PGBouncerSidecars:    {Default: false, PreRelease: featuregate.Alpha},
+	TablespaceVolumes:    {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // DefaultMutableFeatureGate is a mutable, shared global FeatureGate.


### PR DESCRIPTION
**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other

**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

To help developers set up and connect quickly, the operator can now create schemas for `spec.users` without using an init SQL script.

This is a gated feature: to turn on set the FeatureGate `AutoCreateUserSchema=true`.

If turned on, a cluster can be annotated with
`postgres-operator.crunchydata.com/autoCreateUserSchema=true`.

If the feature is turned on and the cluster is annotated, PGO will create a schema named after the user in every database where that user has permissions.

(PG note: creating a schema with the same name as the user means that the PG `search_path` should not need to be updated, since `search_path` defaults to `"$user", public`.)

As with our usual pattern, the operator does not remove/delete PG objects (users, databases) that are removed from the spec.

NOTE: There are several schema names that would be dangerous to the cluster's operation; for instance, if you had pgbouncer enabled (which would create a `pgbouncer` schema) it would be dangerous to create a user named `pgbouncer` and use this feature to create a schema for that user.

**Other Information**:

Issues: [PGO-1333]
Fixes https://github.com/CrunchyData/postgres-operator/issues/3568