### PR TITLE
Fix issue where the presence of --target-timeline was adding --target…

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -1166,10 +1166,16 @@ func (r *Reconciler) reconcileRestoreJob(ctx context.Context,
 		"--pg1-path=" + pgdata,
 		"--repo=" + regexRepoIndex.FindString(repoName)}...)
 
+	// Look specifically for the "--target" flag, NOT flags that contain
+	// "--target" (e.g. "--target-timeline")
+	targetRegex, err := regexp.Compile("--target[ =]")
+	if err != nil {
+		return err
+	}
 	var deltaOptFound, foundTarget bool
 	for _, opt := range opts {
 		switch {
-		case strings.Contains(opt, "--target"):
+		case targetRegex.Match([]byte(opt)):
 			foundTarget = true
 		case strings.Contains(opt, "--delta"):
 			deltaOptFound = true

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -1778,6 +1778,9 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 		configCount, jobCount, pvcCount                         int
 		invalidSourceRepo, invalidSourceCluster, invalidOptions bool
 		expectedClusterCondition                                *metav1.Condition
+		expectedEventMessage                                    string
+		expectedCommandPieces                                   []string
+		missingCommandPieces                                    []string
 	}
 
 	for _, dedicated := range []bool{true, false} {
@@ -1800,6 +1803,8 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 				configCount: 1, jobCount: 1, pvcCount: 1,
 				invalidSourceRepo: false, invalidSourceCluster: false, invalidOptions: false,
 				expectedClusterCondition: nil,
+				expectedCommandPieces:    []string{"--stanza=", "--pg1-path=", "--repo=", "--delta"},
+				missingCommandPieces:     []string{"--target-action"},
 			},
 		}, {
 			desc: "invalid source cluster",
@@ -1813,6 +1818,7 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 				configCount: 0, jobCount: 0, pvcCount: 0,
 				invalidSourceRepo: false, invalidSourceCluster: true, invalidOptions: false,
 				expectedClusterCondition: nil,
+				expectedEventMessage:     "does not exist",
 			},
 		}, {
 			desc: "invalid source repo",
@@ -1826,6 +1832,7 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 				configCount: 1, jobCount: 0, pvcCount: 0,
 				invalidSourceRepo: true, invalidSourceCluster: false, invalidOptions: false,
 				expectedClusterCondition: nil,
+				expectedEventMessage:     "does not have a repo named",
 			},
 		}, {
 			desc: "invalid option: --repo=",
@@ -1840,6 +1847,7 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 				configCount: 1, jobCount: 0, pvcCount: 1,
 				invalidSourceRepo: false, invalidSourceCluster: false, invalidOptions: true,
 				expectedClusterCondition: nil,
+				expectedEventMessage:     "Option '--repo' is not allowed: please use the 'repoName' field instead.",
 			},
 		}, {
 			desc: "invalid option: --repo ",
@@ -1854,6 +1862,7 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 				configCount: 1, jobCount: 0, pvcCount: 1,
 				invalidSourceRepo: false, invalidSourceCluster: false, invalidOptions: true,
 				expectedClusterCondition: nil,
+				expectedEventMessage:     "Option '--repo' is not allowed: please use the 'repoName' field instead.",
 			},
 		}, {
 			desc: "invalid option: stanza",
@@ -1868,6 +1877,7 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 				configCount: 1, jobCount: 0, pvcCount: 1,
 				invalidSourceRepo: false, invalidSourceCluster: false, invalidOptions: true,
 				expectedClusterCondition: nil,
+				expectedEventMessage:     "Option '--stanza' is not allowed: the operator will automatically set this option",
 			},
 		}, {
 			desc: "invalid option: pg1-path",
@@ -1882,6 +1892,68 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 				configCount: 1, jobCount: 0, pvcCount: 1,
 				invalidSourceRepo: false, invalidSourceCluster: false, invalidOptions: true,
 				expectedClusterCondition: nil,
+				expectedEventMessage:     "Option '--pg1-path' is not allowed: the operator will automatically set this option",
+			},
+		}, {
+			desc: "invalid option: target-action",
+			dataSource: &v1beta1.DataSource{PostgresCluster: &v1beta1.PostgresClusterDataSource{
+				ClusterName: "invalid-target-action-option", RepoName: "repo1",
+				Options: []string{"--target-action"},
+			}},
+			clusterBootstrapped: false,
+			sourceClusterName:   "invalid-target-action-option",
+			sourceClusterRepos:  []v1beta1.PGBackRestRepo{{Name: "repo1"}},
+			result: testResult{
+				configCount: 1, jobCount: 0, pvcCount: 1,
+				invalidSourceRepo: false, invalidSourceCluster: false, invalidOptions: true,
+				expectedClusterCondition: nil,
+				expectedEventMessage:     "Option '--target-action' is not allowed: the operator will automatically set this option",
+			},
+		}, {
+			desc: "invalid option: link-map",
+			dataSource: &v1beta1.DataSource{PostgresCluster: &v1beta1.PostgresClusterDataSource{
+				ClusterName: "invalid-link-map-option", RepoName: "repo1",
+				Options: []string{"--link-map"},
+			}},
+			clusterBootstrapped: false,
+			sourceClusterName:   "invalid-link-map-option",
+			sourceClusterRepos:  []v1beta1.PGBackRestRepo{{Name: "repo1"}},
+			result: testResult{
+				configCount: 1, jobCount: 0, pvcCount: 1,
+				invalidSourceRepo: false, invalidSourceCluster: false, invalidOptions: true,
+				expectedClusterCondition: nil,
+				expectedEventMessage:     "Option '--link-map' is not allowed: the operator will automatically set this option",
+			},
+		}, {
+			desc: "valid option: target-timeline",
+			dataSource: &v1beta1.DataSource{PostgresCluster: &v1beta1.PostgresClusterDataSource{
+				ClusterName: "valid-target-timeline-option", RepoName: "repo1",
+				Options: []string{"--target-timeline=1"},
+			}},
+			clusterBootstrapped: false,
+			sourceClusterName:   "valid-target-timeline-option",
+			sourceClusterRepos:  []v1beta1.PGBackRestRepo{{Name: "repo1"}},
+			result: testResult{
+				configCount: 1, jobCount: 1, pvcCount: 1,
+				invalidSourceRepo: false, invalidSourceCluster: false, invalidOptions: false,
+				expectedClusterCondition: nil,
+				expectedCommandPieces:    []string{"--stanza=", "--pg1-path=", "--repo=", "--delta", "--target-timeline=1"},
+				missingCommandPieces:     []string{"--target=", "--target-action=promote"},
+			},
+		}, {
+			desc: "valid option: target",
+			dataSource: &v1beta1.DataSource{PostgresCluster: &v1beta1.PostgresClusterDataSource{
+				ClusterName: "valid-target-option", RepoName: "repo1",
+				Options: []string{"--target=some-date"},
+			}},
+			clusterBootstrapped: false,
+			sourceClusterName:   "valid-target-option",
+			sourceClusterRepos:  []v1beta1.PGBackRestRepo{{Name: "repo1"}},
+			result: testResult{
+				configCount: 1, jobCount: 1, pvcCount: 1,
+				invalidSourceRepo: false, invalidSourceCluster: false, invalidOptions: false,
+				expectedClusterCondition: nil,
+				expectedCommandPieces:    []string{"--stanza=", "--pg1-path=", "--repo=", "--delta", "--target=some-date", "--target-action=promote"},
 			},
 		}, {
 			desc: "cluster bootstrapped init condition missing",
@@ -2004,6 +2076,16 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 				if len(restoreJobs.Items) == 1 {
 					assert.Assert(t, restoreJobs.Items[0].Labels[naming.LabelStartupInstance] != "")
 					assert.Assert(t, restoreJobs.Items[0].Annotations[naming.PGBackRestConfigHash] != "")
+					for _, cmd := range tc.result.expectedCommandPieces {
+						assert.Assert(t, cmp.Contains(
+							strings.Join(restoreJobs.Items[0].Spec.Template.Spec.Containers[0].Command, " "),
+							cmd))
+					}
+					for _, cmd := range tc.result.missingCommandPieces {
+						assert.Assert(t, !strings.Contains(
+							strings.Join(restoreJobs.Items[0].Spec.Template.Spec.Containers[0].Command, " "),
+							cmd))
+					}
 				}
 
 				dataPVCs := &corev1.PersistentVolumeClaimList{}
@@ -2041,7 +2123,11 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 								"involvedObject.namespace": namespace,
 								"reason":                   "InvalidDataSource",
 							})
-							return len(events.Items) == 1, err
+							eventExists := len(events.Items) > 0
+							if eventExists {
+								assert.Assert(t, cmp.Contains(events.Items[0].Message, tc.result.expectedEventMessage))
+							}
+							return eventExists, err
 						}))
 				}
 			})


### PR DESCRIPTION
…-action.

Adjust tests and add more test cases.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Currently, if a user adds the `--target-timeline` flag to the datasource options to be used in a restore, the operator will also add `--target-action` which will result in the restore failing. 

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Now, if `--target-timeline` is added to the restore options, the operator will not add `--target-action` and the restore should proceed as expected.

**Other Information**:
