### PR TITLE
Add a Runner that watches for Kubernetes APIs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,6 +40,9 @@ linters-settings:
           - pkg: github.com/crunchydata/postgres-operator/internal/testing/*
             desc: The "internal/testing" packages should be used only in tests.
 
+          - pkg: k8s.io/client-go/discovery
+            desc: Use the "internal/kubernetes" package instead.
+
       tests:
         files: ['$test']
         deny:
@@ -93,6 +96,11 @@ linters-settings:
 issues:
   exclude-generated: strict
   exclude-rules:
+    # This internal package is the one place we want to do API discovery.
+    - linters: [depguard]
+      path: internal/kubernetes/discovery.go
+      text: k8s.io/client-go/discovery
+
     # These value types have unmarshal methods.
     # https://github.com/raeperd/recvcheck/issues/7
     - linters: [recvcheck]

--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -174,7 +174,7 @@ func main() {
 	token, _ := registrar.CheckToken()
 
 	// add all PostgreSQL Operator controllers to the runtime manager
-	addControllersToManager(mgr, k8s.IsOpenShift(), log, registrar)
+	addControllersToManager(mgr, log, registrar)
 
 	if features.Enabled(feature.BridgeIdentifiers) {
 		constructor := func() *bridge.Client {
@@ -214,10 +214,9 @@ func main() {
 
 // addControllersToManager adds all PostgreSQL Operator controllers to the provided controller
 // runtime manager.
-func addControllersToManager(mgr runtime.Manager, openshift bool, log logging.Logger, reg registration.Registration) {
+func addControllersToManager(mgr runtime.Manager, log logging.Logger, reg registration.Registration) {
 	pgReconciler := &postgrescluster.Reconciler{
 		Client:       mgr.GetClient(),
-		IsOpenShift:  openshift,
 		Owner:        postgrescluster.ControllerName,
 		Recorder:     mgr.GetEventRecorderFor(postgrescluster.ControllerName),
 		Registration: reg,
@@ -242,10 +241,9 @@ func addControllersToManager(mgr runtime.Manager, openshift bool, log logging.Lo
 	}
 
 	pgAdminReconciler := &standalone_pgadmin.PGAdminReconciler{
-		Client:      mgr.GetClient(),
-		Owner:       "pgadmin-controller",
-		Recorder:    mgr.GetEventRecorderFor(naming.ControllerPGAdmin),
-		IsOpenShift: openshift,
+		Client:   mgr.GetClient(),
+		Owner:    "pgadmin-controller",
+		Recorder: mgr.GetEventRecorderFor(naming.ControllerPGAdmin),
 	}
 
 	if err := pgAdminReconciler.SetupWithManager(mgr); err != nil {

--- a/internal/controller/standalone_pgadmin/controller.go
+++ b/internal/controller/standalone_pgadmin/controller.go
@@ -30,8 +30,7 @@ type PGAdminReconciler struct {
 		ctx context.Context, namespace, pod, container string,
 		stdin io.Reader, stdout, stderr io.Writer, command ...string,
 	) error
-	Recorder    record.EventRecorder
-	IsOpenShift bool
+	Recorder record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="pgadmins",verbs={list,watch}

--- a/internal/controller/standalone_pgadmin/statefulset.go
+++ b/internal/controller/standalone_pgadmin/statefulset.go
@@ -25,7 +25,7 @@ func (r *PGAdminReconciler) reconcilePGAdminStatefulSet(
 	ctx context.Context, pgadmin *v1beta1.PGAdmin,
 	configmap *corev1.ConfigMap, dataVolume *corev1.PersistentVolumeClaim,
 ) error {
-	sts := statefulset(r, pgadmin, configmap, dataVolume)
+	sts := statefulset(ctx, pgadmin, configmap, dataVolume)
 
 	// Previous versions of PGO used a StatefulSet Pod Management Policy that could leave the Pod
 	// in a failed state. When we see that it has the wrong policy, we will delete the StatefulSet
@@ -58,7 +58,7 @@ func (r *PGAdminReconciler) reconcilePGAdminStatefulSet(
 
 // statefulset defines the StatefulSet needed to run pgAdmin.
 func statefulset(
-	r *PGAdminReconciler,
+	ctx context.Context,
 	pgadmin *v1beta1.PGAdmin,
 	configmap *corev1.ConfigMap,
 	dataVolume *corev1.PersistentVolumeClaim,
@@ -115,7 +115,7 @@ func statefulset(
 	// set the image pull secrets, if any exist
 	sts.Spec.Template.Spec.ImagePullSecrets = pgadmin.Spec.ImagePullSecrets
 
-	sts.Spec.Template.Spec.SecurityContext = podSecurityContext(r)
+	sts.Spec.Template.Spec.SecurityContext = podSecurityContext(ctx)
 
 	pod(pgadmin, configmap, &sts.Spec.Template.Spec, dataVolume)
 

--- a/internal/kubernetes/apis.go
+++ b/internal/kubernetes/apis.go
@@ -1,0 +1,60 @@
+// Copyright 2024 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// API is a combination of Group, Version, and Kind that can be used to check
+// what is available in the Kubernetes API. There are four ways to populate it:
+//  1. Group without Version nor Kind means any resource in that Group.
+//  2. Group with Version but no Kind means any resource in that GV.
+//  3. Group with Kind but no Version means that Kind in any Version of the Group.
+//  4. Group with Version and Kind means that exact GVK.
+type API = schema.GroupVersionKind
+
+type APIs interface {
+	Has(API) bool
+	HasAll(...API) bool
+	HasAny(...API) bool
+}
+
+// APISet implements [APIs] using empty struct for minimal memory consumption.
+type APISet = sets.Set[API]
+
+func NewAPISet(api ...API) APISet {
+	// Start with everything that's passed in; full GVKs are here.
+	s := sets.New(api...)
+
+	// Add the other combinations; Group, GV, and GK.
+	for i := range api {
+		s.Insert(
+			API{Group: api[i].Group},
+			API{Group: api[i].Group, Version: api[i].Version},
+			API{Group: api[i].Group, Kind: api[i].Kind},
+		)
+	}
+
+	return s
+}
+
+type apiContextKey struct{}
+
+// Has returns true when api was previously stored by [NewAPIContext].
+func Has(ctx context.Context, api API) bool {
+	if i, ok := ctx.Value(apiContextKey{}).(interface{ Has(API) bool }); ok {
+		return i.Has(api)
+	}
+	return false
+}
+
+// NewAPIContext returns a copy of ctx containing apis. Interrogate it using [Has].
+func NewAPIContext(ctx context.Context, apis APIs) context.Context {
+	return context.WithValue(ctx, apiContextKey{}, apis)
+}

--- a/internal/kubernetes/apis_test.go
+++ b/internal/kubernetes/apis_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestAPISet(t *testing.T) {
+	t.Parallel()
+
+	var zero APISet
+	assert.Assert(t, !zero.Has(API{Group: "security.openshift.io"}))
+	assert.Assert(t, !zero.Has(API{Group: "security.openshift.io", Kind: "SecurityContextConstraints"}))
+	assert.Assert(t, !zero.HasAll(API{Group: "security.openshift.io"}, API{Group: "snapshot.storage.k8s.io"}))
+	assert.Assert(t, !zero.HasAny(API{Group: "security.openshift.io"}, API{Group: "snapshot.storage.k8s.io"}))
+
+	empty := NewAPISet()
+	assert.Assert(t, !empty.Has(API{Group: "security.openshift.io"}))
+	assert.Assert(t, !empty.Has(API{Group: "security.openshift.io", Kind: "SecurityContextConstraints"}))
+
+	one := NewAPISet(
+		API{Group: "security.openshift.io", Kind: "SecurityContextConstraints"},
+	)
+	assert.Assert(t, one.Has(API{Group: "security.openshift.io"}))
+	assert.Assert(t, one.Has(API{Group: "security.openshift.io", Kind: "SecurityContextConstraints"}))
+	assert.Assert(t, !one.HasAll(API{Group: "snapshot.storage.k8s.io"}, API{Group: "security.openshift.io"}))
+	assert.Assert(t, !one.HasAny(API{Group: "snapshot.storage.k8s.io"}))
+	assert.Assert(t, one.HasAny(API{Group: "snapshot.storage.k8s.io"}, API{Group: "security.openshift.io"}))
+
+	two := NewAPISet(
+		API{Group: "security.openshift.io", Kind: "SecurityContextConstraints"},
+		API{Group: "snapshot.storage.k8s.io", Kind: "VolumeSnapshot"},
+	)
+	assert.Assert(t, two.Has(API{Group: "security.openshift.io"}))
+	assert.Assert(t, two.Has(API{Group: "snapshot.storage.k8s.io"}))
+	assert.Assert(t, two.HasAll(API{Group: "snapshot.storage.k8s.io"}, API{Group: "security.openshift.io"}))
+	assert.Assert(t, two.HasAny(API{Group: "snapshot.storage.k8s.io"}))
+	assert.Assert(t, two.HasAny(API{Group: "snapshot.storage.k8s.io"}, API{Group: "security.openshift.io"}))
+}
+
+func TestAPIContext(t *testing.T) {
+	t.Parallel()
+
+	// The background context always return false.
+	ctx := context.Background()
+
+	assert.Assert(t, !Has(ctx, API{Group: "security.openshift.io"}))
+	assert.Assert(t, !Has(ctx, API{Group: "snapshot.storage.k8s.io"}))
+
+	// An initialized context returns what is stored.
+	set := NewAPISet(API{Group: "security.openshift.io", Kind: "SecurityContextConstraints"})
+	ctx = NewAPIContext(ctx, set)
+
+	assert.Assert(t, Has(ctx, API{Group: "security.openshift.io"}))
+	assert.Assert(t, !Has(ctx, API{Group: "snapshot.storage.k8s.io"}))
+
+	// The stored value is mutable within the context.
+	set[API{Group: "snapshot.storage.k8s.io"}] = struct{}{}
+	assert.Assert(t, Has(ctx, API{Group: "snapshot.storage.k8s.io"}))
+}

--- a/internal/kubernetes/discovery.go
+++ b/internal/kubernetes/discovery.go
@@ -1,0 +1,208 @@
+// Copyright 2024 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+
+	"github.com/crunchydata/postgres-operator/internal/logging"
+)
+
+type Version = version.Info
+
+// DiscoveryRunner implements [APIs] by reading from a Kubernetes API client.
+// Its methods are safe to call concurrently.
+type DiscoveryRunner struct {
+	// NOTE(tracing): The methods of [discovery.DiscoveryClient] do not take
+	// a Context so their API calls won't have a parent span.
+	Client interface {
+		ServerGroups() (*metav1.APIGroupList, error)
+		ServerResourcesForGroupVersion(string) (*metav1.APIResourceList, error)
+		ServerVersion() (*version.Info, error)
+	}
+
+	refresh time.Duration
+
+	// relevant is the list of APIs to examine during Read.
+	// Has, HasAll, and HasAny return false when this is empty.
+	relevant []API
+
+	have struct {
+		sync.RWMutex
+		APISet
+		Version
+	}
+}
+
+// NewDiscoveryRunner creates a [DiscoveryRunner] that periodically reads from
+// the Kubernetes at config.
+func NewDiscoveryRunner(config *rest.Config) (*DiscoveryRunner, error) {
+	dc, err := discovery.NewDiscoveryClientForConfig(config)
+
+	runner := &DiscoveryRunner{
+		Client:  dc,
+		refresh: 10 * time.Minute,
+		relevant: []API{
+			// https://cert-manager.io/docs/usage/certificate
+			// https://cert-manager.io/docs/trust/trust-manager
+			{Group: "cert-manager.io", Kind: "Certificate"},
+			{Group: "trust.cert-manager.io", Kind: "Bundle"},
+
+			// https://gateway-api.sigs.k8s.io/api-types/referencegrant
+			// https://kep.k8s.io/3766
+			{Group: "gateway.networking.k8s.io", Kind: "ReferenceGrant"},
+
+			// https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html
+			{Group: "security.openshift.io", Kind: "SecurityContextConstraints"},
+
+			// https://docs.k8s.io/concepts/storage/volume-snapshots
+			{Group: "snapshot.storage.k8s.io", Kind: "VolumeSnapshot"},
+		},
+	}
+
+	return runner, err
+}
+
+// Has returns true when api is available in Kuberentes.
+func (r *DiscoveryRunner) Has(api API) bool { return r.HasAny(api) }
+
+// HasAll returns true when every api is available in Kubernetes.
+func (r *DiscoveryRunner) HasAll(api ...API) bool {
+	r.have.RLock()
+	defer r.have.RUnlock()
+	return r.have.HasAll(api...)
+}
+
+// HasAny returns true when at least one api is available in Kubernetes.
+func (r *DiscoveryRunner) HasAny(api ...API) bool {
+	r.have.RLock()
+	defer r.have.RUnlock()
+	return r.have.HasAny(api...)
+}
+
+// NeedLeaderElection returns false so that r runs on any [manager.Manager],
+// regardless of which is elected leader in the Kubernetes namespace.
+func (r *DiscoveryRunner) NeedLeaderElection() bool { return false }
+
+// Read fetches available APIs from Kubernetes.
+func (r *DiscoveryRunner) Read(ctx context.Context) error {
+	return errors.Join(r.readAPIs(ctx), r.readVersion())
+}
+
+func (r *DiscoveryRunner) readAPIs(ctx context.Context) error {
+	// Build an index of the APIs we want to know about.
+	wantAPIs := make(map[string]map[string]sets.Set[string])
+	for _, want := range r.relevant {
+		if wantAPIs[want.Group] == nil {
+			wantAPIs[want.Group] = make(map[string]sets.Set[string])
+		}
+		if wantAPIs[want.Group][want.Version] == nil {
+			wantAPIs[want.Group][want.Version] = sets.New[string]()
+		}
+		if want.Kind != "" {
+			wantAPIs[want.Group][want.Version].Insert(want.Kind)
+		}
+	}
+
+	// Fetch Groups and Versions from Kubernetes.
+	groups, err := r.Client.ServerGroups()
+	if err != nil {
+		return err
+	}
+
+	// Build an index of the Groups and GVs available in Kubernetes;
+	// add GK and GVK for resources that we want to know about.
+	haveAPIs := make(APISet)
+	for _, apiG := range groups.Groups {
+		haveG := apiG.Name
+		haveAPIs.Insert(API{Group: haveG})
+
+		for _, apiGV := range apiG.Versions {
+			haveV := apiGV.Version
+			haveAPIs.Insert(API{Group: haveG, Version: haveV})
+
+			// Only fetch Resources when there are Kinds we want to know about.
+			if wantAPIs[haveG][""].Len() == 0 && wantAPIs[haveG][haveV].Len() == 0 {
+				continue
+			}
+
+			resources, err := r.Client.ServerResourcesForGroupVersion(apiGV.GroupVersion)
+			if err != nil {
+				return err
+			}
+
+			for _, apiR := range resources.APIResources {
+				haveK := apiR.Kind
+				haveAPIs.Insert(
+					API{Group: haveG, Kind: haveK},
+					API{Group: haveG, Kind: haveK, Version: haveV},
+				)
+			}
+		}
+	}
+
+	r.have.Lock()
+	r.have.APISet = haveAPIs
+	r.have.Unlock()
+
+	r.have.RLock()
+	defer r.have.RUnlock()
+	logging.FromContext(ctx).V(1).Info("Found APIs", "index_size", r.have.APISet.Len())
+
+	return nil
+}
+
+func (r *DiscoveryRunner) readVersion() error {
+	info, err := r.Client.ServerVersion()
+
+	if info != nil && err == nil {
+		r.have.Lock()
+		r.have.Version = *info
+		r.have.Unlock()
+	}
+
+	return err
+}
+
+// Start periodically reads the Kuberentes API. It blocks until ctx is cancelled.
+func (r *DiscoveryRunner) Start(ctx context.Context) error {
+	ticker := time.NewTicker(r.refresh)
+	defer ticker.Stop()
+
+	log := logging.FromContext(ctx).WithValues("controller", "kubernetes")
+	ctx = logging.NewContext(ctx, log)
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := r.Read(ctx); err != nil {
+				log.Error(err, "Unable to detect Kubernetes APIs")
+			}
+		case <-ctx.Done():
+			// TODO(controller-runtime): Fixed in v0.19.0
+			// https://github.com/kubernetes-sigs/controller-runtime/issues/1927
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return nil
+			}
+			return ctx.Err()
+		}
+	}
+}
+
+// Version returns the detected version of Kubernetes.
+func (r *DiscoveryRunner) Version() Version {
+	r.have.RLock()
+	defer r.have.RUnlock()
+	return r.have.Version
+}

--- a/internal/kubernetes/discovery.go
+++ b/internal/kubernetes/discovery.go
@@ -91,6 +91,12 @@ func (r *DiscoveryRunner) HasAny(api ...API) bool {
 	return r.have.HasAny(api...)
 }
 
+// IsOpenShift returns true if this Kubernetes might be OpenShift. The result
+// may not be accurate.
+func (r *DiscoveryRunner) IsOpenShift() bool {
+	return r.Has(API{Group: "security.openshift.io", Kind: "SecurityContextConstraints"})
+}
+
 // NeedLeaderElection returns false so that r runs on any [manager.Manager],
 // regardless of which is elected leader in the Kubernetes namespace.
 func (r *DiscoveryRunner) NeedLeaderElection() bool { return false }
@@ -205,4 +211,23 @@ func (r *DiscoveryRunner) Version() Version {
 	r.have.RLock()
 	defer r.have.RUnlock()
 	return r.have.Version
+}
+
+// IsOpenShift returns true if the detected Kubernetes might be OpenShift.
+// The result may not be accurate. When possible, use another technique to
+// detect specific behavior. Use [Has] to check for specific APIs.
+func IsOpenShift(ctx context.Context) bool {
+	if i, ok := ctx.Value(apiContextKey{}).(interface{ IsOpenShift() bool }); ok {
+		return i.IsOpenShift()
+	}
+	return false
+}
+
+// VersionString returns a textual representation of the detected Kubernetes
+// version, if any.
+func VersionString(ctx context.Context) string {
+	if i, ok := ctx.Value(apiContextKey{}).(interface{ Version() Version }); ok {
+		return i.Version().String()
+	}
+	return ""
 }

--- a/internal/kubernetes/discovery_test.go
+++ b/internal/kubernetes/discovery_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/crunchydata/postgres-operator/internal/testing/require"
@@ -52,4 +53,26 @@ func TestDiscoveryRunnerVersion(t *testing.T) {
 	assert.Assert(t, version.Major != "", "got %#v", version)
 	assert.Assert(t, version.Minor != "", "got %#v", version)
 	assert.Assert(t, version.String() != "", "got %q", version.String())
+}
+
+func TestIsOpenShift(t *testing.T) {
+	ctx := context.Background()
+	assert.Assert(t, !IsOpenShift(ctx))
+
+	runner := new(DiscoveryRunner)
+	runner.have.APISet = NewAPISet(
+		API{Group: "security.openshift.io", Kind: "SecurityContextConstraints"},
+	)
+	assert.Assert(t, IsOpenShift(NewAPIContext(ctx, runner)))
+}
+
+func TestVersionString(t *testing.T) {
+	ctx := context.Background()
+	assert.Equal(t, "", VersionString(ctx))
+
+	runner := new(DiscoveryRunner)
+	runner.have.Version = version.Info{
+		Major: "1", Minor: "2", GitVersion: "asdf",
+	}
+	assert.Equal(t, "asdf", VersionString(NewAPIContext(ctx, runner)))
 }

--- a/internal/kubernetes/discovery_test.go
+++ b/internal/kubernetes/discovery_test.go
@@ -1,0 +1,55 @@
+// Copyright 2024 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
+)
+
+func TestDiscoveryRunnerInterfaces(t *testing.T) {
+	var _ APIs = new(DiscoveryRunner)
+	var _ manager.Runnable = new(DiscoveryRunner)
+
+	var runnable manager.LeaderElectionRunnable = new(DiscoveryRunner)
+	assert.Assert(t, false == runnable.NeedLeaderElection())
+}
+
+func TestDiscoveryRunnerAPIs(t *testing.T) {
+	ctx := context.Background()
+	cfg, _ := require.Kubernetes2(t)
+	require.ParallelCapacity(t, 0)
+
+	runner, err := NewDiscoveryRunner(cfg)
+	assert.NilError(t, err)
+
+	// Search for an API that should always exist.
+	runner.relevant = append(runner.relevant, API{Kind: "Pod"})
+	assert.NilError(t, runner.readAPIs(ctx))
+
+	assert.Assert(t, runner.Has(API{Kind: "Pod"}))
+	assert.Assert(t, runner.HasAll(API{Kind: "Pod"}, API{Kind: "Secret"}))
+	assert.Assert(t, runner.HasAny(API{Kind: "Pod"}, API{Kind: "NotGonnaExist"}))
+	assert.Assert(t, !runner.Has(API{Kind: "NotGonnaExist"}))
+}
+
+func TestDiscoveryRunnerVersion(t *testing.T) {
+	cfg, _ := require.Kubernetes2(t)
+	require.ParallelCapacity(t, 0)
+
+	runner, err := NewDiscoveryRunner(cfg)
+	assert.NilError(t, err)
+	assert.NilError(t, runner.readVersion())
+
+	version := runner.Version()
+	assert.Assert(t, version.Major != "", "got %#v", version)
+	assert.Assert(t, version.Minor != "", "got %#v", version)
+	assert.Assert(t, version.String() != "", "got %q", version.String())
+}

--- a/internal/postgres/reconcile.go
+++ b/internal/postgres/reconcile.go
@@ -276,14 +276,14 @@ func InstancePod(ctx context.Context,
 // PodSecurityContext returns a v1.PodSecurityContext for cluster that can write
 // to PersistentVolumes.
 func PodSecurityContext(cluster *v1beta1.PostgresCluster) *corev1.PodSecurityContext {
-	podSecurityContext := initialize.PodSecurityContext()
+	psc := initialize.PodSecurityContext()
 
 	// Use the specified supplementary groups except for root. The CRD has
 	// similar validation, but we should never emit a PodSpec with that group.
 	// - https://docs.k8s.io/concepts/security/pod-security-standards/
 	for i := range cluster.Spec.SupplementalGroups {
 		if gid := cluster.Spec.SupplementalGroups[i]; gid > 0 {
-			podSecurityContext.SupplementalGroups = append(podSecurityContext.SupplementalGroups, gid)
+			psc.SupplementalGroups = append(psc.SupplementalGroups, gid)
 		}
 	}
 
@@ -293,9 +293,9 @@ func PodSecurityContext(cluster *v1beta1.PostgresCluster) *corev1.PodSecurityCon
 	// - https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids
 	// - https://docs.k8s.io/tasks/configure-pod-container/security-context/
 	// - https://docs.openshift.com/container-platform/4.8/authentication/managing-security-context-constraints.html
-	if cluster.Spec.OpenShift == nil || !*cluster.Spec.OpenShift {
-		podSecurityContext.FSGroup = initialize.Int64(26)
+	if !initialize.FromPointer(cluster.Spec.OpenShift) {
+		psc.FSGroup = initialize.Int64(26)
 	}
 
-	return podSecurityContext
+	return psc
 }

--- a/internal/registration/runner.go
+++ b/internal/registration/runner.go
@@ -181,6 +181,7 @@ func (r *Runner) Start(ctx context.Context) error {
 				r.changed()
 			}
 		case <-ctx.Done():
+			// TODO(controller-runtime): Fixed in v0.19.0
 			// https://github.com/kubernetes-sigs/controller-runtime/issues/1927
 			if errors.Is(ctx.Err(), context.Canceled) {
 				return nil

--- a/internal/upgradecheck/header_test.go
+++ b/internal/upgradecheck/header_test.go
@@ -14,14 +14,12 @@ import (
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/client-go/discovery"
 
 	// Google Kubernetes Engine / Google Cloud Platform authentication provider
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/client-go/rest"
 
-	"github.com/crunchydata/postgres-operator/internal/controller/postgrescluster"
 	"github.com/crunchydata/postgres-operator/internal/feature"
+	"github.com/crunchydata/postgres-operator/internal/kubernetes"
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/testing/cmp"
 	"github.com/crunchydata/postgres-operator/internal/testing/require"
@@ -33,12 +31,10 @@ func TestGenerateHeader(t *testing.T) {
 	ctx := context.Background()
 	cfg, cc := require.Kubernetes2(t)
 
-	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	discovery, err := kubernetes.NewDiscoveryRunner(cfg)
 	assert.NilError(t, err)
-	server, err := dc.ServerVersion()
-	assert.NilError(t, err)
-
-	reconciler := postgrescluster.Reconciler{Client: cc}
+	assert.NilError(t, discovery.Read(ctx))
+	ctx = kubernetes.NewAPIContext(ctx, discovery)
 
 	t.Setenv("PGO_INSTALLER", "test")
 	t.Setenv("PGO_INSTALLER_ORIGIN", "test-origin")
@@ -51,11 +47,10 @@ func TestGenerateHeader(t *testing.T) {
 		}
 		ctx, calls := setupLogCapture(ctx)
 
-		res := generateHeader(ctx, cfg, fakeClientWithOptionalError,
-			"1.2.3", reconciler.IsOpenShift, "")
+		res := generateHeader(ctx, fakeClientWithOptionalError, "1.2.3", "")
 		assert.Equal(t, len(*calls), 1)
 		assert.Assert(t, cmp.Contains((*calls)[0], `upgrade check issue: could not apply configmap`))
-		assert.Equal(t, res.IsOpenShift, reconciler.IsOpenShift)
+		assert.Equal(t, discovery.IsOpenShift(), res.IsOpenShift)
 		assert.Equal(t, deploymentID, res.DeploymentID)
 		pgoList := v1beta1.PostgresClusterList{}
 		err := cc.List(ctx, &pgoList)
@@ -66,7 +61,7 @@ func TestGenerateHeader(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, len(bridgeList.Items), res.BridgeClustersTotal)
 		assert.Equal(t, "1.2.3", res.PGOVersion)
-		assert.Equal(t, server.String(), res.KubernetesEnv)
+		assert.Equal(t, discovery.Version().String(), res.KubernetesEnv)
 		assert.Equal(t, "test", res.PGOInstaller)
 		assert.Equal(t, "test-origin", res.PGOInstallerOrigin)
 		assert.Equal(t, "developer", res.BuildSource)
@@ -78,40 +73,18 @@ func TestGenerateHeader(t *testing.T) {
 		}
 		ctx, calls := setupLogCapture(ctx)
 
-		res := generateHeader(ctx, cfg, fakeClientWithOptionalError,
-			"1.2.3", reconciler.IsOpenShift, "")
+		res := generateHeader(ctx, fakeClientWithOptionalError, "1.2.3", "")
 		assert.Equal(t, len(*calls), 2)
 		// Aggregating the logs since we cannot determine which call will be first
 		callsAggregate := strings.Join(*calls, " ")
 		assert.Assert(t, cmp.Contains(callsAggregate, `upgrade check issue: could not count postgres clusters`))
 		assert.Assert(t, cmp.Contains(callsAggregate, `upgrade check issue: could not count bridge clusters`))
-		assert.Equal(t, res.IsOpenShift, reconciler.IsOpenShift)
+		assert.Equal(t, discovery.IsOpenShift(), res.IsOpenShift)
 		assert.Equal(t, deploymentID, res.DeploymentID)
 		assert.Equal(t, 0, res.PGOClustersTotal)
 		assert.Equal(t, 0, res.BridgeClustersTotal)
 		assert.Equal(t, "1.2.3", res.PGOVersion)
-		assert.Equal(t, server.String(), res.KubernetesEnv)
-		assert.Equal(t, "test", res.PGOInstaller)
-		assert.Equal(t, "test-origin", res.PGOInstallerOrigin)
-		assert.Equal(t, "developer", res.BuildSource)
-	})
-
-	t.Run("error getting server version info", func(t *testing.T) {
-		ctx, calls := setupLogCapture(ctx)
-		badcfg := &rest.Config{}
-
-		res := generateHeader(ctx, badcfg, cc,
-			"1.2.3", reconciler.IsOpenShift, "")
-		assert.Equal(t, len(*calls), 1)
-		assert.Assert(t, cmp.Contains((*calls)[0], `upgrade check issue: could not retrieve server version`))
-		assert.Equal(t, res.IsOpenShift, reconciler.IsOpenShift)
-		assert.Equal(t, deploymentID, res.DeploymentID)
-		pgoList := v1beta1.PostgresClusterList{}
-		err := cc.List(ctx, &pgoList)
-		assert.NilError(t, err)
-		assert.Equal(t, len(pgoList.Items), res.PGOClustersTotal)
-		assert.Equal(t, "1.2.3", res.PGOVersion)
-		assert.Equal(t, "", res.KubernetesEnv)
+		assert.Equal(t, discovery.Version().String(), res.KubernetesEnv)
 		assert.Equal(t, "test", res.PGOInstaller)
 		assert.Equal(t, "test-origin", res.PGOInstallerOrigin)
 		assert.Equal(t, "developer", res.BuildSource)
@@ -125,17 +98,16 @@ func TestGenerateHeader(t *testing.T) {
 		}))
 		ctx = feature.NewContext(ctx, gate)
 
-		res := generateHeader(ctx, cfg, cc,
-			"1.2.3", reconciler.IsOpenShift, "")
+		res := generateHeader(ctx, cc, "1.2.3", "")
 		assert.Equal(t, len(*calls), 0)
-		assert.Equal(t, res.IsOpenShift, reconciler.IsOpenShift)
+		assert.Equal(t, discovery.IsOpenShift(), res.IsOpenShift)
 		assert.Equal(t, deploymentID, res.DeploymentID)
 		pgoList := v1beta1.PostgresClusterList{}
 		err := cc.List(ctx, &pgoList)
 		assert.NilError(t, err)
 		assert.Equal(t, len(pgoList.Items), res.PGOClustersTotal)
 		assert.Equal(t, "1.2.3", res.PGOVersion)
-		assert.Equal(t, server.String(), res.KubernetesEnv)
+		assert.Equal(t, discovery.Version().String(), res.KubernetesEnv)
 		assert.Equal(t, "TablespaceVolumes=true", res.FeatureGatesEnabled)
 		assert.Equal(t, "test", res.PGOInstaller)
 		assert.Equal(t, "test-origin", res.PGOInstallerOrigin)
@@ -558,31 +530,6 @@ func TestGetBridgeClusters(t *testing.T) {
 		assert.Assert(t, len(*calls) > 0)
 		assert.Assert(t, cmp.Contains((*calls)[0], `upgrade check issue: could not count bridge clusters`))
 		assert.Assert(t, count == 0)
-	})
-}
-
-func TestGetServerVersion(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		expect, server := setupVersionServer(t, true)
-		ctx, calls := setupLogCapture(context.Background())
-
-		got := getServerVersion(ctx, &rest.Config{
-			Host: server.URL,
-		})
-		assert.Equal(t, len(*calls), 0)
-		assert.Equal(t, got, expect.String())
-	})
-
-	t.Run("failure", func(t *testing.T) {
-		_, server := setupVersionServer(t, false)
-		ctx, calls := setupLogCapture(context.Background())
-
-		got := getServerVersion(ctx, &rest.Config{
-			Host: server.URL,
-		})
-		assert.Equal(t, len(*calls), 1)
-		assert.Assert(t, cmp.Contains((*calls)[0], `upgrade check issue: could not retrieve server version`))
-		assert.Equal(t, got, "")
 	})
 }
 

--- a/internal/upgradecheck/helpers_test.go
+++ b/internal/upgradecheck/helpers_test.go
@@ -6,17 +6,13 @@ package upgradecheck
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/go-logr/logr/funcr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/apimachinery/pkg/version"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -115,31 +111,6 @@ func setupFakeClientWithPGOScheme(t *testing.T, includeCluster bool) crclient.Cl
 			Build()
 	}
 	return fake.NewClientBuilder().WithScheme(runtime.Scheme).Build()
-}
-
-// setupVersionServer sets up and tears down a server and version info for testing
-func setupVersionServer(t *testing.T, works bool) (version.Info, *httptest.Server) {
-	t.Helper()
-	expect := version.Info{
-		Major:     "1",
-		Minor:     "22",
-		GitCommit: "v1.22.2",
-	}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
-		req *http.Request) {
-		if works {
-			output, _ := json.Marshal(expect)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			// We don't need to check the error output from this
-			_, _ = w.Write(output)
-		} else {
-			w.WriteHeader(http.StatusBadRequest)
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	return expect, server
 }
 
 // setupLogCapture captures the logs and keeps count of the logs captured

--- a/internal/upgradecheck/http.go
+++ b/internal/upgradecheck/http.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/rest"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -66,8 +65,8 @@ func init() {
 }
 
 func checkForUpgrades(ctx context.Context, url, versionString string, backoff wait.Backoff,
-	crclient crclient.Client, cfg *rest.Config,
-	isOpenShift bool, registrationToken string) (message string, header string, err error) {
+	crclient crclient.Client, registrationToken string,
+) (message string, header string, err error) {
 	var headerPayloadStruct *clientUpgradeData
 
 	// Prep request
@@ -75,8 +74,8 @@ func checkForUpgrades(ctx context.Context, url, versionString string, backoff wa
 	if err == nil {
 		// generateHeader always returns some sort of struct, using defaults/nil values
 		// in case some of the checks return errors
-		headerPayloadStruct = generateHeader(ctx, cfg, crclient,
-			versionString, isOpenShift, registrationToken)
+		headerPayloadStruct = generateHeader(ctx, crclient,
+			versionString, registrationToken)
 		req = addHeader(req, headerPayloadStruct)
 	}
 
@@ -124,9 +123,7 @@ func checkForUpgrades(ctx context.Context, url, versionString string, backoff wa
 
 type CheckForUpgradesScheduler struct {
 	Client crclient.Client
-	Config *rest.Config
 
-	OpenShift         bool
 	Refresh           time.Duration
 	RegistrationToken string
 	URL, Version      string
@@ -138,7 +135,7 @@ type CheckForUpgradesScheduler struct {
 // so this token is always current; but if that restart behavior is changed,
 // we will want the upgrade mechanism to instantiate its own registration runner
 // or otherwise get the most recent token.
-func ManagedScheduler(m manager.Manager, openshift bool,
+func ManagedScheduler(m manager.Manager,
 	url, version string, registrationToken *jwt.Token) error {
 	if url == "" {
 		url = upgradeCheckURL
@@ -151,8 +148,6 @@ func ManagedScheduler(m manager.Manager, openshift bool,
 
 	return m.Add(&CheckForUpgradesScheduler{
 		Client:            m.GetClient(),
-		Config:            m.GetConfig(),
-		OpenShift:         openshift,
 		Refresh:           24 * time.Hour,
 		RegistrationToken: token,
 		URL:               url,
@@ -191,7 +186,7 @@ func (s *CheckForUpgradesScheduler) check(ctx context.Context) {
 	}()
 
 	info, header, err := checkForUpgrades(ctx,
-		s.URL, s.Version, backoff, s.Client, s.Config, s.OpenShift, s.RegistrationToken)
+		s.URL, s.Version, backoff, s.Client, s.RegistrationToken)
 
 	if err != nil {
 		log.V(1).Info("could not complete upgrade check", "response", err.Error())


### PR DESCRIPTION
This adds an `internal/kubernetes` package with types and functions for interrogating the Kubernetes API version and the APIs it has installed.

- `kubernetes.APIs` is an interface for some read-only methods of [k8s.io/…/sets.Set](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/sets#Set).
- `kubernetes.APISet` implementes the `APIs` interface using a `map`.
- `kubernetes.DiscoveryRunner` implements the `APIs` interface by periodically calling the Kubernetes API.

`main()` configures a DiscoveryRunner and adds it to the Manager and its Context so that the rest of our code can use it with these new functions:

- `kubernetes.Has(Context, API) bool`
- `kubernetes.IsOpenShift(Context) bool`
- `kubernetes.VersionString(Context) string`

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [x] Testing enhancement

**What is the current behavior (link to any open issues here)?**

- When VolumeSnapshots are enabled, we query for VolumeSnapshot APIs every PostgresCluster reconciliation.
  - When this query fails, reconciliation fails.
- We query for OpenShift APIs once at startup.
- We have "is OpenShift" logic in multiple controllers.

**What is the new behavior (if this is a feature change)?**

- We query for a handful of APIs more than once and less than every reconciliation.
  - When this query fails, reconciliation continues unabated with old data.
- Tests use Context and map to emulate different API configurations.
- We have a canonical definition of "is OpenShift" with guidance for its use.
- We have replaced one use of "is OpenShift" with a query for a specific API.

**Other Information**:

This is similar to #3973, but has grown to replace all our runtime use of the upstream discovery client.