### PR TITLE
Remove json:omitempty from required fields

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_crunchybridgeclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_crunchybridgeclusters.yaml
@@ -156,6 +156,7 @@ spec:
             - plan
             - provider
             - region
+            - secret
             - storage
             type: object
           status:

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -549,8 +549,9 @@ func (r *Reconciler) setScheduledJobStatus(ctx context.Context,
 	for _, job := range jobList.Items {
 		// we only care about the scheduled backup Jobs created by the
 		// associated CronJobs
-		sbs := v1beta1.PGBackRestScheduledBackupStatus{}
 		if job.GetLabels()[naming.LabelPGBackRestCronJob] != "" {
+			sbs := v1beta1.PGBackRestScheduledBackupStatus{}
+
 			if len(job.OwnerReferences) > 0 {
 				sbs.CronJobName = job.OwnerReferences[0].Name
 			}

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/crunchy_bridgecluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/crunchy_bridgecluster_types.go
@@ -23,7 +23,7 @@ type CrunchyBridgeClusterSpec struct {
 
 	// Whether the cluster is protected. Protected clusters can't be destroyed until
 	// their protected flag is removed
-	// +optional
+	// +kubebuilder:validation:Optional
 	IsProtected bool `json:"isProtected,omitempty"`
 
 	// The name of the cluster
@@ -65,14 +65,14 @@ type CrunchyBridgeClusterSpec struct {
 	// are retrieved from the Bridge API. An empty list creates no role secrets.
 	// Removing a role from this list does NOT drop the role nor revoke their
 	// access, but it will delete that role's secret from the kube cluster.
+	// +kubebuilder:validation:Optional
 	// +listType=map
 	// +listMapKey=name
-	// +optional
 	Roles []*CrunchyBridgeClusterRoleSpec `json:"roles,omitempty"`
 
 	// The name of the secret containing the API key and team id
 	// +kubebuilder:validation:Required
-	Secret string `json:"secret,omitempty"`
+	Secret string `json:"secret"`
 
 	// The amount of storage available to the cluster in gigabytes.
 	// The amount must be an integer, followed by Gi (gibibytes) or G (gigabytes) to match Kubernetes conventions.
@@ -86,9 +86,11 @@ type CrunchyBridgeClusterSpec struct {
 type CrunchyBridgeClusterRoleSpec struct {
 	// Name of the role within Crunchy Bridge.
 	// More info: https://docs.crunchybridge.com/concepts/users
+	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
 	// The name of the Secret that will hold the role credentials.
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Type=string

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbackrest_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbackrest_types.go
@@ -49,15 +49,15 @@ type PGBackRestJobStatus struct {
 type PGBackRestScheduledBackupStatus struct {
 
 	// The name of the associated pgBackRest scheduled backup CronJob
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	CronJobName string `json:"cronJobName,omitempty"`
 
 	// The name of the associated pgBackRest repository
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	RepoName string `json:"repo,omitempty"`
 
 	// The pgBackRest backup type for this Job
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	Type string `json:"type,omitempty"`
 
 	// Represents the time the manual backup Job was acknowledged by the Job controller.


### PR DESCRIPTION
The version of controller-gen we use ignores `validation:Required` markers when the struct tag has `json:"omitempty"`.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix

**Other Information**:

Issue: PGO-1748