### PR TITLE
Add a New Condition for PVC Resize Errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -114,11 +114,6 @@ issues:
       path: internal/kubernetes/discovery.go
       text: k8s.io/client-go/discovery
 
-    # PGO-2010
-    - linters: [exhaustive]
-      path: internal/controller/postgrescluster/volumes.go
-      text: 'v1.PersistentVolumeClaimConditionType: v1.PersistentVolumeClaimControllerResizeError, v1.PersistentVolumeClaimNodeResizeError$'
-
     # These value types have unmarshal methods.
     # https://github.com/raeperd/recvcheck/issues/7
     - linters: [recvcheck]

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -410,10 +410,11 @@ type PostgresClusterStatus struct {
 
 // PostgresClusterStatus condition types.
 const (
-	PersistentVolumeResizing   = "PersistentVolumeResizing"
-	PostgresClusterProgressing = "Progressing"
-	ProxyAvailable             = "ProxyAvailable"
-	Registered                 = "Registered"
+	PersistentVolumeResizing    = "PersistentVolumeResizing"
+	PersistentVolumeResizeError = "PersistentVolumeResizeError"
+	PostgresClusterProgressing  = "Progressing"
+	ProxyAvailable              = "ProxyAvailable"
+	Registered                  = "Registered"
 )
 
 type PostgresInstanceSetSpec struct {


### PR DESCRIPTION
A new condition has been created to surface controller and node resize error condition details in the PostgresCluster status.  This also allows an exclude rule for the linter to be removed.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other


**What is the current behavior (link to any open issues here)?**

Running the linter fails with the following:

```
internal/controller/postgrescluster/volumes.go:65:4: missing cases in switch of type v1.PersistentVolumeClaimConditionType: v1.PersistentVolumeClaimControllerResizeError, v1.PersistentVolumeClaimNodeResizeError (exhaustive)
                        switch condition.Type {
``` 

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

The linter runs successfully.

**Other Information**:
