### PR TITLE
Remove Divisor from Downward API resrouceFieldRefs

### DIFF
--- a/internal/postgres/reconcile.go
+++ b/internal/postgres/reconcile.go
@@ -8,18 +8,12 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/crunchydata/postgres-operator/internal/config"
 	"github.com/crunchydata/postgres-operator/internal/feature"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
-)
-
-var (
-	oneMillicore = resource.MustParse("1m")
-	oneMebibyte  = resource.MustParse("1Mi")
 )
 
 // DataVolumeMount returns the name and mount path of the PostgreSQL data volume.
@@ -116,28 +110,24 @@ func InstancePod(ctx context.Context,
 					ResourceFieldRef: &corev1.ResourceFieldSelector{
 						ContainerName: naming.ContainerDatabase,
 						Resource:      "limits.cpu",
-						Divisor:       oneMillicore,
 					},
 				}, {
 					Path: "cpu_request",
 					ResourceFieldRef: &corev1.ResourceFieldSelector{
 						ContainerName: naming.ContainerDatabase,
 						Resource:      "requests.cpu",
-						Divisor:       oneMillicore,
 					},
 				}, {
 					Path: "mem_limit",
 					ResourceFieldRef: &corev1.ResourceFieldSelector{
 						ContainerName: naming.ContainerDatabase,
 						Resource:      "limits.memory",
-						Divisor:       oneMebibyte,
 					},
 				}, {
 					Path: "mem_request",
 					ResourceFieldRef: &corev1.ResourceFieldSelector{
 						ContainerName: naming.ContainerDatabase,
 						Resource:      "requests.memory",
-						Divisor:       oneMebibyte,
 					},
 				}, {
 					Path: "labels",

--- a/internal/postgres/reconcile_test.go
+++ b/internal/postgres/reconcile_test.go
@@ -351,22 +351,22 @@ volumes:
     - path: cpu_limit
       resourceFieldRef:
         containerName: database
-        divisor: 1m
+        divisor: "0"
         resource: limits.cpu
     - path: cpu_request
       resourceFieldRef:
         containerName: database
-        divisor: 1m
+        divisor: "0"
         resource: requests.cpu
     - path: mem_limit
       resourceFieldRef:
         containerName: database
-        divisor: 1Mi
+        divisor: "0"
         resource: limits.memory
     - path: mem_request
       resourceFieldRef:
         containerName: database
-        divisor: 1Mi
+        divisor: "0"
         resource: requests.memory
     - fieldRef:
         apiVersion: v1
@@ -442,22 +442,22 @@ volumes:
     - path: cpu_limit
       resourceFieldRef:
         containerName: database
-        divisor: 1m
+        divisor: "0"
         resource: limits.cpu
     - path: cpu_request
       resourceFieldRef:
         containerName: database
-        divisor: 1m
+        divisor: "0"
         resource: requests.cpu
     - path: mem_limit
       resourceFieldRef:
         containerName: database
-        divisor: 1Mi
+        divisor: "0"
         resource: limits.memory
     - path: mem_request
       resourceFieldRef:
         containerName: database
-        divisor: 1Mi
+        divisor: "0"
         resource: requests.memory
     - fieldRef:
         apiVersion: v1
@@ -666,22 +666,22 @@ volumes:
     - path: cpu_limit
       resourceFieldRef:
         containerName: database
-        divisor: 1m
+        divisor: "0"
         resource: limits.cpu
     - path: cpu_request
       resourceFieldRef:
         containerName: database
-        divisor: 1m
+        divisor: "0"
         resource: requests.cpu
     - path: mem_limit
       resourceFieldRef:
         containerName: database
-        divisor: 1Mi
+        divisor: "0"
         resource: limits.memory
     - path: mem_request
       resourceFieldRef:
         containerName: database
-        divisor: 1Mi
+        divisor: "0"
         resource: requests.memory
     - fieldRef:
         apiVersion: v1


### PR DESCRIPTION
Remove `divisor` from Downward API resrouceFieldRefs.  This means CPU and memory information will now be exposed using the default divisor for CPU and memory (with default being "1" for both).  This means memory information will now be represented in bytes, as expected by pgMonitor and the CPK Metrics & Monitoring stack when  consuming Downward API information.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 Fixes memory metrics in the Metrics & Monitoring stack.
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
The divisor for the Downward API volumes for CPU and memory defaults to `1m` for CPU and `1Mi` for memory.


**What is the new behavior (if this is a feature change)?**
- [x] Breaking change (fix or feature that would cause existing functionality to change)
Potential breaking behavior if anyone is consuming Downward API info via a custom sidecar.


**Other Information**:

Issue: PGO-2604