### PR TITLE
Ensure stanza gets created

### DIFF
--- a/internal/pgbackrest/util.go
+++ b/internal/pgbackrest/util.go
@@ -59,21 +59,21 @@ func CalculateConfigHashes(
 	var err error
 	repoConfigHashes := make(map[string]string)
 	for _, repo := range postgresCluster.Spec.Backups.PGBackRest.Repos {
-		// hashes are only calculated for external repo configs
-		if repo.Volume != nil {
-			continue
-		}
+		// hashes are calculated for external repo configs and volume names
 
 		var hash, name string
 		switch {
 		case repo.Azure != nil:
-			hash, err = hashFunc([]string{repo.Azure.Container})
+			hash, err = hashFunc([]string{repo.Name, repo.Azure.Container})
 			name = repo.Name
 		case repo.GCS != nil:
-			hash, err = hashFunc([]string{repo.GCS.Bucket})
+			hash, err = hashFunc([]string{repo.Name, repo.GCS.Bucket})
 			name = repo.Name
 		case repo.S3 != nil:
-			hash, err = hashFunc([]string{repo.S3.Bucket, repo.S3.Endpoint, repo.S3.Region})
+			hash, err = hashFunc([]string{repo.Name, repo.S3.Bucket, repo.S3.Endpoint, repo.S3.Region})
+			name = repo.Name
+		case repo.Volume != nil:
+			hash, err = hashFunc([]string{repo.Name})
 			name = repo.Name
 		default:
 			return map[string]string{}, "", errors.New("found unexpected repo type")

--- a/internal/pgbackrest/util_test.go
+++ b/internal/pgbackrest/util_test.go
@@ -17,7 +17,7 @@ package pgbackrest
 
 import (
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"testing"
 
@@ -41,11 +41,11 @@ func TestCalculateConfigHashes(t *testing.T) {
 	azureOpts, gcsOpts := []string{"container"}, []string{"container"}
 	s3Opts := []string{"bucket", "endpoint", "region"}
 
-	preCalculatedRepo1AzureHash, err := hashFunc(azureOpts)
+	preCalculatedRepo1AzureHash, err := hashFunc(append([]string{"repo1"}, azureOpts...))
 	assert.NilError(t, err)
-	preCalculatedRepo2GCSHash, err := hashFunc(gcsOpts)
+	preCalculatedRepo2GCSHash, err := hashFunc(append([]string{"repo2"}, gcsOpts...))
 	assert.NilError(t, err)
-	preCalculatedRepo3S3Hash, err := hashFunc(s3Opts)
+	preCalculatedRepo3S3Hash, err := hashFunc(append([]string{"repo3"}, s3Opts...))
 	assert.NilError(t, err)
 	preCalculatedConfigHash, err := hashFunc([]string{preCalculatedRepo1AzureHash,
 		preCalculatedRepo2GCSHash, preCalculatedRepo3S3Hash})


### PR DESCRIPTION
When an objectstore repo is added first and
then a repo host, the pgbackrest stanza would
not be created. This commit fixes the issue.