### PR TITLE
Reconcile cronjobs with cluster spec

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -345,18 +345,6 @@ func (r *Reconciler) cleanupRepoResources(ctx context.Context,
 					delete = false
 				}
 			}
-		case hasLabel(naming.LabelPGBackRestBackup):
-			if !backupsSpecFound {
-				break
-			}
-			// If a Job is identified for a repo that no longer exists in the spec then
-			// delete it.  Otherwise add it to the slice and continue.
-			for _, repo := range postgresCluster.Spec.Backups.PGBackRest.Repos {
-				if repo.Name == owned.GetLabels()[naming.LabelPGBackRestRepo] {
-					ownedNoDelete = append(ownedNoDelete, owned)
-					delete = false
-				}
-			}
 		case hasLabel(naming.LabelPGBackRestCronJob):
 			if !backupsSpecFound {
 				break
@@ -369,6 +357,18 @@ func (r *Reconciler) cleanupRepoResources(ctx context.Context,
 						ownedNoDelete = append(ownedNoDelete, owned)
 					}
 					break
+				}
+			}
+		case hasLabel(naming.LabelPGBackRestBackup):
+			if !backupsSpecFound {
+				break
+			}
+			// If a Job is identified for a repo that no longer exists in the spec then
+			// delete it.  Otherwise add it to the slice and continue.
+			for _, repo := range postgresCluster.Spec.Backups.PGBackRest.Repos {
+				if repo.Name == owned.GetLabels()[naming.LabelPGBackRestRepo] {
+					ownedNoDelete = append(ownedNoDelete, owned)
+					delete = false
 				}
 			}
 		case hasLabel(naming.LabelPGBackRestRestore):


### PR DESCRIPTION
Removing the repo backup schedule from the cluster spec will delete the cronJob(s) associated with the backup schedule. 

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

When a backup has a cron scheduled, for example:
```
spec:
  backups:
    pgbackrest:
      repos:
      - name: repo1
        schedules:
          full: "0 1 * * 0"
          differential: "0 1 * * 1-6"
```

Removing the backup schedule from the cluster configuration and applying the changes does not automatically delete the cronJob associated with the backup schedule. The cronJob must be manually deleted for the schedule to be removed. 


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

To address this issue, I've changed the position of the case statement for the cronJob in the function `cleanupRepoResources`.  With this change, cronJobs are automatically deleted when the repo backup schedule is removed from the cluster spec.

**Other Information**:
