### PR TITLE
Use collector.OpenTelemetryMetricsEnabled when config'ing setup

### DIFF
--- a/internal/controller/postgrescluster/pgmonitor.go
+++ b/internal/controller/postgrescluster/pgmonitor.go
@@ -69,7 +69,7 @@ func (r *Reconciler) reconcilePGMonitorExporter(ctx context.Context,
 			return err
 		}
 
-		if feature.Enabled(ctx, feature.OpenTelemetryMetrics) {
+		if collector.OpenTelemetryMetricsEnabled(ctx, cluster) {
 			setup = metricsSetupForOTelCollector
 		} else {
 			// TODO: Revisit how pgbackrest_info.sh is used with pgMonitor.


### PR DESCRIPTION
**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Our setup.sql checker only sees if the OTel metrics feature is enabled when we should check if the feature is enabled _for this cluster_

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Use `collector.OpenTelemetryMetricsEnabled` to check

**Other Information**:
