### PR TITLE
Fix directory scanned by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: .github
     schedule:
       interval: weekly
       day: tuesday


### PR DESCRIPTION
The Dependabot [job](https://github.com/CrunchyData/postgres-operator/actions/runs/10463045154/job/28974398499) is warning:

    Please check your configuration as there are groups where no dependencies match:
    - all-github-actions


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
