### PR TITLE
Omit managed fields from cached Kubernetes objects

### DIFF
--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -20,6 +20,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 
@@ -67,6 +68,7 @@ func initManager(ctx context.Context) (runtime.Options, error) {
 	log := logging.FromContext(ctx)
 
 	options := runtime.Options{}
+	options.Cache.DefaultTransform = cache.TransformStripManagedFields()
 	options.Cache.SyncPeriod = initialize.Pointer(time.Hour)
 
 	// If we aren't using it, http/2 should be disabled

--- a/cmd/postgres-operator/main_test.go
+++ b/cmd/postgres-operator/main_test.go
@@ -21,6 +21,7 @@ func TestInitManager(t *testing.T) {
 		options, err := initManager(ctx)
 		assert.NilError(t, err)
 
+		assert.Assert(t, options.Cache.DefaultTransform != nil)
 		if assert.Check(t, options.Cache.SyncPeriod != nil) {
 			assert.Equal(t, *options.Cache.SyncPeriod, time.Hour)
 		}
@@ -42,6 +43,7 @@ func TestInitManager(t *testing.T) {
 
 		{
 			options.Cache.SyncPeriod = nil
+			options.Cache.DefaultTransform = nil
 			options.Controller.GroupKindConcurrency = nil
 			options.HealthProbeBindAddress = ""
 			options.Metrics.TLSOpts = nil


### PR DESCRIPTION
Tests pass. This should reduce memory usage, but I haven't tried it in a large cluster, yet.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other

Performance / Utilization

**What is the new behavior (if this is a feature change)?**

Reduced memory usage, TBD.

**Other Information**:

Issue: PGO-1362