### PR TITLE
Use Dependabot to update Go and gRPC modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,10 @@
 ---
 version: 2
 updates:
+  # Update all workflows and local composite actions.
   - package-ecosystem: github-actions
     directories:
+      # "/" is a special case that includes ".github/workflows/*"
       - '/'
       - '.github/actions/*'
     schedule:
@@ -18,3 +20,18 @@ updates:
     groups:
       all-github-actions:
         patterns: ['*']
+
+  # Go "x" modules and Go and Google gRPC modules:
+  # https://pkg.go.dev/golang.org/x
+  # https://cloud.google.com/go/google.golang.org
+  - package-ecosystem: gomod
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: wednesday
+    groups:
+      golang-org-modules:
+        patterns:
+          - 'golang.org/x/*'
+          - 'github.com/golang/*'
+          - 'google.golang.org/*'


### PR DESCRIPTION
The `golang.org/x` modules are a frequent source of vulnerabilities. Let's update them regularly to keep security fixes small.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
