### PR TITLE
Changed the pgAdmin readinessProbe to check /misc/ping instead of /login

### DIFF
--- a/internal/controller/standalone_pgadmin/pod.go
+++ b/internal/controller/standalone_pgadmin/pod.go
@@ -147,13 +147,13 @@ func pod(
 		},
 	}
 
-	// Creating a readiness probe that will check that the pgAdmin `/login`
+	// Creating a readiness probe that will check that the pgAdmin `/misc/ping`
 	// endpoint is reachable at the specified port
 	readinessProbe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Port:   intstr.FromInt32(pgAdminPort),
-				Path:   "/login",
+				Path:   "/misc/ping",
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},

--- a/internal/controller/standalone_pgadmin/pod_test.go
+++ b/internal/controller/standalone_pgadmin/pod_test.go
@@ -107,7 +107,7 @@ containers:
     protocol: TCP
   readinessProbe:
     httpGet:
-      path: /login
+      path: /misc/ping
       port: 5050
       scheme: HTTP
   resources: {}
@@ -324,7 +324,7 @@ containers:
     protocol: TCP
   readinessProbe:
     httpGet:
-      path: /login
+      path: /misc/ping
       port: 5050
       scheme: HTTP
   resources:


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [X] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [X] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Users have reported that files in /var/lib/pgadmin/sessions are not expired as expected (based on default values of session_expiration_time and check_session_files_interval parameters). This causes the pgAdmin PVC to fill and the pgAdmin container to get stuck in a "not ready" state.

Open issue: https://github.com/CrunchyData/postgres-operator/issues/4102

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This problem is resolved by using /misc/ping instead of /login for readinessProbe path.


**Other Information**:

Issue: PGO-2028
