### PR TITLE
Updates for an always-on pgBackRest repo host

### DIFF
--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1376,10 +1376,8 @@ func addPGBackRestToInstancePodSpec(
 	ctx context.Context, cluster *v1beta1.PostgresCluster,
 	instanceCertificates *corev1.Secret, instancePod *corev1.PodSpec,
 ) {
-	if pgbackrest.DedicatedRepoHostEnabled(cluster) {
-		pgbackrest.AddServerToInstancePod(ctx, cluster, instancePod,
-			instanceCertificates.Name)
-	}
+	pgbackrest.AddServerToInstancePod(ctx, cluster, instancePod,
+		instanceCertificates.Name)
 
 	pgbackrest.AddConfigToInstancePod(cluster, instancePod)
 }

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -578,14 +578,104 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     readOnly: true
 - name: other
   resources: {}
+- command:
+  - pgbackrest
+  - server
+  livenessProbe:
+    exec:
+      command:
+      - pgbackrest
+      - server-ping
+  name: pgbackrest
+  resources: {}
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumeMounts:
+  - mountPath: /etc/pgbackrest/server
+    name: pgbackrest-server
+    readOnly: true
+  - mountPath: /pgdata
+    name: postgres-data
+  - mountPath: /pgwal
+    name: postgres-wal
+  - mountPath: /etc/pgbackrest/conf.d
+    name: pgbackrest-config
+    readOnly: true
+- command:
+  - bash
+  - -ceu
+  - --
+  - |-
+    monitor() {
+    exec {fd}<> <(:||:)
+    until read -r -t 5 -u "${fd}"; do
+      if
+        [[ "${filename}" -nt "/proc/self/fd/${fd}" ]] &&
+        pkill -HUP --exact --parent=0 pgbackrest
+      then
+        exec {fd}>&- && exec {fd}<> <(:||:)
+        stat --dereference --format='Loaded configuration dated %y' "${filename}"
+      elif
+        { [[ "${directory}" -nt "/proc/self/fd/${fd}" ]] ||
+          [[ "${authority}" -nt "/proc/self/fd/${fd}" ]]
+        } &&
+        pkill -HUP --exact --parent=0 pgbackrest
+      then
+        exec {fd}>&- && exec {fd}<> <(:||:)
+        stat --format='Loaded certificates dated %y' "${directory}"
+      fi
+    done
+    }; export directory="$1" authority="$2" filename="$3"; export -f monitor; exec -a "$0" bash -ceu monitor
+  - pgbackrest-config
+  - /etc/pgbackrest/server
+  - /etc/pgbackrest/conf.d/~postgres-operator/tls-ca.crt
+  - /etc/pgbackrest/conf.d/~postgres-operator_server.conf
+  name: pgbackrest-config
+  resources: {}
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumeMounts:
+  - mountPath: /etc/pgbackrest/server
+    name: pgbackrest-server
+    readOnly: true
+  - mountPath: /etc/pgbackrest/conf.d
+    name: pgbackrest-config
+    readOnly: true
 		`))
 
-		// Instance configuration files but no certificates.
+		// Instance configuration files with certificates.
 		// Other volumes are ignored.
 		assert.Assert(t, marshalMatches(out.Volumes, `
 - name: other
 - name: postgres-data
 - name: postgres-wal
+- name: pgbackrest-server
+  projected:
+    sources:
+    - secret:
+        items:
+        - key: pgbackrest-server.crt
+          path: server-tls.crt
+        - key: pgbackrest-server.key
+          mode: 384
+          path: server-tls.key
+        name: some-secret
 - name: pgbackrest-config
   projected:
     sources:
@@ -595,7 +685,19 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
           path: pgbackrest_instance.conf
         - key: config-hash
           path: config-hash
+        - key: pgbackrest-server.conf
+          path: ~postgres-operator_server.conf
         name: hippo-pgbackrest-config
+    - secret:
+        items:
+        - key: pgbackrest.ca-roots
+          path: ~postgres-operator/tls-ca.crt
+        - key: pgbackrest-client.crt
+          path: ~postgres-operator/client-tls.crt
+        - key: pgbackrest-client.key
+          mode: 384
+          path: ~postgres-operator/client-tls.key
+        name: hippo-pgbackrest
 		`))
 	})
 
@@ -644,7 +746,6 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
           mode: 384
           path: ~postgres-operator/client-tls.key
         name: hippo-pgbackrest
-        optional: true
 			`))
 		}
 

--- a/internal/naming/annotations.go
+++ b/internal/naming/annotations.go
@@ -37,14 +37,6 @@ const (
 	// (and therefore must be recreated)
 	PGBackRestConfigHash = annotationPrefix + "pgbackrest-hash"
 
-	// PGBackRestCurrentConfig is an annotation used to indicate the name of the pgBackRest
-	// configuration associated with a specific Job as determined by either the current primary
-	// (if no dedicated repository host is enabled), or the dedicated repository host.  This helps
-	// in detecting pgBackRest backup Jobs that no longer mount the proper pgBackRest
-	// configuration, e.g. because a failover has occurred, or because dedicated repo host has been
-	// enabled or disabled.
-	PGBackRestCurrentConfig = annotationPrefix + "pgbackrest-config"
-
 	// PGBackRestRestore is the annotation that is added to a PostgresCluster to initiate an in-place
 	// restore.  The value of the annotation will be a unique identifier for a restore Job (e.g. a
 	// timestamp), which will be stored in the PostgresCluster status to properly track completion

--- a/internal/naming/annotations_test.go
+++ b/internal/naming/annotations_test.go
@@ -27,7 +27,6 @@ func TestAnnotationsValid(t *testing.T) {
 	assert.Assert(t, nil == validation.IsQualifiedName(PatroniSwitchover))
 	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestBackup))
 	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestConfigHash))
-	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestCurrentConfig))
 	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestRestore))
 	assert.Assert(t, nil == validation.IsQualifiedName(PGBackRestIPVersion))
 	assert.Assert(t, nil == validation.IsQualifiedName(PostgresExporterCollectorsAnnotation))

--- a/internal/naming/selectors.go
+++ b/internal/naming/selectors.go
@@ -139,13 +139,6 @@ func ClusterPostgresUsers(cluster string) metav1.LabelSelector {
 	}
 }
 
-// ClusterPrimary selects things for the Primary PostgreSQL instance.
-func ClusterPrimary(cluster string) metav1.LabelSelector {
-	s := ClusterInstances(cluster)
-	s.MatchLabels[LabelRole] = RolePatroniLeader
-	return s
-}
-
 // CrunchyBridgeClusterPostgresRoles selects things labeled for CrunchyBridgeCluster
 // PostgreSQL roles in cluster.
 func CrunchyBridgeClusterPostgresRoles(clusterName string) metav1.LabelSelector {

--- a/internal/naming/selectors_test.go
+++ b/internal/naming/selectors_test.go
@@ -147,16 +147,6 @@ func TestClusterPostgresUsers(t *testing.T) {
 	assert.ErrorContains(t, err, "Invalid")
 }
 
-func TestClusterPrimary(t *testing.T) {
-	s, err := AsSelector(ClusterPrimary("something"))
-	assert.NilError(t, err)
-	assert.DeepEqual(t, s.String(), strings.Join([]string{
-		"postgres-operator.crunchydata.com/cluster=something",
-		"postgres-operator.crunchydata.com/instance",
-		"postgres-operator.crunchydata.com/role=master",
-	}, ","))
-}
-
 func TestCrunchyBridgeClusterPostgresRoles(t *testing.T) {
 	s, err := AsSelector(CrunchyBridgeClusterPostgresRoles("something"))
 	assert.NilError(t, err)

--- a/internal/pgbackrest/config.md
+++ b/internal/pgbackrest/config.md
@@ -31,6 +31,8 @@ As shown, the settings with the `cfgSectionGlobal` designation are
 
 `log-path`: The log path provides a location for pgBackRest to store log files.
 
+`log-level-file`: Level for file logging. Set to 'off' when the repo host has no volume.
+
 `repo-path`: Path where backups and archive are stored. 
              The repository is where pgBackRest stores backups and archives WAL segments.
 
@@ -75,6 +77,7 @@ pg1-socket-path
 [global]
 log-path
 repo1-path
+log-level-file
 
 [stanza]
 pg1-host

--- a/internal/pgbackrest/reconcile.go
+++ b/internal/pgbackrest/reconcile.go
@@ -116,22 +116,15 @@ func AddConfigToInstancePod(
 		{Key: ConfigHashKey, Path: ConfigHashKey},
 	}
 
-	// As the cluster transitions from having a repository host to having none,
-	// PostgreSQL instances that have not rolled out expect to mount client
-	// certificates. Specify those files are optional so the configuration
-	// volumes stay valid and Kubernetes propagates their contents to those pods.
 	secret := corev1.VolumeProjection{Secret: &corev1.SecretProjection{}}
 	secret.Secret.Name = naming.PGBackRestSecret(cluster).Name
-	secret.Secret.Optional = initialize.Bool(true)
 
-	if DedicatedRepoHostEnabled(cluster) {
-		configmap.ConfigMap.Items = append(
-			configmap.ConfigMap.Items, corev1.KeyToPath{
-				Key:  serverConfigMapKey,
-				Path: serverConfigProjectionPath,
-			})
-		secret.Secret.Items = append(secret.Secret.Items, clientCertificates()...)
-	}
+	configmap.ConfigMap.Items = append(
+		configmap.ConfigMap.Items, corev1.KeyToPath{
+			Key:  serverConfigMapKey,
+			Path: serverConfigProjectionPath,
+		})
+	secret.Secret.Items = append(secret.Secret.Items, clientCertificates()...)
 
 	// Start with a copy of projections specified in the cluster. Items later in
 	// the list take precedence over earlier items (that is, last write wins).
@@ -424,15 +417,13 @@ func InstanceCertificates(ctx context.Context,
 ) error {
 	var err error
 
-	if DedicatedRepoHostEnabled(inCluster) {
-		initialize.ByteMap(&outInstanceCertificates.Data)
+	initialize.ByteMap(&outInstanceCertificates.Data)
 
-		if err == nil {
-			outInstanceCertificates.Data[certInstanceSecretKey], err = certFile(inDNS)
-		}
-		if err == nil {
-			outInstanceCertificates.Data[certInstancePrivateKeySecretKey], err = certFile(inDNSKey)
-		}
+	if err == nil {
+		outInstanceCertificates.Data[certInstanceSecretKey], err = certFile(inDNS)
+	}
+	if err == nil {
+		outInstanceCertificates.Data[certInstancePrivateKeySecretKey], err = certFile(inDNSKey)
 	}
 
 	return err

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -241,7 +241,19 @@ func TestAddConfigToInstancePod(t *testing.T) {
           path: pgbackrest_instance.conf
         - key: config-hash
           path: config-hash
+        - key: pgbackrest-server.conf
+          path: ~postgres-operator_server.conf
         name: hippo-pgbackrest-config
+    - secret:
+        items:
+        - key: pgbackrest.ca-roots
+          path: ~postgres-operator/tls-ca.crt
+        - key: pgbackrest-client.crt
+          path: ~postgres-operator/client-tls.crt
+        - key: pgbackrest-client.key
+          mode: 384
+          path: ~postgres-operator/client-tls.key
+        name: hippo-pgbackrest
 		`))
 	})
 
@@ -253,7 +265,7 @@ func TestAddConfigToInstancePod(t *testing.T) {
 		AddConfigToInstancePod(cluster, out)
 		alwaysExpect(t, out)
 
-		// Instance configuration files but no certificates.
+		// Instance configuration and certificates.
 		assert.Assert(t, marshalMatches(out.Volumes, `
 - name: pgbackrest-config
   projected:
@@ -264,7 +276,19 @@ func TestAddConfigToInstancePod(t *testing.T) {
           path: pgbackrest_instance.conf
         - key: config-hash
           path: config-hash
+        - key: pgbackrest-server.conf
+          path: ~postgres-operator_server.conf
         name: hippo-pgbackrest-config
+    - secret:
+        items:
+        - key: pgbackrest.ca-roots
+          path: ~postgres-operator/tls-ca.crt
+        - key: pgbackrest-client.crt
+          path: ~postgres-operator/client-tls.crt
+        - key: pgbackrest-client.key
+          mode: 384
+          path: ~postgres-operator/client-tls.key
+        name: hippo-pgbackrest
 		`))
 	})
 
@@ -305,7 +329,6 @@ func TestAddConfigToInstancePod(t *testing.T) {
           mode: 384
           path: ~postgres-operator/client-tls.key
         name: hippo-pgbackrest
-        optional: true
 		`))
 	})
 }

--- a/internal/pgbackrest/tls-server.md
+++ b/internal/pgbackrest/tls-server.md
@@ -21,8 +21,10 @@ on different pods:
 - [dedicated repository host](https://pgbackrest.org/user-guide.html#repo-host)
 - [backup from standby](https://pgbackrest.org/user-guide.html#standby-backup)
 
-When a PostgresCluster is configured to store backups on a PVC, we start a dedicated
-repository host to make that PVC available to all PostgreSQL instances in the cluster.
+When a PostgresCluster is configured to store backups on a PVC, the dedicated
+repository host is used to make that PVC available to all PostgreSQL instances
+in the cluster. Regardless of whether the repo host has a defined PVC, it
+functions as the server for the pgBackRest clients that run on the Instances.
 
 The repository host runs a `pgbackrest` server that is secured through TLS and
 [certificates][]. When performing backups, it connects to `pgbackrest` servers

--- a/internal/pgbackrest/util.go
+++ b/internal/pgbackrest/util.go
@@ -30,9 +30,9 @@ import (
 // multi-repository solution implemented within pgBackRest
 const maxPGBackrestRepos = 4
 
-// DedicatedRepoHostEnabled determines whether not a pgBackRest dedicated repository host is
-// enabled according to the provided PostgresCluster
-func DedicatedRepoHostEnabled(postgresCluster *v1beta1.PostgresCluster) bool {
+// RepoHostVolumeDefined determines whether not at least one pgBackRest dedicated
+// repository host volume has been defined in the PostgresCluster manifest.
+func RepoHostVolumeDefined(postgresCluster *v1beta1.PostgresCluster) bool {
 	for _, repo := range postgresCluster.Spec.Backups.PGBackRest.Repos {
 		if repo.Volume != nil {
 			return true

--- a/testing/kuttl/e2e/pgbackrest-backup-standby/00--cluster.yaml
+++ b/testing/kuttl/e2e/pgbackrest-backup-standby/00--cluster.yaml
@@ -1,0 +1,28 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: pgbackrest-backup-standby
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      replicas: 1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      global:
+        backup-standby: "y"
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/testing/kuttl/e2e/pgbackrest-backup-standby/00-assert.yaml
+++ b/testing/kuttl/e2e/pgbackrest-backup-standby/00-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: pgbackrest-backup-standby
+status:
+  pgbackrest:
+    repoHost:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      ready: true
+    repos:
+    - bound: true
+      name: repo1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: pgbackrest-backup-standby
+    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo1
+status:
+  phase: Failed

--- a/testing/kuttl/e2e/pgbackrest-backup-standby/01--check-backup-logs.yaml
+++ b/testing/kuttl/e2e/pgbackrest-backup-standby/01--check-backup-logs.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# First, find at least one backup job pod.
+# Then, check the logs for the 'unable to find standby cluster' line.
+# If this line isn't found, exit 1.
+- script: |
+    retry() { bash -ceu 'printf "$1\nSleeping...\n" && sleep 5' - "$@"; }
+    contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+
+    pod=$(kubectl get pods -o name -n "${NAMESPACE}" \
+      -l postgres-operator.crunchydata.com/cluster=pgbackrest-backup-standby \
+      -l postgres-operator.crunchydata.com/pgbackrest-backup=replica-create)
+    [ "$pod" = "" ] && retry "Pod not found" && exit 1
+
+    logs=$(kubectl logs "${pod}" --namespace "${NAMESPACE}")
+    { contains "${logs}" 'unable to find standby cluster - cannot proceed'; } || {
+      echo 'did not find expected standby cluster error '
+      exit 1
+    }

--- a/testing/kuttl/e2e/pgbackrest-backup-standby/02--cluster.yaml
+++ b/testing/kuttl/e2e/pgbackrest-backup-standby/02--cluster.yaml
@@ -1,0 +1,28 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: pgbackrest-backup-standby
+spec:
+  postgresVersion: ${KUTTL_PG_VERSION}
+  instances:
+    - name: instance1
+      replicas: 2
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      global:
+        backup-standby: "y"
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/testing/kuttl/e2e/pgbackrest-backup-standby/02-assert.yaml
+++ b/testing/kuttl/e2e/pgbackrest-backup-standby/02-assert.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: pgbackrest-backup-standby
+status:
+  pgbackrest:
+    repoHost:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      ready: true
+    repos:
+    - bound: true
+      name: repo1
+      replicaCreateBackupComplete: true
+      stanzaCreated: true
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: pgbackrest-backup-standby
+    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo1
+status:
+  succeeded: 1

--- a/testing/kuttl/e2e/pgbackrest-backup-standby/README.md
+++ b/testing/kuttl/e2e/pgbackrest-backup-standby/README.md
@@ -1,0 +1,5 @@
+### pgBackRest backup-standby test
+
+* 00: Create a cluster with 'backup-standby' set to 'y' but with only one replica.
+* 01: Check the backup Job Pod logs for the expected error.
+* 02: Update the cluster to have 2 replicas and verify that the cluster can initialize successfully and the backup job can complete.


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
To support the 'backup-standby' pgBackRest configuration setting as well as to simplify the overall pgBackRest integration, this commit changes the pgBackRest repo host behavior to always be created. This allows backups to be consistently run on the repo host Pod instead of being run at times on the primary instance Pod.

Note that in cases where a repo host volume is not defined in the PostgresCluster spec, no volume will be created and pgBackRest log files will not be available in the Pod.



**Other Information**:
Issue: PGO-562