### PR TITLE
Add Disk Auto Grow for pgBackrest repo host volumes

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -18759,6 +18759,9 @@ spec:
                           description: Whether or not the pgBackRest repository PersistentVolumeClaim
                             is bound to a volume
                           type: boolean
+                        desiredRepoVolume:
+                          description: Desired Size of the repo volume
+                          type: string
                         name:
                           description: The name of the pgBackRest repository
                           type: string
@@ -37681,6 +37684,9 @@ spec:
                           description: Whether or not the pgBackRest repository PersistentVolumeClaim
                             is bound to a volume
                           type: boolean
+                        desiredRepoVolume:
+                          description: Desired Size of the repo volume
+                          type: string
                         name:
                           description: The name of the pgBackRest repository
                           type: string

--- a/internal/controller/postgrescluster/autogrow.go
+++ b/internal/controller/postgrescluster/autogrow.go
@@ -6,7 +6,9 @@ package postgrescluster
 
 import (
 	"context"
+	"strings"
 
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -77,34 +79,44 @@ func limitIsSet(cluster *v1beta1.PostgresCluster, volumeType, instanceSetName st
 
 	var limitSet bool
 
-	switch volumeType {
+	switch {
 
 	// Cycle through the instance sets to ensure the correct limit is identified.
-	case "pgData":
+	case volumeType == "pgData":
 		for _, specInstance := range cluster.Spec.InstanceSets {
 			if specInstance.Name == instanceSetName {
 				limitSet = !specInstance.DataVolumeClaimSpec.Resources.Limits.Storage().IsZero()
 			}
 		}
+
+	// VolumeType for the repository host volumes should be in the form 'repoN'
+	// where N is 1-4. As above, cycle through any defined repositories and ensure
+	// the correct limit is identified.
+	case strings.HasPrefix(volumeType, "repo"):
+		for _, specRepo := range cluster.Spec.Backups.PGBackRest.Repos {
+			if specRepo.Name == volumeType && specRepo.Volume != nil {
+				limitSet = !specRepo.Volume.VolumeClaimSpec.Resources.Limits.Storage().IsZero()
+			}
+		}
 	}
-	// TODO: Add cases for pgWAL and repo volumes
+	// TODO: Add case for pgWAL
 
 	return limitSet
 
 }
 
-// setVolumeSize compares the potential sizes from the instance spec, status
-// and limit and sets the appropriate current value.
+// setVolumeSize compares the potential sizes from the cluster status, volume request
+// and volume limit and sets the appropriate current value.
 func (r *Reconciler) setVolumeSize(ctx context.Context, cluster *v1beta1.PostgresCluster,
-	pvc *corev1.PersistentVolumeClaim, volumeType, instanceSpecName string) {
+	spec *corev1.PersistentVolumeClaimSpec, volumeType, host string) {
 
 	log := logging.FromContext(ctx)
 
 	// Store the limit for this instance set. This value will not change below.
-	volumeLimitFromSpec := pvc.Spec.Resources.Limits.Storage()
+	volumeLimitFromSpec := spec.Resources.Limits.Storage()
 
 	// This value will capture our desired update.
-	volumeRequestSize := pvc.Spec.Resources.Requests.Storage()
+	volumeRequestSize := spec.Resources.Requests.Storage()
 
 	// A limit of 0 is ignorned, so the volume request is used.
 	if volumeLimitFromSpec.IsZero() {
@@ -116,9 +128,9 @@ func (r *Reconciler) setVolumeSize(ctx context.Context, cluster *v1beta1.Postgre
 	if volumeRequestSize.Value() > volumeLimitFromSpec.Value() {
 		r.Recorder.Eventf(cluster, corev1.EventTypeWarning, "VolumeRequestOverLimit",
 			"%s volume request (%v) for %s/%s is greater than set limit (%v). Limit value will be used.",
-			volumeType, volumeRequestSize, cluster.Name, instanceSpecName, volumeLimitFromSpec)
+			volumeType, volumeRequestSize, cluster.Name, host, volumeLimitFromSpec)
 
-		pvc.Spec.Resources.Requests = corev1.ResourceList{
+		spec.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceStorage: *resource.NewQuantity(volumeLimitFromSpec.Value(), resource.BinarySI),
 		}
 		// Otherwise, if the feature gate is not enabled, do not autogrow.
@@ -126,9 +138,9 @@ func (r *Reconciler) setVolumeSize(ctx context.Context, cluster *v1beta1.Postgre
 
 		// determine the appropriate volume request based on what's set in the status
 		if dpv, err := getDesiredVolumeSize(
-			cluster, volumeType, instanceSpecName, volumeRequestSize,
+			cluster, volumeType, host, volumeRequestSize,
 		); err != nil {
-			log.Error(err, "For "+cluster.Name+"/"+instanceSpecName+
+			log.Error(err, "For "+cluster.Name+"/"+host+
 				": Unable to parse "+volumeType+" volume request: "+dpv)
 		}
 
@@ -140,19 +152,19 @@ func (r *Reconciler) setVolumeSize(ctx context.Context, cluster *v1beta1.Postgre
 
 			r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "VolumeLimitReached",
 				"%s volume(s) for %s/%s are at size limit (%v).", volumeType,
-				cluster.Name, instanceSpecName, volumeLimitFromSpec)
+				cluster.Name, host, volumeLimitFromSpec)
 
 			// If the volume size request is greater than the limit, issue an
 			// additional event warning.
 			if volumeRequestSize.Value() > volumeLimitFromSpec.Value() {
 				r.Recorder.Eventf(cluster, corev1.EventTypeWarning, "DesiredVolumeAboveLimit",
 					"The desired size (%v) for the %s/%s %s volume(s) is greater than the size limit (%v).",
-					volumeRequestSize, cluster.Name, instanceSpecName, volumeType, volumeLimitFromSpec)
+					volumeRequestSize, cluster.Name, host, volumeType, volumeLimitFromSpec)
 			}
 
 			volumeRequestSize = volumeLimitFromSpec
 		}
-		pvc.Spec.Resources.Requests = corev1.ResourceList{
+		spec.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceStorage: *resource.NewQuantity(volumeRequestSize.Value(), resource.BinarySI),
 		}
 	}
@@ -164,8 +176,8 @@ func getDesiredVolumeSize(cluster *v1beta1.PostgresCluster,
 	volumeType, instanceSpecName string,
 	volumeRequestSize *resource.Quantity) (string, error) {
 
-	switch volumeType {
-	case "pgData":
+	switch {
+	case volumeType == "pgData":
 		for i := range cluster.Status.InstanceSets {
 			if instanceSpecName == cluster.Status.InstanceSets[i].Name {
 				for _, dpv := range cluster.Status.InstanceSets[i].DesiredPGDataVolume {
@@ -182,7 +194,30 @@ func getDesiredVolumeSize(cluster *v1beta1.PostgresCluster,
 				}
 			}
 		}
-		// TODO: Add cases for pgWAL and repo volumes (requires relevant status sections)
+
+	// VolumeType for the repository host volumes should be in the form 'repoN'
+	// where N is 1-4. As above, cycle through any defined repositories and ensure
+	// the correct limit is identified.
+	case strings.HasPrefix(volumeType, "repo"):
+		if cluster.Status.PGBackRest == nil {
+			return "", errors.New("PostgresCluster.Status.PGBackRest is nil")
+		}
+		for i := range cluster.Status.PGBackRest.Repos {
+			if volumeType == cluster.Status.PGBackRest.Repos[i].Name {
+				dpv := cluster.Status.PGBackRest.Repos[i].DesiredRepoVolume
+				if dpv != "" {
+					desiredRequest, err := resource.ParseQuantity(dpv)
+					if err == nil {
+						if desiredRequest.Value() > volumeRequestSize.Value() {
+							*volumeRequestSize = desiredRequest
+						}
+					} else {
+						return dpv, err
+					}
+				}
+			}
+		}
 	}
+	// TODO: Add case for pgWAL
 	return "", nil
 }

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -547,6 +547,32 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
   - --
   - |-
     monitor() {
+    # Parameters for curl when managing autogrow annotation.
+    APISERVER="https://kubernetes.default.svc"
+    SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"
+    NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
+    TOKEN=$(cat ${SERVICEACCOUNT}/token)
+    CACERT=${SERVICEACCOUNT}/ca.crt
+
+    # Manage autogrow annotation.
+    # Return size in Mebibytes.
+    manageAutogrowAnnotation() {
+      local volume=$1
+
+      size=$(df --human-readable --block-size=M /pgbackrest/"${volume}" | awk 'FNR == 2 {print $2}')
+      use=$(df --human-readable /pgbackrest/"${volume}" | awk 'FNR == 2 {print $5}')
+      sizeInt="${size//M/}"
+      # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
+      useInt=$(echo $use | sed 's/[[:punct:]]//g')
+      triggerExpansion="$((useInt > 75))"
+      if [ $triggerExpansion -eq 1 ]; then
+        newSize="$(((sizeInt / 2)+sizeInt))"
+        newSizeMi="${newSize}Mi"
+        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"$newSizeMi"'"}]'
+        curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "$d"
+      fi
+    }
+
     exec {fd}<> <(:||:)
     until read -r -t 5 -u "${fd}"; do
       if
@@ -564,6 +590,27 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
         exec {fd}>&- && exec {fd}<> <(:||:)
         stat --format='Loaded certificates dated %y' "${directory}"
       fi
+
+      # manage autogrow annotation for the repo1 volume, if it exists
+      if [ -d /pgbackrest/repo1 ]; then
+        manageAutogrowAnnotation "repo1"
+      fi
+
+      # manage autogrow annotation for the repo2 volume, if it exists
+      if [ -d /pgbackrest/repo2 ]; then
+        manageAutogrowAnnotation "repo2"
+      fi
+
+      # manage autogrow annotation for the repo3 volume, if it exists
+      if [ -d /pgbackrest/repo3 ]; then
+        manageAutogrowAnnotation "repo3"
+      fi
+
+      # manage autogrow annotation for the repo4 volume, if it exists
+      if [ -d /pgbackrest/repo4 ]; then
+        manageAutogrowAnnotation "repo4"
+      fi
+
     done
     }; export directory="$1" authority="$2" filename="$3"; export -f monitor; exec -a "$0" bash -ceu monitor
   - pgbackrest-config
@@ -664,6 +711,32 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
   - --
   - |-
     monitor() {
+    # Parameters for curl when managing autogrow annotation.
+    APISERVER="https://kubernetes.default.svc"
+    SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"
+    NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
+    TOKEN=$(cat ${SERVICEACCOUNT}/token)
+    CACERT=${SERVICEACCOUNT}/ca.crt
+
+    # Manage autogrow annotation.
+    # Return size in Mebibytes.
+    manageAutogrowAnnotation() {
+      local volume=$1
+
+      size=$(df --human-readable --block-size=M /pgbackrest/"${volume}" | awk 'FNR == 2 {print $2}')
+      use=$(df --human-readable /pgbackrest/"${volume}" | awk 'FNR == 2 {print $5}')
+      sizeInt="${size//M/}"
+      # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
+      useInt=$(echo $use | sed 's/[[:punct:]]//g')
+      triggerExpansion="$((useInt > 75))"
+      if [ $triggerExpansion -eq 1 ]; then
+        newSize="$(((sizeInt / 2)+sizeInt))"
+        newSizeMi="${newSize}Mi"
+        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"$newSizeMi"'"}]'
+        curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "$d"
+      fi
+    }
+
     exec {fd}<> <(:||:)
     until read -r -t 5 -u "${fd}"; do
       if
@@ -681,6 +754,27 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
         exec {fd}>&- && exec {fd}<> <(:||:)
         stat --format='Loaded certificates dated %y' "${directory}"
       fi
+
+      # manage autogrow annotation for the repo1 volume, if it exists
+      if [ -d /pgbackrest/repo1 ]; then
+        manageAutogrowAnnotation "repo1"
+      fi
+
+      # manage autogrow annotation for the repo2 volume, if it exists
+      if [ -d /pgbackrest/repo2 ]; then
+        manageAutogrowAnnotation "repo2"
+      fi
+
+      # manage autogrow annotation for the repo3 volume, if it exists
+      if [ -d /pgbackrest/repo3 ]; then
+        manageAutogrowAnnotation "repo3"
+      fi
+
+      # manage autogrow annotation for the repo4 volume, if it exists
+      if [ -d /pgbackrest/repo4 ]; then
+        manageAutogrowAnnotation "repo4"
+      fi
+
     done
     }; export directory="$1" authority="$2" filename="$3"; export -f monitor; exec -a "$0" bash -ceu monitor
   - pgbackrest-config

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -550,8 +550,8 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     # Parameters for curl when managing autogrow annotation.
     APISERVER="https://kubernetes.default.svc"
     SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"
-    NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
-    TOKEN=$(cat ${SERVICEACCOUNT}/token)
+    NAMESPACE=$(cat "${SERVICEACCOUNT}"/namespace)
+    TOKEN=$(cat "${SERVICEACCOUNT}"/token)
     CACERT=${SERVICEACCOUNT}/ca.crt
 
     # Manage autogrow annotation.
@@ -559,17 +559,19 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     manageAutogrowAnnotation() {
       local volume=$1
 
-      size=$(df --human-readable --block-size=M /pgbackrest/"${volume}" | awk 'FNR == 2 {print $2}')
-      use=$(df --human-readable /pgbackrest/"${volume}" | awk 'FNR == 2 {print $5}')
+      size=$(df --human-readable --block-size=M "/pgbackrest/${volume}")
+      read -r _ size _ <<< "${size#*$'\n'}"
+      use=$(df --human-readable "/pgbackrest/${volume}")
+      read -r _ _ _ _ use _ <<< "${use#*$'\n'}"
       sizeInt="${size//M/}"
       # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
-      useInt=$(echo $use | sed 's/[[:punct:]]//g')
+      useInt=${use//[[:punct:]]/}
       triggerExpansion="$((useInt > 75))"
-      if [ $triggerExpansion -eq 1 ]; then
+      if [[ ${triggerExpansion} -eq 1 ]]; then
         newSize="$(((sizeInt / 2)+sizeInt))"
         newSizeMi="${newSize}Mi"
-        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"$newSizeMi"'"}]'
-        curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "$d"
+        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
+        curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
       fi
     }
 
@@ -592,22 +594,22 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
       fi
 
       # manage autogrow annotation for the repo1 volume, if it exists
-      if [ -d /pgbackrest/repo1 ]; then
+      if [[ -d /pgbackrest/repo1 ]]; then
         manageAutogrowAnnotation "repo1"
       fi
 
       # manage autogrow annotation for the repo2 volume, if it exists
-      if [ -d /pgbackrest/repo2 ]; then
+      if [[ -d /pgbackrest/repo2 ]]; then
         manageAutogrowAnnotation "repo2"
       fi
 
       # manage autogrow annotation for the repo3 volume, if it exists
-      if [ -d /pgbackrest/repo3 ]; then
+      if [[ -d /pgbackrest/repo3 ]]; then
         manageAutogrowAnnotation "repo3"
       fi
 
       # manage autogrow annotation for the repo4 volume, if it exists
-      if [ -d /pgbackrest/repo4 ]; then
+      if [[ -d /pgbackrest/repo4 ]]; then
         manageAutogrowAnnotation "repo4"
       fi
 
@@ -714,8 +716,8 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     # Parameters for curl when managing autogrow annotation.
     APISERVER="https://kubernetes.default.svc"
     SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"
-    NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
-    TOKEN=$(cat ${SERVICEACCOUNT}/token)
+    NAMESPACE=$(cat "${SERVICEACCOUNT}"/namespace)
+    TOKEN=$(cat "${SERVICEACCOUNT}"/token)
     CACERT=${SERVICEACCOUNT}/ca.crt
 
     # Manage autogrow annotation.
@@ -723,17 +725,19 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     manageAutogrowAnnotation() {
       local volume=$1
 
-      size=$(df --human-readable --block-size=M /pgbackrest/"${volume}" | awk 'FNR == 2 {print $2}')
-      use=$(df --human-readable /pgbackrest/"${volume}" | awk 'FNR == 2 {print $5}')
+      size=$(df --human-readable --block-size=M "/pgbackrest/${volume}")
+      read -r _ size _ <<< "${size#*$'\n'}"
+      use=$(df --human-readable "/pgbackrest/${volume}")
+      read -r _ _ _ _ use _ <<< "${use#*$'\n'}"
       sizeInt="${size//M/}"
       # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
-      useInt=$(echo $use | sed 's/[[:punct:]]//g')
+      useInt=${use//[[:punct:]]/}
       triggerExpansion="$((useInt > 75))"
-      if [ $triggerExpansion -eq 1 ]; then
+      if [[ ${triggerExpansion} -eq 1 ]]; then
         newSize="$(((sizeInt / 2)+sizeInt))"
         newSizeMi="${newSize}Mi"
-        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"$newSizeMi"'"}]'
-        curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "$d"
+        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
+        curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
       fi
     }
 
@@ -756,22 +760,22 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
       fi
 
       # manage autogrow annotation for the repo1 volume, if it exists
-      if [ -d /pgbackrest/repo1 ]; then
+      if [[ -d /pgbackrest/repo1 ]]; then
         manageAutogrowAnnotation "repo1"
       fi
 
       # manage autogrow annotation for the repo2 volume, if it exists
-      if [ -d /pgbackrest/repo2 ]; then
+      if [[ -d /pgbackrest/repo2 ]]; then
         manageAutogrowAnnotation "repo2"
       fi
 
       # manage autogrow annotation for the repo3 volume, if it exists
-      if [ -d /pgbackrest/repo3 ]; then
+      if [[ -d /pgbackrest/repo3 ]]; then
         manageAutogrowAnnotation "repo3"
       fi
 
       # manage autogrow annotation for the repo4 volume, if it exists
-      if [ -d /pgbackrest/repo4 ]; then
+      if [[ -d /pgbackrest/repo4 ]]; then
         manageAutogrowAnnotation "repo4"
       fi
 

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -559,9 +559,9 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     manageAutogrowAnnotation() {
       local volume=$1
 
-      size=$(df --human-readable --block-size=M "/pgbackrest/${volume}")
+      size=$(df --block-size=M "/pgbackrest/${volume}")
       read -r _ size _ <<< "${size#*$'\n'}"
-      use=$(df --human-readable "/pgbackrest/${volume}")
+      use=$(df "/pgbackrest/${volume}")
       read -r _ _ _ _ use _ <<< "${use#*$'\n'}"
       sizeInt="${size//M/}"
       # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
@@ -725,9 +725,9 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
     manageAutogrowAnnotation() {
       local volume=$1
 
-      size=$(df --human-readable --block-size=M "/pgbackrest/${volume}")
+      size=$(df --block-size=M "/pgbackrest/${volume}")
       read -r _ size _ <<< "${size#*$'\n'}"
-      use=$(df --human-readable "/pgbackrest/${volume}")
+      use=$(df "/pgbackrest/${volume}")
       read -r _ _ _ _ use _ <<< "${use#*$'\n'}"
       sizeInt="${size//M/}"
       # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -2778,7 +2778,7 @@ func (r *Reconciler) reconcileRepos(ctx context.Context,
 	if feature.Enabled(ctx, feature.AutoGrowVolumes) {
 		// get the autogrow annotations so that the correct volume size values can be
 		// used and the cluster status can be updated
-		errors = append(errors, r.getRepoHostVolumeRequests(ctx, postgresCluster))
+		errors = append(errors, r.writeRepoVolumeSizeRequestStatus(ctx, postgresCluster))
 	}
 
 	for i, repo := range postgresCluster.Spec.Backups.PGBackRest.Repos {
@@ -2820,11 +2820,11 @@ func (r *Reconciler) reconcileRepos(ctx context.Context,
 
 // +kubebuilder:rbac:groups="",resources="pods",verbs={list}
 
-// getRepoHostVolumeRequests gets the pgBackRest repo host volume request annotations
+// writeRepoVolumeSizeRequestStatus gets the pgBackRest repo host volume request annotations
 // from the repo host Pod and stores them in the Postgres Cluster object's status.
 // If there is no repo host or there are no annotations, this function returns
 // without updating the status.
-func (r *Reconciler) getRepoHostVolumeRequests(ctx context.Context,
+func (r *Reconciler) writeRepoVolumeSizeRequestStatus(ctx context.Context,
 	cluster *v1beta1.PostgresCluster) error {
 
 	pods := &corev1.PodList{}

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -4514,7 +4514,7 @@ func TestGetRepoHostVolumeRequests(t *testing.T) {
 				cluster.Status.PGBackRest.Repos = tc.repoStatus
 			}
 
-			err := reconciler.getRepoHostVolumeRequests(ctx, cluster)
+			err := reconciler.writeRepoVolumeSizeRequestStatus(ctx, cluster)
 
 			if tc.repoHostExists {
 				assert.NilError(t, err)

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -4515,7 +4515,13 @@ func TestGetRepoHostVolumeRequests(t *testing.T) {
 			}
 
 			err := reconciler.getRepoHostVolumeRequests(ctx, cluster)
-			assert.NilError(t, err)
+
+			if tc.repoHostExists {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, "Found 0 pgBackRest repo host Pods. Expected 1.")
+			}
+
 			assert.Assert(t, cluster.Status.PGBackRest != nil)
 
 			var i int

--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -774,7 +774,7 @@ func (r *Reconciler) reconcilePostgresDataVolume(
 		}
 	}
 
-	r.setVolumeSize(ctx, cluster, pvc, "pgData", instanceSpec.Name)
+	r.setVolumeSize(ctx, cluster, &pvc.Spec, "pgData", instanceSpec.Name)
 
 	// Clear any set limit before applying PVC. This is needed to allow the limit
 	// value to change later.

--- a/internal/controller/postgrescluster/snapshots.go
+++ b/internal/controller/postgrescluster/snapshots.go
@@ -315,7 +315,7 @@ func (r *Reconciler) createDedicatedSnapshotVolume(ctx context.Context,
 	pvc.Spec = instanceSpec.DataVolumeClaimSpec.AsPersistentVolumeClaimSpec()
 
 	// Set the snapshot volume to the same size as the pgdata volume. The size should scale with auto-grow.
-	r.setVolumeSize(ctx, cluster, pvc, "pgData", instanceSpec.Name)
+	r.setVolumeSize(ctx, cluster, &pvc.Spec, "pgData", instanceSpec.Name)
 
 	// Clear any set limit before applying PVC. This is needed to allow the limit
 	// value to change later.

--- a/internal/controller/postgrescluster/watches.go
+++ b/internal/controller/postgrescluster/watches.go
@@ -61,16 +61,30 @@ func (*Reconciler) watchPods() handler.Funcs {
 				return
 			}
 
+			// auto-grow volume resize annotations
+			volumeAnnotations := []string{
+				"suggested-pgdata-pvc-size",
+				"suggested-repo1-pvc-size",
+				"suggested-repo2-pvc-size",
+				"suggested-repo3-pvc-size",
+				"suggested-repo4-pvc-size",
+			}
+
 			oldAnnotations := e.ObjectOld.GetAnnotations()
 			newAnnotations := e.ObjectNew.GetAnnotations()
-			// If the suggested-pgdata-pvc-size annotation is added or changes, reconcile.
-			if len(cluster) != 0 && oldAnnotations["suggested-pgdata-pvc-size"] != newAnnotations["suggested-pgdata-pvc-size"] {
-				q.Add(reconcile.Request{NamespacedName: client.ObjectKey{
-					Namespace: e.ObjectNew.GetNamespace(),
-					Name:      cluster,
-				}})
-				return
+
+			// cycle through each annotation and check for changes
+			for _, annotation := range volumeAnnotations {
+				// If the suggested-pgdata-pvc-size annotation is added or changes, reconcile.
+				if len(cluster) != 0 && oldAnnotations[annotation] != newAnnotations[annotation] {
+					q.Add(reconcile.Request{NamespacedName: client.ObjectKey{
+						Namespace: e.ObjectNew.GetNamespace(),
+						Name:      cluster,
+					}})
+					return
+				}
 			}
+
 		},
 	}
 }

--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -627,9 +627,11 @@ func reloadCommand(name string) []string {
 	// the '1M-blocks' output (second column) and the 'use' variable gets the value
 	// from the 'Use%' column (fifth column). This value is grabbed after stripping
 	// out the column headers (before the '\n') and then getting the respective
-	// value delimited by the white spaces. The percent value is stripped of the
-	// '%' and then used to determine if a expansion should be triggered by setting
-	// the calculated volume size using the 'size' variable.
+	// value delimited by the white spaces by using the 'read -r' command.
+	// The underscores (_) discard fields and the variables store them. This allows
+	// for selective parsing of the provided lines. The percent value is stripped of
+	// the '%' and then used to determine if a expansion should be triggered by
+	// setting the calculated volume size using the 'size' variable.
 	const script = `
 # Parameters for curl when managing autogrow annotation.
 APISERVER="https://kubernetes.default.svc"

--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -625,8 +625,8 @@ func reloadCommand(name string) []string {
 # Parameters for curl when managing autogrow annotation.
 APISERVER="https://kubernetes.default.svc"
 SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"
-NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
-TOKEN=$(cat ${SERVICEACCOUNT}/token)
+NAMESPACE=$(cat "${SERVICEACCOUNT}"/namespace)
+TOKEN=$(cat "${SERVICEACCOUNT}"/token)
 CACERT=${SERVICEACCOUNT}/ca.crt
 
 # Manage autogrow annotation.
@@ -634,17 +634,19 @@ CACERT=${SERVICEACCOUNT}/ca.crt
 manageAutogrowAnnotation() {
   local volume=$1
 
-  size=$(df --human-readable --block-size=M /pgbackrest/"${volume}" | awk 'FNR == 2 {print $2}')
-  use=$(df --human-readable /pgbackrest/"${volume}" | awk 'FNR == 2 {print $5}')
+  size=$(df --human-readable --block-size=M "/pgbackrest/${volume}")
+  read -r _ size _ <<< "${size#*$'\n'}"
+  use=$(df --human-readable "/pgbackrest/${volume}")
+  read -r _ _ _ _ use _ <<< "${use#*$'\n'}"
   sizeInt="${size//M/}"
   # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
-  useInt=$(echo $use | sed 's/[[:punct:]]//g')
+  useInt=${use//[[:punct:]]/}
   triggerExpansion="$((useInt > 75))"
-  if [ $triggerExpansion -eq 1 ]; then
+  if [[ ${triggerExpansion} -eq 1 ]]; then
     newSize="$(((sizeInt / 2)+sizeInt))"
     newSizeMi="${newSize}Mi"
-    d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"$newSizeMi"'"}]'
-    curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "$d"
+    d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
+    curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
   fi
 }
 
@@ -667,22 +669,22 @@ until read -r -t 5 -u "${fd}"; do
   fi
 
   # manage autogrow annotation for the repo1 volume, if it exists
-  if [ -d /pgbackrest/repo1 ]; then
+  if [[ -d /pgbackrest/repo1 ]]; then
     manageAutogrowAnnotation "repo1"
   fi
 
   # manage autogrow annotation for the repo2 volume, if it exists
-  if [ -d /pgbackrest/repo2 ]; then
+  if [[ -d /pgbackrest/repo2 ]]; then
     manageAutogrowAnnotation "repo2"
   fi
 
   # manage autogrow annotation for the repo3 volume, if it exists
-  if [ -d /pgbackrest/repo3 ]; then
+  if [[ -d /pgbackrest/repo3 ]]; then
     manageAutogrowAnnotation "repo3"
   fi
 
   # manage autogrow annotation for the repo4 volume, if it exists
-  if [ -d /pgbackrest/repo4 ]; then
+  if [[ -d /pgbackrest/repo4 ]]; then
     manageAutogrowAnnotation "repo4"
   fi
 

--- a/internal/pgbackrest/rbac.go
+++ b/internal/pgbackrest/rbac.go
@@ -33,3 +33,19 @@ func Permissions(cluster *v1beta1.PostgresCluster) []rbacv1.PolicyRule {
 
 	return rules
 }
+
+// +kubebuilder:rbac:groups="",resources="pods",verbs={patch}
+
+// RepoHostPermissions returns the RBAC rules the pgBackRest repo host needs.
+func RepoHostPermissions(cluster *v1beta1.PostgresCluster) []rbacv1.PolicyRule {
+
+	rules := make([]rbacv1.PolicyRule, 0, 1)
+
+	rules = append(rules, rbacv1.PolicyRule{
+		APIGroups: []string{corev1.SchemeGroupVersion.Group},
+		Resources: []string{"pods"},
+		Verbs:     []string{"patch"},
+	})
+
+	return rules
+}

--- a/internal/pgbackrest/rbac_test.go
+++ b/internal/pgbackrest/rbac_test.go
@@ -52,3 +52,24 @@ func TestPermissions(t *testing.T) {
   - create
 	`))
 }
+
+func TestRepoHostPermissions(t *testing.T) {
+	cluster := new(v1beta1.PostgresCluster)
+	cluster.Default()
+
+	permissions := RepoHostPermissions(cluster)
+	for _, rule := range permissions {
+		assert.Assert(t, isUniqueAndSorted(rule.APIGroups), "got %q", rule.APIGroups)
+		assert.Assert(t, isUniqueAndSorted(rule.Resources), "got %q", rule.Resources)
+		assert.Assert(t, isUniqueAndSorted(rule.Verbs), "got %q", rule.Verbs)
+	}
+
+	assert.Assert(t, cmp.MarshalMatches(permissions, `
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - patch
+	`))
+}

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -734,6 +734,32 @@ func TestAddServerToInstancePod(t *testing.T) {
   - --
   - |-
     monitor() {
+    # Parameters for curl when managing autogrow annotation.
+    APISERVER="https://kubernetes.default.svc"
+    SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"
+    NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
+    TOKEN=$(cat ${SERVICEACCOUNT}/token)
+    CACERT=${SERVICEACCOUNT}/ca.crt
+
+    # Manage autogrow annotation.
+    # Return size in Mebibytes.
+    manageAutogrowAnnotation() {
+      local volume=$1
+
+      size=$(df --human-readable --block-size=M /pgbackrest/"${volume}" | awk 'FNR == 2 {print $2}')
+      use=$(df --human-readable /pgbackrest/"${volume}" | awk 'FNR == 2 {print $5}')
+      sizeInt="${size//M/}"
+      # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
+      useInt=$(echo $use | sed 's/[[:punct:]]//g')
+      triggerExpansion="$((useInt > 75))"
+      if [ $triggerExpansion -eq 1 ]; then
+        newSize="$(((sizeInt / 2)+sizeInt))"
+        newSizeMi="${newSize}Mi"
+        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"$newSizeMi"'"}]'
+        curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "$d"
+      fi
+    }
+
     exec {fd}<> <(:||:)
     until read -r -t 5 -u "${fd}"; do
       if
@@ -751,6 +777,27 @@ func TestAddServerToInstancePod(t *testing.T) {
         exec {fd}>&- && exec {fd}<> <(:||:)
         stat --format='Loaded certificates dated %y' "${directory}"
       fi
+
+      # manage autogrow annotation for the repo1 volume, if it exists
+      if [ -d /pgbackrest/repo1 ]; then
+        manageAutogrowAnnotation "repo1"
+      fi
+
+      # manage autogrow annotation for the repo2 volume, if it exists
+      if [ -d /pgbackrest/repo2 ]; then
+        manageAutogrowAnnotation "repo2"
+      fi
+
+      # manage autogrow annotation for the repo3 volume, if it exists
+      if [ -d /pgbackrest/repo3 ]; then
+        manageAutogrowAnnotation "repo3"
+      fi
+
+      # manage autogrow annotation for the repo4 volume, if it exists
+      if [ -d /pgbackrest/repo4 ]; then
+        manageAutogrowAnnotation "repo4"
+      fi
+
     done
     }; export directory="$1" authority="$2" filename="$3"; export -f monitor; exec -a "$0" bash -ceu monitor
   - pgbackrest-config
@@ -863,6 +910,32 @@ func TestAddServerToInstancePod(t *testing.T) {
   - --
   - |-
     monitor() {
+    # Parameters for curl when managing autogrow annotation.
+    APISERVER="https://kubernetes.default.svc"
+    SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"
+    NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
+    TOKEN=$(cat ${SERVICEACCOUNT}/token)
+    CACERT=${SERVICEACCOUNT}/ca.crt
+
+    # Manage autogrow annotation.
+    # Return size in Mebibytes.
+    manageAutogrowAnnotation() {
+      local volume=$1
+
+      size=$(df --human-readable --block-size=M /pgbackrest/"${volume}" | awk 'FNR == 2 {print $2}')
+      use=$(df --human-readable /pgbackrest/"${volume}" | awk 'FNR == 2 {print $5}')
+      sizeInt="${size//M/}"
+      # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
+      useInt=$(echo $use | sed 's/[[:punct:]]//g')
+      triggerExpansion="$((useInt > 75))"
+      if [ $triggerExpansion -eq 1 ]; then
+        newSize="$(((sizeInt / 2)+sizeInt))"
+        newSizeMi="${newSize}Mi"
+        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"$newSizeMi"'"}]'
+        curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "$d"
+      fi
+    }
+
     exec {fd}<> <(:||:)
     until read -r -t 5 -u "${fd}"; do
       if
@@ -880,6 +953,27 @@ func TestAddServerToInstancePod(t *testing.T) {
         exec {fd}>&- && exec {fd}<> <(:||:)
         stat --format='Loaded certificates dated %y' "${directory}"
       fi
+
+      # manage autogrow annotation for the repo1 volume, if it exists
+      if [ -d /pgbackrest/repo1 ]; then
+        manageAutogrowAnnotation "repo1"
+      fi
+
+      # manage autogrow annotation for the repo2 volume, if it exists
+      if [ -d /pgbackrest/repo2 ]; then
+        manageAutogrowAnnotation "repo2"
+      fi
+
+      # manage autogrow annotation for the repo3 volume, if it exists
+      if [ -d /pgbackrest/repo3 ]; then
+        manageAutogrowAnnotation "repo3"
+      fi
+
+      # manage autogrow annotation for the repo4 volume, if it exists
+      if [ -d /pgbackrest/repo4 ]; then
+        manageAutogrowAnnotation "repo4"
+      fi
+
     done
     }; export directory="$1" authority="$2" filename="$3"; export -f monitor; exec -a "$0" bash -ceu monitor
   - pgbackrest-config
@@ -981,6 +1075,32 @@ func TestAddServerToRepoPod(t *testing.T) {
   - --
   - |-
     monitor() {
+    # Parameters for curl when managing autogrow annotation.
+    APISERVER="https://kubernetes.default.svc"
+    SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"
+    NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
+    TOKEN=$(cat ${SERVICEACCOUNT}/token)
+    CACERT=${SERVICEACCOUNT}/ca.crt
+
+    # Manage autogrow annotation.
+    # Return size in Mebibytes.
+    manageAutogrowAnnotation() {
+      local volume=$1
+
+      size=$(df --human-readable --block-size=M /pgbackrest/"${volume}" | awk 'FNR == 2 {print $2}')
+      use=$(df --human-readable /pgbackrest/"${volume}" | awk 'FNR == 2 {print $5}')
+      sizeInt="${size//M/}"
+      # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
+      useInt=$(echo $use | sed 's/[[:punct:]]//g')
+      triggerExpansion="$((useInt > 75))"
+      if [ $triggerExpansion -eq 1 ]; then
+        newSize="$(((sizeInt / 2)+sizeInt))"
+        newSizeMi="${newSize}Mi"
+        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"$newSizeMi"'"}]'
+        curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "$d"
+      fi
+    }
+
     exec {fd}<> <(:||:)
     until read -r -t 5 -u "${fd}"; do
       if
@@ -998,6 +1118,27 @@ func TestAddServerToRepoPod(t *testing.T) {
         exec {fd}>&- && exec {fd}<> <(:||:)
         stat --format='Loaded certificates dated %y' "${directory}"
       fi
+
+      # manage autogrow annotation for the repo1 volume, if it exists
+      if [ -d /pgbackrest/repo1 ]; then
+        manageAutogrowAnnotation "repo1"
+      fi
+
+      # manage autogrow annotation for the repo2 volume, if it exists
+      if [ -d /pgbackrest/repo2 ]; then
+        manageAutogrowAnnotation "repo2"
+      fi
+
+      # manage autogrow annotation for the repo3 volume, if it exists
+      if [ -d /pgbackrest/repo3 ]; then
+        manageAutogrowAnnotation "repo3"
+      fi
+
+      # manage autogrow annotation for the repo4 volume, if it exists
+      if [ -d /pgbackrest/repo4 ]; then
+        manageAutogrowAnnotation "repo4"
+      fi
+
     done
     }; export directory="$1" authority="$2" filename="$3"; export -f monitor; exec -a "$0" bash -ceu monitor
   - pgbackrest-config

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -737,8 +737,8 @@ func TestAddServerToInstancePod(t *testing.T) {
     # Parameters for curl when managing autogrow annotation.
     APISERVER="https://kubernetes.default.svc"
     SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"
-    NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
-    TOKEN=$(cat ${SERVICEACCOUNT}/token)
+    NAMESPACE=$(cat "${SERVICEACCOUNT}"/namespace)
+    TOKEN=$(cat "${SERVICEACCOUNT}"/token)
     CACERT=${SERVICEACCOUNT}/ca.crt
 
     # Manage autogrow annotation.
@@ -746,17 +746,19 @@ func TestAddServerToInstancePod(t *testing.T) {
     manageAutogrowAnnotation() {
       local volume=$1
 
-      size=$(df --human-readable --block-size=M /pgbackrest/"${volume}" | awk 'FNR == 2 {print $2}')
-      use=$(df --human-readable /pgbackrest/"${volume}" | awk 'FNR == 2 {print $5}')
+      size=$(df --human-readable --block-size=M "/pgbackrest/${volume}")
+      read -r _ size _ <<< "${size#*$'\n'}"
+      use=$(df --human-readable "/pgbackrest/${volume}")
+      read -r _ _ _ _ use _ <<< "${use#*$'\n'}"
       sizeInt="${size//M/}"
       # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
-      useInt=$(echo $use | sed 's/[[:punct:]]//g')
+      useInt=${use//[[:punct:]]/}
       triggerExpansion="$((useInt > 75))"
-      if [ $triggerExpansion -eq 1 ]; then
+      if [[ ${triggerExpansion} -eq 1 ]]; then
         newSize="$(((sizeInt / 2)+sizeInt))"
         newSizeMi="${newSize}Mi"
-        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"$newSizeMi"'"}]'
-        curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "$d"
+        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
+        curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
       fi
     }
 
@@ -779,22 +781,22 @@ func TestAddServerToInstancePod(t *testing.T) {
       fi
 
       # manage autogrow annotation for the repo1 volume, if it exists
-      if [ -d /pgbackrest/repo1 ]; then
+      if [[ -d /pgbackrest/repo1 ]]; then
         manageAutogrowAnnotation "repo1"
       fi
 
       # manage autogrow annotation for the repo2 volume, if it exists
-      if [ -d /pgbackrest/repo2 ]; then
+      if [[ -d /pgbackrest/repo2 ]]; then
         manageAutogrowAnnotation "repo2"
       fi
 
       # manage autogrow annotation for the repo3 volume, if it exists
-      if [ -d /pgbackrest/repo3 ]; then
+      if [[ -d /pgbackrest/repo3 ]]; then
         manageAutogrowAnnotation "repo3"
       fi
 
       # manage autogrow annotation for the repo4 volume, if it exists
-      if [ -d /pgbackrest/repo4 ]; then
+      if [[ -d /pgbackrest/repo4 ]]; then
         manageAutogrowAnnotation "repo4"
       fi
 
@@ -913,8 +915,8 @@ func TestAddServerToInstancePod(t *testing.T) {
     # Parameters for curl when managing autogrow annotation.
     APISERVER="https://kubernetes.default.svc"
     SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"
-    NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
-    TOKEN=$(cat ${SERVICEACCOUNT}/token)
+    NAMESPACE=$(cat "${SERVICEACCOUNT}"/namespace)
+    TOKEN=$(cat "${SERVICEACCOUNT}"/token)
     CACERT=${SERVICEACCOUNT}/ca.crt
 
     # Manage autogrow annotation.
@@ -922,17 +924,19 @@ func TestAddServerToInstancePod(t *testing.T) {
     manageAutogrowAnnotation() {
       local volume=$1
 
-      size=$(df --human-readable --block-size=M /pgbackrest/"${volume}" | awk 'FNR == 2 {print $2}')
-      use=$(df --human-readable /pgbackrest/"${volume}" | awk 'FNR == 2 {print $5}')
+      size=$(df --human-readable --block-size=M "/pgbackrest/${volume}")
+      read -r _ size _ <<< "${size#*$'\n'}"
+      use=$(df --human-readable "/pgbackrest/${volume}")
+      read -r _ _ _ _ use _ <<< "${use#*$'\n'}"
       sizeInt="${size//M/}"
       # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
-      useInt=$(echo $use | sed 's/[[:punct:]]//g')
+      useInt=${use//[[:punct:]]/}
       triggerExpansion="$((useInt > 75))"
-      if [ $triggerExpansion -eq 1 ]; then
+      if [[ ${triggerExpansion} -eq 1 ]]; then
         newSize="$(((sizeInt / 2)+sizeInt))"
         newSizeMi="${newSize}Mi"
-        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"$newSizeMi"'"}]'
-        curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "$d"
+        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
+        curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
       fi
     }
 
@@ -955,22 +959,22 @@ func TestAddServerToInstancePod(t *testing.T) {
       fi
 
       # manage autogrow annotation for the repo1 volume, if it exists
-      if [ -d /pgbackrest/repo1 ]; then
+      if [[ -d /pgbackrest/repo1 ]]; then
         manageAutogrowAnnotation "repo1"
       fi
 
       # manage autogrow annotation for the repo2 volume, if it exists
-      if [ -d /pgbackrest/repo2 ]; then
+      if [[ -d /pgbackrest/repo2 ]]; then
         manageAutogrowAnnotation "repo2"
       fi
 
       # manage autogrow annotation for the repo3 volume, if it exists
-      if [ -d /pgbackrest/repo3 ]; then
+      if [[ -d /pgbackrest/repo3 ]]; then
         manageAutogrowAnnotation "repo3"
       fi
 
       # manage autogrow annotation for the repo4 volume, if it exists
-      if [ -d /pgbackrest/repo4 ]; then
+      if [[ -d /pgbackrest/repo4 ]]; then
         manageAutogrowAnnotation "repo4"
       fi
 
@@ -1078,8 +1082,8 @@ func TestAddServerToRepoPod(t *testing.T) {
     # Parameters for curl when managing autogrow annotation.
     APISERVER="https://kubernetes.default.svc"
     SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"
-    NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
-    TOKEN=$(cat ${SERVICEACCOUNT}/token)
+    NAMESPACE=$(cat "${SERVICEACCOUNT}"/namespace)
+    TOKEN=$(cat "${SERVICEACCOUNT}"/token)
     CACERT=${SERVICEACCOUNT}/ca.crt
 
     # Manage autogrow annotation.
@@ -1087,17 +1091,19 @@ func TestAddServerToRepoPod(t *testing.T) {
     manageAutogrowAnnotation() {
       local volume=$1
 
-      size=$(df --human-readable --block-size=M /pgbackrest/"${volume}" | awk 'FNR == 2 {print $2}')
-      use=$(df --human-readable /pgbackrest/"${volume}" | awk 'FNR == 2 {print $5}')
+      size=$(df --human-readable --block-size=M "/pgbackrest/${volume}")
+      read -r _ size _ <<< "${size#*$'\n'}"
+      use=$(df --human-readable "/pgbackrest/${volume}")
+      read -r _ _ _ _ use _ <<< "${use#*$'\n'}"
       sizeInt="${size//M/}"
       # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
-      useInt=$(echo $use | sed 's/[[:punct:]]//g')
+      useInt=${use//[[:punct:]]/}
       triggerExpansion="$((useInt > 75))"
-      if [ $triggerExpansion -eq 1 ]; then
+      if [[ ${triggerExpansion} -eq 1 ]]; then
         newSize="$(((sizeInt / 2)+sizeInt))"
         newSizeMi="${newSize}Mi"
-        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"$newSizeMi"'"}]'
-        curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "$d"
+        d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
+        curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
       fi
     }
 
@@ -1120,22 +1126,22 @@ func TestAddServerToRepoPod(t *testing.T) {
       fi
 
       # manage autogrow annotation for the repo1 volume, if it exists
-      if [ -d /pgbackrest/repo1 ]; then
+      if [[ -d /pgbackrest/repo1 ]]; then
         manageAutogrowAnnotation "repo1"
       fi
 
       # manage autogrow annotation for the repo2 volume, if it exists
-      if [ -d /pgbackrest/repo2 ]; then
+      if [[ -d /pgbackrest/repo2 ]]; then
         manageAutogrowAnnotation "repo2"
       fi
 
       # manage autogrow annotation for the repo3 volume, if it exists
-      if [ -d /pgbackrest/repo3 ]; then
+      if [[ -d /pgbackrest/repo3 ]]; then
         manageAutogrowAnnotation "repo3"
       fi
 
       # manage autogrow annotation for the repo4 volume, if it exists
-      if [ -d /pgbackrest/repo4 ]; then
+      if [[ -d /pgbackrest/repo4 ]]; then
         manageAutogrowAnnotation "repo4"
       fi
 

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -746,9 +746,9 @@ func TestAddServerToInstancePod(t *testing.T) {
     manageAutogrowAnnotation() {
       local volume=$1
 
-      size=$(df --human-readable --block-size=M "/pgbackrest/${volume}")
+      size=$(df --block-size=M "/pgbackrest/${volume}")
       read -r _ size _ <<< "${size#*$'\n'}"
-      use=$(df --human-readable "/pgbackrest/${volume}")
+      use=$(df "/pgbackrest/${volume}")
       read -r _ _ _ _ use _ <<< "${use#*$'\n'}"
       sizeInt="${size//M/}"
       # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
@@ -924,9 +924,9 @@ func TestAddServerToInstancePod(t *testing.T) {
     manageAutogrowAnnotation() {
       local volume=$1
 
-      size=$(df --human-readable --block-size=M "/pgbackrest/${volume}")
+      size=$(df --block-size=M "/pgbackrest/${volume}")
       read -r _ size _ <<< "${size#*$'\n'}"
-      use=$(df --human-readable "/pgbackrest/${volume}")
+      use=$(df "/pgbackrest/${volume}")
       read -r _ _ _ _ use _ <<< "${use#*$'\n'}"
       sizeInt="${size//M/}"
       # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.
@@ -1091,9 +1091,9 @@ func TestAddServerToRepoPod(t *testing.T) {
     manageAutogrowAnnotation() {
       local volume=$1
 
-      size=$(df --human-readable --block-size=M "/pgbackrest/${volume}")
+      size=$(df --block-size=M "/pgbackrest/${volume}")
       read -r _ size _ <<< "${size#*$'\n'}"
-      use=$(df --human-readable "/pgbackrest/${volume}")
+      use=$(df "/pgbackrest/${volume}")
       read -r _ _ _ _ use _ <<< "${use#*$'\n'}"
       sizeInt="${size//M/}"
       # Use the sed punctuation class, because the shell will not accept the percent sign in an expansion.

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbackrest_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbackrest_types.go
@@ -427,6 +427,10 @@ type RepoStatus struct {
 	// commands accordingly.
 	// +optional
 	RepoOptionsHash string `json:"repoOptionsHash,omitempty"`
+
+	// Desired Size of the repo volume
+	// +optional
+	DesiredRepoVolume string `json:"desiredRepoVolume,omitempty"`
 }
 
 // PGBackRestDataSource defines a pgBackRest configuration specifically for restoring from cloud-based data source


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This update adds the ability to automatically grow repo host PVCs. The AutoGrowVolumes feature gate must be enabled and the relevant volumes must include a Limit value.

Once enabled, this feature tracks the current disk utilization and, when utilization reaches 75%, the disk request is updated to 150% of the observed value. At this point and beyond, the requested value will be tracked by CPK.

The volume request can grow up to the configured limit value. Note: This change now treats limit values as authoritative regardless of the feature gate setting. However, the implementation also now allows limits to be updated after being set.



**Other Information**:
Issue: PGO-1427