### PR TITLE
Consolidate arguments to a Patroni function

### DIFF
--- a/internal/controller/postgrescluster/patroni.go
+++ b/internal/controller/postgrescluster/patroni.go
@@ -204,14 +204,9 @@ func (r *Reconciler) reconcilePatroniDynamicConfiguration(
 		return r.PodExec(ctx, pod.Namespace, pod.Name, naming.ContainerDatabase, stdin, stdout, stderr, command...)
 	}
 
-	var configuration map[string]any
-	if cluster.Spec.Patroni != nil {
-		configuration = cluster.Spec.Patroni.DynamicConfiguration
-	}
-	configuration = patroni.DynamicConfiguration(cluster, configuration, pgHBAs, pgParameters)
-
 	return errors.WithStack(
-		patroni.Executor(exec).ReplaceConfiguration(ctx, configuration))
+		patroni.Executor(exec).ReplaceConfiguration(ctx,
+			patroni.DynamicConfiguration(&cluster.Spec, pgHBAs, pgParameters)))
 }
 
 // generatePatroniLeaderLeaseService returns a v1.Service that exposes the


### PR DESCRIPTION
When called at runtime, the second argument is always derived from the first. This simplifies those call sites and clarifies the behavior in tests.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
