### PR TITLE
Add required Status fields and conditions to Job objects in tests.

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -2958,14 +2958,23 @@ func TestObserveRestoreEnv(t *testing.T) {
 			},
 		}
 
+		currentTime := metav1.Now()
+		startTime := metav1.NewTime(currentTime.AddDate(0, 0, -1))
+		restoreJob.Status.StartTime = &startTime
+
 		if completed != nil {
 			if *completed {
+				restoreJob.Status.CompletionTime = &currentTime
 				restoreJob.Status.Conditions = append(restoreJob.Status.Conditions, batchv1.JobCondition{
 					Type:    batchv1.JobComplete,
 					Status:  corev1.ConditionTrue,
 					Reason:  "test",
 					Message: "test",
-				})
+				},
+					batchv1.JobCondition{
+						Type:   batchv1.JobSuccessCriteriaMet,
+						Status: corev1.ConditionTrue,
+					})
 			} else {
 				restoreJob.Status.Conditions = append(restoreJob.Status.Conditions, batchv1.JobCondition{
 					Type:    batchv1.JobComplete,
@@ -2981,7 +2990,12 @@ func TestObserveRestoreEnv(t *testing.T) {
 					Status:  corev1.ConditionTrue,
 					Reason:  "test",
 					Message: "test",
-				})
+				},
+					batchv1.JobCondition{
+						Type:   batchv1.JobFailureTarget,
+						Status: corev1.ConditionTrue,
+					},
+				)
 			} else {
 				restoreJob.Status.Conditions = append(restoreJob.Status.Conditions, batchv1.JobCondition{
 					Type:    batchv1.JobFailed,


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Some of our tests currently fail in k8s 1.32 due to changes in required fields on batchv1.Job objects.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Added the required fields and conditions to the Job objects we create in our tests so that our tests pass.

**Other Information**:
