### PR TITLE
Ensure Postgres data directories have group-read permission

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CONTROLLER ?= $(GO) tool sigs.k8s.io/controller-tools/cmd/controller-gen
 
 # Run tests using the latest tools.
 ENVTEST ?= $(GO) run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-KUTTL ?= $(GO) run github.com/kudobuilder/kuttl/pkg/kuttlctl/cmd/kubectl-kuttl@latest
+KUTTL ?= $(GO) run github.com/kudobuilder/kuttl/cmd/kubectl-kuttl@latest
 KUTTL_TEST ?= $(KUTTL) test
 
 ##@ General
@@ -171,6 +171,10 @@ check-envtest-existing: createnamespaces
 	kubectl delete -k ./config/dev
 
 # Expects operator to be running
+#
+# KUTTL runs with a single kubectl context named "cluster".
+# If you experience `cluster "minikube" does not exist`, try `MINIKUBE_PROFILE=cluster`.
+#
 .PHONY: check-kuttl
 check-kuttl: ## Run kuttl end-to-end tests
 check-kuttl: ## example command: make check-kuttl KUTTL_TEST='

--- a/internal/controller/pgupgrade/jobs.go
+++ b/internal/controller/pgupgrade/jobs.go
@@ -98,7 +98,7 @@ func upgradeCommand(spec *v1beta1.PGUpgradeSettings, fetchKeyCommand string) []s
 		// proper permissions have to be set on the old pgdata directory and the
 		// preload library settings must be copied over.
 		`echo -e "\nStep 3: Setting the expected permissions on the old pgdata directory...\n"`,
-		`chmod 700 /pgdata/pg"${old_version}"`,
+		`chmod 750 /pgdata/pg"${old_version}"`,
 		`echo -e "Step 4: Copying shared_preload_libraries setting to new postgresql.conf file...\n"`,
 		`echo "shared_preload_libraries = '$(/usr/pgsql-"""${old_version}"""/bin/postgres -D \`,
 		`/pgdata/pg"""${old_version}""" -C shared_preload_libraries)'" >> /pgdata/pg"${new_version}"/postgresql.conf`,

--- a/internal/controller/pgupgrade/jobs_test.go
+++ b/internal/controller/pgupgrade/jobs_test.go
@@ -214,7 +214,7 @@ spec:
           echo -e "Step 2: Initializing new pgdata directory...\n"
           /usr/pgsql-"${new_version}"/bin/initdb -k -D /pgdata/pg"${new_version}"
           echo -e "\nStep 3: Setting the expected permissions on the old pgdata directory...\n"
-          chmod 700 /pgdata/pg"${old_version}"
+          chmod 750 /pgdata/pg"${old_version}"
           echo -e "Step 4: Copying shared_preload_libraries setting to new postgresql.conf file...\n"
           echo "shared_preload_libraries = '$(/usr/pgsql-"""${old_version}"""/bin/postgres -D \
           /pgdata/pg"""${old_version}""" -C shared_preload_libraries)'" >> /pgdata/pg"${new_version}"/postgresql.conf

--- a/internal/controller/runtime/pod_client.go
+++ b/internal/controller/runtime/pod_client.go
@@ -24,8 +24,8 @@ type podExecutor func(
 ) error
 
 func newPodClient(config *rest.Config) (rest.Interface, error) {
-	codecs := serializer.NewCodecFactory(scheme.Scheme)
-	gvk, _ := apiutil.GVKForObject(&corev1.Pod{}, scheme.Scheme)
+	codecs := serializer.NewCodecFactory(Scheme)
+	gvk, _ := apiutil.GVKForObject(&corev1.Pod{}, Scheme)
 	httpClient, err := rest.HTTPClientFor(config)
 	if err != nil {
 		return nil, err

--- a/internal/patroni/config.go
+++ b/internal/patroni/config.go
@@ -518,22 +518,7 @@ func instanceYAML(
 	if command := pgbackrestReplicaCreateCommand; len(command) > 0 {
 
 		// Regardless of the "keep_data" setting below, Patroni deletes the
-		// data directory when all methods fail. pgBackRest will not restore
-		// when the data directory is missing, so create it before running the
-		// command. PostgreSQL requires that the directory is writable by only
-		// itself.
-		// - https://github.com/zalando/patroni/blob/v2.0.2/patroni/ha.py#L249
-		// - https://github.com/pgbackrest/pgbackrest/issues/1445
-		// - https://git.postgresql.org/gitweb/?p=postgresql.git;f=src/backend/utils/init/miscinit.c;hb=REL_13_0#l319
-		//
-		// NOTE(cbandy): The "PATRONI_POSTGRESQL_DATA_DIR" environment variable
-		// is defined in this package, but it is removed by Patroni at runtime.
-		command = append([]string{
-			"bash", "-ceu", "--",
-			`install --directory --mode=0700 "${PGDATA?}" && exec "$@"`,
-			"-",
-		}, command...)
-
+		// data directory when all methods fail.
 		postgresql[pgBackRestCreateReplicaMethod] = map[string]any{
 			"command":   strings.Join(shell.QuoteWords(command...), " "),
 			"keep_data": true, // Use the data directory from a prior method.

--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -356,7 +356,7 @@ func DedicatedSnapshotVolumeRestoreCommand(pgdata string, args ...string) []stri
 BACKUP_LABEL=$([[ ! -e "${pgdata}/backup_label" ]] || md5sum "${pgdata}/backup_label")
 echo "Starting pgBackRest delta restore"
 
-install --directory --mode=0700 "${pgdata}"
+install --directory --mode=0750 "${pgdata}"
 rm -f "${pgdata}/postmaster.pid"
 bash -xc "pgbackrest restore ${opts}"
 rm -f "${pgdata}/patroni.dynamic.json"

--- a/internal/postgres/reconcile_test.go
+++ b/internal/postgres/reconcile_test.go
@@ -263,9 +263,9 @@ initContainers:
     [[ -d "${bootstrap_dir}" ]] && results 'bootstrap directory' "${bootstrap_dir}"
     [[ -d "${bootstrap_dir}" ]] && postgres_data_directory="${bootstrap_dir}"
     if [[ ! -e "${postgres_data_directory}" || -O "${postgres_data_directory}" ]]; then
-    install --directory --mode=0700 "${postgres_data_directory}"
+    install --directory --mode=0750 "${postgres_data_directory}"
     elif [[ -w "${postgres_data_directory}" && -g "${postgres_data_directory}" ]]; then
-    recreate "${postgres_data_directory}" '0700'
+    recreate "${postgres_data_directory}" '0750'
     else (halt Permissions!); fi ||
     halt "$(permissions "${postgres_data_directory}" ||:)"
     (mkdir -p '/pgdata/pgbackrest/log' && { chmod 0775 '/pgdata/pgbackrest/log' '/pgdata/pgbackrest' || :; }) ||

--- a/internal/registration/runner_test.go
+++ b/internal/registration/runner_test.go
@@ -20,9 +20,9 @@ import (
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/crunchydata/postgres-operator/internal/controller/runtime"
 	"github.com/crunchydata/postgres-operator/internal/testing/events"
 )
 
@@ -381,7 +381,7 @@ func TestRunnerRequiredEvents(t *testing.T) {
 
 					conditions := append([]metav1.Condition{}, tt.before...)
 					object := &corev1.ConfigMap{}
-					recorder := events.NewRecorder(t, scheme.Scheme)
+					recorder := events.NewRecorder(t, runtime.Scheme)
 
 					result := r.Required(recorder, object, &conditions)
 
@@ -413,7 +413,7 @@ func TestRunnerRequiredEvents(t *testing.T) {
 			} {
 				conditions := append([]metav1.Condition{}, tt.before...)
 				object := &corev1.ConfigMap{}
-				recorder := events.NewRecorder(t, scheme.Scheme)
+				recorder := events.NewRecorder(t, runtime.Scheme)
 
 				result := r.Required(recorder, object, &conditions)
 
@@ -441,7 +441,7 @@ func TestRunnerRequiredEvents(t *testing.T) {
 			} {
 				conditions := append([]metav1.Condition{}, tt.before...)
 				object := &corev1.ConfigMap{}
-				recorder := events.NewRecorder(t, scheme.Scheme)
+				recorder := events.NewRecorder(t, runtime.Scheme)
 
 				result := r.Required(recorder, object, &conditions)
 
@@ -475,7 +475,7 @@ func TestRunnerRequiredEvents(t *testing.T) {
 
 					conditions := append([]metav1.Condition{}, tt.before...)
 					object := &corev1.ConfigMap{}
-					recorder := events.NewRecorder(t, scheme.Scheme)
+					recorder := events.NewRecorder(t, runtime.Scheme)
 
 					result := r.Required(recorder, object, &conditions)
 
@@ -508,7 +508,7 @@ func TestRunnerRequiredEvents(t *testing.T) {
 			} {
 				conditions := append([]metav1.Condition{}, tt.before...)
 				object := &corev1.ConfigMap{}
-				recorder := events.NewRecorder(t, scheme.Scheme)
+				recorder := events.NewRecorder(t, runtime.Scheme)
 
 				result := r.Required(recorder, object, &conditions)
 

--- a/internal/testing/require/kubernetes.go
+++ b/internal/testing/require/kubernetes.go
@@ -139,14 +139,14 @@ func kubernetes3(t TestingT) (*envtest.Environment, client.Client) {
 		// Calculate the project directory as reported by [goruntime.CallersFrames].
 		frame, ok := frames.Next()
 		self := frame.File
-		root := strings.TrimSuffix(self,
-			filepath.Join("internal", "testing", "require", "kubernetes.go"))
+		root := Value(filepath.EvalSymlinks(strings.TrimSuffix(self,
+			filepath.Join("internal", "testing", "require", "kubernetes.go"))))
 
 		// Find the first caller that is not in this file.
 		for ok && frame.File == self {
 			frame, ok = frames.Next()
 		}
-		caller := frame.File
+		caller := Value(filepath.EvalSymlinks(frame.File))
 
 		// Calculate the project directory path relative to the caller.
 		base := Value(filepath.Rel(filepath.Dir(caller), root))
@@ -159,8 +159,7 @@ func kubernetes3(t TestingT) (*envtest.Environment, client.Client) {
 		); assert.Check(t,
 			err == nil && len(pkgs) > 0 && pkgs[0].Module != nil, "got %v\n%#v", err, pkgs,
 		) {
-			snapshotter, err = filepath.Rel(root, pkgs[0].Module.Dir)
-			assert.NilError(t, err)
+			snapshotter = Value(filepath.Rel(root, pkgs[0].Module.Dir))
 		}
 
 		env := EnvTest(t, envtest.CRDInstallOptions{


### PR DESCRIPTION
Postgres has allowed group-read on its data directories since v11. This permission enables more avenues for data recovery when storage misbehaves.

🙇🏻 This includes some unrelated fixes and improvements to the test suite.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix
 - [x] Testing enhancement

**What is the current behavior (link to any open issues here)?**

PGO sets permissions on Postgres directories to `0700` after which Postgres creates files and directories with zero group permissions, `g-rwx`.

**What is the new behavior (if this is a feature change)?**

PGO sets permissions on these directories to `0750`, the most liberal allowed by Postgres. With that, Postgres creates files and directories with group-read, `g+rx`. This group access allows:

- PGO to read these files when the container UID changes, e.g. OpenShift SCC mistakes.
- other processes in the pod to read these files, e.g. log files in the data directory.

**Other Information**:

Issue: PGO-300