### PR TITLE
Rotate pgAdmin/gunicorn logs according to retentionPeriod

### DIFF
--- a/internal/collector/config.go
+++ b/internal/collector/config.go
@@ -153,7 +153,7 @@ func AddLogrotateConfigs(ctx context.Context, spec *v1beta1.InstrumentationSpec,
 func generateLogrotateConfig(
 	config LogrotateConfig, retentionPeriod metav1.Duration,
 ) string {
-	number, interval := parseDurationForLogrotate(retentionPeriod)
+	number, interval := ParseDurationForLogrotate(retentionPeriod)
 
 	return fmt.Sprintf(
 		logrotateConfigFormatString,
@@ -164,12 +164,12 @@ func generateLogrotateConfig(
 	)
 }
 
-// parseDurationForLogrotate takes a retention period and returns the rotate
+// ParseDurationForLogrotate takes a retention period and returns the rotate
 // number and interval string that should be used in the logrotate config.
 // If the retentionPeriod is less than 24 hours, the function will return the
 // number of hours and "hourly"; otherwise, we will round up to the nearest day
 // and return the day count and "daily"
-func parseDurationForLogrotate(retentionPeriod metav1.Duration) (int, string) {
+func ParseDurationForLogrotate(retentionPeriod metav1.Duration) (int, string) {
 	hours := math.Ceil(retentionPeriod.Hours())
 	if hours < 24 {
 		return int(hours), "hourly"

--- a/internal/collector/config_test.go
+++ b/internal/collector/config_test.go
@@ -197,7 +197,7 @@ func TestParseDurationForLogrotate(t *testing.T) {
 		t.Run(tt.retentionPeriod, func(t *testing.T) {
 			duration, err := v1beta1.NewDuration(tt.retentionPeriod)
 			assert.NilError(t, err)
-			number, interval := parseDurationForLogrotate(duration.AsDuration())
+			number, interval := ParseDurationForLogrotate(duration.AsDuration())
 			assert.Equal(t, tt.number, number)
 			assert.Equal(t, tt.interval, interval)
 		})

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1242,7 +1242,7 @@ func (r *Reconciler) reconcileInstance(
 	// add an emptyDir volume to the PodTemplateSpec and an associated '/tmp' volume mount to
 	// all containers included within that spec
 	if err == nil {
-		addTMPEmptyDir(&instance.Spec.Template)
+		AddTMPEmptyDir(&instance.Spec.Template)
 	}
 
 	// mount shared memory to the Postgres instance

--- a/internal/controller/postgrescluster/pgadmin.go
+++ b/internal/controller/postgrescluster/pgadmin.go
@@ -365,7 +365,7 @@ func (r *Reconciler) reconcilePGAdminStatefulSet(
 
 	// add an emptyDir volume to the PodTemplateSpec and an associated '/tmp'
 	// volume mount to all containers included within that spec
-	addTMPEmptyDir(&sts.Spec.Template)
+	AddTMPEmptyDir(&sts.Spec.Template)
 
 	return errors.WithStack(r.apply(ctx, sts))
 }

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -720,7 +720,7 @@ func (r *Reconciler) generateRepoHostIntent(ctx context.Context, postgresCluster
 		postgresCluster.Spec.ImagePullPolicy,
 		&repo.Spec.Template)
 
-	addTMPEmptyDir(&repo.Spec.Template)
+	AddTMPEmptyDir(&repo.Spec.Template)
 
 	// set ownership references
 	if err := r.setControllerReference(postgresCluster, repo); err != nil {
@@ -1272,7 +1272,7 @@ func (r *Reconciler) reconcileRestoreJob(ctx context.Context,
 		cluster.Spec.ImagePullPolicy,
 		&restoreJob.Spec.Template)
 
-	addTMPEmptyDir(&restoreJob.Spec.Template)
+	AddTMPEmptyDir(&restoreJob.Spec.Template)
 
 	return errors.WithStack(r.apply(ctx, restoreJob))
 }

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -476,7 +476,7 @@ func (r *Reconciler) generatePGBouncerDeployment(
 	}
 
 	// Add tmp directory and volume for log files
-	addTMPEmptyDir(&deploy.Spec.Template)
+	AddTMPEmptyDir(&deploy.Spec.Template)
 
 	return deploy, true, err
 }

--- a/internal/controller/postgrescluster/snapshots.go
+++ b/internal/controller/postgrescluster/snapshots.go
@@ -394,7 +394,7 @@ func (r *Reconciler) dedicatedSnapshotVolumeRestore(ctx context.Context,
 		cluster.Spec.ImagePullPolicy,
 		&restoreJob.Spec.Template)
 
-	addTMPEmptyDir(&restoreJob.Spec.Template)
+	AddTMPEmptyDir(&restoreJob.Spec.Template)
 
 	restoreJob.Annotations[naming.PGBackRestBackupJobCompletion] = backupJob.Status.CompletionTime.Format(time.RFC3339)
 	return errors.WithStack(r.apply(ctx, restoreJob))

--- a/internal/controller/postgrescluster/util.go
+++ b/internal/controller/postgrescluster/util.go
@@ -134,13 +134,13 @@ func addDevSHM(template *corev1.PodTemplateSpec) {
 	}
 }
 
-// addTMPEmptyDir adds a "tmp" EmptyDir volume to the provided Pod template, while then also adding a
+// AddTMPEmptyDir adds a "tmp" EmptyDir volume to the provided Pod template, while then also adding a
 // volume mount at /tmp for all containers defined within the Pod template
 // The '/tmp' directory is currently utilized for the following:
 //   - As the pgBackRest lock directory (this is the default lock location for pgBackRest)
 //   - The location where the replication client certificates can be loaded with the proper
 //     permissions set
-func addTMPEmptyDir(template *corev1.PodTemplateSpec) {
+func AddTMPEmptyDir(template *corev1.PodTemplateSpec) {
 
 	template.Spec.Volumes = append(template.Spec.Volumes, corev1.Volume{
 		Name: "tmp",

--- a/internal/controller/standalone_pgadmin/config.go
+++ b/internal/controller/standalone_pgadmin/config.go
@@ -7,10 +7,9 @@ package standalone_pgadmin
 // Include configs here used by multiple files
 const (
 	// ConfigMap keys used also in mounting volume to pod
-	settingsConfigMapKey     = "pgadmin-settings.json"
-	settingsClusterMapKey    = "pgadmin-shared-clusters.json"
-	gunicornLoggingConfigKey = "gunicorn-logging-config.json"
-	gunicornConfigKey        = "gunicorn-config.json"
+	settingsConfigMapKey  = "pgadmin-settings.json"
+	settingsClusterMapKey = "pgadmin-shared-clusters.json"
+	gunicornConfigKey     = "gunicorn-config.json"
 
 	// Port address used to define pod and service
 	pgAdminPort = 5050

--- a/internal/controller/standalone_pgadmin/config.go
+++ b/internal/controller/standalone_pgadmin/config.go
@@ -7,9 +7,10 @@ package standalone_pgadmin
 // Include configs here used by multiple files
 const (
 	// ConfigMap keys used also in mounting volume to pod
-	settingsConfigMapKey  = "pgadmin-settings.json"
-	settingsClusterMapKey = "pgadmin-shared-clusters.json"
-	gunicornConfigKey     = "gunicorn-config.json"
+	settingsConfigMapKey     = "pgadmin-settings.json"
+	settingsClusterMapKey    = "pgadmin-shared-clusters.json"
+	gunicornLoggingConfigKey = "gunicorn-logging-config.json"
+	gunicornConfigKey        = "gunicorn-config.json"
 
 	// Port address used to define pod and service
 	pgAdminPort = 5050

--- a/internal/controller/standalone_pgadmin/configmap.go
+++ b/internal/controller/standalone_pgadmin/configmap.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/crunchydata/postgres-operator/internal/collector"
+	"github.com/crunchydata/postgres-operator/internal/feature"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
@@ -32,7 +33,7 @@ func (r *PGAdminReconciler) reconcilePGAdminConfigMap(
 	ctx context.Context, pgadmin *v1beta1.PGAdmin,
 	clusters map[string][]*v1beta1.PostgresCluster,
 ) (*corev1.ConfigMap, error) {
-	configmap, err := configmap(pgadmin, clusters)
+	configmap, err := configmap(ctx, pgadmin, clusters)
 	if err != nil {
 		return configmap, err
 	}
@@ -50,7 +51,7 @@ func (r *PGAdminReconciler) reconcilePGAdminConfigMap(
 }
 
 // configmap returns a v1.ConfigMap for pgAdmin.
-func configmap(pgadmin *v1beta1.PGAdmin,
+func configmap(ctx context.Context, pgadmin *v1beta1.PGAdmin,
 	clusters map[string][]*v1beta1.PostgresCluster,
 ) (*corev1.ConfigMap, error) {
 	configmap := &corev1.ConfigMap{ObjectMeta: naming.StandalonePGAdmin(pgadmin)}
@@ -63,9 +64,9 @@ func configmap(pgadmin *v1beta1.PGAdmin,
 
 	// TODO(tjmoore4): Populate configuration details.
 	initialize.Map(&configmap.Data)
-	configSettings, err := generateConfig(pgadmin)
+	pgadminConfigSettings, err := generateConfig(ctx, pgadmin)
 	if err == nil {
-		configmap.Data[settingsConfigMapKey] = configSettings
+		configmap.Data[settingsConfigMapKey] = pgadminConfigSettings
 	}
 
 	clusterSettings, err := generateClusterConfig(clusters)
@@ -73,16 +74,19 @@ func configmap(pgadmin *v1beta1.PGAdmin,
 		configmap.Data[settingsClusterMapKey] = clusterSettings
 	}
 
-	gunicornSettings, err := generateGunicornConfig(pgadmin)
+	gunicornSettings, gunicornLoggingSettings, err := generateGunicornConfig(ctx, pgadmin)
 	if err == nil {
 		configmap.Data[gunicornConfigKey] = gunicornSettings
+		configmap.Data[gunicornLoggingConfigKey] = gunicornLoggingSettings
 	}
 
 	return configmap, err
 }
 
-// generateConfig generates the config settings for the pgAdmin
-func generateConfig(pgadmin *v1beta1.PGAdmin) (string, error) {
+// generateConfigs generates the config settings for the pgAdmin and gunicorn
+func generateConfig(ctx context.Context, pgadmin *v1beta1.PGAdmin) (
+	string, error,
+) {
 	settings := map[string]any{
 		// Bind to all IPv4 addresses by default. "0.0.0.0" here represents INADDR_ANY.
 		// - https://flask.palletsprojects.com/en/2.2.x/api/#flask.Flask.run
@@ -102,6 +106,48 @@ func generateConfig(pgadmin *v1beta1.PGAdmin) (string, error) {
 	settings["UPGRADE_CHECK_ENABLED"] = false
 	settings["UPGRADE_CHECK_URL"] = ""
 	settings["UPGRADE_CHECK_KEY"] = ""
+	settings["DATA_DIR"] = dataMountPath
+	settings["LOG_FILE"] = LogFileAbsolutePath
+
+	// If OTel logs feature gate is enabled, we want to change the pgAdmin/gunicorn logging
+	if feature.Enabled(ctx, feature.OpenTelemetryLogs) && pgadmin.Spec.Instrumentation != nil {
+
+		var (
+			maxBackupRetentionNumber = 1
+			// One day in minutes for pgadmin rotation
+			pgAdminRetentionPeriod = 24 * 60
+		)
+
+		// If the user has set a retention period, we will use those values for log rotation,
+		// which is otherwise managed by python.
+		if pgadmin.Spec.Instrumentation.Logs != nil &&
+			pgadmin.Spec.Instrumentation.Logs.RetentionPeriod != nil {
+
+			retentionNumber, period := collector.ParseDurationForLogrotate(pgadmin.Spec.Instrumentation.Logs.RetentionPeriod.AsDuration())
+			// `LOG_ROTATION_MAX_LOG_FILES`` in pgadmin refers to the already rotated logs.
+			// `backupCount` for gunicorn is similar.
+			// Our retention unit is for total number of log files, so subtract 1 to account
+			// for the currently-used log file.
+			maxBackupRetentionNumber = retentionNumber - 1
+			if period == "hourly" {
+				// If the period is hourly, set the pgadmin
+				// and gunicorn retention periods to hourly.
+				pgAdminRetentionPeriod = 60
+			}
+		}
+
+		settings["LOG_ROTATION_AGE"] = pgAdminRetentionPeriod
+		settings["LOG_ROTATION_MAX_LOG_FILES"] = maxBackupRetentionNumber
+		settings["JSON_LOGGER"] = true
+		settings["CONSOLE_LOG_LEVEL"] = "WARNING"
+		settings["FILE_LOG_LEVEL"] = "INFO"
+		settings["FILE_LOG_FORMAT_JSON"] = map[string]string{
+			"time":    "created",
+			"name":    "name",
+			"level":   "levelname",
+			"message": "message",
+		}
+	}
 
 	// To avoid spurious reconciles, the following value must not change when
 	// the spec does not change. [json.Encoder] and [json.Marshal] do this by
@@ -185,7 +231,9 @@ func generateClusterConfig(
 
 // generateGunicornConfig generates the config settings for the gunicorn server
 // - https://docs.gunicorn.org/en/latest/settings.html
-func generateGunicornConfig(pgadmin *v1beta1.PGAdmin) (string, error) {
+func generateGunicornConfig(ctx context.Context, pgadmin *v1beta1.PGAdmin) (
+	string, string, error,
+) {
 	settings := map[string]any{
 		// Bind to all IPv4 addresses and set 25 threads by default.
 		// - https://docs.gunicorn.org/en/latest/settings.html#bind
@@ -213,5 +261,105 @@ func generateGunicornConfig(pgadmin *v1beta1.PGAdmin) (string, error) {
 	encoder.SetIndent("", "  ")
 	err := encoder.Encode(settings)
 
-	return buffer.String(), err
+	// Gunicorn logging dict settings
+	logSettings := map[string]any{}
+
+	// If OTel logs feature gate is enabled, we want to change the pgAdmin/gunicorn logging
+	if feature.Enabled(ctx, feature.OpenTelemetryLogs) &&
+		pgadmin.Spec.Instrumentation != nil {
+
+		var (
+			maxBackupRetentionNumber = "1"
+			// Daily rotation for gunicorn rotation
+			gunicornRetentionPeriod = "D"
+		)
+
+		// If the user has set a retention period, we will use those values for log rotation,
+		// which is otherwise managed by python.
+		if pgadmin.Spec.Instrumentation.Logs != nil &&
+			pgadmin.Spec.Instrumentation.Logs.RetentionPeriod != nil {
+
+			retentionNumber, period := collector.ParseDurationForLogrotate(pgadmin.Spec.Instrumentation.Logs.RetentionPeriod.AsDuration())
+			// `LOG_ROTATION_MAX_LOG_FILES`` in pgadmin refers to the already rotated logs.
+			// `backupCount` for gunicorn is similar.
+			// Our retention unit is for total number of log files, so subtract 1 to account
+			// for the currently-used log file.
+			maxBackupRetentionNumber = strconv.Itoa(retentionNumber - 1)
+			if period == "hourly" {
+				// If the period is hourly, set the pgadmin
+				// and gunicorn retention periods to hourly.
+				gunicornRetentionPeriod = "H"
+			}
+		}
+
+		// Gunicorn uses the Python logging package, which sets the following attributes:
+		// https://docs.python.org/3/library/logging.html#logrecord-attributes.
+		// JsonFormatter is used to format the log: https://pypi.org/project/jsonformatter/
+		// We override the gunicorn defaults (using `logconfig_dict`) to set our own file handler.
+		// - https://docs.gunicorn.org/en/stable/settings.html#logconfig-dict
+		// - https://github.com/benoitc/gunicorn/blob/23.0.0/gunicorn/glogging.py#L47
+		logSettings = map[string]any{
+
+			"loggers": map[string]any{
+				"gunicorn.access": map[string]any{
+					"handlers":  []string{"file"},
+					"level":     "INFO",
+					"propagate": true,
+					"qualname":  "gunicorn.access",
+				},
+				"gunicorn.error": map[string]any{
+					"handlers":  []string{"file"},
+					"level":     "INFO",
+					"propagate": true,
+					"qualname":  "gunicorn.error",
+				},
+			},
+			"handlers": map[string]any{
+				"file": map[string]any{
+					"class":       "logging.handlers.TimedRotatingFileHandler",
+					"filename":    GunicornLogFileAbsolutePath,
+					"backupCount": maxBackupRetentionNumber,
+					"interval":    1,
+					"when":        gunicornRetentionPeriod,
+					"formatter":   "json",
+				},
+				"console": map[string]any{
+					"class":     "logging.StreamHandler",
+					"formatter": "generic",
+					"stream":    "ext://sys.stdout",
+				},
+			},
+			"formatters": map[string]any{
+				"generic": map[string]any{
+					"class":   "logging.Formatter",
+					"datefmt": "[%Y-%m-%d %H:%M:%S %z]",
+					"format":  "%(asctime)s [%(process)d] [%(levelname)s] %(message)s",
+				},
+				"json": map[string]any{
+					"class":      "jsonformatter.JsonFormatter",
+					"separators": []string{",", ":"},
+					"format": map[string]string{
+						"time":    "created",
+						"name":    "name",
+						"level":   "levelname",
+						"message": "message",
+					},
+				},
+			},
+		}
+	}
+
+	// To avoid spurious reconciles, the following value must not change when
+	// the spec does not change. [json.Encoder] and [json.Marshal] do this by
+	// emitting map keys in sorted order. Indent so the value is not rendered
+	// as one long line by `kubectl`.
+	logBuffer := new(bytes.Buffer)
+	logEncoder := json.NewEncoder(logBuffer)
+	logEncoder.SetEscapeHTML(false)
+	logEncoder.SetIndent("", "  ")
+
+	// Combine errors
+	err = logEncoder.Encode(logSettings)
+
+	return buffer.String(), logBuffer.String(), err
 }

--- a/internal/controller/standalone_pgadmin/pod.go
+++ b/internal/controller/standalone_pgadmin/pod.go
@@ -155,7 +155,7 @@ func pod(
 
 	startup := corev1.Container{
 		Name:            naming.ContainerPGAdminStartup,
-		Command:         startupCommand(inPGAdmin),
+		Command:         startupCommand(),
 		Image:           container.Image,
 		ImagePullPolicy: container.ImagePullPolicy,
 		Resources:       container.Resources,
@@ -346,7 +346,7 @@ done
 }
 
 // startupCommand returns an entrypoint that prepares the filesystem for pgAdmin.
-func startupCommand(inPgadmin *v1beta1.PGAdmin) []string {
+func startupCommand() []string {
 	// pgAdmin reads from the `/etc/pgadmin/config_system.py` file during startup
 	// after all other config files.
 	// - https://github.com/pgadmin-org/pgadmin4/blob/REL-7_7/docs/en_US/config_py.rst

--- a/internal/controller/standalone_pgadmin/pod.go
+++ b/internal/controller/standalone_pgadmin/pod.go
@@ -270,7 +270,7 @@ func startupScript(pgadmin *v1beta1.PGAdmin) []string {
 	// - https://www.pgadmin.org/docs/pgadmin4/development/server_deployment.html#standalone-gunicorn-configuration
 	// - https://docs.gunicorn.org/en/latest/configure.html
 	var startScript = fmt.Sprintf(`
-export PGADMIN_SETUP_PASSWORD="admin"
+export PGADMIN_SETUP_PASSWORD="$(date +%%s | sha256sum | base64 | head -c 32)"
 PGADMIN_DIR=%s
 APP_RELEASE=$(cd $PGADMIN_DIR && python3 -c "import config; print(config.APP_RELEASE)")
 

--- a/internal/controller/standalone_pgadmin/pod.go
+++ b/internal/controller/standalone_pgadmin/pod.go
@@ -45,7 +45,6 @@ const (
 
 // pod populates a PodSpec with the container and volumes needed to run pgAdmin.
 func pod(
-	ctx context.Context,
 	inPGAdmin *v1beta1.PGAdmin,
 	inConfigMap *corev1.ConfigMap,
 	outPod *corev1.PodSpec,
@@ -156,7 +155,7 @@ func pod(
 
 	startup := corev1.Container{
 		Name:            naming.ContainerPGAdminStartup,
-		Command:         startupCommand(ctx, inPGAdmin),
+		Command:         startupCommand(inPGAdmin),
 		Image:           container.Image,
 		ImagePullPolicy: container.ImagePullPolicy,
 		Resources:       container.Resources,
@@ -347,7 +346,7 @@ done
 }
 
 // startupCommand returns an entrypoint that prepares the filesystem for pgAdmin.
-func startupCommand(ctx context.Context, inPgadmin *v1beta1.PGAdmin) []string {
+func startupCommand(inPgadmin *v1beta1.PGAdmin) []string {
 	// pgAdmin reads from the `/etc/pgadmin/config_system.py` file during startup
 	// after all other config files.
 	// - https://github.com/pgadmin-org/pgadmin4/blob/REL-7_7/docs/en_US/config_py.rst

--- a/internal/controller/standalone_pgadmin/pod_test.go
+++ b/internal/controller/standalone_pgadmin/pod_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/crunchydata/postgres-operator/internal/feature"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/kubernetes"
 	"github.com/crunchydata/postgres-operator/internal/testing/cmp"
@@ -29,9 +28,8 @@ func TestPod(t *testing.T) {
 	config := new(corev1.ConfigMap)
 	testpod := new(corev1.PodSpec)
 	pvc := new(corev1.PersistentVolumeClaim)
-	ctx := context.Background()
 
-	call := func() { pod(ctx, pgadmin, config, testpod, pvc) }
+	call := func() { pod(pgadmin, config, testpod, pvc) }
 
 	t.Run("Defaults", func(t *testing.T) {
 
@@ -222,13 +220,6 @@ volumes:
 				RetentionPeriod: retentionPeriod,
 			},
 		}
-
-		// Turn on the Feature gate
-		gate := feature.NewGate()
-		assert.NilError(t, gate.SetFromMap(map[string]bool{
-			feature.OpenTelemetryLogs: true,
-		}))
-		ctx = feature.NewContext(context.Background(), gate)
 
 		call()
 

--- a/internal/controller/standalone_pgadmin/pod_test.go
+++ b/internal/controller/standalone_pgadmin/pod_test.go
@@ -59,7 +59,7 @@ containers:
     if [ $APP_RELEASE -eq 7 ]; then
         pgadmin4 &
     else
-        gunicorn -c /etc/pgadmin/gunicorn_config.py --reload-extra-file /etc/pgadmin/conf.d/~postgres-operator/gunicorn-logging-config.json --log-config-json /etc/pgadmin/conf.d/~postgres-operator/gunicorn-logging-config.json --chdir $PGADMIN_DIR pgAdmin4:app &
+        gunicorn -c /etc/pgadmin/gunicorn_config.py --chdir $PGADMIN_DIR pgAdmin4:app &
     fi
     echo $! > $PGADMIN4_PIDFILE
 
@@ -74,7 +74,7 @@ containers:
 
     exec {fd}<> <(:||:)
     while read -r -t 5 -u "${fd}" ||:; do
-        if [[ "${cluster_file}" -nt "/proc/self/fd/${fd}" ]] && loadServerCommand
+        if [[ "${cluster_file}" -nt "/proc/self/fd/${fd}" ]] && loadServerCommand && kill -KILL $(head -1 ${PGADMIN4_PIDFILE?});
         then
             exec {fd}>&- && exec {fd}<> <(:||:)
             stat --format='Loaded shared servers dated %y' "${cluster_file}"
@@ -84,7 +84,7 @@ containers:
             if [[ $APP_RELEASE -eq 7 ]]; then
                 pgadmin4 &
             else
-                gunicorn -c /etc/pgadmin/gunicorn_config.py --reload-extra-file /etc/pgadmin/conf.d/~postgres-operator/gunicorn-logging-config.json --log-config-json /etc/pgadmin/conf.d/~postgres-operator/gunicorn-logging-config.json --chdir $PGADMIN_DIR pgAdmin4:app &
+                gunicorn -c /etc/pgadmin/gunicorn_config.py --chdir $PGADMIN_DIR pgAdmin4:app &
             fi
             echo $! > $PGADMIN4_PIDFILE
             echo "Restarting pgAdmin4"
@@ -190,8 +190,6 @@ volumes:
           path: ~postgres-operator/pgadmin-shared-clusters.json
         - key: gunicorn-config.json
           path: ~postgres-operator/gunicorn-config.json
-        - key: gunicorn-logging-config.json
-          path: ~postgres-operator/gunicorn-logging-config.json
 - name: pgadmin-data
   persistentVolumeClaim:
     claimName: ""
@@ -247,7 +245,7 @@ containers:
     if [ $APP_RELEASE -eq 7 ]; then
         pgadmin4 &
     else
-        gunicorn -c /etc/pgadmin/gunicorn_config.py --reload-extra-file /etc/pgadmin/conf.d/~postgres-operator/gunicorn-logging-config.json --log-config-json /etc/pgadmin/conf.d/~postgres-operator/gunicorn-logging-config.json --chdir $PGADMIN_DIR pgAdmin4:app &
+        gunicorn -c /etc/pgadmin/gunicorn_config.py --chdir $PGADMIN_DIR pgAdmin4:app &
     fi
     echo $! > $PGADMIN4_PIDFILE
 
@@ -262,7 +260,7 @@ containers:
 
     exec {fd}<> <(:||:)
     while read -r -t 5 -u "${fd}" ||:; do
-        if [[ "${cluster_file}" -nt "/proc/self/fd/${fd}" ]] && loadServerCommand
+        if [[ "${cluster_file}" -nt "/proc/self/fd/${fd}" ]] && loadServerCommand && kill -KILL $(head -1 ${PGADMIN4_PIDFILE?});
         then
             exec {fd}>&- && exec {fd}<> <(:||:)
             stat --format='Loaded shared servers dated %y' "${cluster_file}"
@@ -272,7 +270,7 @@ containers:
             if [[ $APP_RELEASE -eq 7 ]]; then
                 pgadmin4 &
             else
-                gunicorn -c /etc/pgadmin/gunicorn_config.py --reload-extra-file /etc/pgadmin/conf.d/~postgres-operator/gunicorn-logging-config.json --log-config-json /etc/pgadmin/conf.d/~postgres-operator/gunicorn-logging-config.json --chdir $PGADMIN_DIR pgAdmin4:app &
+                gunicorn -c /etc/pgadmin/gunicorn_config.py --chdir $PGADMIN_DIR pgAdmin4:app &
             fi
             echo $! > $PGADMIN4_PIDFILE
             echo "Restarting pgAdmin4"
@@ -386,8 +384,6 @@ volumes:
           path: ~postgres-operator/pgadmin-shared-clusters.json
         - key: gunicorn-config.json
           path: ~postgres-operator/gunicorn-config.json
-        - key: gunicorn-logging-config.json
-          path: ~postgres-operator/gunicorn-logging-config.json
 - name: pgadmin-data
   persistentVolumeClaim:
     claimName: ""
@@ -430,8 +426,6 @@ func TestPodConfigFiles(t *testing.T) {
       path: ~postgres-operator/pgadmin-shared-clusters.json
     - key: gunicorn-config.json
       path: ~postgres-operator/gunicorn-config.json
-    - key: gunicorn-logging-config.json
-      path: ~postgres-operator/gunicorn-logging-config.json
     name: some-cm
 	`))
 }

--- a/internal/controller/standalone_pgadmin/pod_test.go
+++ b/internal/controller/standalone_pgadmin/pod_test.go
@@ -139,6 +139,7 @@ initContainers:
   - --
   - |-
     mkdir -p '/etc/pgadmin/conf.d' && chmod 0775 '/etc/pgadmin/conf.d'
+    mkdir -p '/var/lib/pgadmin/logs' && chmod 0775 '/var/lib/pgadmin/logs'
     echo "$1" > /etc/pgadmin/config_system.py
     echo "$2" > /etc/pgadmin/gunicorn_config.py
   - startup
@@ -337,6 +338,7 @@ initContainers:
   - --
   - |-
     mkdir -p '/etc/pgadmin/conf.d' && chmod 0775 '/etc/pgadmin/conf.d'
+    mkdir -p '/var/lib/pgadmin/logs' && chmod 0775 '/var/lib/pgadmin/logs'
     echo "$1" > /etc/pgadmin/config_system.py
     echo "$2" > /etc/pgadmin/gunicorn_config.py
   - startup
@@ -358,7 +360,6 @@ initContainers:
     LOG_FILE = '/var/lib/pgadmin/logs/pgadmin.log'
 
     LOG_ROTATION_AGE = 60 # minutes
-    LOG_ROTATION_SIZE = 5 # MiB
     LOG_ROTATION_MAX_LOG_FILES = 11
 
     JSON_LOGGER = True

--- a/internal/controller/standalone_pgadmin/statefulset.go
+++ b/internal/controller/standalone_pgadmin/statefulset.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/crunchydata/postgres-operator/internal/collector"
+	"github.com/crunchydata/postgres-operator/internal/controller/postgrescluster"
 	"github.com/crunchydata/postgres-operator/internal/feature"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
@@ -119,10 +120,11 @@ func statefulset(
 
 	sts.Spec.Template.Spec.SecurityContext = podSecurityContext(ctx)
 
-	pod(pgadmin, configmap, &sts.Spec.Template.Spec, dataVolume)
+	pod(ctx, pgadmin, configmap, &sts.Spec.Template.Spec, dataVolume)
 
-	if feature.Enabled(ctx, feature.OpenTelemetryLogs) {
+	if pgadmin.Spec.Instrumentation != nil && feature.Enabled(ctx, feature.OpenTelemetryLogs) {
 		// Logs for gunicorn and pgadmin write to /var/lib/pgadmin/logs
+		// so the collector needs access to that that path.
 		dataVolumeMount := corev1.VolumeMount{
 			Name:      "pgadmin-data",
 			MountPath: "/var/lib/pgadmin",
@@ -132,8 +134,10 @@ func statefulset(
 		}
 
 		collector.AddToPod(ctx, pgadmin.Spec.Instrumentation, pgadmin.Spec.ImagePullPolicy,
-			configmap, &sts.Spec.Template.Spec, volumeMounts, "", []string{}, false)
+			configmap, &sts.Spec.Template.Spec, volumeMounts, "", []string{LogDirectoryAbsolutePath}, false)
 	}
+
+	postgrescluster.AddTMPEmptyDir(&sts.Spec.Template)
 
 	return sts
 }

--- a/internal/controller/standalone_pgadmin/statefulset.go
+++ b/internal/controller/standalone_pgadmin/statefulset.go
@@ -120,7 +120,7 @@ func statefulset(
 
 	sts.Spec.Template.Spec.SecurityContext = podSecurityContext(ctx)
 
-	pod(ctx, pgadmin, configmap, &sts.Spec.Template.Spec, dataVolume)
+	pod(pgadmin, configmap, &sts.Spec.Template.Spec, dataVolume)
 
 	if pgadmin.Spec.Instrumentation != nil && feature.Enabled(ctx, feature.OpenTelemetryLogs) {
 		// Logs for gunicorn and pgadmin write to /var/lib/pgadmin/logs


### PR DESCRIPTION
**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

pgAdmin/Gunicorn log rotation is hard-coded

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

pgAdmin has a built in logfile rotation system, as does gunicorn. We want to use those systems, but respect the retention setting that a user sets in the instrumentation section. This PR uses the RetentionPeriod to
- set the number of backups for gunicorn and pgAdmin;
- set the rotation cycle for pgAdmin.


**Other Information**:

Issues: [PGO-2168]
