### PR TITLE
Create warning event when postgres version is EOL.

### DIFF
--- a/internal/postgres/versions.go
+++ b/internal/postgres/versions.go
@@ -1,0 +1,26 @@
+// Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import "time"
+
+// https://www.postgresql.org/support/versioning
+var finalReleaseDates = map[int]time.Time{
+	10: time.Date(2022, time.November+1, 10, 0, 0, 0, 0, time.UTC),
+	11: time.Date(2023, time.November+1, +9, 0, 0, 0, 0, time.UTC),
+	12: time.Date(2024, time.November+1, 14, 0, 0, 0, 0, time.UTC),
+	13: time.Date(2025, time.November+1, 13, 0, 0, 0, 0, time.UTC),
+	14: time.Date(2026, time.November+1, 12, 0, 0, 0, 0, time.UTC),
+	15: time.Date(2027, time.November+1, 11, 0, 0, 0, 0, time.UTC),
+	16: time.Date(2028, time.November+1, +9, 0, 0, 0, 0, time.UTC),
+	17: time.Date(2029, time.November+1, +8, 0, 0, 0, 0, time.UTC),
+}
+
+// ReleaseIsFinal returns whether or not t is definitively past the final
+// scheduled release of a Postgres version.
+func ReleaseIsFinal(majorVersion int, t time.Time) bool {
+	known, ok := finalReleaseDates[majorVersion]
+	return ok && t.After(known)
+}

--- a/internal/postgres/versions_test.go
+++ b/internal/postgres/versions_test.go
@@ -1,0 +1,34 @@
+// Copyright 2021 - 2024 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestReleaseIsFinal(t *testing.T) {
+	// On November 4th, 2024, PG 10 and 11 were EOL and 12-17 were supported.
+	testDate, err := time.Parse("2006-Jan-02", "2024-Nov-04")
+	assert.NilError(t, err)
+	assert.Check(t, ReleaseIsFinal(10, testDate))
+	assert.Check(t, ReleaseIsFinal(11, testDate))
+	assert.Check(t, !ReleaseIsFinal(12, testDate))
+	assert.Check(t, !ReleaseIsFinal(13, testDate))
+	assert.Check(t, !ReleaseIsFinal(14, testDate))
+	assert.Check(t, !ReleaseIsFinal(15, testDate))
+	assert.Check(t, !ReleaseIsFinal(16, testDate))
+	assert.Check(t, !ReleaseIsFinal(17, testDate))
+
+	// On December 15th, 2024 we alert that PG 12 is EOL
+	testDate = testDate.AddDate(0, 1, 11)
+	assert.Check(t, ReleaseIsFinal(12, testDate))
+
+	// ReleaseIsFinal covers PG versions 10 and greater. Any version not covered
+	// by the case statement in ReleaseIsFinal returns false
+	assert.Check(t, !ReleaseIsFinal(1, testDate))
+}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

When a user has a postgrescluster that is using an End-Of-Life version of postgres, we don't warn them.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

We add a warning event to the postgrescluster if the postgres version is End-Of-Life.

**Other Information**:
