### PR TITLE
Prefer OTEL to exporter if both enabled

### DIFF
--- a/internal/pgmonitor/util.go
+++ b/internal/pgmonitor/util.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/crunchydata/postgres-operator/internal/collector"
 	"github.com/crunchydata/postgres-operator/internal/logging"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
@@ -27,6 +28,11 @@ func GetQueriesConfigDir(ctx context.Context) string {
 
 // ExporterEnabled returns true if the monitoring exporter is enabled
 func ExporterEnabled(ctx context.Context, cluster *v1beta1.PostgresCluster) bool {
+	// If OpenTelemetry metrics are enabled for this cluster, that takes precedence
+	// over the postgres_exporter metrics.
+	if collector.OpenTelemetryMetricsEnabled(ctx, cluster) {
+		return false
+	}
 	if cluster.Spec.Monitoring == nil {
 		return false
 	}

--- a/internal/pgmonitor/util_test.go
+++ b/internal/pgmonitor/util_test.go
@@ -10,6 +10,8 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/crunchydata/postgres-operator/internal/feature"
+	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -26,4 +28,19 @@ func TestExporterEnabled(t *testing.T) {
 
 	cluster.Spec.Monitoring.PGMonitor.Exporter = &v1beta1.ExporterSpec{}
 	assert.Assert(t, ExporterEnabled(ctx, cluster))
+
+	// Enabling the OpenTelemetryMetrics is not sufficient to disable the exporter
+	gate := feature.NewGate()
+	assert.NilError(t, gate.SetFromMap(map[string]bool{
+		feature.OpenTelemetryMetrics: true,
+	}))
+	ctx = feature.NewContext(ctx, gate)
+	assert.Assert(t, ExporterEnabled(ctx, cluster))
+
+	require.UnmarshalInto(t, &cluster.Spec, `{
+		instrumentation: {
+			logs: { retentionPeriod: 5h },
+		},
+	}`)
+	assert.Assert(t, !ExporterEnabled(ctx, cluster))
 }


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

We had logic to prefer OTel if both were enabled, but that was dropped so we could discuss it; this reenables that behavior with the collector util func logic.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

If both Exporter and OTel Metrics are enabled, CPK prefers OTel.

**Other Information**:
