### PR TITLE
Check that snapshot.Status is not nil when checking Status properties.

### DIFF
--- a/internal/controller/postgrescluster/snapshots.go
+++ b/internal/controller/postgrescluster/snapshots.go
@@ -103,7 +103,7 @@ func (r *Reconciler) reconcileVolumeSnapshots(ctx context.Context,
 		r.Recorder.Event(postgrescluster, corev1.EventTypeWarning, "VolumeSnapshotError",
 			*snapshotWithLatestError.Status.Error.Message)
 		for _, snapshot := range snapshots.Items {
-			if snapshot.Status.Error != nil &&
+			if snapshot.Status != nil && snapshot.Status.Error != nil &&
 				snapshot.Status.Error.Time.Before(snapshotWithLatestError.Status.Error.Time) {
 				err = r.deleteControlled(ctx, postgrescluster, &snapshot)
 				if err != nil {
@@ -537,7 +537,7 @@ func getSnapshotWithLatestError(snapshots *volumesnapshotv1.VolumeSnapshotList) 
 		},
 	}
 	for _, snapshot := range snapshots.Items {
-		if snapshot.Status.Error != nil &&
+		if snapshot.Status != nil && snapshot.Status.Error != nil &&
 			snapshotWithLatestError.Status.Error.Time.Before(snapshot.Status.Error.Time) {
 			snapshotWithLatestError = snapshot
 		}
@@ -577,7 +577,7 @@ func getLatestReadySnapshot(snapshots *volumesnapshotv1.VolumeSnapshotList) *vol
 		},
 	}
 	for _, snapshot := range snapshots.Items {
-		if snapshot.Status.ReadyToUse != nil && *snapshot.Status.ReadyToUse &&
+		if snapshot.Status != nil && snapshot.Status.ReadyToUse != nil && *snapshot.Status.ReadyToUse &&
 			latestReadySnapshot.Status.CreationTime.Before(snapshot.Status.CreationTime) {
 			latestReadySnapshot = snapshot
 		}

--- a/internal/controller/postgrescluster/snapshots_test.go
+++ b/internal/controller/postgrescluster/snapshots_test.go
@@ -978,6 +978,17 @@ func TestGetSnapshotWithLatestError(t *testing.T) {
 		assert.Check(t, snapshotWithLatestError == nil)
 	})
 
+	t.Run("NoSnapshotsWithStatus", func(t *testing.T) {
+		snapshotList := &volumesnapshotv1.VolumeSnapshotList{
+			Items: []volumesnapshotv1.VolumeSnapshot{
+				{},
+				{},
+			},
+		}
+		snapshotWithLatestError := getSnapshotWithLatestError(snapshotList)
+		assert.Check(t, snapshotWithLatestError == nil)
+	})
+
 	t.Run("NoSnapshotsWithErrors", func(t *testing.T) {
 		snapshotList := &volumesnapshotv1.VolumeSnapshotList{
 			Items: []volumesnapshotv1.VolumeSnapshot{
@@ -1199,6 +1210,17 @@ func TestGetSnapshotsForCluster(t *testing.T) {
 func TestGetLatestReadySnapshot(t *testing.T) {
 	t.Run("NoSnapshots", func(t *testing.T) {
 		snapshotList := &volumesnapshotv1.VolumeSnapshotList{}
+		latestReadySnapshot := getLatestReadySnapshot(snapshotList)
+		assert.Assert(t, latestReadySnapshot == nil)
+	})
+
+	t.Run("NoSnapshotsWithStatus", func(t *testing.T) {
+		snapshotList := &volumesnapshotv1.VolumeSnapshotList{
+			Items: []volumesnapshotv1.VolumeSnapshot{
+				{},
+				{},
+			},
+		}
 		latestReadySnapshot := getLatestReadySnapshot(snapshotList)
 		assert.Assert(t, latestReadySnapshot == nil)
 	})


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

We currently don't check that a snapshot's Status isn't nil when checking Status properties. There is an edge case where a snapshot does not yet have a `Status` which can lead to a nil pointer dereference.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

We now check for the existence of `snapshot.Status` when checking a snapshot's Status properties.

**Other Information**:
