### PR TITLE
Use multiple processors when PGUpgrade is given CPU resources

### DIFF
--- a/internal/controller/pgupgrade/jobs_test.go
+++ b/internal/controller/pgupgrade/jobs_test.go
@@ -150,8 +150,7 @@ status: {}
 	`))
 
 	tdeJob := reconciler.generateUpgradeJob(ctx, upgrade, startup, "echo testKey")
-	b, _ := yaml.Marshal(tdeJob)
-	assert.Assert(t, strings.Contains(string(b),
+	assert.Assert(t, cmp.MarshalContains(tdeJob,
 		`/usr/pgsql-"${new_version}"/bin/initdb -k -D /pgdata/pg"${new_version}" --encryption-key-command "echo testKey"`))
 }
 

--- a/internal/controller/pgupgrade/jobs_test.go
+++ b/internal/controller/pgupgrade/jobs_test.go
@@ -16,10 +16,84 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/yaml"
 
+	"github.com/crunchydata/postgres-operator/internal/feature"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/testing/cmp"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
+
+func TestLargestWholeCPU(t *testing.T) {
+	assert.Equal(t, 0,
+		largestWholeCPU(corev1.ResourceRequirements{}),
+		"expected the zero value to be zero")
+
+	for _, tt := range []struct {
+		Name, ResourcesYAML string
+		Result              int
+	}{
+		{
+			Name: "Negatives", ResourcesYAML: `{requests: {cpu: -3}, limits: {cpu: -5}}`,
+			Result: 0,
+		},
+		{
+			Name: "SmallPositive", ResourcesYAML: `limits: {cpu: 600m}`,
+			Result: 0,
+		},
+		{
+			Name: "FractionalPositive", ResourcesYAML: `requests: {cpu: 2200m}`,
+			Result: 2,
+		},
+		{
+			Name: "LargePositive", ResourcesYAML: `limits: {cpu: 10}`,
+			Result: 10,
+		},
+		{
+			Name: "RequestsAndLimits", ResourcesYAML: `{requests: {cpu: 2}, limits: {cpu: 4}}`,
+			Result: 4,
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			var resources corev1.ResourceRequirements
+			assert.NilError(t, yaml.Unmarshal([]byte(tt.ResourcesYAML), &resources))
+			assert.Equal(t, tt.Result, largestWholeCPU(resources))
+		})
+	}
+}
+
+func TestUpgradeCommand(t *testing.T) {
+	expectScript := func(t *testing.T, script string) {
+		t.Helper()
+
+		t.Run("PrettyYAML", func(t *testing.T) {
+			b, err := yaml.Marshal(script)
+			assert.NilError(t, err)
+			assert.Assert(t, strings.HasPrefix(string(b), `|`),
+				"expected literal block scalar, got:\n%s", b)
+		})
+	}
+
+	t.Run("CPUs", func(t *testing.T) {
+		for _, tt := range []struct {
+			CPUs int
+			Jobs string
+		}{
+			{CPUs: 0, Jobs: "--jobs=1"},
+			{CPUs: 1, Jobs: "--jobs=1"},
+			{CPUs: 2, Jobs: "--jobs=1"},
+			{CPUs: 3, Jobs: "--jobs=2"},
+			{CPUs: 10, Jobs: "--jobs=9"},
+		} {
+			command := upgradeCommand(10, 11, "", tt.CPUs)
+			assert.Assert(t, len(command) > 3)
+			assert.DeepEqual(t, []string{"bash", "-ceu", "--"}, command[:3])
+
+			script := command[3]
+			assert.Assert(t, cmp.Contains(script, tt.Jobs))
+
+			expectScript(t, script)
+		}
+	})
+}
 
 func TestGenerateUpgradeJob(t *testing.T) {
 	ctx := context.Background()
@@ -120,11 +194,11 @@ spec:
           echo -e "Step 5: Running pg_upgrade check...\n"
           time /usr/pgsql-"${new_version}"/bin/pg_upgrade --old-bindir /usr/pgsql-"${old_version}"/bin \
           --new-bindir /usr/pgsql-"${new_version}"/bin --old-datadir /pgdata/pg"${old_version}"\
-           --new-datadir /pgdata/pg"${new_version}" --link --check
+           --new-datadir /pgdata/pg"${new_version}" --link --check --jobs=1
           echo -e "\nStep 6: Running pg_upgrade...\n"
           time /usr/pgsql-"${new_version}"/bin/pg_upgrade --old-bindir /usr/pgsql-"${old_version}"/bin \
           --new-bindir /usr/pgsql-"${new_version}"/bin --old-datadir /pgdata/pg"${old_version}" \
-          --new-datadir /pgdata/pg"${new_version}" --link
+          --new-datadir /pgdata/pg"${new_version}" --link --jobs=1
           echo -e "\nStep 7: Copying patroni.dynamic.json...\n"
           cp /pgdata/pg"${old_version}"/patroni.dynamic.json /pgdata/pg"${new_version}"
           echo -e "\npg_upgrade Job Complete!"
@@ -148,6 +222,17 @@ spec:
         name: vol2
 status: {}
 	`))
+
+	t.Run(feature.PGUpgradeCPUConcurrency+"Enabled", func(t *testing.T) {
+		gate := feature.NewGate()
+		assert.NilError(t, gate.SetFromMap(map[string]bool{
+			feature.PGUpgradeCPUConcurrency: true,
+		}))
+		ctx := feature.NewContext(context.Background(), gate)
+
+		job := reconciler.generateUpgradeJob(ctx, upgrade, startup, "")
+		assert.Assert(t, cmp.MarshalContains(job, `--jobs=2`))
+	})
 
 	tdeJob := reconciler.generateUpgradeJob(ctx, upgrade, startup, "echo testKey")
 	assert.Assert(t, cmp.MarshalContains(tdeJob,

--- a/internal/feature/features.go
+++ b/internal/feature/features.go
@@ -83,6 +83,9 @@ const (
 	// Support custom sidecars for pgBouncer Pods
 	PGBouncerSidecars = "PGBouncerSidecars"
 
+	// Adjust PGUpgrade parallelism according to CPU resources
+	PGUpgradeCPUConcurrency = "PGUpgradeCPUConcurrency"
+
 	// Support tablespace volumes
 	TablespaceVolumes = "TablespaceVolumes"
 
@@ -95,14 +98,15 @@ func NewGate() MutableGate {
 	gate := featuregate.NewFeatureGate()
 
 	if err := gate.Add(map[Feature]featuregate.FeatureSpec{
-		AppendCustomQueries:  {Default: false, PreRelease: featuregate.Alpha},
-		AutoCreateUserSchema: {Default: true, PreRelease: featuregate.Beta},
-		AutoGrowVolumes:      {Default: false, PreRelease: featuregate.Alpha},
-		BridgeIdentifiers:    {Default: false, PreRelease: featuregate.Alpha},
-		InstanceSidecars:     {Default: false, PreRelease: featuregate.Alpha},
-		PGBouncerSidecars:    {Default: false, PreRelease: featuregate.Alpha},
-		TablespaceVolumes:    {Default: false, PreRelease: featuregate.Alpha},
-		VolumeSnapshots:      {Default: false, PreRelease: featuregate.Alpha},
+		AppendCustomQueries:     {Default: false, PreRelease: featuregate.Alpha},
+		AutoCreateUserSchema:    {Default: true, PreRelease: featuregate.Beta},
+		AutoGrowVolumes:         {Default: false, PreRelease: featuregate.Alpha},
+		BridgeIdentifiers:       {Default: false, PreRelease: featuregate.Alpha},
+		InstanceSidecars:        {Default: false, PreRelease: featuregate.Alpha},
+		PGBouncerSidecars:       {Default: false, PreRelease: featuregate.Alpha},
+		PGUpgradeCPUConcurrency: {Default: false, PreRelease: featuregate.Alpha},
+		TablespaceVolumes:       {Default: false, PreRelease: featuregate.Alpha},
+		VolumeSnapshots:         {Default: false, PreRelease: featuregate.Alpha},
 	}); err != nil {
 		panic(err)
 	}

--- a/internal/feature/features_test.go
+++ b/internal/feature/features_test.go
@@ -22,6 +22,7 @@ func TestDefaults(t *testing.T) {
 	assert.Assert(t, false == gate.Enabled(BridgeIdentifiers))
 	assert.Assert(t, false == gate.Enabled(InstanceSidecars))
 	assert.Assert(t, false == gate.Enabled(PGBouncerSidecars))
+	assert.Assert(t, false == gate.Enabled(PGUpgradeCPUConcurrency))
 	assert.Assert(t, false == gate.Enabled(TablespaceVolumes))
 	assert.Assert(t, false == gate.Enabled(VolumeSnapshots))
 }

--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -13,13 +13,12 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"sigs.k8s.io/yaml"
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
+	"github.com/crunchydata/postgres-operator/internal/testing/cmp"
 	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
@@ -213,13 +212,13 @@ pg1-socket-path = /tmp/postgres
 			[]string{"some-instance"})
 
 		assert.Assert(t,
-			strings.Contains(configmap.Data["pgbackrest_instance.conf"],
+			cmp.Contains(configmap.Data["pgbackrest_instance.conf"],
 				"archive-header-check = n"))
 		assert.Assert(t,
-			strings.Contains(configmap.Data["pgbackrest_instance.conf"],
+			cmp.Contains(configmap.Data["pgbackrest_instance.conf"],
 				"page-header-check = n"))
 		assert.Assert(t,
-			strings.Contains(configmap.Data["pgbackrest_instance.conf"],
+			cmp.Contains(configmap.Data["pgbackrest_instance.conf"],
 				"pg-version-force"))
 
 		cluster.Spec.Backups.PGBackRest.Repos = []v1beta1.PGBackRestRepo{
@@ -234,13 +233,13 @@ pg1-socket-path = /tmp/postgres
 			[]string{"some-instance"})
 
 		assert.Assert(t,
-			strings.Contains(configmap.Data["pgbackrest_repo.conf"],
+			cmp.Contains(configmap.Data["pgbackrest_repo.conf"],
 				"archive-header-check = n"))
 		assert.Assert(t,
-			strings.Contains(configmap.Data["pgbackrest_repo.conf"],
+			cmp.Contains(configmap.Data["pgbackrest_repo.conf"],
 				"page-header-check = n"))
 		assert.Assert(t,
-			strings.Contains(configmap.Data["pgbackrest_repo.conf"],
+			cmp.Contains(configmap.Data["pgbackrest_repo.conf"],
 				"pg-version-force"))
 	})
 }
@@ -323,10 +322,8 @@ func TestReloadCommand(t *testing.T) {
 }
 
 func TestReloadCommandPrettyYAML(t *testing.T) {
-	b, err := yaml.Marshal(reloadCommand("any"))
-	assert.NilError(t, err)
-	assert.Assert(t, strings.Contains(string(b), "\n- |"),
-		"expected literal block scalar, got:\n%s", b)
+	assert.Assert(t, cmp.MarshalContains(reloadCommand("any"), "\n- |"),
+		"expected literal block scalar")
 }
 
 func TestRestoreCommand(t *testing.T) {
@@ -351,19 +348,21 @@ func TestRestoreCommand(t *testing.T) {
 }
 
 func TestRestoreCommandPrettyYAML(t *testing.T) {
-	b, err := yaml.Marshal(RestoreCommand("/dir", "try", "", nil, "--options"))
-
-	assert.NilError(t, err)
-	assert.Assert(t, strings.Contains(string(b), "\n- |"),
-		"expected literal block scalar, got:\n%s", b)
+	assert.Assert(t,
+		cmp.MarshalContains(
+			RestoreCommand("/dir", "try", "", nil, "--options"),
+			"\n- |",
+		),
+		"expected literal block scalar")
 }
 
 func TestRestoreCommandTDE(t *testing.T) {
-	b, err := yaml.Marshal(RestoreCommand("/dir", "try", "echo testValue", nil, "--options"))
-
-	assert.NilError(t, err)
-	assert.Assert(t, strings.Contains(string(b), "encryption_key_command = 'echo testValue'"),
-		"expected encryption_key_command setting, got:\n%s", b)
+	assert.Assert(t,
+		cmp.MarshalContains(
+			RestoreCommand("/dir", "try", "echo testValue", nil, "--options"),
+			"encryption_key_command = 'echo testValue'",
+		),
+		"expected encryption_key_command setting")
 }
 
 func TestDedicatedSnapshotVolumeRestoreCommand(t *testing.T) {
@@ -388,11 +387,12 @@ func TestDedicatedSnapshotVolumeRestoreCommand(t *testing.T) {
 }
 
 func TestDedicatedSnapshotVolumeRestoreCommandPrettyYAML(t *testing.T) {
-	b, err := yaml.Marshal(DedicatedSnapshotVolumeRestoreCommand("/dir", "--options"))
-
-	assert.NilError(t, err)
-	assert.Assert(t, strings.Contains(string(b), "\n- |"),
-		"expected literal block scalar, got:\n%s", b)
+	assert.Assert(t,
+		cmp.MarshalContains(
+			DedicatedSnapshotVolumeRestoreCommand("/dir", "--options"),
+			"\n- |",
+		),
+		"expected literal block scalar")
 }
 
 func TestServerConfig(t *testing.T) {

--- a/internal/testing/cmp/cmp.go
+++ b/internal/testing/cmp/cmp.go
@@ -50,6 +50,15 @@ func DeepEqual(x, y any, opts ...gocmp.Option) Comparison {
 	return gotest.DeepEqual(x, y, opts...)
 }
 
+// MarshalContains converts actual to YAML and succeeds if expected is in the result.
+func MarshalContains(actual any, expected string) Comparison {
+	b, err := yaml.Marshal(actual)
+	if err != nil {
+		return func() gotest.Result { return gotest.ResultFromError(err) }
+	}
+	return Contains(string(b), expected)
+}
+
 // MarshalMatches converts actual to YAML and compares that to expected.
 func MarshalMatches(actual any, expected string) Comparison {
 	b, err := yaml.Marshal(actual)


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature

**What is the current behavior (link to any open issues here)?**

PGUpgrade always runs `pg_upgrade` as a single process.

**What is the new behavior (if this is a feature change)?**

PGUpgrade always runs `pg_upgrade` with a `--jobs` argument.

The value to that argument is >1 when the `PGUpgradeCPUConcurrency` feature is enabled and PGUpgrade specifies more than 3 CPUs.

**Other Information**:

Issue: PGO-1958