### PR TITLE
Adds Env Vars for PGAdmin Kerberos Support

### DIFF
--- a/internal/controller/standalone_pgadmin/pod.go
+++ b/internal/controller/standalone_pgadmin/pod.go
@@ -118,6 +118,19 @@ func pod(
 				Name:  "PGADMIN_LISTEN_PORT",
 				Value: fmt.Sprintf("%d", pgAdminPort),
 			},
+			// Setting the KRB5_CONFIG for kerberos
+			// - https://web.mit.edu/kerberos/krb5-current/doc/admin/conf_files/krb5_conf.html
+			{
+				Name:  "KRB5_CONFIG",
+				Value: configMountPath + "/krb5.conf",
+			},
+			// In testing it was determined that we need to set this env var for the replay cache
+			// otherwise it defaults to the read-only location `/var/tmp/`
+			// - https://web.mit.edu/kerberos/krb5-current/doc/basic/rcache_def.html#replay-cache-types
+			{
+				Name:  "KRB5RCACHEDIR",
+				Value: "/tmp",
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/internal/controller/standalone_pgadmin/pod_test.go
+++ b/internal/controller/standalone_pgadmin/pod_test.go
@@ -96,6 +96,10 @@ containers:
     value: admin@pgadmin.postgres-operator.svc
   - name: PGADMIN_LISTEN_PORT
     value: "5050"
+  - name: KRB5_CONFIG
+    value: /etc/pgadmin/conf.d/krb5.conf
+  - name: KRB5RCACHEDIR
+    value: /tmp
   name: pgadmin
   ports:
   - containerPort: 5050
@@ -279,6 +283,10 @@ containers:
     value: admin@pgadmin.postgres-operator.svc
   - name: PGADMIN_LISTEN_PORT
     value: "5050"
+  - name: KRB5_CONFIG
+    value: /etc/pgadmin/conf.d/krb5.conf
+  - name: KRB5RCACHEDIR
+    value: /tmp
   image: new-image
   imagePullPolicy: Always
   name: pgadmin


### PR DESCRIPTION
Adds the `KRB5_CONFIG` and `KRB5RCACHEDIR` env vars to pgAdmin deployments in order to add full support for Kerberos authentication via the standalone `PGAdmin` API.
