### PR TITLE
Set standby_leader_label_value for Patroni v4 Compatibility

### DIFF
--- a/internal/patroni/config.go
+++ b/internal/patroni/config.go
@@ -58,7 +58,9 @@ func clusterYAML(
 			"use_endpoints": true,
 			// To support transitioning to Patroni v4, set the value to 'master'.
 			// In a future release, this can be removed in favor of the default.
-			"leader_label_value": naming.RolePatroniLeader,
+			// Do this for leaders in both primary and standby clusters.
+			"leader_label_value":         naming.RolePatroniLeader,
+			"standby_leader_label_value": naming.RolePatroniLeader,
 
 			// In addition to "scope_label" above, Patroni will add the following to
 			// every object it creates. It will also use these as filters when doing

--- a/internal/patroni/config_test.go
+++ b/internal/patroni/config_test.go
@@ -56,6 +56,7 @@ kubernetes:
   namespace: some-namespace
   role_label: postgres-operator.crunchydata.com/role
   scope_label: postgres-operator.crunchydata.com/patroni
+  standby_leader_label_value: master
   use_endpoints: true
 postgresql:
   authentication:
@@ -113,6 +114,7 @@ kubernetes:
   namespace: some-namespace
   role_label: postgres-operator.crunchydata.com/role
   scope_label: postgres-operator.crunchydata.com/patroni
+  standby_leader_label_value: master
   use_endpoints: true
 postgresql:
   authentication:
@@ -179,6 +181,7 @@ kubernetes:
   namespace: some-namespace
   role_label: postgres-operator.crunchydata.com/role
   scope_label: postgres-operator.crunchydata.com/patroni
+  standby_leader_label_value: master
   use_endpoints: true
 log:
   dir: /pgdata/patroni/log


### PR DESCRIPTION
Sets Patroni's `standby_leader_label_value` setting to `master` to make standby clusters compatible with Patroni v4.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Standby leaders get a `primary` label.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Standby leaders get a `master` label for compatibility with PGO.

**Other Information**:

Issue: PGO-2293