### PR TITLE
Wait for one WAL archive after changing parameters

### DIFF
--- a/testing/chainsaw/e2e/pgbackrest-restore/chainsaw-test.yaml
+++ b/testing/chainsaw/e2e/pgbackrest-restore/chainsaw-test.yaml
@@ -21,18 +21,18 @@ spec:
 
   steps:
     - name: 'Create Cluster with replica, tablespace'
-      use: 
+      use:
         template: 'templates/create-cluster.yaml'
 
     - name: 'Create Data'
-      use: 
+      use:
         template: 'templates/psql-data.yaml'
         with:
           bindings:
             - name: target
               value: original
             - name: job
-              value: original-data            
+              value: original-data
             - name: command
               value: |
                      CREATE SCHEMA IF NOT EXISTS "original";
@@ -40,7 +40,7 @@ spec:
                      CREATE TABLE cows (name) TABLESPACE barn AS VALUES ('nellie');
 
     - name: 'Create Backup #1'
-      use: 
+      use:
         template: 'templates/create-backup.yaml'
         with:
           bindings:
@@ -89,11 +89,16 @@ spec:
               kind: PostgresCluster
               name: clone-one
 
-    - name: 'Restart Cluster'
+    - name: 'Update Cluster'
       description: >
-        Sets a timestamp and restarts the cluster, using the timestamp for comparison
-      use: 
-        template: 'templates/restart-cluster.yaml'
+        Update the cluster with parameters that require attention during recovery
+      use:
+        template: 'templates/change-parameters.yaml'
+        with:
+          bindings:
+            - name: parameters
+              value:
+                max_connections: 1000
 
     - name: 'Update Data'
       use:
@@ -110,9 +115,9 @@ spec:
     - name: 'Verify WAL backup'
       use:
         template: 'templates/verify-backup.yaml'
-    
+
     - name: 'Create Backup #2'
-      use: 
+      use:
         template: 'templates/create-backup.yaml'
         with:
           bindings:
@@ -197,5 +202,5 @@ spec:
     - name: 'Confirm Replica'
       description: >
         Verify that the data has streamed and is streaming to the replica
-      use: 
+      use:
         template: 'templates/verify-replica.yaml'

--- a/testing/chainsaw/e2e/pgbackrest-restore/templates/change-parameters.yaml
+++ b/testing/chainsaw/e2e/pgbackrest-restore/templates/change-parameters.yaml
@@ -1,8 +1,12 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: StepTemplate
 metadata:
-  name: restart-cluster
+  name: change-parameters
 spec:
+  bindings:
+    - name: parameters
+      value: 'The key/value map of Postgres parameters to change'
+
   try:
     -
       description: >
@@ -54,12 +58,11 @@ spec:
             name: original
           spec:
             config:
-              parameters:
-                max_connections: 1000
+              parameters: ($parameters)
 
     -
       description: >
-        Wait for Postgres to restart
+        Wait for Postgres to restart, signal the WAL archiver, then wait for WAL to archive
       script:
         skipCommandOutput: true
         timeout: 30s
@@ -78,6 +81,11 @@ spec:
           done
           echo "${START} != ${BEFORE}"
 
-          # Reset counters in the "pg_stat_archiver" view.
+          # Reset counters in the "pg_stat_archiver" view and signal the archiver.
           kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" \
-            -- psql -qb --command "SELECT pg_stat_reset_shared('archiver')" --output /dev/null
+            -- psql -qb --command "SELECT pg_stat_reset_shared('archiver'), pg_switch_wal()"
+
+          while [ 0 = "$(
+            kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" \
+              -- psql -qAt --command 'SELECT archived_count FROM pg_stat_archiver'
+          )" ]; do sleep 1; done

--- a/testing/chainsaw/e2e/pgbackrest-restore/templates/lose-data.yaml
+++ b/testing/chainsaw/e2e/pgbackrest-restore/templates/lose-data.yaml
@@ -62,9 +62,7 @@ spec:
           - --command
           - DROP TABLE original.important
           - --command
-          - SELECT pg_stat_reset_shared('archiver')
-          - --command
-          - SELECT pg_switch_wal()
+          - SELECT pg_stat_reset_shared('archiver'), pg_switch_wal()
 
     -
       description: >


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement

**What is the new behavior (if this is a feature change)?**

This step template can now be called multiple times to add different parameter changes to the WAL stream. The test still only changes one parameter once because waiting for restarts and archives is slow.

**Other Information**:

This addresses the "unused template" in my PR from [last week](https://github.com/CrunchyData/postgres-operator/pull/4228#discussion_r2248866792).