### PR TITLE
Adds the 'environment' Field to the PostgresCluster Spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ endef
 CONTROLLER ?= hack/tools/controller-gen
 tools: tools/controller-gen
 tools/controller-gen:
-	$(call go-get-tool,$(CONTROLLER),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0)
+	$(call go-get-tool,$(CONTROLLER),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.3)
 
 ENVTEST ?= hack/tools/setup-envtest
 tools: tools/setup-envtest

--- a/config/crd/bases/postgres-operator.crunchydata.com_crunchybridgeclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_crunchybridgeclusters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: pgo
     app.kubernetes.io/version: latest
@@ -45,11 +45,7 @@ spec:
               to be managed by Crunchy Data Bridge
             properties:
               clusterName:
-                description: |-
-                  The name of the cluster
-                  ---
-                  According to Bridge API/GUI errors,
-                  "Field name should be between 5 and 50 characters in length, containing only unicode characters, unicode numbers, hyphens, spaces, or underscores, and starting with a character", and ending with a character or number.
+                description: The name of the cluster
                 maxLength: 50
                 minLength: 5
                 pattern: ^[A-Za-z][A-Za-z0-9\-_ ]*[A-Za-z0-9]$
@@ -156,6 +152,7 @@ spec:
             - plan
             - provider
             - region
+            - secret
             - storage
             type: object
           status:
@@ -166,16 +163,8 @@ spec:
                 description: conditions represent the observations of postgres cluster's
                   current state.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -216,12 +205,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/crd/bases/postgres-operator.crunchydata.com_pgadmins.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_pgadmins.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: pgo
     app.kubernetes.io/version: latest
@@ -1003,13 +1003,10 @@ spec:
                             ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                             of ClusterTrustBundle objects in an auto-updating file.
 
-
                             Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                             ClusterTrustBundle objects can either be selected by name, or by the
                             combination of signer name and a label selector.
-
 
                             Kubelet performs aggressive normalization of the PEM contents written
                             into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -1594,10 +1591,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -1822,16 +1817,8 @@ spec:
                   conditions represent the observations of pgAdmin's current state.
                   Known .status.conditions.type is: "PersistentVolumeResizing"
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -1872,12 +1859,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: pgo
     app.kubernetes.io/version: latest
@@ -1028,10 +1028,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -1138,16 +1136,8 @@ spec:
                 description: conditions represent the observations of PGUpgrade's
                   current state.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -1188,12 +1178,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -7599,6 +7599,19 @@ spec:
                   scheduling constraints will be used in addition to any custom constraints
                   provided.
                 type: boolean
+              environment:
+                default: production
+                description: |-
+                  Environment allows PGO to adapt its behavior according to the specific infrastructure
+                  and/or stage of development the PostgresCluster is associated with.  This includes
+                  requiring and/or loosening the requirements for certain components and settings, while
+                  also providing deeper insights, events and status that more closely align with
+                  PostgresCluster's intended use.
+                  Defaults to “production”.  Acceptable values are "development" and "production".
+                enum:
+                - production
+                - development
+                type: string
               image:
                 description: |-
                   The image name to use for PostgreSQL containers. When omitted, the value
@@ -16874,6 +16887,10 @@ spec:
             - instances
             - postgresVersion
             type: object
+            x-kubernetes-validations:
+            - message: Backups must be enabled for production PostgresCluster's.
+              rule: '(self.environment == ''production'') ? self.backups.pgbackrest
+                != null : true'
           status:
             description: PostgresClusterStatus defines the observed state of PostgresCluster
             properties:

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -4317,6 +4317,8 @@ spec:
                     required:
                     - volumeSnapshotClassName
                     type: object
+                required:
+                - pgbackrest
                 type: object
               config:
                 properties:
@@ -16814,11 +16816,8 @@ spec:
             - postgresVersion
             type: object
             x-kubernetes-validations:
-            - fieldPath: .backups
-              message: Backups must be enabled in a production environment.
-              reason: FieldValueRequired
-              rule: '(self.environment == ''production'') ? (has(self.backups) &&
-                has(self.backups.pgbackrest)) : true'
+            - message: Backups must be enabled in a production environment.
+              rule: '(self.environment == ''production'') ? has(self.backups) : true'
           status:
             description: PostgresClusterStatus defines the observed state of PostgresCluster
             properties:

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -7602,11 +7602,9 @@ spec:
               environment:
                 default: production
                 description: |-
-                  Environment allows PGO to adapt its behavior according to the specific infrastructure
-                  and/or stage of development the PostgresCluster is associated with.  This includes
-                  requiring and/or loosening the requirements for certain components and settings, while
-                  also providing deeper insights, events and status that more closely align with
-                  PostgresCluster's intended use.
+                  Environment allows PGO to adapt its behavior according to the intended use of this cluster.
+                  This includes adjusting requirements for different components, providing deeper insights,
+                  and emitting events and status that better align with its purpose.
                   Defaults to “production”.  Acceptable values are "development" and "production".
                 enum:
                 - production
@@ -16888,9 +16886,9 @@ spec:
             - postgresVersion
             type: object
             x-kubernetes-validations:
-            - message: Backups must be enabled for production PostgresCluster's.
-              rule: '(self.environment == ''production'') ? self.backups.pgbackrest
-                != null : true'
+            - message: Backups must be enabled in a production environment.
+              rule: '(self.environment == ''production'') ? has(self.backups.pgbackrest)
+                : true'
           status:
             description: PostgresClusterStatus defines the observed state of PostgresCluster
             properties:

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -16814,9 +16814,11 @@ spec:
             - postgresVersion
             type: object
             x-kubernetes-validations:
-            - message: Backups must be enabled in a production environment.
-              rule: '(self.environment == ''production'') ? has(self.backups.pgbackrest)
-                : true'
+            - fieldPath: .backups
+              message: Backups must be enabled in a production environment.
+              reason: FieldValueRequired
+              rule: '(self.environment == ''production'') ? (has(self.backups) &&
+                has(self.backups.pgbackrest)) : true'
           status:
             description: PostgresClusterStatus defines the observed state of PostgresCluster
             properties:

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: pgo
     app.kubernetes.io/version: latest
@@ -62,13 +62,10 @@ spec:
                                 ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                 of ClusterTrustBundle objects in an auto-updating file.
 
-
                                 Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                 ClusterTrustBundle objects can either be selected by name, or by the
                                 combination of signer name and a label selector.
-
 
                                 Kubelet performs aggressive normalization of the PEM contents written
                                 into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -1340,10 +1337,8 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-
                                   This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
-
 
                                   This field is immutable. It can only be set for containers.
                                 items:
@@ -2428,10 +2423,8 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-
                                   This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
-
 
                                   This field is immutable. It can only be set for containers.
                                 items:
@@ -2695,7 +2688,6 @@ spec:
                                     Keys that don't exist in the incoming pod labels will
                                     be ignored. A null or empty list means only match against labelSelector.
 
-
                                     This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                                   items:
                                     type: string
@@ -2735,7 +2727,6 @@ spec:
                                     Valid values are integers greater than 0.
                                     When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
 
-
                                     For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
                                     labelSelector spread as 2/2/2:
                                     | zone1 | zone2 | zone3 |
@@ -2753,7 +2744,6 @@ spec:
                                     - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
                                     - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
-
                                     If this value is nil, the behavior is equivalent to the Honor policy.
                                     This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                   type: string
@@ -2764,7 +2754,6 @@ spec:
                                     - Honor: nodes without taints, along with tainted nodes for which the incoming pod
                                     has a toleration, are included.
                                     - Ignore: node taints are ignored. All nodes are included.
-
 
                                     If this value is nil, the behavior is equivalent to the Ignore policy.
                                     This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
@@ -4102,10 +4091,8 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-
                                   This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
-
 
                                   This field is immutable. It can only be set for containers.
                                 items:
@@ -4210,10 +4197,8 @@ spec:
                                       Claims lists the names of resources, defined in spec.resourceClaims,
                                       that are used by this container.
 
-
                                       This is an alpha field and requires enabling the
                                       DynamicResourceAllocation feature gate.
-
 
                                       This field is immutable. It can only be set for containers.
                                     items:
@@ -4271,10 +4256,8 @@ spec:
                                       Claims lists the names of resources, defined in spec.resourceClaims,
                                       that are used by this container.
 
-
                                       This is an alpha field and requires enabling the
                                       DynamicResourceAllocation feature gate.
-
 
                                       This field is immutable. It can only be set for containers.
                                     items:
@@ -4347,13 +4330,10 @@ spec:
                             ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                             of ClusterTrustBundle objects in an auto-updating file.
 
-
                             Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                             ClusterTrustBundle objects can either be selected by name, or by the
                             combination of signer name and a label selector.
-
 
                             Kubelet performs aggressive normalization of the PEM contents written
                             into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -5726,13 +5706,10 @@ spec:
                                 ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                 of ClusterTrustBundle objects in an auto-updating file.
 
-
                                 Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                 ClusterTrustBundle objects can either be selected by name, or by the
                                 combination of signer name and a label selector.
-
 
                                 Kubelet performs aggressive normalization of the PEM contents written
                                 into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -6352,10 +6329,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -7430,10 +7405,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -9062,10 +9035,10 @@ spec:
                                     format: int32
                                     type: integer
                                   service:
+                                    default: ""
                                     description: |-
                                       Service is the name of the service to place in the gRPC HealthCheckRequest
                                       (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                       If this is not specified, the default behavior is defined by gRPC.
                                     type: string
@@ -9277,10 +9250,10 @@ spec:
                                     format: int32
                                     type: integer
                                   service:
+                                    default: ""
                                     description: |-
                                       Service is the name of the service to place in the gRPC HealthCheckRequest
                                       (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                       If this is not specified, the default behavior is defined by gRPC.
                                     type: string
@@ -9430,10 +9403,8 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-
                                   This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
-
 
                                   This field is immutable. It can only be set for containers.
                                 items:
@@ -9731,10 +9702,10 @@ spec:
                                     format: int32
                                     type: integer
                                   service:
+                                    default: ""
                                     description: |-
                                       Service is the name of the service to place in the gRPC HealthCheckRequest
                                       (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                       If this is not specified, the default behavior is defined by gRPC.
                                     type: string
@@ -9950,9 +9921,7 @@ spec:
                                     RecursiveReadOnly specifies whether read-only mounts should be handled
                                     recursively.
 
-
                                     If ReadOnly is false, this field has no meaning and must be unspecified.
-
 
                                     If ReadOnly is true, and this field is set to Disabled, the mount is not made
                                     recursively read-only.  If this field is set to IfPossible, the mount is made
@@ -9961,10 +9930,8 @@ spec:
                                     supported by the container runtime, otherwise the pod will not be started and
                                     an error will be generated to indicate the reason.
 
-
                                     If this field is set to IfPossible or Enabled, MountPropagation must be set to
                                     None (or be unspecified, which defaults to None).
-
 
                                     If this field is not specified, it is treated as an equivalent of Disabled.
                                   type: string
@@ -10255,10 +10222,8 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-
                             This is an alpha field and requires enabling the
                             DynamicResourceAllocation feature gate.
-
 
                             This field is immutable. It can only be set for containers.
                           items:
@@ -10317,10 +10282,8 @@ spec:
                                     Claims lists the names of resources, defined in spec.resourceClaims,
                                     that are used by this container.
 
-
                                     This is an alpha field and requires enabling the
                                     DynamicResourceAllocation feature gate.
-
 
                                     This field is immutable. It can only be set for containers.
                                   items:
@@ -10702,7 +10665,6 @@ spec:
                               Keys that don't exist in the incoming pod labels will
                               be ignored. A null or empty list means only match against labelSelector.
 
-
                               This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                             items:
                               type: string
@@ -10742,7 +10704,6 @@ spec:
                               Valid values are integers greater than 0.
                               When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
 
-
                               For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
                               labelSelector spread as 2/2/2:
                               | zone1 | zone2 | zone3 |
@@ -10760,7 +10721,6 @@ spec:
                               - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
                               - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
-
                               If this value is nil, the behavior is equivalent to the Honor policy.
                               This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                             type: string
@@ -10771,7 +10731,6 @@ spec:
                               - Honor: nodes without taints, along with tainted nodes for which the incoming pod
                               has a toleration, are included.
                               - Ignore: node taints are ignored. All nodes are included.
-
 
                               If this value is nil, the behavior is equivalent to the Ignore policy.
                               This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
@@ -11069,13 +11028,10 @@ spec:
                                     ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                     of ClusterTrustBundle objects in an auto-updating file.
 
-
                                     Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                     ClusterTrustBundle objects can either be selected by name, or by the
                                     combination of signer name and a label selector.
-
 
                                     Kubelet performs aggressive normalization of the PEM contents written
                                     into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -11448,10 +11404,8 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-
                                   This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
-
 
                                   This field is immutable. It can only be set for containers.
                                 items:
@@ -12569,13 +12523,10 @@ spec:
                                     ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                     of ClusterTrustBundle objects in an auto-updating file.
 
-
                                     Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                     ClusterTrustBundle objects can either be selected by name, or by the
                                     combination of signer name and a label selector.
-
 
                                     Kubelet performs aggressive normalization of the PEM contents written
                                     into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -13377,10 +13328,10 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       description: |-
                                         Service is the name of the service to place in the gRPC HealthCheckRequest
                                         (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                         If this is not specified, the default behavior is defined by gRPC.
                                       type: string
@@ -13592,10 +13543,10 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       description: |-
                                         Service is the name of the service to place in the gRPC HealthCheckRequest
                                         (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                         If this is not specified, the default behavior is defined by gRPC.
                                       type: string
@@ -13745,10 +13696,8 @@ spec:
                                     Claims lists the names of resources, defined in spec.resourceClaims,
                                     that are used by this container.
 
-
                                     This is an alpha field and requires enabling the
                                     DynamicResourceAllocation feature gate.
-
 
                                     This field is immutable. It can only be set for containers.
                                   items:
@@ -14047,10 +13996,10 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       description: |-
                                         Service is the name of the service to place in the gRPC HealthCheckRequest
                                         (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                         If this is not specified, the default behavior is defined by gRPC.
                                       type: string
@@ -14267,9 +14216,7 @@ spec:
                                       RecursiveReadOnly specifies whether read-only mounts should be handled
                                       recursively.
 
-
                                       If ReadOnly is false, this field has no meaning and must be unspecified.
-
 
                                       If ReadOnly is true, and this field is set to Disabled, the mount is not made
                                       recursively read-only.  If this field is set to IfPossible, the mount is made
@@ -14278,10 +14225,8 @@ spec:
                                       supported by the container runtime, otherwise the pod will not be started and
                                       an error will be generated to indicate the reason.
 
-
                                       If this field is set to IfPossible or Enabled, MountPropagation must be set to
                                       None (or be unspecified, which defaults to None).
-
 
                                       If this field is not specified, it is treated as an equivalent of Disabled.
                                     type: string
@@ -14430,10 +14375,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -14536,10 +14479,8 @@ spec:
                                       Claims lists the names of resources, defined in spec.resourceClaims,
                                       that are used by this container.
 
-
                                       This is an alpha field and requires enabling the
                                       DynamicResourceAllocation feature gate.
-
 
                                       This field is immutable. It can only be set for containers.
                                     items:
@@ -14697,7 +14638,6 @@ spec:
                                 Keys that don't exist in the incoming pod labels will
                                 be ignored. A null or empty list means only match against labelSelector.
 
-
                                 This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                               items:
                                 type: string
@@ -14737,7 +14677,6 @@ spec:
                                 Valid values are integers greater than 0.
                                 When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
 
-
                                 For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
                                 labelSelector spread as 2/2/2:
                                 | zone1 | zone2 | zone3 |
@@ -14755,7 +14694,6 @@ spec:
                                 - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
                                 - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
-
                                 If this value is nil, the behavior is equivalent to the Honor policy.
                                 This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                               type: string
@@ -14766,7 +14704,6 @@ spec:
                                 - Honor: nodes without taints, along with tainted nodes for which the incoming pod
                                 has a toleration, are included.
                                 - Ignore: node taints are ignored. All nodes are included.
-
 
                                 If this value is nil, the behavior is equivalent to the Ignore policy.
                                 This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
@@ -15911,13 +15848,10 @@ spec:
                                     ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                     of ClusterTrustBundle objects in an auto-updating file.
 
-
                                     Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                     ClusterTrustBundle objects can either be selected by name, or by the
                                     combination of signer name and a label selector.
-
 
                                     Kubelet performs aggressive normalization of the PEM contents written
                                     into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -16492,10 +16426,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -16693,7 +16625,6 @@ spec:
                                 Keys that don't exist in the incoming pod labels will
                                 be ignored. A null or empty list means only match against labelSelector.
 
-
                                 This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                               items:
                                 type: string
@@ -16733,7 +16664,6 @@ spec:
                                 Valid values are integers greater than 0.
                                 When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
 
-
                                 For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
                                 labelSelector spread as 2/2/2:
                                 | zone1 | zone2 | zone3 |
@@ -16751,7 +16681,6 @@ spec:
                                 - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
                                 - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
-
                                 If this value is nil, the behavior is equivalent to the Honor policy.
                                 This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                               type: string
@@ -16762,7 +16691,6 @@ spec:
                                 - Honor: nodes without taints, along with tainted nodes for which the incoming pod
                                 has a toleration, are included.
                                 - Ignore: node taints are ignored. All nodes are included.
-
 
                                 If this value is nil, the behavior is equivalent to the Ignore policy.
                                 This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
@@ -17215,6 +17143,10 @@ spec:
                         type:
                           description: The pgBackRest backup type for this Job
                           type: string
+                      required:
+                      - cronJobName
+                      - repo
+                      - type
                       type: object
                     type: array
                 type: object

--- a/internal/patroni/rbac.go
+++ b/internal/patroni/rbac.go
@@ -12,25 +12,25 @@ import (
 )
 
 // "list", "patch", and "watch" are required. Include "get" for good measure.
-// +kubebuilder:rbac:namespace=patroni,groups="",resources="pods",verbs={get}
-// +kubebuilder:rbac:namespace=patroni,groups="",resources="pods",verbs={list,watch}
-// +kubebuilder:rbac:namespace=patroni,groups="",resources="pods",verbs={patch}
+// +kubebuilder:rbac:groups="",resources="pods",verbs={get}
+// +kubebuilder:rbac:groups="",resources="pods",verbs={list,watch}
+// +kubebuilder:rbac:groups="",resources="pods",verbs={patch}
 
 // TODO(cbandy): Separate these so that one can choose ConfigMap over Endpoints.
 
 // When using Endpoints for DCS, "create", "list", "patch", and "watch" are
 // required. Include "get" for good measure. The `patronictl scaffold` and
 // `patronictl remove` commands require "deletecollection".
-// +kubebuilder:rbac:namespace=patroni,groups="",resources="endpoints",verbs={get}
-// +kubebuilder:rbac:namespace=patroni,groups="",resources="endpoints",verbs={create,deletecollection}
-// +kubebuilder:rbac:namespace=patroni,groups="",resources="endpoints",verbs={list,watch}
-// +kubebuilder:rbac:namespace=patroni,groups="",resources="endpoints",verbs={patch}
-// +kubebuilder:rbac:namespace=patroni,groups="",resources="services",verbs={create}
+// +kubebuilder:rbac:groups="",resources="endpoints",verbs={get}
+// +kubebuilder:rbac:groups="",resources="endpoints",verbs={create,deletecollection}
+// +kubebuilder:rbac:groups="",resources="endpoints",verbs={list,watch}
+// +kubebuilder:rbac:groups="",resources="endpoints",verbs={patch}
+// +kubebuilder:rbac:groups="",resources="services",verbs={create}
 
 // The OpenShift RestrictedEndpointsAdmission plugin requires special
 // authorization to create Endpoints that contain Pod IPs.
 // - https://github.com/openshift/origin/pull/9383
-// +kubebuilder:rbac:namespace=patroni,groups="",resources="endpoints/restricted",verbs={create}
+// +kubebuilder:rbac:groups="",resources="endpoints/restricted",verbs={create}
 
 // Permissions returns the RBAC rules Patroni needs for cluster.
 func Permissions(cluster *v1beta1.PostgresCluster) []rbacv1.PolicyRule {

--- a/internal/pgbackrest/rbac.go
+++ b/internal/pgbackrest/rbac.go
@@ -11,8 +11,8 @@ import (
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
-// +kubebuilder:rbac:namespace=pgbackrest,groups="",resources="pods",verbs={list}
-// +kubebuilder:rbac:namespace=pgbackrest,groups="",resources="pods/exec",verbs={create}
+// +kubebuilder:groups="",resources="pods",verbs={list}
+// +kubebuilder:groups="",resources="pods/exec",verbs={create}
 
 // Permissions returns the RBAC rules pgBackRest needs for a cluster.
 func Permissions(cluster *v1beta1.PostgresCluster) []rbacv1.PolicyRule {

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_test.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_test.go
@@ -43,6 +43,7 @@ spec:
     pgbackrest:
       repos: null
   config: {}
+  environment: production
   instances: null
   patroni:
     leaderLeaseDurationSeconds: 30
@@ -76,6 +77,7 @@ spec:
     pgbackrest:
       repos: null
   config: {}
+  environment: production
   instances:
   - dataVolumeClaimSpec:
       resources: {}

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PostgresClusterSpec defines the desired state of PostgresCluster
-// +kubebuilder:validation:XValidation:rule="(self.environment == 'production') ? has(self.backups.pgbackrest) : true", message="Backups must be enabled in a production environment."
+// +kubebuilder:validation:XValidation:rule="(self.environment == 'production') ? (has(self.backups) && has(self.backups.pgbackrest)) : true", message="Backups must be enabled in a production environment.",fieldPath=".backups",reason="FieldValueRequired"
 type PostgresClusterSpec struct {
 	// +optional
 	Metadata *Metadata `json:"metadata,omitempty"`

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PostgresClusterSpec defines the desired state of PostgresCluster
-// +kubebuilder:validation:XValidation:rule="(self.environment == 'production') ? self.backups.pgbackrest != null : true", message="Backups must be enabled for production PostgresCluster's."
+// +kubebuilder:validation:XValidation:rule="(self.environment == 'production') ? has(self.backups.pgbackrest) : true", message="Backups must be enabled in a production environment."
 type PostgresClusterSpec struct {
 	// +optional
 	Metadata *Metadata `json:"metadata,omitempty"`
@@ -59,11 +59,9 @@ type PostgresClusterSpec struct {
 	// +optional
 	DisableDefaultPodScheduling *bool `json:"disableDefaultPodScheduling,omitempty"`
 
-	// Environment allows PGO to adapt its behavior according to the specific infrastructure
-	// and/or stage of development the PostgresCluster is associated with.  This includes
-	// requiring and/or loosening the requirements for certain components and settings, while
-	// also providing deeper insights, events and status that more closely align with
-	// PostgresCluster's intended use.
+	// Environment allows PGO to adapt its behavior according to the intended use of this cluster.
+	// This includes adjusting requirements for different components, providing deeper insights,
+	// and emitting events and status that better align with its purpose.
 	// Defaults to “production”.  Acceptable values are "development" and "production".
 	// +kubebuilder:validation:Enum={production,development}
 	// +kubebuilder:default=production

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -13,6 +13,7 @@ import (
 )
 
 // PostgresClusterSpec defines the desired state of PostgresCluster
+// +kubebuilder:validation:XValidation:rule="(self.environment == 'production') ? self.backups.pgbackrest != null : true", message="Backups must be enabled for production PostgresCluster's."
 type PostgresClusterSpec struct {
 	// +optional
 	Metadata *Metadata `json:"metadata,omitempty"`
@@ -57,6 +58,17 @@ type PostgresClusterSpec struct {
 	// provided.
 	// +optional
 	DisableDefaultPodScheduling *bool `json:"disableDefaultPodScheduling,omitempty"`
+
+	// Environment allows PGO to adapt its behavior according to the specific infrastructure
+	// and/or stage of development the PostgresCluster is associated with.  This includes
+	// requiring and/or loosening the requirements for certain components and settings, while
+	// also providing deeper insights, events and status that more closely align with
+	// PostgresCluster's intended use.
+	// Defaults to “production”.  Acceptable values are "development" and "production".
+	// +kubebuilder:validation:Enum={production,development}
+	// +kubebuilder:default=production
+	// +optional
+	Environment *string `json:"environment,omitempty"`
 
 	// The image name to use for PostgreSQL containers. When omitted, the value
 	// comes from an operator environment variable. For standard PostgreSQL images,
@@ -304,6 +316,11 @@ func (s *PostgresClusterSpec) Default() {
 
 	if s.UserInterface != nil {
 		s.UserInterface.Default()
+	}
+
+	if s.Environment == nil {
+		s.Environment = new(string)
+		*s.Environment = "production"
 	}
 }
 

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PostgresClusterSpec defines the desired state of PostgresCluster
-// +kubebuilder:validation:XValidation:rule="(self.environment == 'production') ? (has(self.backups) && has(self.backups.pgbackrest)) : true", message="Backups must be enabled in a production environment.",fieldPath=".backups",reason="FieldValueRequired"
+// +kubebuilder:validation:XValidation:rule="(self.environment == 'production') ? has(self.backups) : true", message="Backups must be enabled in a production environment."
 type PostgresClusterSpec struct {
 	// +optional
 	Metadata *Metadata `json:"metadata,omitempty"`
@@ -326,7 +326,6 @@ func (s *PostgresClusterSpec) Default() {
 type Backups struct {
 
 	// pgBackRest archive configuration
-	// +optional
 	PGBackRest PGBackRestArchive `json:"pgbackrest"`
 
 	// VolumeSnapshot configuration

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
@@ -1681,6 +1681,11 @@ func (in *PostgresClusterSpec) DeepCopyInto(out *PostgresClusterSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Environment != nil {
+		in, out := &in.Environment, &out.Environment
+		*out = new(string)
+		**out = **in
+	}
 	if in.ImagePullSecrets != nil {
 		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
 		*out = make([]corev1.LocalObjectReference, len(*in))


### PR DESCRIPTION
An `environment` field is now available within the PostgresCluster spec, which allows the user to specify the infrastructure and/or stage in development the PostgresCluster is associated with.  Accepted values for this field are `production` and `development`. `production` is the default.

Additionally, a CEL validation rule has been added to the CRD that requires backups to be configured for `production` PostgresCluster's.  This change is fully backward compatible and non-breaking with existing PostgresCluster specs.

Issue: PGO-1645