### PR TITLE
Move Postgres log rotation parameters to the postgres package

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -75,6 +75,8 @@ linters:
               desc: Use "go.opentelemetry.io/otel/semconv/v1.27.0" instead.
             - pkg: io/ioutil
               desc: Use the "io" and "os" packages instead. See https://go.dev/doc/go1.16#ioutil
+            - pkg: math/rand$
+              desc: Use the "math/rand/v2" package instead. See https://go.dev/doc/go1.22#math_rand_v2
         not-tests:
           files: ['!$test','!**/internal/testing/**']
           list-mode: lax
@@ -139,6 +141,11 @@ linters:
       - legacy
       - std-error-handling
     rules:
+      # It is fine for tests to use "math/rand" packages.
+      - linters: [gosec]
+        path: '(.+)_test[.]go'
+        text: weak random number generator
+
       # This internal package is the one place we want to do API discovery.
       - linters: [depguard]
         path: internal/kubernetes/discovery.go

--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -131,7 +131,7 @@ func (*Reconciler) generatePostgresParameters(
 ) *postgres.ParameterSet {
 	builtin := postgres.NewParameters()
 	pgaudit.PostgreSQLParameters(&builtin)
-	pgbackrest.PostgreSQL(cluster, &builtin, backupsSpecFound)
+	pgbackrest.PostgreSQLParameters(cluster, &builtin, backupsSpecFound)
 	pgmonitor.PostgreSQLParameters(ctx, cluster, &builtin)
 	postgres.SetHugePages(cluster, &builtin)
 

--- a/internal/pgbackrest/postgres.go
+++ b/internal/pgbackrest/postgres.go
@@ -11,8 +11,8 @@ import (
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
-// PostgreSQL populates outParameters with any settings needed to run pgBackRest.
-func PostgreSQL(
+// PostgreSQLParameters populates outParameters with any settings needed to run pgBackRest.
+func PostgreSQLParameters(
 	inCluster *v1beta1.PostgresCluster,
 	outParameters *postgres.Parameters,
 	backupsEnabled bool,

--- a/internal/pgbackrest/postgres_test.go
+++ b/internal/pgbackrest/postgres_test.go
@@ -17,7 +17,7 @@ func TestPostgreSQLParameters(t *testing.T) {
 	cluster := new(v1beta1.PostgresCluster)
 	parameters := new(postgres.Parameters)
 
-	PostgreSQL(cluster, parameters, true)
+	PostgreSQLParameters(cluster, parameters, true)
 	assert.DeepEqual(t, parameters.Mandatory.AsMap(), map[string]string{
 		"archive_mode":    "on",
 		"archive_command": `pgbackrest --stanza=db archive-push "%p"`,
@@ -28,7 +28,7 @@ func TestPostgreSQLParameters(t *testing.T) {
 		"archive_timeout": "60s",
 	})
 
-	PostgreSQL(cluster, parameters, false)
+	PostgreSQLParameters(cluster, parameters, false)
 	assert.DeepEqual(t, parameters.Mandatory.AsMap(), map[string]string{
 		"archive_mode":    "on",
 		"archive_command": "true",
@@ -40,7 +40,7 @@ func TestPostgreSQLParameters(t *testing.T) {
 		RepoName: "repo99",
 	}
 
-	PostgreSQL(cluster, parameters, true)
+	PostgreSQLParameters(cluster, parameters, true)
 	assert.DeepEqual(t, parameters.Mandatory.AsMap(), map[string]string{
 		"archive_mode":    "on",
 		"archive_command": `pgbackrest --stanza=db archive-push "%p"`,

--- a/internal/pgbackrest/util_test.go
+++ b/internal/pgbackrest/util_test.go
@@ -6,7 +6,7 @@ package pgbackrest
 
 import (
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"testing"
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

This moves the `log_filename` and `log_rotation` parameters into `internal/postgres`, documents how they're related, and adds some tests. 📝 The `internal/collector` tests don't change.

Issue: PGO-2558