### PR TITLE
Updates GH workflows test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,9 +67,9 @@ jobs:
         with:
           k3s-channel: "${{ matrix.kubernetes }}"
           prefetch-images: |
-            registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.54.1-1
-            registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.23-4
-            registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.8-0
+            registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi9-2.54.2-2513
+            registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi9-1.24-2513
+            registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-16.8-2513
 
       - run: make createnamespaces check-envtest-existing
         env:
@@ -101,17 +101,15 @@ jobs:
         with:
           k3s-channel: "${{ matrix.kubernetes }}"
           prefetch-images: |
-            registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-4.30-35
-            registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.54.1-1
-            registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.23-4
-            registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:latest
-            registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:latest
-            registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.8-0
-            registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-16.8-3.3-0
-            registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-16.8-3.4-0
-            registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-17.4-0
-            registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-17.4-3.4-0
-            registry.developers.crunchydata.com/crunchydata/postgres-operator:latest
+            registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi9-2.54.2-2513
+            registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi9-1.24-2513
+            registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi9-0.16.0-2513
+            registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi9-17.4-2513
+            registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-16.8-2513
+            registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-16.8-3.3-2513
+            registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-16.8-3.4-2513
+            registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi9-17.4-2513
+            registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-17.4-3.4-2513
       - run: go mod download
       - name: Build executable
         run: PGO_VERSION='${{ github.sha }}' make build-postgres-operator
@@ -133,18 +131,17 @@ jobs:
             --env 'CHECK_FOR_UPGRADES=false' \
             --env 'QUERIES_CONFIG_DIR=/mnt/hack/tools/queries' \
             --env 'KUBECONFIG=hack/.kube/postgres-operator/pgo' \
-            --env 'RELATED_IMAGE_PGADMIN=registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-4.30-35' \
-            --env 'RELATED_IMAGE_PGBACKREST=registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.54.1-1' \
-            --env 'RELATED_IMAGE_PGBOUNCER=registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.23-4' \
-            --env 'RELATED_IMAGE_PGEXPORTER=registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:latest' \
-            --env 'RELATED_IMAGE_PGUPGRADE=registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:latest' \
-            --env 'RELATED_IMAGE_POSTGRES_16=registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.8-0' \
-            --env 'RELATED_IMAGE_POSTGRES_16_GIS_3.3=registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-16.8-3.3-0' \
-            --env 'RELATED_IMAGE_POSTGRES_16_GIS_3.4=registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-16.8-3.4-0' \
-            --env 'RELATED_IMAGE_POSTGRES_17=registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-17.4-0' \
-            --env 'RELATED_IMAGE_POSTGRES_17_GIS_3.4=registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-17.4-3.4-0' \
-            --env 'RELATED_IMAGE_STANDALONE_PGADMIN=registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-8.14-2' \
-            --env 'RELATED_IMAGE_COLLECTOR=registry.developers.crunchydata.com/crunchydata/postgres-operator:latest' \
+            --env 'RELATED_IMAGE_PGBACKREST=registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi9-2.54.2-2513' \
+            --env 'RELATED_IMAGE_PGBOUNCER=registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi9-1.24-2513' \
+            --env 'RELATED_IMAGE_PGEXPORTER=registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi9-0.16.0-2513' \
+            --env 'RELATED_IMAGE_PGUPGRADE=registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi9-17.4-2513' \
+            --env 'RELATED_IMAGE_POSTGRES_16=registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-16.8-2513' \
+            --env 'RELATED_IMAGE_POSTGRES_16_GIS_3.3=registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-16.8-3.3-2513' \
+            --env 'RELATED_IMAGE_POSTGRES_16_GIS_3.4=registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-16.8-3.4-2513' \
+            --env 'RELATED_IMAGE_POSTGRES_17=registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi9-17.4-2513' \
+            --env 'RELATED_IMAGE_POSTGRES_17_GIS_3.4=registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-17.4-3.4-2513' \
+            --env 'RELATED_IMAGE_STANDALONE_PGADMIN=registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi9-9.1-2513' \
+            --env 'RELATED_IMAGE_COLLECTOR=registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi9-5.8.0-0' \
             --env 'PGO_FEATURE_GATES=TablespaceVolumes=true,OpenTelemetryLogs=true,OpenTelemetryMetrics=true' \
             --name 'postgres-operator' ubuntu \
             postgres-operator
@@ -159,7 +156,7 @@ jobs:
           KUTTL_PG_UPGRADE_TO_VERSION: '17'
           KUTTL_PG_VERSION: '16'
           KUTTL_POSTGIS_VERSION: '3.4'
-          KUTTL_PSQL_IMAGE: 'registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.6-2'
+          KUTTL_PSQL_IMAGE: 'registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-16.8-2513'
       - run: |
           make check-kuttl && exit
           failed=$?

--- a/Makefile
+++ b/Makefile
@@ -225,11 +225,11 @@ check-kuttl: ## example command: make check-kuttl KUTTL_TEST='
 		--config testing/kuttl/kuttl-test.yaml
 
 .PHONY: generate-kuttl
-generate-kuttl: export KUTTL_PG_UPGRADE_FROM_VERSION ?= 15
-generate-kuttl: export KUTTL_PG_UPGRADE_TO_VERSION ?= 16
+generate-kuttl: export KUTTL_PG_UPGRADE_FROM_VERSION ?= 16
+generate-kuttl: export KUTTL_PG_UPGRADE_TO_VERSION ?= 17
 generate-kuttl: export KUTTL_PG_VERSION ?= 16
 generate-kuttl: export KUTTL_POSTGIS_VERSION ?= 3.4
-generate-kuttl: export KUTTL_PSQL_IMAGE ?= registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.8-0
+generate-kuttl: export KUTTL_PSQL_IMAGE ?= registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-16.8-2513
 generate-kuttl: export KUTTL_TEST_DELETE_NAMESPACE ?= kuttl-test-delete-namespace
 generate-kuttl: ## Generate kuttl tests
 	[ ! -d testing/kuttl/e2e-generated ] || rm -r testing/kuttl/e2e-generated

--- a/testing/kuttl/e2e/security-context/00--cluster.yaml
+++ b/testing/kuttl/e2e/security-context/00--cluster.yaml
@@ -18,9 +18,6 @@ spec:
   proxy:
     pgBouncer:
       replicas: 1
-  userInterface:
-    pgAdmin:
-      dataVolumeClaimSpec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 1Gi } } }
   monitoring:
     pgmonitor:
       exporter: {}

--- a/testing/kuttl/e2e/security-context/00-assert.yaml
+++ b/testing/kuttl/e2e/security-context/00-assert.yaml
@@ -92,38 +92,6 @@ spec:
       readOnlyRootFilesystem: true
       runAsNonRoot: true
 ---
-# pgAdmin
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    postgres-operator.crunchydata.com/cluster: security-context
-    postgres-operator.crunchydata.com/data: pgadmin
-    postgres-operator.crunchydata.com/role: pgadmin
-    statefulset.kubernetes.io/pod-name: security-context-pgadmin-0
-  name: security-context-pgadmin-0
-spec:
-  containers:
-  - name: pgadmin
-    securityContext:
-      allowPrivilegeEscalation: false
-      privileged: false
-      readOnlyRootFilesystem: true
-      runAsNonRoot: true
-  initContainers:
-  - name: pgadmin-startup
-    securityContext:
-      allowPrivilegeEscalation: false
-      privileged: false
-      readOnlyRootFilesystem: true
-      runAsNonRoot: true
-  - name: nss-wrapper-init
-    securityContext:
-      allowPrivilegeEscalation: false
-      privileged: false
-      readOnlyRootFilesystem: true
-      runAsNonRoot: true
----
 # pgBouncer
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
The latest version discontinues pgadmin4 v4.30.
This commit removes it from related images, updates to the latest developer images, and removes tests
that rely on the old pgadmin image.
