### PR TITLE
Consider pg_ctl successful when progress is made

### DIFF
--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -174,7 +174,7 @@ func MakePGBackrestLogDir(template *corev1.PodTemplateSpec,
 func RestoreCommand(pgdata, hugePagesSetting, fetchKeyCommand string, tablespaceVolumes []*corev1.PersistentVolumeClaim, args ...string) []string {
 
 	// After pgBackRest restores files, PostgreSQL starts in recovery to finish
-	// replaying WAL files. "hot_standby" is "on" (by default) so we can detect
+	// replaying WAL files. "hot_standby" is "on" so we can detect
 	// when recovery has finished. In that mode, some parameters cannot be
 	// smaller than they were when PostgreSQL was backed up. Configure them to
 	// match the values reported by "pg_controldata". Those parameters are also
@@ -233,6 +233,7 @@ cat > /tmp/postgres.restore.conf <<EOF
 archive_command = 'false'
 archive_mode = 'on'
 hba_file = '/tmp/pg_hba.restore.conf'
+hot_standby = 'on'
 max_connections = '${max_conn}'
 max_locks_per_transaction = '${max_lock}'
 max_prepared_transactions = '${max_ptxn}'

--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -248,7 +248,10 @@ read -r max_wals <<< "${control##*max_wal_senders setting:}"
 echo >> /tmp/postgres.restore.conf "max_wal_senders = '${max_wals}'"
 fi
 
-pg_ctl start --silent --timeout=31536000 --wait --options='--config-file=/tmp/postgres.restore.conf'
+read -r stopped <<< "${control##*recovery ending location:}"
+pg_ctl start --silent --timeout=31536000 --wait --options='--config-file=/tmp/postgres.restore.conf' || failed=$?
+[[ "${started-}" == "${stopped}" && -n "${failed-}" ]] && exit "${failed}"
+started="${stopped}" && [[ -n "${failed-}" ]] && failed= && continue
 fi
 
 recovery=$(psql -Atc "SELECT CASE

--- a/internal/postgres/parameters.go
+++ b/internal/postgres/parameters.go
@@ -5,6 +5,8 @@
 package postgres
 
 import (
+	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -124,3 +126,21 @@ func (ps *ParameterSet) Value(name string) string {
 	value, _ := ps.Get(name)
 	return value
 }
+
+func (ps *ParameterSet) String() string {
+	keys := make([]string, 0, len(ps.values))
+	for k := range ps.values {
+		keys = append(keys, k)
+	}
+
+	slices.Sort(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		_, _ = fmt.Fprintf(&b, "%s = '%s'\n", k, escapeParameterQuotes(ps.values[k]))
+	}
+	return b.String()
+}
+
+// escapeParameterQuotes is used by [ParameterSet.String].
+var escapeParameterQuotes = strings.NewReplacer(`'`, `''`).Replace

--- a/internal/postgres/parameters_test.go
+++ b/internal/postgres/parameters_test.go
@@ -56,6 +56,10 @@ func TestParameterSet(t *testing.T) {
 
 	ps2.Add("x", "n")
 	assert.Assert(t, ps2.Value("x") != ps.Value("x"))
+
+	assert.DeepEqual(t, ps.String(), ``+
+		`abc = 'j''l'`+"\n"+
+		`x = 'z'`+"\n")
 }
 
 func TestParameterSetAppendToList(t *testing.T) {


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix

**What is the current behavior (link to any open issues here)?**

When the WAL immediately after a full backup contains configuration changes on Postgres 13 or earlier, restoring from that backup may retry unnecessarily. 

**What is the new behavior (if this is a feature change)?**

The restore job detects the race that can occur in Postgres 13, addresses it, and continues.

**Other Information**:

Issue: PGO-1945