### PR TITLE
Validate and use pgbouncer logfile config

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -14375,7 +14375,13 @@ spec:
                             description: |-
                               Settings that apply to the entire PgBouncer process.
                               More info: https://www.pgbouncer.org/config.html
+
+                              # Logging
                             type: object
+                            x-kubernetes-map-type: granular
+                            x-kubernetes-validations:
+                            - message: logfile config must end with '.log'
+                              rule: '!has(self.logfile) || self.logfile.endsWith(''.log'')'
                           users:
                             additionalProperties:
                               type: string
@@ -33300,7 +33306,13 @@ spec:
                             description: |-
                               Settings that apply to the entire PgBouncer process.
                               More info: https://www.pgbouncer.org/config.html
+
+                              # Logging
                             type: object
+                            x-kubernetes-map-type: granular
+                            x-kubernetes-validations:
+                            - message: logfile config must end with '.log'
+                              rule: '!has(self.logfile) || self.logfile.endsWith(''.log'')'
                           users:
                             additionalProperties:
                               type: string

--- a/internal/collector/pgbouncer_test.go
+++ b/internal/collector/pgbouncer_test.go
@@ -11,6 +11,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/crunchydata/postgres-operator/internal/feature"
+	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
@@ -28,7 +29,7 @@ func TestEnablePgBouncerLogging(t *testing.T) {
 		require.UnmarshalInto(t, &cluster.Spec, `{
 			instrumentation: {}
 		}`)
-		EnablePgBouncerLogging(ctx, cluster, config)
+		EnablePgBouncerLogging(ctx, cluster, config, naming.PGBouncerFullLogPath)
 
 		result, err := config.ToYAML()
 		assert.NilError(t, err)
@@ -127,7 +128,7 @@ service:
 		cluster := new(v1beta1.PostgresCluster)
 		cluster.Spec.Instrumentation = testInstrumentationSpec()
 
-		EnablePgBouncerLogging(ctx, cluster, config)
+		EnablePgBouncerLogging(ctx, cluster, config, naming.PGBouncerFullLogPath)
 
 		result, err := config.ToYAML()
 		assert.NilError(t, err)

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/pgbouncer"
 	"github.com/crunchydata/postgres-operator/internal/pki"
 	"github.com/crunchydata/postgres-operator/internal/postgres"
+	"github.com/crunchydata/postgres-operator/internal/util"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -477,7 +478,7 @@ func (r *Reconciler) generatePGBouncerDeployment(
 	// Do not add environment variables describing services in this namespace.
 	deploy.Spec.Template.Spec.EnableServiceLinks = initialize.Bool(false)
 
-	deploy.Spec.Template.Spec.SecurityContext = initialize.PodSecurityContext()
+	deploy.Spec.Template.Spec.SecurityContext = util.PodSecurityContext(ctx, 2, cluster.Spec.SupplementalGroups)
 
 	// set the image pull secrets, if any exist
 	deploy.Spec.Template.Spec.ImagePullSecrets = cluster.Spec.ImagePullSecrets

--- a/internal/pgbouncer/reconcile.go
+++ b/internal/pgbouncer/reconcile.go
@@ -37,7 +37,8 @@ func ConfigMap(
 	initialize.Map(&outConfigMap.Data)
 
 	outConfigMap.Data[emptyConfigMapKey] = ""
-	outConfigMap.Data[iniFileConfigMapKey] = clusterINI(ctx, inCluster)
+	clusterINI := clusterINI(ctx, inCluster)
+	outConfigMap.Data[iniFileConfigMapKey] = clusterINI
 }
 
 // Secret populates the PgBouncer Secret.

--- a/internal/util/pod_security.go
+++ b/internal/util/pod_security.go
@@ -1,0 +1,43 @@
+// Copyright 2017 - 2025 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/crunchydata/postgres-operator/internal/initialize"
+	"github.com/crunchydata/postgres-operator/internal/kubernetes"
+)
+
+// PodSecurityContext returns a v1.PodSecurityContext for cluster that can write
+// to PersistentVolumes.
+func PodSecurityContext(ctx context.Context, fsgroup int64, supplementalGroups []int64) *corev1.PodSecurityContext {
+	psc := initialize.PodSecurityContext()
+
+	// Use the specified supplementary groups except for root. The CRD has
+	// similar validation, but we should never emit a PodSpec with that group.
+	// - https://docs.k8s.io/concepts/security/pod-security-standards/
+	for i := range supplementalGroups {
+		if gid := supplementalGroups[i]; gid > 0 {
+			psc.SupplementalGroups = append(psc.SupplementalGroups, gid)
+		}
+	}
+
+	// OpenShift assigns a filesystem group based on a SecurityContextConstraint.
+	// Otherwise, set a filesystem group so PostgreSQL can write to files
+	// regardless of the UID or GID of a container.
+	// - https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids
+	// - https://docs.k8s.io/tasks/configure-pod-container/security-context/
+	// - https://docs.openshift.com/container-platform/4.8/authentication/managing-security-context-constraints.html
+	if !kubernetes.Has(ctx, kubernetes.API{
+		Group: "security.openshift.io", Kind: "SecurityContextConstraints",
+	}) {
+		psc.FSGroup = initialize.Int64(fsgroup)
+	}
+
+	return psc
+}

--- a/internal/util/pod_security_test.go
+++ b/internal/util/pod_security_test.go
@@ -1,0 +1,58 @@
+// Copyright 2017 - 2025 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/crunchydata/postgres-operator/internal/kubernetes"
+	"github.com/crunchydata/postgres-operator/internal/testing/cmp"
+)
+
+func TestPodSecurityContext(t *testing.T) {
+	ctx := context.Background()
+	assert.Assert(t, cmp.MarshalMatches(PodSecurityContext(ctx, 2, []int64{}), `
+fsGroup: 2
+fsGroupChangePolicy: OnRootMismatch
+	`))
+
+	supplementalGroups := []int64{3, 4}
+	assert.Assert(t, cmp.MarshalMatches(PodSecurityContext(ctx, 26, supplementalGroups), `
+fsGroup: 26
+fsGroupChangePolicy: OnRootMismatch
+supplementalGroups:
+- 3
+- 4
+	`))
+
+	ctx = kubernetes.NewAPIContext(ctx, kubernetes.NewAPISet(kubernetes.API{
+		Group: "security.openshift.io", Version: "v1",
+		Kind: "SecurityContextConstraints",
+	}))
+	assert.Assert(t, cmp.MarshalMatches(PodSecurityContext(ctx, 2, []int64{}),
+		`fsGroupChangePolicy: OnRootMismatch`))
+
+	assert.Assert(t, cmp.MarshalMatches(PodSecurityContext(ctx, 2, supplementalGroups), `
+fsGroupChangePolicy: OnRootMismatch
+	`))
+
+	assert.Assert(t, cmp.MarshalMatches(PodSecurityContext(ctx, 2, supplementalGroups), `
+fsGroupChangePolicy: OnRootMismatch
+supplementalGroups:
+- 3
+- 4
+	`))
+
+	t.Run("NoRootGID", func(t *testing.T) {
+		supplementalGroups = []int64{999, 0, 100, 0}
+		assert.DeepEqual(t, []int64{999, 100}, PodSecurityContext(ctx, 2, supplementalGroups).SupplementalGroups)
+
+		supplementalGroups = []int64{0}
+		assert.Assert(t, PodSecurityContext(ctx, 2, supplementalGroups).SupplementalGroups == nil)
+	})
+}

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbouncer_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbouncer_types.go
@@ -26,7 +26,12 @@ type PGBouncerConfiguration struct {
 
 	// Settings that apply to the entire PgBouncer process.
 	// More info: https://www.pgbouncer.org/config.html
+	//
+	// # Logging
+	// +kubebuilder:validation:XValidation:rule=`!has(self.logfile) || self.logfile.endsWith('.log')`,message=`logfile config must end with '.log'`
+	//
 	// +optional
+	// +mapType=granular
 	Global map[string]string `json:"global,omitempty"`
 
 	// PgBouncer database definitions. The key is the database requested by a


### PR DESCRIPTION
**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Users can set any logfile config for pgbouncer, which might interfere with our OTEL

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

We now restrict users to only set a logfile with the `.log` suffix; and we get the config to handle the OTEL-related logic

TODO: Restrict the logfile to only certain locations?

**Other Information**:
Issues: [PGO-2565]