### PR TITLE
Add constructors for valid reconcile.Result values

### DIFF
--- a/internal/bridge/crunchybridgecluster/crunchybridgecluster_controller_test.go
+++ b/internal/bridge/crunchybridgecluster/crunchybridgecluster_controller_test.go
@@ -197,7 +197,7 @@ func TestHandleCreateCluster(t *testing.T) {
 		cluster.Namespace = ns
 
 		controllerResult := reconciler.handleCreateCluster(ctx, testApiKey, testTeamId, cluster)
-		assert.Equal(t, controllerResult, ctrl.Result{RequeueAfter: 3 * time.Minute})
+		assert.Equal(t, controllerResult.RequeueAfter, 3*time.Minute)
 		assert.Equal(t, cluster.Status.ID, "0")
 
 		readyCondition := meta.FindStatusCondition(cluster.Status.Conditions, v1beta1.ConditionReady)
@@ -484,7 +484,7 @@ func TestHandleUpgrade(t *testing.T) {
 		cluster.Spec.Plan = "standard-16" // originally "standard-8"
 
 		controllerResult := reconciler.handleUpgrade(ctx, testApiKey, cluster)
-		assert.Equal(t, controllerResult, ctrl.Result{RequeueAfter: 3 * time.Minute})
+		assert.Equal(t, controllerResult.RequeueAfter, 3*time.Minute)
 		upgradingCondition := meta.FindStatusCondition(cluster.Status.Conditions, v1beta1.ConditionUpgrading)
 		if assert.Check(t, upgradingCondition != nil) {
 			assert.Equal(t, upgradingCondition.Status, metav1.ConditionTrue)
@@ -506,7 +506,7 @@ func TestHandleUpgrade(t *testing.T) {
 		cluster.Spec.PostgresVersion = 16 // originally "15"
 
 		controllerResult := reconciler.handleUpgrade(ctx, testApiKey, cluster)
-		assert.Equal(t, controllerResult, ctrl.Result{RequeueAfter: 3 * time.Minute})
+		assert.Equal(t, controllerResult.RequeueAfter, 3*time.Minute)
 		upgradingCondition := meta.FindStatusCondition(cluster.Status.Conditions, v1beta1.ConditionUpgrading)
 		if assert.Check(t, upgradingCondition != nil) {
 			assert.Equal(t, upgradingCondition.Status, metav1.ConditionTrue)
@@ -528,7 +528,7 @@ func TestHandleUpgrade(t *testing.T) {
 		cluster.Spec.Storage = resource.MustParse("15Gi") // originally "10Gi"
 
 		controllerResult := reconciler.handleUpgrade(ctx, testApiKey, cluster)
-		assert.Equal(t, controllerResult, ctrl.Result{RequeueAfter: 3 * time.Minute})
+		assert.Equal(t, controllerResult.RequeueAfter, 3*time.Minute)
 		upgradingCondition := meta.FindStatusCondition(cluster.Status.Conditions, v1beta1.ConditionUpgrading)
 		if assert.Check(t, upgradingCondition != nil) {
 			assert.Equal(t, upgradingCondition.Status, metav1.ConditionTrue)
@@ -592,7 +592,7 @@ func TestHandleUpgradeHA(t *testing.T) {
 		cluster.Spec.IsHA = true // originally "false"
 
 		controllerResult := reconciler.handleUpgradeHA(ctx, testApiKey, cluster)
-		assert.Equal(t, controllerResult, ctrl.Result{RequeueAfter: 3 * time.Minute})
+		assert.Equal(t, controllerResult.RequeueAfter, 3*time.Minute)
 		upgradingCondition := meta.FindStatusCondition(cluster.Status.Conditions, v1beta1.ConditionUpgrading)
 		if assert.Check(t, upgradingCondition != nil) {
 			assert.Equal(t, upgradingCondition.Status, metav1.ConditionTrue)
@@ -613,7 +613,7 @@ func TestHandleUpgradeHA(t *testing.T) {
 		cluster.Status.ID = "2345"
 
 		controllerResult := reconciler.handleUpgradeHA(ctx, testApiKey, cluster)
-		assert.Equal(t, controllerResult, ctrl.Result{RequeueAfter: 3 * time.Minute})
+		assert.Equal(t, controllerResult.RequeueAfter, 3*time.Minute)
 		upgradingCondition := meta.FindStatusCondition(cluster.Status.Conditions, v1beta1.ConditionUpgrading)
 		if assert.Check(t, upgradingCondition != nil) {
 			assert.Equal(t, upgradingCondition.Status, metav1.ConditionTrue)
@@ -672,7 +672,7 @@ func TestHandleUpdate(t *testing.T) {
 		cluster.Spec.ClusterName = "new-cluster-name" // originally "hippo-cluster"
 
 		controllerResult := reconciler.handleUpdate(ctx, testApiKey, cluster)
-		assert.Equal(t, controllerResult, ctrl.Result{RequeueAfter: 3 * time.Minute})
+		assert.Equal(t, controllerResult.RequeueAfter, 3*time.Minute)
 		upgradingCondition := meta.FindStatusCondition(cluster.Status.Conditions, v1beta1.ConditionUpgrading)
 		if assert.Check(t, upgradingCondition != nil) {
 			assert.Equal(t, upgradingCondition.Status, metav1.ConditionTrue)
@@ -690,7 +690,7 @@ func TestHandleUpdate(t *testing.T) {
 		cluster.Spec.IsProtected = true // originally "false"
 
 		controllerResult := reconciler.handleUpdate(ctx, testApiKey, cluster)
-		assert.Equal(t, controllerResult, ctrl.Result{RequeueAfter: 3 * time.Minute})
+		assert.Equal(t, controllerResult.RequeueAfter, 3*time.Minute)
 		upgradingCondition := meta.FindStatusCondition(cluster.Status.Conditions, v1beta1.ConditionUpgrading)
 		if assert.Check(t, upgradingCondition != nil) {
 			assert.Equal(t, upgradingCondition.Status, metav1.ConditionTrue)

--- a/internal/bridge/crunchybridgecluster/delete.go
+++ b/internal/bridge/crunchybridgecluster/delete.go
@@ -22,6 +22,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/crunchydata/postgres-operator/internal/controller/runtime"
+	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -58,7 +60,7 @@ func (r *CrunchyBridgeClusterReconciler) handleDelete(
 			}
 
 			if !deletedAlready {
-				return &ctrl.Result{RequeueAfter: 1 * time.Second}, err
+				return initialize.Pointer(runtime.RequeueWithoutBackoff(time.Second)), err
 			}
 
 			// Remove finalizer if deleted already

--- a/internal/bridge/crunchybridgecluster/delete_test.go
+++ b/internal/bridge/crunchybridgecluster/delete_test.go
@@ -85,7 +85,7 @@ func TestHandleDeleteCluster(t *testing.T) {
 		cluster.Status.ID = "1234"
 		controllerResult, err = reconciler.handleDelete(ctx, cluster, "9012")
 		assert.NilError(t, err)
-		assert.Equal(t, *controllerResult, ctrl.Result{RequeueAfter: 1 * time.Second})
+		assert.Equal(t, controllerResult.RequeueAfter, 1*time.Second)
 		assert.Equal(t, len(testBridgeClient.Clusters), 1)
 		assert.Equal(t, testBridgeClient.Clusters[0].ClusterName, "bridge-cluster-2")
 

--- a/internal/controller/pgupgrade/pgupgrade_controller.go
+++ b/internal/controller/pgupgrade/pgupgrade_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	"github.com/crunchydata/postgres-operator/internal/config"
+	"github.com/crunchydata/postgres-operator/internal/controller/runtime"
 	"github.com/crunchydata/postgres-operator/internal/registration"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
@@ -493,7 +494,7 @@ func (r *PGUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		// Requeue to verify that Patroni endpoints are deleted
-		return ctrl.Result{Requeue: true}, err // FIXME
+		return runtime.RequeueWithBackoff(), err // FIXME
 	}
 
 	// TODO: write upgradeJob back to world? No, we will wake and see it when it
@@ -501,9 +502,7 @@ func (r *PGUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// TODO: consider what it means to "re-use" the same PGUpgrade for more than
 	// one postgres version. Should the job name include the version number?
 
-	log.Info("Reconciled", "requeue", err != nil ||
-		result.Requeue ||
-		result.RequeueAfter > 0)
+	log.Info("Reconciled", "requeue", !result.IsZero() || err != nil)
 	return
 }
 

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crunchydata/postgres-operator/internal/config"
+	"github.com/crunchydata/postgres-operator/internal/controller/runtime"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/logging"
 	"github.com/crunchydata/postgres-operator/internal/naming"
@@ -502,7 +503,7 @@ func (r *Reconciler) deleteInstances(
 		// mistake that something else is deleting objects. Use RequeueAfter to
 		// avoid being rate-limited due to a deluge of delete events.
 		if err != nil {
-			result.RequeueAfter = 10 * time.Second
+			result = runtime.RequeueWithoutBackoff(10 * time.Second)
 		}
 		return client.IgnoreNotFound(err)
 	}

--- a/internal/controller/postgrescluster/patroni.go
+++ b/internal/controller/postgrescluster/patroni.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/logging"
@@ -318,8 +317,8 @@ func (r *Reconciler) reconcilePatroniLeaderLease(
 func (r *Reconciler) reconcilePatroniStatus(
 	ctx context.Context, cluster *v1beta1.PostgresCluster,
 	observedInstances *observedInstances,
-) (reconcile.Result, error) {
-	result := reconcile.Result{}
+) (time.Duration, error) {
+	var requeue time.Duration
 	log := logging.FromContext(ctx)
 
 	var readyInstance bool
@@ -346,12 +345,11 @@ func (r *Reconciler) reconcilePatroniStatus(
 			// is detected in the cluster we assume this is the case, and simply log a message and
 			// requeue in order to try again until the expected value is found.
 			log.Info("detected ready instance but no initialize value")
-			result.RequeueAfter = 1 * time.Second
-			return result, nil
+			requeue = time.Second
 		}
 	}
 
-	return result, err
+	return requeue, err
 }
 
 // reconcileReplicationSecret creates a secret containing the TLS

--- a/internal/controller/postgrescluster/patroni_test.go
+++ b/internal/controller/postgrescluster/patroni_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
@@ -524,13 +523,13 @@ func TestReconcilePatroniStatus(t *testing.T) {
 		t.Run(fmt.Sprintf("%+v", tc), func(t *testing.T) {
 			postgresCluster, observedInstances := createResources(i, tc.readyReplicas,
 				tc.writeAnnotation)
-			result, err := r.reconcilePatroniStatus(ctx, postgresCluster, observedInstances)
+			requeue, err := r.reconcilePatroniStatus(ctx, postgresCluster, observedInstances)
 			if tc.requeueExpected {
 				assert.NilError(t, err)
-				assert.Assert(t, result.RequeueAfter == 1*time.Second)
+				assert.Equal(t, requeue, time.Second)
 			} else {
 				assert.NilError(t, err)
-				assert.DeepEqual(t, result, reconcile.Result{})
+				assert.Equal(t, requeue, time.Duration(0))
 			}
 		})
 	}

--- a/internal/controller/postgrescluster/util.go
+++ b/internal/controller/postgrescluster/util.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
@@ -296,23 +295,4 @@ func safeHash32(content func(w io.Writer) error) (string, error) {
 		return "", err
 	}
 	return rand.SafeEncodeString(fmt.Sprint(hash.Sum32())), nil
-}
-
-// updateReconcileResult creates a new Result based on the new and existing results provided to it.
-// This includes setting "Requeue" to true in the Result if set to true in the new Result but not
-// in the existing Result, while also updating RequeueAfter if the RequeueAfter value for the new
-// result is less than the RequeueAfter value for the existing Result.
-func updateReconcileResult(currResult, newResult reconcile.Result) reconcile.Result {
-
-	if newResult.Requeue {
-		currResult.Requeue = true
-	}
-
-	if newResult.RequeueAfter != 0 {
-		if currResult.RequeueAfter == 0 || newResult.RequeueAfter < currResult.RequeueAfter {
-			currResult.RequeueAfter = newResult.RequeueAfter
-		}
-	}
-
-	return currResult
 }

--- a/internal/controller/postgrescluster/util_test.go
+++ b/internal/controller/postgrescluster/util_test.go
@@ -17,16 +17,13 @@ package postgrescluster
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"testing"
-	"time"
 
 	"gotest.tools/v3/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/testing/cmp"
@@ -51,142 +48,6 @@ func TestSafeHash32(t *testing.T) {
 	})
 	assert.NilError(t, err)
 	assert.Equal(t, same, stuff, "expected deterministic hash")
-}
-
-func TestUpdateReconcileResult(t *testing.T) {
-
-	testCases := []struct {
-		currResult           reconcile.Result
-		newResult            reconcile.Result
-		requeueExpected      bool
-		expectedRequeueAfter time.Duration
-	}{{
-		currResult:           reconcile.Result{},
-		newResult:            reconcile.Result{},
-		requeueExpected:      false,
-		expectedRequeueAfter: 0,
-	}, {
-		currResult:           reconcile.Result{Requeue: false},
-		newResult:            reconcile.Result{Requeue: true},
-		requeueExpected:      true,
-		expectedRequeueAfter: 0,
-	}, {
-		currResult:           reconcile.Result{Requeue: true},
-		newResult:            reconcile.Result{Requeue: false},
-		requeueExpected:      true,
-		expectedRequeueAfter: 0,
-	}, {
-		currResult:           reconcile.Result{Requeue: true},
-		newResult:            reconcile.Result{Requeue: true},
-		requeueExpected:      true,
-		expectedRequeueAfter: 0,
-	}, {
-		currResult:           reconcile.Result{Requeue: false},
-		newResult:            reconcile.Result{Requeue: false},
-		requeueExpected:      false,
-		expectedRequeueAfter: 0,
-	}, {
-		currResult:           reconcile.Result{},
-		newResult:            reconcile.Result{RequeueAfter: 5 * time.Second},
-		requeueExpected:      false,
-		expectedRequeueAfter: 5 * time.Second,
-	}, {
-		currResult:           reconcile.Result{RequeueAfter: 5 * time.Second},
-		newResult:            reconcile.Result{},
-		requeueExpected:      false,
-		expectedRequeueAfter: 5 * time.Second,
-	}, {
-		currResult:           reconcile.Result{RequeueAfter: 1 * time.Second},
-		newResult:            reconcile.Result{RequeueAfter: 5 * time.Second},
-		requeueExpected:      false,
-		expectedRequeueAfter: 1 * time.Second,
-	}, {
-		currResult:           reconcile.Result{RequeueAfter: 5 * time.Second},
-		newResult:            reconcile.Result{RequeueAfter: 1 * time.Second},
-		requeueExpected:      false,
-		expectedRequeueAfter: 1 * time.Second,
-	}, {
-		currResult:           reconcile.Result{RequeueAfter: 5 * time.Second},
-		newResult:            reconcile.Result{RequeueAfter: 5 * time.Second},
-		requeueExpected:      false,
-		expectedRequeueAfter: 5 * time.Second,
-	}, {
-		currResult: reconcile.Result{
-			Requeue: true, RequeueAfter: 5 * time.Second,
-		},
-		newResult: reconcile.Result{
-			Requeue: true, RequeueAfter: 1 * time.Second,
-		},
-		requeueExpected:      true,
-		expectedRequeueAfter: 1 * time.Second,
-	}, {
-		currResult: reconcile.Result{
-			Requeue: true, RequeueAfter: 1 * time.Second,
-		},
-		newResult: reconcile.Result{
-			Requeue: true, RequeueAfter: 5 * time.Second,
-		},
-		requeueExpected:      true,
-		expectedRequeueAfter: 1 * time.Second,
-	}, {
-		currResult: reconcile.Result{
-			Requeue: false, RequeueAfter: 1 * time.Second,
-		},
-		newResult: reconcile.Result{
-			Requeue: true, RequeueAfter: 5 * time.Second,
-		},
-		requeueExpected:      true,
-		expectedRequeueAfter: 1 * time.Second,
-	}, {
-		currResult: reconcile.Result{
-			Requeue: true, RequeueAfter: 1 * time.Second,
-		},
-		newResult: reconcile.Result{
-			Requeue: false, RequeueAfter: 5 * time.Second,
-		},
-		requeueExpected:      true,
-		expectedRequeueAfter: 1 * time.Second,
-	}, {
-		currResult: reconcile.Result{
-			Requeue: false, RequeueAfter: 5 * time.Second,
-		},
-		newResult: reconcile.Result{
-			Requeue: false, RequeueAfter: 1 * time.Second,
-		},
-		requeueExpected:      false,
-		expectedRequeueAfter: 1 * time.Second,
-	}, {
-		currResult: reconcile.Result{
-			Requeue: false, RequeueAfter: 1 * time.Second,
-		},
-		newResult: reconcile.Result{
-			Requeue: false, RequeueAfter: 5 * time.Second,
-		},
-		requeueExpected:      false,
-		expectedRequeueAfter: 1 * time.Second,
-	}, {
-		currResult: reconcile.Result{},
-		newResult: reconcile.Result{
-			Requeue: true, RequeueAfter: 5 * time.Second,
-		},
-		requeueExpected:      true,
-		expectedRequeueAfter: 5 * time.Second,
-	}, {
-		currResult: reconcile.Result{
-			Requeue: true, RequeueAfter: 5 * time.Second,
-		},
-		newResult:            reconcile.Result{},
-		requeueExpected:      true,
-		expectedRequeueAfter: 5 * time.Second,
-	}}
-
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("curr: %v, new: %v", tc.currResult, tc.newResult), func(t *testing.T) {
-			result := updateReconcileResult(tc.currResult, tc.newResult)
-			assert.Assert(t, result.Requeue == tc.requeueExpected)
-			assert.Assert(t, result.RequeueAfter == tc.expectedRequeueAfter)
-		})
-	}
 }
 
 func TestAddDevSHM(t *testing.T) {

--- a/internal/controller/runtime/reconcile.go
+++ b/internal/controller/runtime/reconcile.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// ErrorWithBackoff returns a Result and error that indicate a non-nil err
+// should be logged and measured and its [reconcile.Request] should be retried
+// later. When err is nil, nothing is logged and the Request is not retried.
+// When err unwraps to [reconcile.TerminalError], the Request is not retried.
+func ErrorWithBackoff(err error) (reconcile.Result, error) {
+	// Result should be zero to avoid warning messages.
+	return reconcile.Result{}, err
+
+	// When error is not nil and not a TerminalError, the controller-runtime Controller
+	// puts [reconcile.Request] back into the workqueue using AddRateLimited.
+	// - https://github.com/kubernetes-sigs/controller-runtime/blob/v0.18.4/pkg/internal/controller/controller.go#L317
+	// - https://pkg.go.dev/k8s.io/client-go/util/workqueue#RateLimitingInterface
+}
+
+// ErrorWithoutBackoff returns a Result and error that indicate a non-nil err
+// should be logged and measured without retrying its [reconcile.Request].
+// When err is nil, nothing is logged and the Request is not retried.
+func ErrorWithoutBackoff(err error) (reconcile.Result, error) {
+	if err != nil {
+		err = reconcile.TerminalError(err)
+	}
+
+	// Result should be zero to avoid warning messages.
+	return reconcile.Result{}, err
+
+	// When error is a TerminalError, the controller-runtime Controller increments
+	// a counter rather than interact with the workqueue.
+	// - https://github.com/kubernetes-sigs/controller-runtime/blob/v0.18.4/pkg/internal/controller/controller.go#L314
+}
+
+// RequeueWithBackoff returns a Result that indicates a [reconcile.Request]
+// should be retried later.
+func RequeueWithBackoff() reconcile.Result {
+	return reconcile.Result{Requeue: true}
+
+	// When [reconcile.Result].Requeue is true, the controller-runtime Controller
+	// puts [reconcile.Request] back into the workqueue using AddRateLimited.
+	// - https://github.com/kubernetes-sigs/controller-runtime/blob/v0.18.4/pkg/internal/controller/controller.go#L334
+	// - https://pkg.go.dev/k8s.io/client-go/util/workqueue#RateLimitingInterface
+}
+
+// RequeueWithoutBackoff returns a Result that indicates a [reconcile.Request]
+// should be retried on or before delay.
+func RequeueWithoutBackoff(delay time.Duration) reconcile.Result {
+	// RequeueAfter must be positive to not backoff.
+	if delay <= 0 {
+		delay = time.Nanosecond
+	}
+
+	// RequeueAfter implies Requeue, but set both to remove any ambiguity.
+	return reconcile.Result{Requeue: true, RequeueAfter: delay}
+
+	// When [reconcile.Result].RequeueAfter is positive, the controller-runtime Controller
+	// puts [reconcile.Request] back into the workqueue using AddAfter.
+	// - https://github.com/kubernetes-sigs/controller-runtime/blob/v0.18.4/pkg/internal/controller/controller.go#L325
+	// - https://pkg.go.dev/k8s.io/client-go/util/workqueue#DelayingInterface
+}

--- a/internal/controller/runtime/reconcile_test.go
+++ b/internal/controller/runtime/reconcile_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestErrorWithBackoff(t *testing.T) {
+	result, err := ErrorWithBackoff(nil)
+	assert.Assert(t, result.IsZero())
+	assert.NilError(t, err)
+
+	expected := errors.New("doot")
+	result, err = ErrorWithBackoff(expected)
+	assert.Assert(t, result.IsZero())
+	assert.Equal(t, err, expected)
+}
+
+func TestErrorWithoutBackoff(t *testing.T) {
+	result, err := ErrorWithoutBackoff(nil)
+	assert.Assert(t, result.IsZero())
+	assert.NilError(t, err)
+
+	expected := errors.New("doot")
+	result, err = ErrorWithoutBackoff(expected)
+	assert.Assert(t, result.IsZero())
+	assert.Assert(t, errors.Is(err, reconcile.TerminalError(nil)))
+	assert.Equal(t, errors.Unwrap(err), expected)
+}
+
+func TestRequeueWithBackoff(t *testing.T) {
+	result := RequeueWithBackoff()
+	assert.Assert(t, result.Requeue)
+	assert.Assert(t, result.RequeueAfter == 0)
+}
+
+func TestRequeueWithoutBackoff(t *testing.T) {
+	result := RequeueWithoutBackoff(0)
+	assert.Assert(t, result.Requeue)
+	assert.Assert(t, result.RequeueAfter > 0)
+
+	result = RequeueWithoutBackoff(-1)
+	assert.Assert(t, result.Requeue)
+	assert.Assert(t, result.RequeueAfter > 0)
+
+	result = RequeueWithoutBackoff(time.Minute)
+	assert.Assert(t, result.Requeue)
+	assert.Equal(t, result.RequeueAfter, time.Minute)
+}


### PR DESCRIPTION
The result list of Reconciler.Reconcile is a pair of types with multiple fields and special values. Some combinations are confusing, ignored, or cause warnings at runtime. The following values can be combined eighteen ways:

    Result.Requeue = { true, false }
    Result.RequeueAfter = { negative, zero, positive }
    error = { nil, non-nil, terminal }

These constructors provide names and documentation for four of the valid combinations.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other
