### PR TITLE
Rotate pgbackrest

### DIFF
--- a/internal/collector/pgbackrest.go
+++ b/internal/collector/pgbackrest.go
@@ -47,10 +47,9 @@ func NewConfigForPgBackrestRepoHostPod(
 
 		// Keep track of what log records and files have been processed.
 		// Use a subdirectory of the logs directory to stay within the same failure domain.
-		// TODO(log-rotation): Create this directory during Collector startup.
 		config.Extensions["file_storage/pgbackrest_logs"] = map[string]any{
 			"directory":        directory + "/receiver",
-			"create_directory": true,
+			"create_directory": false,
 			"fsync":            true,
 		}
 

--- a/internal/collector/pgbackrest_test.go
+++ b/internal/collector/pgbackrest_test.go
@@ -39,7 +39,7 @@ exporters:
     verbosity: detailed
 extensions:
   file_storage/pgbackrest_logs:
-    create_directory: true
+    create_directory: false
     directory: /pgbackrest/repo1/log/receiver
     fsync: true
 processors:
@@ -131,7 +131,7 @@ exporters:
     project: google-project-name
 extensions:
   file_storage/pgbackrest_logs:
-    create_directory: true
+    create_directory: false
     directory: /pgbackrest/repo1/log/receiver
     fsync: true
 processors:

--- a/internal/collector/pgbouncer.go
+++ b/internal/collector/pgbouncer.go
@@ -54,12 +54,11 @@ func EnablePgBouncerLogging(ctx context.Context,
 
 		// Keep track of what log records and files have been processed.
 		// Use a subdirectory of the logs directory to stay within the same failure domain.
-		// TODO(log-rotation): Create this directory during Collector startup.
 		//
 		// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/-/extension/storage/filestorage#readme
 		outConfig.Extensions["file_storage/pgbouncer_logs"] = map[string]any{
 			"directory":        directory + "/receiver",
-			"create_directory": true,
+			"create_directory": false,
 			"fsync":            true,
 		}
 

--- a/internal/collector/pgbouncer_test.go
+++ b/internal/collector/pgbouncer_test.go
@@ -35,7 +35,7 @@ exporters:
     verbosity: detailed
 extensions:
   file_storage/pgbouncer_logs:
-    create_directory: true
+    create_directory: false
     directory: /tmp/receiver
     fsync: true
 processors:
@@ -124,7 +124,7 @@ exporters:
     project: google-project-name
 extensions:
   file_storage/pgbouncer_logs:
-    create_directory: true
+    create_directory: false
     directory: /tmp/receiver
     fsync: true
 processors:

--- a/internal/collector/postgres.go
+++ b/internal/collector/postgres.go
@@ -27,10 +27,13 @@ func NewConfigForPostgresPod(ctx context.Context,
 ) *Config {
 	config := NewConfig(inCluster.Spec.Instrumentation)
 
+	// Metrics
 	EnablePostgresMetrics(ctx, inCluster, config)
 	EnablePatroniMetrics(ctx, inCluster, config)
-	EnablePatroniLogging(ctx, inCluster, config)
+
+	// Logging
 	EnablePostgresLogging(ctx, inCluster, config, outParameters)
+	EnablePatroniLogging(ctx, inCluster, config)
 
 	return config
 }
@@ -229,10 +232,9 @@ func EnablePostgresLogging(
 		}
 
 		// pgBackRest pipeline
-		// TODO(log-rotation): Create this directory during Collector startup.
 		outConfig.Extensions["file_storage/pgbackrest_logs"] = map[string]any{
 			"directory":        naming.PGBackRestPGDataLogPath + "/receiver",
-			"create_directory": true,
+			"create_directory": false,
 			"fsync":            true,
 		}
 

--- a/internal/collector/postgres_test.go
+++ b/internal/collector/postgres_test.go
@@ -40,7 +40,7 @@ exporters:
     verbosity: detailed
 extensions:
   file_storage/pgbackrest_logs:
-    create_directory: true
+    create_directory: false
     directory: /pgdata/pgbackrest/log/receiver
     fsync: true
   file_storage/postgres_logs:
@@ -272,7 +272,7 @@ exporters:
     project: google-project-name
 extensions:
   file_storage/pgbackrest_logs:
-    create_directory: true
+    create_directory: false
     directory: /pgdata/pgbackrest/log/receiver
     fsync: true
   file_storage/postgres_logs:

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1219,8 +1219,10 @@ func (r *Reconciler) reconcileInstance(
 		}
 
 		// For now, we are not using logrotate to rotate postgres or patroni logs
+		// but we are using it for pgbackrest logs in the postgres pod
 		collector.AddToPod(ctx, cluster.Spec.Instrumentation, cluster.Spec.ImagePullPolicy, instanceConfigMap, &instance.Spec.Template.Spec,
-			[]corev1.VolumeMount{postgres.DataVolumeMount()}, pgPassword, []string{}, false)
+			[]corev1.VolumeMount{postgres.DataVolumeMount()}, pgPassword,
+			[]string{naming.PGBackRestPGDataLogPath}, true)
 	}
 
 	// Add postgres-exporter to the instance Pod spec

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1220,7 +1220,7 @@ func (r *Reconciler) reconcileInstance(
 
 		// For now, we are not using logrotate to rotate postgres or patroni logs
 		collector.AddToPod(ctx, cluster.Spec.Instrumentation, cluster.Spec.ImagePullPolicy, instanceConfigMap, &instance.Spec.Template.Spec,
-			[]corev1.VolumeMount{postgres.DataVolumeMount()}, pgPassword, false)
+			[]corev1.VolumeMount{postgres.DataVolumeMount()}, pgPassword, []string{}, false)
 	}
 
 	// Add postgres-exporter to the instance Pod spec
@@ -1425,8 +1425,24 @@ func (r *Reconciler) reconcileInstanceConfigMap(
 		})
 
 	// If OTel logging or metrics is enabled, add collector config
-	if err == nil && (feature.Enabled(ctx, feature.OpenTelemetryLogs) || feature.Enabled(ctx, feature.OpenTelemetryMetrics)) {
+	if err == nil &&
+		(feature.Enabled(ctx, feature.OpenTelemetryLogs) ||
+			feature.Enabled(ctx, feature.OpenTelemetryMetrics)) {
 		err = collector.AddToConfigMap(ctx, otelConfig, instanceConfigMap)
+
+		// Add pgbackrest logrotate if OpenTelemetryLogs is enabled and
+		// local volumes are available
+		if err == nil &&
+			feature.Enabled(ctx, feature.OpenTelemetryLogs) &&
+			pgbackrest.RepoHostVolumeDefined(cluster) &&
+			cluster.Spec.Instrumentation != nil {
+
+			collector.AddLogrotateConfigs(ctx, cluster.Spec.Instrumentation,
+				instanceConfigMap,
+				[]collector.LogrotateConfig{{
+					LogFiles: []string{naming.PGBackRestPGDataLogPath + "/*.log"},
+				}})
+		}
 	}
 	if err == nil {
 		err = patroni.InstanceConfigMap(ctx, cluster, spec, instanceConfigMap)

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -688,18 +688,17 @@ func (r *Reconciler) generateRepoHostIntent(ctx context.Context, postgresCluster
 
 	if pgbackrest.RepoHostVolumeDefined(postgresCluster) {
 		// add the init container to make the pgBackRest repo volume log directory
-		pgbackrest.MakePGBackrestLogDir(&repo.Spec.Template, postgresCluster)
+		pgBackRestLogPath := pgbackrest.MakePGBackrestLogDir(&repo.Spec.Template, postgresCluster)
 
 		containersToAdd := []string{naming.PGBackRestRepoContainerName}
 
 		// If OpenTelemetryLogs is enabled, we want to add the collector to the pod
 		// and also add the RepoVolumes to the container.
-		if feature.Enabled(ctx, feature.OpenTelemetryLogs) {
-			// TODO: Setting the includeLogrotate argument to false for now. This
-			// should be changed when we implement log rotation for pgbackrest
+		if postgresCluster.Spec.Instrumentation != nil && feature.Enabled(ctx, feature.OpenTelemetryLogs) {
 			collector.AddToPod(ctx, postgresCluster.Spec.Instrumentation, postgresCluster.Spec.ImagePullPolicy,
 				&corev1.ConfigMap{ObjectMeta: naming.PGBackRestConfig(postgresCluster)},
-				&repo.Spec.Template.Spec, []corev1.VolumeMount{}, "", false)
+				&repo.Spec.Template.Spec, []corev1.VolumeMount{}, "",
+				[]string{pgBackRestLogPath}, true)
 
 			containersToAdd = append(containersToAdd, naming.ContainerCollector)
 		}

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -100,7 +100,8 @@ func (r *Reconciler) reconcilePGBouncerConfigMap(
 	}
 	// If OTel logging or metrics is enabled, add collector config
 	if otelConfig != nil &&
-		(feature.Enabled(ctx, feature.OpenTelemetryLogs) || feature.Enabled(ctx, feature.OpenTelemetryMetrics)) {
+		(feature.Enabled(ctx, feature.OpenTelemetryLogs) ||
+			feature.Enabled(ctx, feature.OpenTelemetryMetrics)) {
 		err = collector.AddToConfigMap(ctx, otelConfig, configmap)
 	}
 	// If OTel logging is enabled, add logrotate config

--- a/internal/controller/standalone_pgadmin/statefulset.go
+++ b/internal/controller/standalone_pgadmin/statefulset.go
@@ -132,7 +132,7 @@ func statefulset(
 		}
 
 		collector.AddToPod(ctx, pgadmin.Spec.Instrumentation, pgadmin.Spec.ImagePullPolicy,
-			configmap, &sts.Spec.Template.Spec, volumeMounts, "", false)
+			configmap, &sts.Spec.Template.Spec, volumeMounts, "", []string{}, false)
 	}
 
 	return sts

--- a/internal/pgbouncer/reconcile.go
+++ b/internal/pgbouncer/reconcile.go
@@ -192,7 +192,7 @@ func Pod(
 
 	if feature.Enabled(ctx, feature.OpenTelemetryLogs) || feature.Enabled(ctx, feature.OpenTelemetryMetrics) {
 		collector.AddToPod(ctx, inCluster.Spec.Instrumentation, inCluster.Spec.ImagePullPolicy, inConfigMap,
-			outPod, []corev1.VolumeMount{configVolumeMount}, string(inSecret.Data["pgbouncer-password"]), []string{},
+			outPod, []corev1.VolumeMount{configVolumeMount}, string(inSecret.Data["pgbouncer-password"]), []string{naming.PGBouncerLogPath},
 			true)
 	}
 }

--- a/internal/pgbouncer/reconcile.go
+++ b/internal/pgbouncer/reconcile.go
@@ -192,7 +192,7 @@ func Pod(
 
 	if feature.Enabled(ctx, feature.OpenTelemetryLogs) || feature.Enabled(ctx, feature.OpenTelemetryMetrics) {
 		collector.AddToPod(ctx, inCluster.Spec.Instrumentation, inCluster.Spec.ImagePullPolicy, inConfigMap,
-			outPod, []corev1.VolumeMount{configVolumeMount}, string(inSecret.Data["pgbouncer-password"]),
+			outPod, []corev1.VolumeMount{configVolumeMount}, string(inSecret.Data["pgbouncer-password"]), []string{},
 			true)
 	}
 }


### PR DESCRIPTION
**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other

**What is the current behavior (link to any open issues here)?**

PgBackRest logs don't rotate

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PgBackRest logs -- in both postgres and repohost -- rotate.
This also includes a change where the collector container can create the `/receiver` dir that it requires. (This will need to be updated if/when we have multiple logrotates in a container.)

**Other Information**:
Issues: [PGO-2171]