### PR TITLE
Provide a method for adding custom LDAP CA cert

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,6 +57,11 @@ linters-settings:
               k8s.io/kubernetes is for managing dependencies of the Kubernetes
               project, i.e. building kubelet and kubeadm.
 
+  gosec:
+    excludes:
+      # Flags for potentially-unsafe casting of ints, similar problem to globally-disabled G103
+      - G115
+
   importas:
     alias:
       - pkg: k8s.io/api/(\w+)/(v[\w\w]+)

--- a/internal/patroni/config.go
+++ b/internal/patroni/config.go
@@ -450,6 +450,19 @@ func instanceEnvironment(
 			Name:  "PATRONICTL_CONFIG_FILE",
 			Value: configDirectory,
 		},
+		// This allows a custom CA certificate to be mounted for Postgres LDAP
+		// authentication via spec.config.files.
+		// - https://wiki.postgresql.org/wiki/LDAP_Authentication_against_AD
+		//
+		// When setting the TLS_CACERT for LDAP as an environment variable, 'LDAP'
+		// must be appended as a prefix.
+		// - https://www.openldap.org/software/man.cgi?query=ldap.conf
+		//
+		// Testing with LDAPTLS_CACERTDIR did not work as expected during testing.
+		{
+			Name:  "LDAPTLS_CACERT",
+			Value: "/etc/postgres/ldap/ca.crt",
+		},
 	}
 
 	return variables

--- a/internal/patroni/config_test.go
+++ b/internal/patroni/config_test.go
@@ -838,6 +838,8 @@ func TestInstanceEnvironment(t *testing.T) {
   value: '*:8008'
 - name: PATRONICTL_CONFIG_FILE
   value: /etc/patroni
+- name: LDAPTLS_CACERT
+  value: /etc/postgres/ldap/ca.crt
 	`))
 
 	t.Run("MatchingPorts", func(t *testing.T) {
@@ -880,6 +882,8 @@ func TestInstanceEnvironment(t *testing.T) {
   value: '*:8008'
 - name: PATRONICTL_CONFIG_FILE
   value: /etc/patroni
+- name: LDAPTLS_CACERT
+  value: /etc/postgres/ldap/ca.crt
 		`))
 	})
 }

--- a/internal/patroni/reconcile_test.go
+++ b/internal/patroni/reconcile_test.go
@@ -184,6 +184,8 @@ containers:
     value: '*:8008'
   - name: PATRONICTL_CONFIG_FILE
     value: /etc/patroni
+  - name: LDAPTLS_CACERT
+    value: /etc/postgres/ldap/ca.crt
   livenessProbe:
     failureThreshold: 3
     httpGet:


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This update allows a custom CA cert to be mounted for Postgres LDAP authentication. This uses the existing spec.config.files method to mount a Secret containing the ca.crt file. The required path and file name is 'ldap/ca.crt'.

**Other Information**:
Issue: PGO-1000