### PR TITLE
Make each PostgresCluster..volumes.additional atomic

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -11033,39 +11033,42 @@ spec:
                           items:
                             properties:
                               claimName:
-                                description: A reference to a preexisting PVC.
+                                description: Name of an existing PersistentVolumeClaim.
                                 maxLength: 253
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               containers:
                                 description: |-
-                                  The containers to attach this volume to.
-                                  An omitted `Containers` field matches all containers.
-                                  An empty `Containers` field matches no containers.
+                                  The names of containers in which to mount this volume.
+                                  The default mounts the volume in *all* containers. An empty list does not mount the volume to any containers.
                                 items:
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                   type: string
                                 maxItems: 10
                                 type: array
-                                x-kubernetes-list-type: atomic
+                                x-kubernetes-list-type: set
                               name:
                                 allOf:
                                 - maxLength: 63
                                 - maxLength: 55
                                 description: |-
-                                  The name of the volume used for mounting path.
-                                  Volumes are mounted in the pods at `volumes/<NAME>`
-                                  Must be unique.
+                                  The name of the directory in which to mount this volume.
+                                  Volumes are mounted in containers at `/volumes/{name}`.
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               readOnly:
-                                description: Sets the write/read mode of the volume
+                                description: When true, mount the volume read-only,
+                                  otherwise read-write. Defaults to false.
                                 type: boolean
                             required:
                             - claimName
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           maxItems: 10
                           type: array
                           x-kubernetes-list-map-keys:
@@ -29648,39 +29651,42 @@ spec:
                           items:
                             properties:
                               claimName:
-                                description: A reference to a preexisting PVC.
+                                description: Name of an existing PersistentVolumeClaim.
                                 maxLength: 253
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               containers:
                                 description: |-
-                                  The containers to attach this volume to.
-                                  An omitted `Containers` field matches all containers.
-                                  An empty `Containers` field matches no containers.
+                                  The names of containers in which to mount this volume.
+                                  The default mounts the volume in *all* containers. An empty list does not mount the volume to any containers.
                                 items:
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                   type: string
                                 maxItems: 10
                                 type: array
-                                x-kubernetes-list-type: atomic
+                                x-kubernetes-list-type: set
                               name:
                                 allOf:
                                 - maxLength: 63
                                 - maxLength: 55
                                 description: |-
-                                  The name of the volume used for mounting path.
-                                  Volumes are mounted in the pods at `volumes/<NAME>`
-                                  Must be unique.
+                                  The name of the directory in which to mount this volume.
+                                  Volumes are mounted in containers at `/volumes/{name}`.
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               readOnly:
-                                description: Sets the write/read mode of the volume
+                                description: When true, mount the volume read-only,
+                                  otherwise read-write. Defaults to false.
                                 type: boolean
                             required:
                             - claimName
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           maxItems: 10
                           type: array
                           x-kubernetes-list-map-keys:

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -541,34 +541,50 @@ type PostgresVolumesSpec struct {
 	Temp *VolumeClaimSpec `json:"temp,omitempty"`
 }
 
+// ---
+// Only one applier should be managing each volume definition.
+// https://docs.k8s.io/reference/using-api/server-side-apply#merge-strategy
+// +structType=atomic
 type AdditionalVolume struct {
-	// A reference to a preexisting PVC.
+	// Name of an existing PersistentVolumeClaim.
 	// ---
+	// https://pkg.go.dev/k8s.io/kubernetes/pkg/apis/core/validation#ValidatePersistentVolumeClaim
+	// https://pkg.go.dev/k8s.io/kubernetes/pkg/apis/core/validation#ValidatePersistentVolumeName
+	//
 	// +required
 	ClaimName DNS1123Subdomain `json:"claimName"`
 
-	// The containers to attach this volume to.
-	// An omitted `Containers` field matches all containers.
-	// An empty `Containers` field matches no containers.
+	// The names of containers in which to mount this volume.
+	// The default mounts the volume in *all* containers. An empty list does not mount the volume to any containers.
 	// ---
-	// +optional
-	// +listType=atomic
+	// These are matched against [corev1.Container.Name] in a PodSpec, which is a [DNS1123Label].
+	// https://pkg.go.dev/k8s.io/kubernetes/pkg/apis/core/validation#ValidatePodSpec
+	//
+	// Container names are unique within a Pod, so this list can be, too.
+	// +listType=set
+	//
 	// +kubebuilder:validation:MaxItems=10
-	Containers []string `json:"containers,omitempty"`
+	// +optional
+	Containers []DNS1123Label `json:"containers"`
 
-	// The name of the volume used for mounting path.
-	// Volumes are mounted in the pods at `volumes/<NAME>`
-	// Must be unique.
+	// The name of the directory in which to mount this volume.
+	// Volumes are mounted in containers at `/volumes/{name}`.
 	// ---
-	// The `Name` field is a `DNS1123Label` type to enforce
-	// the max length.
-	// +required
-	// Max length is less than max 63 to allow prepending `volumes-` to name
+	// This also goes into the [corev1.Volume.Name] field, which is a [DNS1123Label].
+	// https://pkg.go.dev/k8s.io/kubernetes/pkg/apis/core/validation#ValidatePodSpec
+	// https://pkg.go.dev/k8s.io/kubernetes/pkg/apis/core/validation#ValidateVolumes
+	//
+	// We prepend "volumes-" to avoid collisions with other [corev1.PodSpec.Volumes],
+	// so the maximum is 8 less than the inherited 63.
 	// +kubebuilder:validation:MaxLength=55
+	//
+	// +required
 	Name DNS1123Label `json:"name"`
 
-	// Sets the write/read mode of the volume
+	// When true, mount the volume read-only, otherwise read-write. Defaults to false.
 	// ---
+	// [corev1.VolumeMount.ReadOnly]
+	//
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty"`
 }

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/shared_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/shared_types.go
@@ -23,7 +23,7 @@ import (
 type ConfigDataKey = string
 
 // ---
-// https://docs.k8s.io/concepts/overview/working-with-objects/names/#dns-subdomain-names
+// https://docs.k8s.io/concepts/overview/working-with-objects/names#dns-subdomain-names
 // https://pkg.go.dev/k8s.io/apimachinery/pkg/util/validation#IsDNS1123Subdomain
 // https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Format
 //

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
@@ -38,7 +38,7 @@ func (in *AdditionalVolume) DeepCopyInto(out *AdditionalVolume) {
 	*out = *in
 	if in.Containers != nil {
 		in, out := &in.Containers, &out.Containers
-		*out = make([]string, len(*in))
+		*out = make([]DNS1123Label, len(*in))
 		copy(*out, *in)
 	}
 }


### PR DESCRIPTION
This limits each volume to a single manager and allows us to express that container names are a unique set.

I intended to touch only validation and documentation for it, but I edited the field language as well. I'm less certain about my word-smithing there, so happy to drop or change those:

```diff
--- explain.main.txt	2025-08-13 13:50:07.000000000 -0500
+++ explain.branch.txt	2025-08-13 13:50:28.000000000 -0500
@@ -10,19 +10,19 @@
     
 FIELDS:
   claimName	<string> -required-
-    A reference to a preexisting PVC.
+    Name of an existing PersistentVolumeClaim.
 
   containers	<[]string>
-    The containers to attach this volume to.
-    An omitted `Containers` field matches all containers.
-    An empty `Containers` field matches no containers.
+    The names of containers in which to mount this volume.
+    The default mounts the volume in *all* containers. An empty list does not
+    mount the volume.
 
   name	<string> -required-
-    The name of the volume used for mounting path.
-    Volumes are mounted in the pods at `volumes/<NAME>`
-    Must be unique.
+    The name of the directory in which to mount this volume.
+    Volumes are mounted in containers at `/volumes/{name}`.
 
   readOnly	<boolean>
-    Sets the write/read mode of the volume
+    When true, mount the volume read-only, otherwise read-write. Defaults to
+    false.
```

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

`make check check-envtest check-chainsaw` passes, but I didn't try any KUTTL tests.

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Documentation
 - [x] Other
