### PR TITLE
Fix directory scanned by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,13 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates
+#
+# See: https://www.github.com/dependabot/dependabot-core/issues/4605
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: .github
+    directory: /
     schedule:
       interval: weekly
       day: tuesday


### PR DESCRIPTION
The Dependabot job is warning:

    Please check your configuration as there are groups where no dependencies match:
    - all-github-actions

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
