### PR TITLE
Add health checks to PGO.

### DIFF
--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	"github.com/crunchydata/postgres-operator/internal/bridge"
 	"github.com/crunchydata/postgres-operator/internal/bridge/crunchybridgecluster"
@@ -72,6 +73,8 @@ func initManager() (runtime.Options, error) {
 
 	options := runtime.Options{}
 	options.Cache.SyncPeriod = initialize.Pointer(time.Hour)
+
+	options.HealthProbeBindAddress = ":8081"
 
 	// Enable leader elections when configured with a valid Lease.coordination.k8s.io name.
 	// - https://docs.k8s.io/concepts/architecture/leases
@@ -174,6 +177,10 @@ func main() {
 	} else {
 		log.Info("upgrade checking disabled")
 	}
+
+	// Enable health probes
+	assertNoError(mgr.AddHealthzCheck("health", healthz.Ping))
+	assertNoError(mgr.AddReadyzCheck("check", healthz.Ping))
 
 	log.Info("starting controller runtime manager and will wait for signal to exit")
 

--- a/cmd/postgres-operator/main_test.go
+++ b/cmd/postgres-operator/main_test.go
@@ -33,6 +33,8 @@ func TestInitManager(t *testing.T) {
 			assert.Equal(t, *options.Cache.SyncPeriod, time.Hour)
 		}
 
+		assert.Assert(t, options.HealthProbeBindAddress == ":8081")
+
 		assert.DeepEqual(t, options.Controller.GroupKindConcurrency,
 			map[string]int{
 				"PostgresCluster.postgres-operator.crunchydata.com": 2,
@@ -44,6 +46,7 @@ func TestInitManager(t *testing.T) {
 		{
 			options.Cache.SyncPeriod = nil
 			options.Controller.GroupKindConcurrency = nil
+			options.HealthProbeBindAddress = ""
 
 			assert.Assert(t, reflect.ValueOf(options).IsZero(),
 				"expected remaining fields to be unset:\n%+v", options)


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

We currently do not have any health probes available on postgres-operator.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This PR adds readiness and liveness probes to the postgres-operator using `controller-runtime`'s health probe capabilities.

**Other Information**:
