### PR TITLE
Use the upstream Trivy action to scan licenses

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -19,31 +19,15 @@ jobs:
         with: { go-version: stable }
       - run: go mod download
 
-      # Login to the GitHub Packages registry to avoid rate limiting.
-      # - https://aquasecurity.github.io/trivy/v0.55/docs/references/troubleshooting/#github-rate-limiting
-      # - https://github.com/aquasecurity/trivy/issues/7580
-      # - https://github.com/aquasecurity/trivy-action/issues/389
-      # - https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
-      # - https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions
-      - name: Login to GitHub Packages
-        run: >
-          docker login ghcr.io
-          --username '${{ github.actor }}'
-          --password-stdin <<< '${{ secrets.GITHUB_TOKEN }}'
-
       # Report success only when detected licenses are listed in [/trivy.yaml].
-      # The "aquasecurity/trivy-action" action cannot access the Go module cache,
-      # so run Trivy from an image with the cache and local configuration mounted.
-      # - https://github.com/aquasecurity/trivy-action/issues/219
-      # - https://github.com/aquasecurity/trivy/pkgs/container/trivy
       - name: Scan licenses
-        run: >
-          docker run
-          --env 'DOCKER_CONFIG=/docker' --volume "${HOME}/.docker:/docker"
-          --env 'GOPATH=/go' --volume "$(go env GOPATH):/go"
-          --workdir '/mnt' --volume "$(pwd):/mnt"
-          'ghcr.io/aquasecurity/trivy:latest'
-          filesystem --debug --exit-code=1 --scanners=license .
+        uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DEBUG: true
+        with:
+          scan-type: filesystem
+          scanners: license
+          exit-code: 1
 
   vulnerabilities:
     if: ${{ github.repository == 'CrunchyData/postgres-operator' }}

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -21,7 +21,7 @@ jobs:
 
       # Report success only when detected licenses are listed in [/trivy.yaml].
       - name: Scan licenses
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.26.0
         env:
           TRIVY_DEBUG: true
         with:
@@ -46,7 +46,7 @@ jobs:
       # and is a convenience/redundant effort for those who prefer to
       # read logs and/or if anything goes wrong with the upload.
       - name: Log all detected vulnerabilities
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.26.0
         with:
           scan-type: filesystem
           hide-progress: true
@@ -58,7 +58,7 @@ jobs:
       # - https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github
       # - https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning
       - name: Report actionable vulnerabilities
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.26.0
         with:
           scan-type: filesystem
           ignore-unfixed: true


### PR DESCRIPTION
The upstream action no longer runs in a container, so it can access the job environment and Go modules. The license job no longer needs any `ghcr.io` package, so it is no longer affected by the recent rate limiting issues.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
