### PR TITLE
fix: include logrotate on collector only if local volumes are setup

### DIFF
--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1220,10 +1220,12 @@ func (r *Reconciler) reconcileInstance(
 
 		// For now, we are not using logrotate to rotate postgres or patroni logs,
 		// but we are using it for pgbackrest logs in the postgres pod, so we will
-		// set includeLogrotate to true, but only if backups are enabled.
+		// set includeLogrotate to true, but only if backups are enabled
+		// and local volumes are available.
+		includeLogrotate := backupsSpecFound && pgbackrest.RepoHostVolumeDefined(cluster)
 		collector.AddToPod(ctx, cluster.Spec.Instrumentation, cluster.Spec.ImagePullPolicy, instanceConfigMap, &instance.Spec.Template,
 			[]corev1.VolumeMount{postgres.DataVolumeMount()}, pgPassword,
-			[]string{naming.PGBackRestPGDataLogPath}, backupsSpecFound, true)
+			[]string{naming.PGBackRestPGDataLogPath}, includeLogrotate, true)
 	}
 
 	// Add postgres-exporter to the instance Pod spec


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
Fixes https://github.com/CrunchyData/postgres-operator/issues/4194
