### PR TITLE
Update field manager for deployment id / configmap

### DIFF
--- a/internal/upgradecheck/header.go
+++ b/internal/upgradecheck/header.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/crunchydata/postgres-operator/internal/controller/postgrescluster"
 	"github.com/crunchydata/postgres-operator/internal/feature"
 	"github.com/crunchydata/postgres-operator/internal/logging"
 	"github.com/crunchydata/postgres-operator/internal/naming"
@@ -128,7 +129,7 @@ func manageUpgradeCheckConfigMap(ctx context.Context, crClient crclient.Client,
 		}
 	}
 
-	err = applyConfigMap(ctx, crClient, cm, currentID)
+	err = applyConfigMap(ctx, crClient, cm, postgrescluster.ControllerName)
 	if err != nil {
 		log.V(1).Info("upgrade check issue: could not apply configmap",
 			"response", err.Error())


### PR DESCRIPTION
For some reason, this was originally created without PGO listed as the manager for the configmap used by upgrade check.
