### PR TITLE
Always set Postgres "log_file_mode" parameter

### DIFF
--- a/internal/collector/postgres.go
+++ b/internal/collector/postgres.go
@@ -117,7 +117,6 @@ func EnablePostgresLogging(
 		for k, v := range postgres.LogRotation(retentionPeriod, "postgresql-", ".log") {
 			outParameters.Add(k, v)
 		}
-		outParameters.Add("log_file_mode", "0660")
 
 		// Log in a timezone that the OpenTelemetry Collector will understand.
 		outParameters.Add("log_timezone", "UTC")

--- a/internal/postgres/parameters.go
+++ b/internal/postgres/parameters.go
@@ -48,6 +48,16 @@ func NewParameters() Parameters {
 	// - https://www.postgresql.org/docs/current/auth-password.html
 	parameters.Default.Add("password_encryption", "scram-sha-256")
 
+	// Pod "securityContext.fsGroup" ensures processes and filesystems agree on a GID;
+	// use the same permissions for group and owner.
+	// This allows every process in the pod to read Postgres log files.
+	//
+	// S_IRUSR, S_IWUSR: (0600) enable owner read and write permissions
+	// S_IRGRP, S_IWGRP: (0060) enable group read and write permissions.
+	//
+	// PostgreSQL must be reloaded when changing this value.
+	parameters.Mandatory.Add("log_file_mode", "0660")
+
 	return parameters
 }
 

--- a/internal/postgres/parameters_test.go
+++ b/internal/postgres/parameters_test.go
@@ -14,6 +14,8 @@ func TestNewParameters(t *testing.T) {
 	parameters := NewParameters()
 
 	assert.DeepEqual(t, parameters.Mandatory.AsMap(), map[string]string{
+		"log_file_mode": "0660",
+
 		"ssl":           "on",
 		"ssl_ca_file":   "/pgconf/tls/ca.crt",
 		"ssl_cert_file": "/pgconf/tls/tls.crt",

--- a/internal/shell/paths_test.go
+++ b/internal/shell/paths_test.go
@@ -93,4 +93,11 @@ func TestMakeDirectories(t *testing.T) {
 				"expected plain unquoted scalar, got:\n%s", b)
 		})
 	})
+
+	t.Run("Unrelated", func(t *testing.T) {
+		assert.Equal(t,
+			MakeDirectories("/one", "/two/three/four"),
+			`mkdir -p '/two/three/four' && { chmod 0775 '/two/three/four' || :; }`,
+			"expected no chmod of parent directories")
+	})
 }


### PR DESCRIPTION
We set it when OpenTelemetry is enabled, but group permissions are good on Kubernetes storage generally. This adds some more validation tests around Postgres logging parameters.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
 - [x] Other


**Other Information**:

Issue: PGO-2558
