### PR TITLE
Validation for pgBackRest Data Sources

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -6519,6 +6519,11 @@ spec:
                     - repo
                     - stanza
                     type: object
+                    x-kubernetes-validations:
+                    - fieldPath: .repo
+                      message: Only S3, GCS or Azure repos can be used as a pgBackRest
+                        data source.
+                      rule: '!has(self.repo.volume)'
                   postgresCluster:
                     description: |-
                       Defines a pgBackRest data source that can be used to pre-populate the PostgreSQL data

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -194,6 +194,7 @@ type DataSource struct {
 	// The PGBackRest field is incompatible with the PostgresCluster field: only one
 	// data source can be used for pre-populating a new PostgreSQL cluster
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="!has(self.repo.volume)", message="Only S3, GCS or Azure repos can be used as a pgBackRest data source.", fieldPath=".repo"
 	PGBackRest *PGBackRestDataSource `json:"pgbackrest,omitempty"`
 
 	// Defines a pgBackRest data source that can be used to pre-populate the PostgreSQL data


### PR DESCRIPTION
Adds validation to ensure only cloud-based repos (S3, Azure or GCS) are configured as a pgBackRest data source.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other


**What is the current behavior (link to any open issues here)?**

Volume-based repos can be specified as a pgBackRest data source, even though they are not allowed.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Only cloud-based repos (S3, Azure or GCS) can be configured as a pgBackRest data source.

**Other Information**:
