### PR TITLE
Add ability to watch multiple namespaces without watching all namespa…

### DIFF
--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"go.opentelemetry.io/otel"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -86,8 +87,29 @@ func initManager() (runtime.Options, error) {
 		options.LeaderElectionNamespace = os.Getenv("PGO_NAMESPACE")
 	}
 
-	if namespace := os.Getenv("PGO_TARGET_NAMESPACE"); len(namespace) > 0 {
-		options.Cache.DefaultNamespaces = map[string]runtime.CacheConfig{namespace: {}}
+	// Check PGO_TARGET_NAMESPACE for backwards compatibility with
+	// "singlenamespace" installations
+	singlenamespace := strings.TrimSpace(os.Getenv("PGO_TARGET_NAMESPACE"))
+
+	// Check PGO_TARGET_NAMESPACES for non-cluster-wide, multi-namespace
+	// installations
+	multinamespace := strings.TrimSpace(os.Getenv("PGO_TARGET_NAMESPACES"))
+
+	// Initialize DefaultNamespaces if any target namespaces are set
+	if len(singlenamespace) > 0 || len(multinamespace) > 0 {
+		options.Cache.DefaultNamespaces = map[string]runtime.CacheConfig{}
+	}
+
+	if len(singlenamespace) > 0 {
+		options.Cache.DefaultNamespaces[singlenamespace] = runtime.CacheConfig{}
+	}
+
+	if len(multinamespace) > 0 {
+		for _, namespace := range strings.FieldsFunc(multinamespace, func(c rune) bool {
+			return c != '-' && !unicode.IsLetter(c) && !unicode.IsNumber(c)
+		}) {
+			options.Cache.DefaultNamespaces[namespace] = runtime.CacheConfig{}
+		}
 	}
 
 	options.Controller.GroupKindConcurrency = map[string]int{

--- a/cmd/postgres-operator/main_test.go
+++ b/cmd/postgres-operator/main_test.go
@@ -83,9 +83,19 @@ func TestInitManager(t *testing.T) {
 		assert.Assert(t, cmp.Len(options.Cache.DefaultNamespaces, 1),
 			"expected only one configured namespace")
 
-		for k := range options.Cache.DefaultNamespaces {
-			assert.Equal(t, k, "some-such")
-		}
+		assert.Assert(t, cmp.Contains(options.Cache.DefaultNamespaces, "some-such"))
+	})
+
+	t.Run("PGO_TARGET_NAMESPACES", func(t *testing.T) {
+		t.Setenv("PGO_TARGET_NAMESPACES", "some-such,another-one")
+
+		options, err := initManager()
+		assert.NilError(t, err)
+		assert.Assert(t, cmp.Len(options.Cache.DefaultNamespaces, 2),
+			"expect two configured namespaces")
+
+		assert.Assert(t, cmp.Contains(options.Cache.DefaultNamespaces, "some-such"))
+		assert.Assert(t, cmp.Contains(options.Cache.DefaultNamespaces, "another-one"))
 	})
 
 	t.Run("PGO_WORKERS", func(t *testing.T) {


### PR DESCRIPTION
…ces in a cluster.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Currently, when installing PGO, the user must choose between watching only one namespace, or watching all namespaces in a kube cluster.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

With these changes, uses can choose to have PGO watch multiple namespaces in a cluster, but not watch ALL namespaces in the cluster.

**Other Information**:
