### PR TITLE
Keep pgAdmin configuration writable

### DIFF
--- a/internal/controller/standalone_pgadmin/pod.go
+++ b/internal/controller/standalone_pgadmin/pod.go
@@ -430,12 +430,11 @@ with open('` + configMountPath + `/` + gunicornConfigFilePath + `') as _f:
 
 	script := strings.Join([]string{
 		// Use the initContainer to create this path to avoid the error noted here:
-		// - https://github.com/kubernetes/kubernetes/issues/121294
-		`mkdir -p /etc/pgadmin/conf.d`,
-		// Write the system configuration into a read-only file.
-		`(umask a-w && echo "$1" > ` + scriptMountPath + `/config_system.py` + `)`,
-		// Write the server configuration into a read-only file.
-		`(umask a-w && echo "$2" > ` + scriptMountPath + `/gunicorn_config.py` + `)`,
+		// - https://issue.k8s.io/121294
+		`mkdir -p ` + configMountPath,
+		// Write the system and server configurations.
+		`echo "$1" > ` + scriptMountPath + `/config_system.py`,
+		`echo "$2" > ` + scriptMountPath + `/gunicorn_config.py`,
 	}, "\n")
 
 	return append([]string{"bash", "-ceu", "--", script, "startup"}, args...)

--- a/internal/controller/standalone_pgadmin/pod_test.go
+++ b/internal/controller/standalone_pgadmin/pod_test.go
@@ -139,8 +139,8 @@ initContainers:
   - --
   - |-
     mkdir -p /etc/pgadmin/conf.d
-    (umask a-w && echo "$1" > /etc/pgadmin/config_system.py)
-    (umask a-w && echo "$2" > /etc/pgadmin/gunicorn_config.py)
+    echo "$1" > /etc/pgadmin/config_system.py
+    echo "$2" > /etc/pgadmin/gunicorn_config.py
   - startup
   - |
     import glob, json, re, os
@@ -328,8 +328,8 @@ initContainers:
   - --
   - |-
     mkdir -p /etc/pgadmin/conf.d
-    (umask a-w && echo "$1" > /etc/pgadmin/config_system.py)
-    (umask a-w && echo "$2" > /etc/pgadmin/gunicorn_config.py)
+    echo "$1" > /etc/pgadmin/config_system.py
+    echo "$2" > /etc/pgadmin/gunicorn_config.py
   - startup
   - |
     import glob, json, re, os


### PR DESCRIPTION
The init container should have permission to write and replace these files. Kubernetes ensures the application container cannot write to them.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix


**What is the current behavior (link to any open issues here)?**

In some environments, the init container will fail with `line 1: /etc/pgadmin/config_system.py: Permission denied`.

**Other Information**:

Issue: PGO-1280