### PR TITLE
Change omitempty to omitzero on non-pointer API structs

### DIFF
--- a/internal/bridge/client.go
+++ b/internal/bridge/client.go
@@ -71,7 +71,7 @@ type ClusterApiResource struct {
 	Network                string                       `json:"network_id,omitempty"`
 	Parent                 string                       `json:"parent_id,omitempty"`
 	Plan                   string                       `json:"plan_id,omitempty"`
-	PostgresVersion        intstr.IntOrString           `json:"postgres_version_id,omitempty"`
+	PostgresVersion        intstr.IntOrString           `json:"postgres_version_id,omitzero"`
 	Provider               string                       `json:"provider_id,omitempty"`
 	Region                 string                       `json:"region_id,omitempty"`
 	Replicas               []*ClusterApiResource        `json:"replicas,omitempty"`
@@ -188,7 +188,7 @@ type PostClustersRequestPayload struct {
 	IsHA            bool               `json:"is_ha,omitempty"`
 	Keychain        string             `json:"keychain_id,omitempty"`
 	Network         string             `json:"network_id,omitempty"`
-	PostgresVersion intstr.IntOrString `json:"postgres_version_id,omitempty"`
+	PostgresVersion intstr.IntOrString `json:"postgres_version_id,omitzero"`
 	Provider        string             `json:"provider_id,omitempty"`
 	Region          string             `json:"region_id,omitempty"`
 	Storage         int64              `json:"storage,omitempty"`
@@ -198,7 +198,7 @@ type PostClustersRequestPayload struct {
 // changing its plan, upgrading its major version, or increasing its storage size.
 type PostClustersUpgradeRequestPayload struct {
 	Plan             string             `json:"plan_id,omitempty"`
-	PostgresVersion  intstr.IntOrString `json:"postgres_version_id,omitempty"`
+	PostgresVersion  intstr.IntOrString `json:"postgres_version_id,omitzero"`
 	UpgradeStartTime string             `json:"starting_from,omitempty"`
 	Storage          int64              `json:"storage,omitempty"`
 }
@@ -207,7 +207,7 @@ type PostClustersUpgradeRequestPayload struct {
 // TODO: Implement the ability to update an upgrade (this isn't currently being used)
 type PutClustersUpgradeRequestPayload struct {
 	Plan                 string             `json:"plan_id,omitempty"`
-	PostgresVersion      intstr.IntOrString `json:"postgres_version_id,omitempty"`
+	PostgresVersion      intstr.IntOrString `json:"postgres_version_id,omitzero"`
 	UpgradeStartTime     string             `json:"starting_from,omitempty"`
 	Storage              int64              `json:"storage,omitempty"`
 	UseMaintenanceWindow *bool              `json:"use_cluster_maintenance_window,omitempty"`

--- a/internal/testing/validation/postgrescluster_test.go
+++ b/internal/testing/validation/postgrescluster_test.go
@@ -11,11 +11,10 @@ import (
 
 	"gotest.tools/v3/assert"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
-	"github.com/crunchydata/postgres-operator/internal/controller/runtime"
 	"github.com/crunchydata/postgres-operator/internal/testing/cmp"
 	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	v1 "github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1"
@@ -271,13 +270,15 @@ func TestPostgresConfigParameters(t *testing.T) {
 			key   string
 			value any
 		}{
-			{"archive_timeout", int64(100)},
+			{"archive_timeout", 100},
 			{"archive_timeout", "20s"},
 		} {
 			t.Run(tt.key, func(t *testing.T) {
-				cluster := require.Value(runtime.ToUnstructuredObject(base))
-				assert.NilError(t, unstructured.SetNestedField(cluster.Object,
-					tt.value, "spec", "config", "parameters", tt.key))
+				cluster := base.DeepCopy()
+				require.UnmarshalInto(t, &cluster.Spec.Config,
+					require.Value(yaml.Marshal(map[string]any{
+						"parameters": map[string]any{tt.key: tt.value},
+					})))
 
 				assert.NilError(t, cc.Create(ctx, cluster, client.DryRunAll))
 			})
@@ -299,13 +300,15 @@ func TestPostgresConfigParameters(t *testing.T) {
 			{key: "listen_addresses", value: ""},
 			{key: "log_file_mode", value: ""},
 			{key: "logging_collector", value: "off"},
-			{key: "port", value: int64(5)},
+			{key: "port", value: 5},
 			{key: "wal_log_hints", value: "off"},
 		} {
 			t.Run(tt.key, func(t *testing.T) {
-				cluster := require.Value(runtime.ToUnstructuredObject(base))
-				assert.NilError(t, unstructured.SetNestedField(cluster.Object,
-					tt.value, "spec", "config", "parameters", tt.key))
+				cluster := base.DeepCopy()
+				require.UnmarshalInto(t, &cluster.Spec.Config,
+					require.Value(yaml.Marshal(map[string]any{
+						"parameters": map[string]any{tt.key: tt.value},
+					})))
 
 				err := cc.Create(ctx, cluster, client.DryRunAll)
 				assert.Assert(t, apierrors.IsInvalid(err))
@@ -332,9 +335,11 @@ func TestPostgresConfigParameters(t *testing.T) {
 			{key: "unix_socket_group", value: "two"},
 		} {
 			t.Run(tt.key, func(t *testing.T) {
-				cluster := require.Value(runtime.ToUnstructuredObject(base))
-				assert.NilError(t, unstructured.SetNestedField(cluster.Object,
-					tt.value, "spec", "config", "parameters", tt.key))
+				cluster := base.DeepCopy()
+				require.UnmarshalInto(t, &cluster.Spec.Config,
+					require.Value(yaml.Marshal(map[string]any{
+						"parameters": map[string]any{tt.key: tt.value},
+					})))
 
 				err := cc.Create(ctx, cluster, client.DryRunAll)
 				assert.Assert(t, apierrors.IsInvalid(err))
@@ -354,9 +359,11 @@ func TestPostgresConfigParameters(t *testing.T) {
 			{key: "recovery_target_name", value: "doot"},
 		} {
 			t.Run(tt.key, func(t *testing.T) {
-				cluster := require.Value(runtime.ToUnstructuredObject(base))
-				assert.NilError(t, unstructured.SetNestedField(cluster.Object,
-					tt.value, "spec", "config", "parameters", tt.key))
+				cluster := base.DeepCopy()
+				require.UnmarshalInto(t, &cluster.Spec.Config,
+					require.Value(yaml.Marshal(map[string]any{
+						"parameters": map[string]any{tt.key: tt.value},
+					})))
 
 				err := cc.Create(ctx, cluster, client.DryRunAll)
 				assert.Assert(t, apierrors.IsInvalid(err))
@@ -408,9 +415,11 @@ func TestPostgresConfigParameters(t *testing.T) {
 			{key: "recovery_min_apply_delay", value: ""},
 		} {
 			t.Run(tt.key, func(t *testing.T) {
-				cluster := require.Value(runtime.ToUnstructuredObject(base))
-				assert.NilError(t, unstructured.SetNestedField(cluster.Object,
-					tt.value, "spec", "config", "parameters", tt.key))
+				cluster := base.DeepCopy()
+				require.UnmarshalInto(t, &cluster.Spec.Config,
+					require.Value(yaml.Marshal(map[string]any{
+						"parameters": map[string]any{tt.key: tt.value},
+					})))
 
 				err := cc.Create(ctx, cluster, client.DryRunAll)
 				assert.Assert(t, apierrors.IsInvalid(err))

--- a/internal/testing/validation/postgrescluster_test.go
+++ b/internal/testing/validation/postgrescluster_test.go
@@ -32,11 +32,6 @@ func TestPostgresAuthenticationRules(t *testing.T) {
 	// Start with a bunch of required fields.
 	require.UnmarshalInto(t, &base.Spec, `{
 		postgresVersion: 16,
-		backups: {
-			pgbackrest: {
-				repos: [{ name: repo1 }],
-			},
-		},
 		instances: [{
 			dataVolumeClaimSpec: {
 				accessModes: [ReadWriteOnce],
@@ -246,11 +241,6 @@ func TestPostgresConfigParameters(t *testing.T) {
 	// Start with a bunch of required fields.
 	require.UnmarshalInto(t, &base.Spec, `{
 		postgresVersion: 16,
-		backups: {
-			pgbackrest: {
-				repos: [{ name: repo1 }],
-			},
-		},
 		instances: [{
 			dataVolumeClaimSpec: {
 				accessModes: [ReadWriteOnce],
@@ -439,11 +429,6 @@ func TestPostgresUserOptions(t *testing.T) {
 	// Start with a bunch of required fields.
 	require.UnmarshalInto(t, &base.Spec, `{
 		postgresVersion: 16,
-		backups: {
-			pgbackrest: {
-				repos: [{ name: repo1 }],
-			},
-		},
 		instances: [{
 			dataVolumeClaimSpec: {
 				accessModes: [ReadWriteOnce],
@@ -551,11 +536,6 @@ func TestPostgresUserInterfaceAcrossVersions(t *testing.T) {
 			},
 		},
 		postgresVersion: 16,
-		backups: {
-			pgbackrest: {
-				repos: [{ name: repo1 }],
-			},
-		},
 		instances: [{
 			dataVolumeClaimSpec: {
 				accessModes: [ReadWriteOnce],
@@ -578,11 +558,6 @@ func TestPostgresUserInterfaceAcrossVersions(t *testing.T) {
 			},
 		},
 		postgresVersion: 16,
-		backups: {
-			pgbackrest: {
-				repos: [{ name: repo1 }],
-			},
-		},
 		instances: [{
 			dataVolumeClaimSpec: {
 				accessModes: [ReadWriteOnce],

--- a/pkg/apis/postgres-operator.crunchydata.com/v1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1/postgrescluster_types.go
@@ -29,7 +29,7 @@ type PostgresClusterSpec struct {
 
 	// PostgreSQL backup configuration
 	// +optional
-	Backups Backups `json:"backups,omitempty"`
+	Backups Backups `json:"backups,omitzero"`
 
 	// General configuration of the PostgreSQL server
 	// +optional
@@ -294,7 +294,7 @@ type PostgresClusterDataSource struct {
 
 	// Resource requirements for the pgBackRest restore Job.
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// Scheduling constraints of the pgBackRest restore Job.
 	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node
@@ -363,7 +363,7 @@ type PostgresClusterStatus struct {
 	InstanceSets []PostgresInstanceSetStatus `json:"instances,omitempty"`
 
 	// +optional
-	Patroni v1beta1.PatroniStatus `json:"patroni,omitempty"`
+	Patroni v1beta1.PatroniStatus `json:"patroni,omitzero"`
 
 	// Status information for pgBackRest
 	// +optional
@@ -382,7 +382,7 @@ type PostgresClusterStatus struct {
 
 	// Current state of the PostgreSQL proxy.
 	// +optional
-	Proxy PostgresProxyStatus `json:"proxy,omitempty"`
+	Proxy PostgresProxyStatus `json:"proxy,omitzero"`
 
 	// The instance that should be started first when bootstrapping and/or starting a
 	// PostgresCluster.
@@ -402,7 +402,7 @@ type PostgresClusterStatus struct {
 
 	// Current state of PostgreSQL cluster monitoring tool configuration
 	// +optional
-	Monitoring MonitoringStatus `json:"monitoring,omitempty"`
+	Monitoring MonitoringStatus `json:"monitoring,omitzero"`
 
 	// DatabaseInitSQL state of custom database initialization in the cluster
 	// +optional
@@ -495,7 +495,7 @@ type PostgresInstanceSetSpec struct {
 
 	// Compute resources of a PostgreSQL container.
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// Configuration for instance sidecar containers
 	// +optional
@@ -617,7 +617,8 @@ type RegistrationRequirementStatus struct {
 }
 
 type PostgresProxyStatus struct {
-	PGBouncer v1beta1.PGBouncerPodStatus `json:"pgBouncer,omitempty"`
+	// +optional
+	PGBouncer v1beta1.PGBouncerPodStatus `json:"pgBouncer,omitzero"`
 }
 
 // PostgresStandbySpec defines if/how the cluster should be a hot standby.
@@ -663,7 +664,8 @@ func (s *UserInterfaceSpec) Default() {
 type PostgresUserInterfaceStatus struct {
 
 	// The state of the pgAdmin user interface.
-	PGAdmin v1beta1.PGAdminPodStatus `json:"pgAdmin,omitempty"`
+	// +optional
+	PGAdmin v1beta1.PGAdminPodStatus `json:"pgAdmin,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -676,14 +678,17 @@ type PostgresCluster struct {
 	// - https://docs.k8s.io/concepts/overview/working-with-objects/names/#dns-subdomain-names
 	// - https://releases.k8s.io/v1.21.0/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/validator.go#L60
 
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// NOTE(cbandy): Every PostgresCluster needs a Spec, but it is optional here
 	// so ObjectMeta can be managed independently.
 
-	Spec   PostgresClusterSpec   `json:"spec,omitempty"`
-	Status PostgresClusterStatus `json:"status,omitempty"`
+	// +optional
+	Spec PostgresClusterSpec `json:"spec,omitzero"`
+	// +optional
+	Status PostgresClusterStatus `json:"status,omitzero"`
 }
 
 // Default implements "sigs.k8s.io/controller-runtime/pkg/webhook.Defaulter" so
@@ -704,7 +709,7 @@ func (c *PostgresCluster) Default() {
 // PostgresClusterList contains a list of PostgresCluster
 type PostgresClusterList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []PostgresCluster `json:"items"`
 }
 

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/crunchy_bridgecluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/crunchy_bridgecluster_types.go
@@ -204,14 +204,17 @@ type CrunchyBridgeCluster struct {
 	// - https://releases.k8s.io/v1.21.0/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/validator.go#L60
 
 	// In Bridge json, meta.name is "name"
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// NOTE(cbandy): Every CrunchyBridgeCluster needs a Spec, but it is optional here
 	// so ObjectMeta can be managed independently.
 
-	Spec   CrunchyBridgeClusterSpec   `json:"spec,omitempty"`
-	Status CrunchyBridgeClusterStatus `json:"status,omitempty"`
+	// +optional
+	Spec CrunchyBridgeClusterSpec `json:"spec,omitzero"`
+	// +optional
+	Status CrunchyBridgeClusterStatus `json:"status,omitzero"`
 }
 
 // Default implements "sigs.k8s.io/controller-runtime/pkg/webhook.Defaulter" so
@@ -231,7 +234,9 @@ func (c *CrunchyBridgeCluster) Default() {
 // CrunchyBridgeClusterList contains a list of CrunchyBridgeCluster
 type CrunchyBridgeClusterList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+
+	// +optional
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []CrunchyBridgeCluster `json:"items"`
 }
 

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/instrumentation_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/instrumentation_types.go
@@ -18,7 +18,7 @@ type InstrumentationSpec struct {
 	// Resources holds the resource requirements for the collector container.
 	// ---
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// Config is the place for users to configure exporters and provide files.
 	// ---

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgadmin_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgadmin_types.go
@@ -44,7 +44,7 @@ type PGAdminPodSpec struct {
 	// values will be loaded without validation. Be careful, as
 	// you may put pgAdmin into an unusable state.
 	// +optional
-	Config PGAdminConfiguration `json:"config,omitempty"`
+	Config PGAdminConfiguration `json:"config,omitzero"`
 
 	// Defines a PersistentVolumeClaim for pgAdmin data.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
@@ -76,7 +76,7 @@ type PGAdminPodSpec struct {
 	// pgAdmin to restart.
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// Specification of the service that exposes pgAdmin.
 	// +optional

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbackrest_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbackrest_types.go
@@ -153,7 +153,7 @@ type BackupJobs struct {
 	// Resource limits for backup jobs. Includes manual, scheduled and replica
 	// create backups
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// Priority class name for the pgBackRest backup Job pods.
 	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
@@ -208,7 +208,7 @@ type PGBackRestRepoHost struct {
 
 	// Resource requirements for a pgBackRest repository host
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// Tolerations of a PgBackRest repo host pod. Changing this value causes a restart.
 	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
@@ -442,7 +442,7 @@ type PGBackRestDataSource struct {
 
 	// Resource requirements for the pgBackRest restore Job.
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// Scheduling constraints of the pgBackRest restore Job.
 	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbouncer_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbouncer_types.go
@@ -60,7 +60,7 @@ type PGBouncerPodSpec struct {
 	// you may put PgBouncer into an unusable state.
 	// More info: https://www.pgbouncer.org/usage.html#reload
 	// +optional
-	Config PGBouncerConfiguration `json:"config,omitempty"`
+	Config PGBouncerConfiguration `json:"config,omitzero"`
 
 	// Custom sidecars for a PgBouncer pod. Changing this value causes
 	// PgBouncer to restart.
@@ -110,7 +110,7 @@ type PGBouncerPodSpec struct {
 	// PgBouncer to restart.
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// Specification of the service that exposes PgBouncer.
 	// +optional

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgmonitor_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgmonitor_types.go
@@ -35,5 +35,5 @@ type ExporterSpec struct {
 	// Changing this value causes PostgreSQL and the exporter to restart.
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 }

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgupgrade_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgupgrade_types.go
@@ -49,7 +49,7 @@ type PGUpgradeSpec struct {
 
 	// Resource requirements for the PGUpgrade container.
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// Scheduling constraints of the PGUpgrade pod.
 	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node
@@ -140,11 +140,14 @@ type PGUpgradeStatus struct {
 
 // PGUpgrade is the Schema for the pgupgrades API
 type PGUpgrade struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
-	Spec   PGUpgradeSpec   `json:"spec,omitempty"`
-	Status PGUpgradeStatus `json:"status,omitempty"`
+	// +optional
+	Spec PGUpgradeSpec `json:"spec,omitzero"`
+	// +optional
+	Status PGUpgradeStatus `json:"status,omitzero"`
 }
 
 //+kubebuilder:object:root=true
@@ -152,7 +155,7 @@ type PGUpgrade struct {
 // PGUpgradeList contains a list of PGUpgrade
 type PGUpgradeList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []PGUpgrade `json:"items"`
 }
 

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -27,7 +27,7 @@ type PostgresClusterSpec struct {
 
 	// PostgreSQL backup configuration
 	// +optional
-	Backups Backups `json:"backups,omitempty"`
+	Backups Backups `json:"backups,omitzero"`
 
 	// General configuration of the PostgreSQL server
 	// +optional
@@ -291,7 +291,7 @@ type PostgresClusterDataSource struct {
 
 	// Resource requirements for the pgBackRest restore Job.
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// Scheduling constraints of the pgBackRest restore Job.
 	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node
@@ -360,7 +360,7 @@ type PostgresClusterStatus struct {
 	InstanceSets []PostgresInstanceSetStatus `json:"instances,omitempty"`
 
 	// +optional
-	Patroni PatroniStatus `json:"patroni,omitempty"`
+	Patroni PatroniStatus `json:"patroni,omitzero"`
 
 	// Status information for pgBackRest
 	// +optional
@@ -379,7 +379,7 @@ type PostgresClusterStatus struct {
 
 	// Current state of the PostgreSQL proxy.
 	// +optional
-	Proxy PostgresProxyStatus `json:"proxy,omitempty"`
+	Proxy PostgresProxyStatus `json:"proxy,omitzero"`
 
 	// The instance that should be started first when bootstrapping and/or starting a
 	// PostgresCluster.
@@ -399,7 +399,7 @@ type PostgresClusterStatus struct {
 
 	// Current state of PostgreSQL cluster monitoring tool configuration
 	// +optional
-	Monitoring MonitoringStatus `json:"monitoring,omitempty"`
+	Monitoring MonitoringStatus `json:"monitoring,omitzero"`
 
 	// DatabaseInitSQL state of custom database initialization in the cluster
 	// +optional
@@ -492,7 +492,7 @@ type PostgresInstanceSetSpec struct {
 
 	// Compute resources of a PostgreSQL container.
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// Configuration for instance sidecar containers
 	// +optional
@@ -614,7 +614,8 @@ type RegistrationRequirementStatus struct {
 }
 
 type PostgresProxyStatus struct {
-	PGBouncer PGBouncerPodStatus `json:"pgBouncer,omitempty"`
+	// +optional
+	PGBouncer PGBouncerPodStatus `json:"pgBouncer,omitzero"`
 }
 
 // PostgresStandbySpec defines if/how the cluster should be a hot standby.
@@ -660,7 +661,8 @@ func (s *UserInterfaceSpec) Default() {
 type PostgresUserInterfaceStatus struct {
 
 	// The state of the pgAdmin user interface.
-	PGAdmin PGAdminPodStatus `json:"pgAdmin,omitempty"`
+	// +optional
+	PGAdmin PGAdminPodStatus `json:"pgAdmin,omitzero"`
 }
 
 //+kubebuilder:object:root=true
@@ -675,14 +677,17 @@ type PostgresCluster struct {
 	// - https://docs.k8s.io/concepts/overview/working-with-objects/names/#dns-subdomain-names
 	// - https://releases.k8s.io/v1.21.0/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/validator.go#L60
 
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// NOTE(cbandy): Every PostgresCluster needs a Spec, but it is optional here
 	// so ObjectMeta can be managed independently.
 
-	Spec   PostgresClusterSpec   `json:"spec,omitempty"`
-	Status PostgresClusterStatus `json:"status,omitempty"`
+	// +optional
+	Spec PostgresClusterSpec `json:"spec,omitzero"`
+	// +optional
+	Status PostgresClusterStatus `json:"status,omitzero"`
 }
 
 // Default implements "sigs.k8s.io/controller-runtime/pkg/webhook.Defaulter" so
@@ -703,7 +708,7 @@ func (c *PostgresCluster) Default() {
 // PostgresClusterList contains a list of PostgresCluster
 type PostgresClusterList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []PostgresCluster `json:"items"`
 }
 

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types_test.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types_test.go
@@ -31,12 +31,7 @@ func TestPostgresClusterDefault(t *testing.T) {
 		assert.DeepEqual(t, string(b), strings.TrimSpace(`
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
-metadata:
-  creationTimestamp: null
 spec:
-  backups:
-    pgbackrest:
-      repos: null
   instances: null
   patroni:
     leaderLeaseDurationSeconds: 30
@@ -44,13 +39,7 @@ spec:
     syncPeriodSeconds: 10
   port: 5432
   postgresVersion: 0
-status:
-  monitoring: {}
-  patroni: {}
-  postgresVersion: 0
-  proxy:
-    pgBouncer: {}
-								`)+"\n")
+		`)+"\n")
 	})
 
 	t.Run("one instance set", func(t *testing.T) {
@@ -63,31 +52,19 @@ status:
 		assert.DeepEqual(t, string(b), strings.TrimSpace(`
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
-metadata:
-  creationTimestamp: null
 spec:
-  backups:
-    pgbackrest:
-      repos: null
   instances:
   - dataVolumeClaimSpec:
       resources: {}
     name: "00"
     replicas: 1
-    resources: {}
   patroni:
     leaderLeaseDurationSeconds: 30
     port: 8008
     syncPeriodSeconds: 10
   port: 5432
   postgresVersion: 0
-status:
-  monitoring: {}
-  patroni: {}
-  postgresVersion: 0
-  proxy:
-    pgBouncer: {}
-								`)+"\n")
+		`)+"\n")
 	})
 
 	t.Run("empty proxy", func(t *testing.T) {
@@ -109,10 +86,8 @@ status:
 		assert.NilError(t, err)
 		assert.DeepEqual(t, string(b), strings.TrimSpace(`
 pgBouncer:
-  config: {}
   port: 5432
   replicas: 1
-  resources: {}
 		`)+"\n")
 	})
 }
@@ -128,7 +103,6 @@ dataVolumeClaimSpec:
   resources: {}
 name: "05"
 replicas: 1
-resources: {}
 	`)+"\n")
 }
 

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/standalone_pgadmin_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/standalone_pgadmin_types.go
@@ -89,7 +89,7 @@ type PGAdminSpec struct {
 	// values will be loaded without validation. Be careful, as
 	// you may put pgAdmin into an unusable state.
 	// +optional
-	Config StandalonePGAdminConfiguration `json:"config,omitempty"`
+	Config StandalonePGAdminConfiguration `json:"config,omitzero"`
 
 	// Defines a PersistentVolumeClaim for pgAdmin data.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
@@ -127,7 +127,7 @@ type PGAdminSpec struct {
 
 	// Resource requirements for the PGAdmin container.
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// Scheduling constraints of the PGAdmin pod.
 	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node
@@ -183,7 +183,7 @@ type ServerGroup struct {
 	// PostgresClusterSelector selects clusters to dynamically add to pgAdmin by matching labels.
 	// An empty selector like `{}` will select ALL clusters in the namespace.
 	// +kubebuilder:validation:Optional
-	PostgresClusterSelector metav1.LabelSelector `json:"postgresClusterSelector,omitempty"`
+	PostgresClusterSelector metav1.LabelSelector `json:"postgresClusterSelector,omitzero"`
 }
 
 type PGAdminUser struct {
@@ -240,11 +240,14 @@ type PGAdminStatus struct {
 
 // PGAdmin is the Schema for the PGAdmin API
 type PGAdmin struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
-	Spec   PGAdminSpec   `json:"spec,omitempty"`
-	Status PGAdminStatus `json:"status,omitempty"`
+	// +optional
+	Spec PGAdminSpec `json:"spec,omitzero"`
+	// +optional
+	Status PGAdminStatus `json:"status,omitzero"`
 }
 
 // Default implements "sigs.k8s.io/controller-runtime/pkg/webhook.Defaulter" so
@@ -270,7 +273,7 @@ func NewPGAdmin() *PGAdmin {
 // PGAdminList contains a list of PGAdmin
 type PGAdminList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []PGAdmin `json:"items"`
 }
 


### PR DESCRIPTION
The `modernize` analyzer of `gopls` recommends this change, and it simplifies some validation tests. The old tag implies `+optional` for backward compatibility. The new tag does not, so a few fields need the marker.

This eliminates the last results from `modernize -test ./...`

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

**Other Information**:

Issue: PGO-2582