### PR TITLE
Change the default authentication method to SCRAM-SHA-256

### DIFF
--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -53,11 +53,11 @@ func (*Reconciler) generatePostgresHBA(spec *v1beta1.PostgresHBARule) *postgres.
 	result.Origin(spec.Connection)
 
 	// The "password" method is not recommended. More likely, the user wants to
-	// use passwords generally. The most compatible method for that is "md5"
-	// which accepts a password in the format in which it is hashed in the database.
+	// use passwords generally. The "scram-sha-256" method is the preferred way
+	// to do that.
 	// - https://www.postgresql.org/docs/current/auth-password.html
 	if spec.Method == "password" {
-		result.Method("md5")
+		result.Method("scram-sha-256")
 	} else {
 		result.Method(spec.Method)
 	}

--- a/internal/controller/postgrescluster/postgres_test.go
+++ b/internal/controller/postgrescluster/postgres_test.go
@@ -59,10 +59,10 @@ func TestGeneratePostgresHBA(t *testing.T) {
 			rule:     `{ connection: hostssl, method: md5, options: { clientcert: verify-ca } }`,
 			expected: `"hostssl" all all all "md5"  "clientcert"="verify-ca"`,
 		},
-		// "password" input should be "md5" output
+		// "password" input should be "scram-sha-256" output
 		{
 			rule:     `{ connection: hostssl, method: password }`,
-			expected: `"hostssl" all all all "md5"`,
+			expected: `"hostssl" all all all "scram-sha-256"`,
 		},
 	} {
 		var rule *v1beta1.PostgresHBARule

--- a/internal/postgres/hba.go
+++ b/internal/postgres/hba.go
@@ -29,11 +29,11 @@ func NewHBAs() HBAs {
 		},
 
 		Default: []*HostBasedAuthentication{
-			// Allow TLS connections to any database using passwords. The "md5"
-			// authentication method automatically verifies passwords encrypted
-			// using either MD5 or SCRAM-SHA-256.
+			// Allow TLS connections to any database using passwords. Passwords are
+			// hashed and stored using SCRAM-SHA-256 by default. Since PostgreSQL 10,
+			// the "scram-sha-256" method is the preferred way to use those passwords.
 			// - https://www.postgresql.org/docs/current/auth-password.html
-			NewHBA().TLS().Method("md5"),
+			NewHBA().TLS().Method("scram-sha-256"),
 		},
 	}
 }

--- a/internal/postgres/hba_test.go
+++ b/internal/postgres/hba_test.go
@@ -36,7 +36,7 @@ hostssl  "postgres"   "_crunchyrepl"  all   "cert"
 host     all          "_crunchyrepl"  all   "reject"
 	`))
 	assert.Assert(t, matches(hba.Default, `
-hostssl  all  all  all  "md5"
+hostssl  all  all  all  "scram-sha-256"
 	`))
 }
 

--- a/testing/kuttl/e2e/password-change/04--secret.yaml
+++ b/testing/kuttl/e2e/password-change/04--secret.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,14 @@ stringData:
   password: infopond
   verifier: "md585eb8fa4f697b2ea949d3aba788e8631"
   uri: ""
+---
+# Enable authenticating with MD5 passwords
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: password-change
+spec:
+  authentication:
+    rules:
+      - connection: hostssl
+        method: md5


### PR DESCRIPTION
PostgreSQL has stored passwords as SCRAM-SHA-256 since PostgreSQL 14. PGO has stored passwords as SCRAM-SHA-256 since PostgreSQL 10.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other

**What is the current behavior (link to any open issues here)?**

When not configured, PostgresCluster allows connections from users with an MD5 password stored in the database.

PGO has configured Postgres to hash new and rotated passwords with SCRAM for years.

**What is the new behavior (if this is a feature change)?**
- [x] Breaking change (fix or feature that would cause existing functionality to change)

When not configured, PostgresCluster requires users to have a SCRAM password in the database.

Passwords stored as MD5 are the exception now. In those cases, one can use `spec.authentication.rules` and `spec.config.parameters` to downgrade to MD5.

**Other Information**:

Issue: PGO-2290
See: https://www.postgresql.org/docs/current/auth-password.html
