### PR TITLE
Bump Trivy to v0.57.1

### DIFF
--- a/.github/actions/trivy/action.yaml
+++ b/.github/actions/trivy/action.yaml
@@ -19,7 +19,7 @@ inputs:
       How Trivy should handle its data; one of update or skip.
 
   setup:
-    default: v0.57.0,cache
+    default: v0.57.1,cache
     description: >-
       How to install Trivy; one or more of version, none, or cache.
 


### PR DESCRIPTION
This version includes multiple official database sources. Less throttling, in theory.

See: https://github.com/aquasecurity/trivy/releases/tag/v0.57.1