### PR TITLE
Enable the "errchkjson" linter

### DIFF
--- a/.golangci.next.yaml
+++ b/.golangci.next.yaml
@@ -26,6 +26,12 @@ linters:
     - wastedassign
 
 issues:
+  exclude-rules:
+    # We call external linters when they are installed: Flake8, ShellCheck, etc.
+    - linters: [gosec]
+      path: '_test[.]go$'
+      text: 'G204: Subprocess launched with variable'
+
   # https://github.com/golangci/golangci-lint/issues/2239
   exclude-use-default: false
 

--- a/.golangci.next.yaml
+++ b/.golangci.next.yaml
@@ -10,7 +10,6 @@ linters:
   enable:
     - contextcheck
     - err113
-    - errchkjson
     - gocritic
     - godot
     - godox
@@ -31,9 +30,6 @@ issues:
   exclude-use-default: false
 
 linters-settings:
-  errchkjson:
-    check-error-free-encoding: true
-
   thelper:
     # https://github.com/kulti/thelper/issues/27
     tb:   { begin: true, first: true }

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,7 +3,6 @@
 linters:
   disable:
     - contextcheck
-    - errchkjson
     - gci
     - gofumpt
   enable:
@@ -40,6 +39,9 @@ linters-settings:
 
           - pkg: github.com/crunchydata/postgres-operator/internal/testing/*
             desc: The "internal/testing" packages should be used only in tests.
+
+  errchkjson:
+    check-error-free-encoding: true
 
   exhaustive:
     default-signifies-exhaustive: true

--- a/internal/bridge/client.go
+++ b/internal/bridge/client.go
@@ -724,10 +724,7 @@ func (c *Client) UpdateCluster(
 ) (*ClusterApiResource, error) {
 	result := &ClusterApiResource{}
 
-	clusterbyte, err := json.Marshal(clusterRequestPayload)
-	if err != nil {
-		return result, err
-	}
+	clusterbyte, _ := json.Marshal(clusterRequestPayload)
 
 	response, err := c.doWithRetry(ctx, "PATCH", "/clusters/"+id, nil, clusterbyte, http.Header{
 		"Accept":        []string{"application/json"},

--- a/internal/controller/postgrescluster/patroni_test.go
+++ b/internal/controller/postgrescluster/patroni_test.go
@@ -539,17 +539,17 @@ func TestReconcilePatroniSwitchover(t *testing.T) {
 			switch {
 			case timelineCall:
 				timelineCall = false
-				stdout.Write([]byte(`[{"Cluster": "hippo-ha", "Member": "hippo-instance1-67mc-0", "Host": "hippo-instance1-67mc-0.hippo-pods", "Role": "Leader", "State": "running", "TL": 4}, {"Cluster": "hippo-ha", "Member": "hippo-instance1-ltcf-0", "Host": "hippo-instance1-ltcf-0.hippo-pods", "Role": "Replica", "State": "running", "TL": 4, "Lag in MB": 0}]`))
+				_, _ = stdout.Write([]byte(`[{"Cluster": "hippo-ha", "Member": "hippo-instance1-67mc-0", "Host": "hippo-instance1-67mc-0.hippo-pods", "Role": "Leader", "State": "running", "TL": 4}, {"Cluster": "hippo-ha", "Member": "hippo-instance1-ltcf-0", "Host": "hippo-instance1-ltcf-0.hippo-pods", "Role": "Replica", "State": "running", "TL": 4, "Lag in MB": 0}]`))
 			case timelineCallNoLeader:
-				stdout.Write([]byte(`[{"Cluster": "hippo-ha", "Member": "hippo-instance1-ltcf-0", "Host": "hippo-instance1-ltcf-0.hippo-pods", "Role": "Replica", "State": "running", "TL": 4, "Lag in MB": 0}]`))
+				_, _ = stdout.Write([]byte(`[{"Cluster": "hippo-ha", "Member": "hippo-instance1-ltcf-0", "Host": "hippo-instance1-ltcf-0.hippo-pods", "Role": "Replica", "State": "running", "TL": 4, "Lag in MB": 0}]`))
 			case callError:
 				return errors.New("boom")
 			case callFails:
-				stdout.Write([]byte("bang"))
+				_, _ = stdout.Write([]byte("bang"))
 			case failover:
-				stdout.Write([]byte("failed over"))
+				_, _ = stdout.Write([]byte("failed over"))
 			default:
-				stdout.Write([]byte("switched over"))
+				_, _ = stdout.Write([]byte("switched over"))
 			}
 			return nil
 		},

--- a/internal/controller/standalone_pgadmin/users.go
+++ b/internal/controller/standalone_pgadmin/users.go
@@ -293,11 +293,7 @@ cd $PGADMIN_DIR
 	// to add a user, that user will not be in intentUsers. If errors occurred when attempting to
 	// update a user, the user will be in intentUsers as it existed before. We now want to marshal the
 	// intentUsers to json and write the users.json file to the secret.
-	usersJSON, err := json.Marshal(intentUsers)
-	if err != nil {
-		return err
-	}
-	intentUserSecret.Data["users.json"] = usersJSON
+	intentUserSecret.Data["users.json"], _ = json.Marshal(intentUsers)
 
 	err = errors.WithStack(r.setControllerReference(pgadmin, intentUserSecret))
 	if err == nil {

--- a/internal/controller/standalone_pgadmin/users_test.go
+++ b/internal/controller/standalone_pgadmin/users_test.go
@@ -112,7 +112,7 @@ func TestReconcilePGAdminUsers(t *testing.T) {
 
 			// Simulate a v7 version of pgAdmin by setting stdout to "7" for
 			// podexec call in reconcilePGAdminMajorVersion
-			stdout.Write([]byte("7"))
+			_, _ = stdout.Write([]byte("7"))
 			return nil
 		}
 
@@ -147,7 +147,7 @@ func TestReconcilePGAdminUsers(t *testing.T) {
 
 			// Simulate a v7 version of pgAdmin by setting stdout to "7" for
 			// podexec call in reconcilePGAdminMajorVersion
-			stdout.Write([]byte("7"))
+			_, _ = stdout.Write([]byte("7"))
 			return nil
 		}
 
@@ -182,7 +182,7 @@ func TestReconcilePGAdminMajorVersion(t *testing.T) {
 
 			// Simulate a v7 version of pgAdmin by setting stdout to "7" for
 			// podexec call in reconcilePGAdminMajorVersion
-			stdout.Write([]byte("7"))
+			_, _ = stdout.Write([]byte("7"))
 			return nil
 		}
 
@@ -197,7 +197,7 @@ func TestReconcilePGAdminMajorVersion(t *testing.T) {
 			stdin io.Reader, stdout, stderr io.Writer, command ...string,
 		) error {
 			// Simulate the python call giving bad data (not a version int)
-			stdout.Write([]byte("asdfjkl;"))
+			_, _ = stdout.Write([]byte("asdfjkl;"))
 			return nil
 		}
 
@@ -547,7 +547,7 @@ func TestWritePGAdminUsers(t *testing.T) {
 		) error {
 			calls++
 
-			stderr.Write([]byte("issue running setup.py update-user command"))
+			_, _ = stderr.Write([]byte("issue running setup.py update-user command"))
 
 			return nil
 		}
@@ -627,7 +627,7 @@ func TestWritePGAdminUsers(t *testing.T) {
 		) error {
 			calls++
 
-			stderr.Write([]byte("issue running setup.py add-user command"))
+			_, _ = stderr.Write([]byte("issue running setup.py add-user command"))
 
 			return nil
 		}
@@ -655,7 +655,7 @@ func TestWritePGAdminUsers(t *testing.T) {
 		) error {
 			calls++
 
-			stdout.Write([]byte("Invalid email address"))
+			_, _ = stdout.Write([]byte("Invalid email address"))
 
 			return nil
 		}
@@ -684,7 +684,7 @@ func TestWritePGAdminUsers(t *testing.T) {
 		) error {
 			calls++
 
-			stdout.Write([]byte("Password must be at least 6 characters long"))
+			_, _ = stdout.Write([]byte("Password must be at least 6 characters long"))
 
 			return nil
 		}

--- a/internal/patroni/api_test.go
+++ b/internal/patroni/api_test.go
@@ -243,7 +243,7 @@ func TestExecutorGetTimeline(t *testing.T) {
 		tl, actual := Executor(func(
 			_ context.Context, stdin io.Reader, stdout, stderr io.Writer, command ...string,
 		) error {
-			stderr.Write([]byte(`no luck`))
+			_, _ = stderr.Write([]byte(`no luck`))
 			return nil
 		}).GetTimeline(context.Background())
 
@@ -255,7 +255,7 @@ func TestExecutorGetTimeline(t *testing.T) {
 		tl, actual := Executor(func(
 			_ context.Context, stdin io.Reader, stdout, stderr io.Writer, command ...string,
 		) error {
-			stdout.Write([]byte(`no luck`))
+			_, _ = stdout.Write([]byte(`no luck`))
 			return nil
 		}).GetTimeline(context.Background())
 
@@ -267,7 +267,7 @@ func TestExecutorGetTimeline(t *testing.T) {
 		tl, actual := Executor(func(
 			_ context.Context, stdin io.Reader, stdout, stderr io.Writer, command ...string,
 		) error {
-			stdout.Write([]byte(`[{"Cluster": "hippo-ha", "Member": "hippo-instance1-ltcf-0", "Host": "hippo-instance1-ltcf-0.hippo-pods", "Role": "Replica", "State": "running", "TL": 4, "Lag in MB": 0}]`))
+			_, _ = stdout.Write([]byte(`[{"Cluster": "hippo-ha", "Member": "hippo-instance1-ltcf-0", "Host": "hippo-instance1-ltcf-0.hippo-pods", "Role": "Replica", "State": "running", "TL": 4, "Lag in MB": 0}]`))
 			return nil
 		}).GetTimeline(context.Background())
 
@@ -279,7 +279,7 @@ func TestExecutorGetTimeline(t *testing.T) {
 		tl, actual := Executor(func(
 			_ context.Context, stdin io.Reader, stdout, stderr io.Writer, command ...string,
 		) error {
-			stdout.Write([]byte(`[{"Cluster": "hippo-ha", "Member": "hippo-instance1-67mc-0", "Host": "hippo-instance1-67mc-0.hippo-pods", "Role": "Leader", "State": "running", "TL": 4}, {"Cluster": "hippo-ha", "Member": "hippo-instance1-ltcf-0", "Host": "hippo-instance1-ltcf-0.hippo-pods", "Role": "Replica", "State": "running", "TL": 4, "Lag in MB": 0}]`))
+			_, _ = stdout.Write([]byte(`[{"Cluster": "hippo-ha", "Member": "hippo-instance1-67mc-0", "Host": "hippo-instance1-67mc-0.hippo-pods", "Role": "Leader", "State": "running", "TL": 4}, {"Cluster": "hippo-ha", "Member": "hippo-instance1-ltcf-0", "Host": "hippo-instance1-ltcf-0.hippo-pods", "Role": "Replica", "State": "running", "TL": 4, "Lag in MB": 0}]`))
 			return nil
 		}).GetTimeline(context.Background())
 

--- a/internal/upgradecheck/header.go
+++ b/internal/upgradecheck/header.go
@@ -209,11 +209,8 @@ func getServerVersion(ctx context.Context, cfg *rest.Config) string {
 	return versionInfo.String()
 }
 
-func addHeader(req *http.Request, upgradeInfo *clientUpgradeData) (*http.Request, error) {
-	marshaled, err := json.Marshal(upgradeInfo)
-	if err == nil {
-		upgradeInfoString := string(marshaled)
-		req.Header.Add(clientHeader, upgradeInfoString)
-	}
-	return req, err
+func addHeader(req *http.Request, upgradeInfo *clientUpgradeData) *http.Request {
+	marshaled, _ := json.Marshal(upgradeInfo)
+	req.Header.Add(clientHeader, string(marshaled))
+	return req
 }

--- a/internal/upgradecheck/header_test.go
+++ b/internal/upgradecheck/header_test.go
@@ -596,12 +596,11 @@ func TestAddHeader(t *testing.T) {
 			PGOVersion: versionString,
 		}
 
-		result, err := addHeader(req, upgradeInfo)
-		assert.NilError(t, err)
+		result := addHeader(req, upgradeInfo)
 		header := result.Header[clientHeader]
 
 		passedThroughData := &clientUpgradeData{}
-		err = json.Unmarshal([]byte(header[0]), passedThroughData)
+		err := json.Unmarshal([]byte(header[0]), passedThroughData)
 		assert.NilError(t, err)
 
 		assert.Equal(t, passedThroughData.PGOVersion, "1.2.3")

--- a/internal/upgradecheck/http.go
+++ b/internal/upgradecheck/http.go
@@ -77,7 +77,7 @@ func checkForUpgrades(ctx context.Context, url, versionString string, backoff wa
 		// in case some of the checks return errors
 		headerPayloadStruct = generateHeader(ctx, cfg, crclient,
 			versionString, isOpenShift, registrationToken)
-		req, err = addHeader(req, headerPayloadStruct)
+		req = addHeader(req, headerPayloadStruct)
 	}
 
 	// wait.ExponentialBackoff will retry the func according to the backoff object until


### PR DESCRIPTION
This is part of the `bugs` preset of golangci-lint. I want to enable this entire preset eventually.

The `check-error-free-encoding` setting is recommended upstream and simplifies code where `json.Marshal` is known to succeed.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
 - [x] Other
