### PR TITLE
Wait only for local write of controller SQL

### DIFF
--- a/internal/controller/postgrescluster/pgmonitor_test.go
+++ b/internal/controller/postgrescluster/pgmonitor_test.go
@@ -602,7 +602,7 @@ func TestReconcilePGMonitorExporterStatus(t *testing.T) {
 		podExecCalled:   false,
 		// Status was generated manually for this test case
 		// TODO (jmckulk): add code to generate status
-		status:                      v1beta1.MonitoringStatus{ExporterConfiguration: "6d874c58df"},
+		status:                      v1beta1.MonitoringStatus{ExporterConfiguration: "5c5f955485"},
 		statusChangedAfterReconcile: false,
 	}} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/pgaudit/postgres.go
+++ b/internal/pgaudit/postgres.go
@@ -35,7 +35,9 @@ func EnableInPostgreSQL(ctx context.Context, exec postgres.Executor) error {
 
 	stdout, stderr, err := exec.ExecInAllDatabases(ctx,
 		// Quiet the NOTICE from IF EXISTS, and install the pgAudit event triggers.
+		// Use the default setting for "synchronous_commit".
 		// - https://www.postgresql.org/docs/current/runtime-config-client.html
+		// - https://www.postgresql.org/docs/current/runtime-config-wal.html
 		// - https://github.com/pgaudit/pgaudit#settings
 		`SET client_min_messages = WARNING; CREATE EXTENSION IF NOT EXISTS pgaudit;`,
 		map[string]string{

--- a/internal/pgbouncer/postgres.go
+++ b/internal/pgbouncer/postgres.go
@@ -68,6 +68,10 @@ func DisableInPostgreSQL(ctx context.Context, exec postgres.Executor) error {
 			// - https://www.postgresql.org/docs/current/runtime-config-client.html
 			`SET client_min_messages = WARNING;`,
 
+			// Do not wait for changes to be replicated. [Since PostgreSQL v9.1]
+			// - https://www.postgresql.org/docs/current/runtime-config-wal.html
+			`SET synchronous_commit = LOCAL;`,
+
 			// Drop the following objects in a transaction.
 			`BEGIN;`,
 
@@ -102,7 +106,7 @@ SELECT pg_catalog.format('DROP OWNED BY %I CASCADE', :'username')
 		// Remove the PgBouncer user now that the objects and other privileges are gone.
 		stdout, stderr, err = exec.ExecInDatabasesFromQuery(ctx,
 			`SELECT pg_catalog.current_database()`,
-			`SET client_min_messages = WARNING; DROP ROLE IF EXISTS :"username";`,
+			`SET client_min_messages = WARNING; SET synchronous_commit = LOCAL; DROP ROLE IF EXISTS :"username";`,
 			map[string]string{
 				"username": postgresqlUser,
 
@@ -129,6 +133,10 @@ func EnableInPostgreSQL(
 			// Quiet NOTICE messages from IF NOT EXISTS statements.
 			// - https://www.postgresql.org/docs/current/runtime-config-client.html
 			`SET client_min_messages = WARNING;`,
+
+			// Do not wait for changes to be replicated. [Since PostgreSQL v9.1]
+			// - https://www.postgresql.org/docs/current/runtime-config-wal.html
+			`SET synchronous_commit = LOCAL;`,
 
 			// Create the following objects in a transaction so that permissions
 			// are correct before any other session sees them.

--- a/internal/pgbouncer/postgres_test.go
+++ b/internal/pgbouncer/postgres_test.go
@@ -49,6 +49,7 @@ func TestDisableInPostgreSQL(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Equal(t, string(b), strings.TrimSpace(`
 SET client_min_messages = WARNING;
+SET synchronous_commit = LOCAL;
 BEGIN;
 DROP FUNCTION IF EXISTS :"namespace".get_auth(username TEXT);
 DROP SCHEMA IF EXISTS :"namespace" CASCADE;
@@ -90,7 +91,7 @@ COMMIT;`))
 
 			b, err := io.ReadAll(stdin)
 			assert.NilError(t, err)
-			assert.Equal(t, string(b), `SET client_min_messages = WARNING; DROP ROLE IF EXISTS :"username";`)
+			assert.Equal(t, string(b), `SET client_min_messages = WARNING; SET synchronous_commit = LOCAL; DROP ROLE IF EXISTS :"username";`)
 			gomega.NewWithT(t).Expect(command).To(gomega.ContainElements(
 				`--set=username=_crunchypgbouncer`,
 			), "expected query parameters")
@@ -135,6 +136,7 @@ func TestEnableInPostgreSQL(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, string(b), strings.TrimSpace(`
 SET client_min_messages = WARNING;
+SET synchronous_commit = LOCAL;
 BEGIN;
 SELECT pg_catalog.format('CREATE ROLE %I NOLOGIN', :'username')
  WHERE NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = :'username')

--- a/internal/pgmonitor/postgres.go
+++ b/internal/pgmonitor/postgres.go
@@ -79,6 +79,10 @@ func EnableExporterInPostgreSQL(ctx context.Context, exec postgres.Executor,
 			// - https://www.postgresql.org/docs/current/runtime-config-client.html
 			`SET client_min_messages = WARNING;`,
 
+			// Do not wait for changes to be replicated. [Since PostgreSQL v9.1]
+			// - https://www.postgresql.org/docs/current/runtime-config-wal.html
+			`SET synchronous_commit = LOCAL;`,
+
 			// Exporter expects that extension(s) to be installed in all databases
 			// pg_stat_statements: https://access.crunchydata.com/documentation/pgmonitor/latest/exporter/
 			"CREATE EXTENSION IF NOT EXISTS pg_stat_statements;",
@@ -102,6 +106,10 @@ func EnableExporterInPostgreSQL(ctx context.Context, exec postgres.Executor,
 				// Quiet NOTICE messages from IF EXISTS statements.
 				// - https://www.postgresql.org/docs/current/runtime-config-client.html
 				`SET client_min_messages = WARNING;`,
+
+				// Do not wait for changes to be replicated. [Since PostgreSQL v9.1]
+				// - https://www.postgresql.org/docs/current/runtime-config-wal.html
+				`SET synchronous_commit = LOCAL;`,
 
 				// Setup.sql file from the exporter image. sql is specific
 				// to the PostgreSQL version

--- a/internal/postgis/postgis.go
+++ b/internal/postgis/postgis.go
@@ -26,6 +26,10 @@ func EnableInPostgreSQL(ctx context.Context, exec postgres.Executor) error {
 			// - https://www.postgresql.org/docs/current/runtime-config-client.html
 			`SET client_min_messages = WARNING;`,
 
+			// Do not wait for changes to be replicated. [Since PostgreSQL v9.1]
+			// - https://www.postgresql.org/docs/current/runtime-config-wal.html
+			`SET synchronous_commit = LOCAL;`,
+
 			`CREATE EXTENSION IF NOT EXISTS postgis;`,
 			`CREATE EXTENSION IF NOT EXISTS postgis_topology;`,
 			`CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;`,

--- a/internal/postgis/postgis_test.go
+++ b/internal/postgis/postgis_test.go
@@ -29,6 +29,7 @@ func TestEnableInPostgreSQL(t *testing.T) {
 		b, err := io.ReadAll(stdin)
 		assert.NilError(t, err)
 		assert.Equal(t, string(b), `SET client_min_messages = WARNING;
+SET synchronous_commit = LOCAL;
 CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE EXTENSION IF NOT EXISTS postgis_topology;
 CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;

--- a/internal/postgres/users.go
+++ b/internal/postgres/users.go
@@ -69,6 +69,10 @@ func WriteUsersInPostgreSQL(
 	var err error
 	var sql bytes.Buffer
 
+	// Do not wait for changes to be replicated. [Since PostgreSQL v9.1]
+	// - https://www.postgresql.org/docs/current/runtime-config-wal.html
+	_, _ = sql.WriteString(`SET synchronous_commit = LOCAL;`)
+
 	// Prevent unexpected dereferences by emptying "search_path". The "pg_catalog"
 	// schema is still searched, and only temporary objects can be created.
 	// - https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-SEARCH-PATH
@@ -218,6 +222,10 @@ func WriteUsersSchemasInPostgreSQL(ctx context.Context, exec Executor,
 				// Quiet NOTICE messages from IF EXISTS statements.
 				// - https://www.postgresql.org/docs/current/runtime-config-client.html
 				`SET client_min_messages = WARNING;`,
+
+				// Do not wait for changes to be replicated. [Since PostgreSQL v9.1]
+				// - https://www.postgresql.org/docs/current/runtime-config-wal.html
+				`SET synchronous_commit = LOCAL;`,
 
 				// Creates a schema named after and owned by the user
 				// - https://www.postgresql.org/docs/current/ddl-schemas.html

--- a/internal/postgres/users_test.go
+++ b/internal/postgres/users_test.go
@@ -63,7 +63,7 @@ func TestWriteUsersInPostgreSQL(t *testing.T) {
 			b, err := io.ReadAll(stdin)
 			assert.NilError(t, err)
 			assert.Equal(t, string(b), strings.TrimSpace(`
-SET search_path TO '';
+SET synchronous_commit = LOCAL;SET search_path TO '';
 CREATE TEMPORARY TABLE input (id serial, data json);
 \copy input (data) from stdin with (format text)
 \.


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix

**What is the current behavior (link to any open issues here)?**

When Postgres replication is broken and synchronous commit is enabled, the controller blocks waiting for a remote write that will never happen.

**What is the new behavior (if this is a feature change)?**

This change allows the controller to return from SQL writes and repair replication.

**Other Information**:

Issue: PGO-1592