### PR TITLE
Create stanza after repohost is added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /vendor/
 /testing/kuttl/e2e-generated*/
+gke_gcloud_auth_plugin_cache

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -2595,7 +2595,7 @@ func (r *Reconciler) reconcileStanzaCreate(ctx context.Context,
 
 	// Always attempt to create pgBackRest stanza first
 	configHashMismatch, err := pgbackrest.Executor(exec).StanzaCreateOrUpgrade(ctx, configHash,
-		false)
+		false, postgresCluster)
 	if err != nil {
 		// record and log any errors resulting from running the stanza-create command
 		r.Recorder.Event(postgresCluster, corev1.EventTypeWarning, EventUnableToCreateStanzas,

--- a/internal/pgbackrest/pgbackrest_test.go
+++ b/internal/pgbackrest/pgbackrest_test.go
@@ -39,16 +39,17 @@ func TestStanzaCreateOrUpgrade(t *testing.T) {
 	ctx := context.Background()
 	configHash := "7f5d4d5bdc"
 	expectedCommand := []string{"bash", "-ceu", "--", `
-declare -r hash="$1" stanza="$2" message="$3" cmd="$4" check_repo_cmd="$5"
+declare -r hash="$1" stanza="$2" hash_msg="$3" vol_msg="$4" cmd="$5" check_repo_cmd="$6"
 if [[ "$(< /etc/pgbackrest/conf.d/config-hash)" != "${hash}" ]]; then
-    printf >&2 "%s" "${message}"; exit 1;
+    printf >&2 "%s" "${hash_msg}"; exit 1;
 elif ! bash -c "${check_repo_cmd}"; then
-		printf >&2 "%s" "${message}"; exit 1;
+ 	 printf >&2 "%s" "${vol_msg}"; exit 1;
 else
     pgbackrest "${cmd}" --stanza="${stanza}"
 fi
 `,
 		"-", "7f5d4d5bdc", "db", "postgres operator error: pgBackRest config hash mismatch",
+		"postgres operator error: pgBackRest stale volume-backed repo configuration",
 		"stanza-create",
 		"grep repo1-path /etc/pgbackrest/conf.d/pgbackrest_instance.conf",
 	}

--- a/internal/pgbackrest/pgbackrest_test.go
+++ b/internal/pgbackrest/pgbackrest_test.go
@@ -24,8 +24,13 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/crunchydata/postgres-operator/internal/testing/require"
+
+	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func TestStanzaCreateOrUpgrade(t *testing.T) {
@@ -34,15 +39,19 @@ func TestStanzaCreateOrUpgrade(t *testing.T) {
 	ctx := context.Background()
 	configHash := "7f5d4d5bdc"
 	expectedCommand := []string{"bash", "-ceu", "--", `
-declare -r hash="$1" stanza="$2" message="$3" cmd="$4"
+declare -r hash="$1" stanza="$2" message="$3" cmd="$4" check_repo_cmd="$5"
 if [[ "$(< /etc/pgbackrest/conf.d/config-hash)" != "${hash}" ]]; then
     printf >&2 "%s" "${message}"; exit 1;
+elif ! bash -c "${check_repo_cmd}"; then
+		printf >&2 "%s" "${message}"; exit 1;
 else
     pgbackrest "${cmd}" --stanza="${stanza}"
 fi
 `,
 		"-", "7f5d4d5bdc", "db", "postgres operator error: pgBackRest config hash mismatch",
-		"stanza-create"}
+		"stanza-create",
+		"grep repo1-path /etc/pgbackrest/conf.d/pgbackrest_instance.conf",
+	}
 
 	var shellCheckScript string
 	stanzaExec := func(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer,
@@ -56,8 +65,36 @@ fi
 
 		return nil
 	}
+	postgresCluster := &v1beta1.PostgresCluster{
+		Spec: v1beta1.PostgresClusterSpec{
+			Backups: v1beta1.Backups{
+				PGBackRest: v1beta1.PGBackRestArchive{
+					Repos: []v1beta1.PGBackRestRepo{{
+						Name: "repo1",
+						Volume: &v1beta1.RepoPVC{
+							VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+								Resources: corev1.VolumeResourceRequirements{
+									Requests: map[corev1.ResourceName]resource.Quantity{
+										corev1.ResourceStorage: resource.MustParse("1Gi"),
+									},
+								},
+							},
+						},
+					}, {
+						Name: "repo2",
+						S3: &v1beta1.RepoS3{
+							Bucket:   "bucket",
+							Endpoint: "endpoint",
+							Region:   "region",
+						},
+					}},
+				},
+			},
+		},
+	}
 
-	configHashMismatch, err := Executor(stanzaExec).StanzaCreateOrUpgrade(ctx, configHash, false)
+	configHashMismatch, err := Executor(stanzaExec).StanzaCreateOrUpgrade(ctx, configHash, false, postgresCluster)
 	assert.NilError(t, err)
 	assert.Assert(t, !configHashMismatch)
 


### PR DESCRIPTION
Given a cloud host is already in place,
the user should still be able to add a
repohost.
