### PR TITLE
Separate controller client concerns

### DIFF
--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -307,8 +307,8 @@ func main() {
 func addControllersToManager(mgr runtime.Manager, log logging.Logger, reg registration.Registration) {
 	pgReconciler := &postgrescluster.Reconciler{
 		Client:       mgr.GetClient(),
-		Owner:        postgrescluster.ControllerName,
-		Recorder:     mgr.GetEventRecorderFor(postgrescluster.ControllerName),
+		Owner:        naming.ControllerPostgresCluster,
+		Recorder:     mgr.GetEventRecorderFor(naming.ControllerPostgresCluster),
 		Registration: reg,
 	}
 
@@ -319,8 +319,8 @@ func addControllersToManager(mgr runtime.Manager, log logging.Logger, reg regist
 
 	upgradeReconciler := &pgupgrade.PGUpgradeReconciler{
 		Client:       mgr.GetClient(),
-		Owner:        "pgupgrade-controller",
-		Recorder:     mgr.GetEventRecorderFor("pgupgrade-controller"),
+		Owner:        naming.ControllerPGUpgrade,
+		Recorder:     mgr.GetEventRecorderFor(naming.ControllerPGUpgrade),
 		Registration: reg,
 	}
 
@@ -331,7 +331,7 @@ func addControllersToManager(mgr runtime.Manager, log logging.Logger, reg regist
 
 	pgAdminReconciler := &standalone_pgadmin.PGAdminReconciler{
 		Client:   mgr.GetClient(),
-		Owner:    "pgadmin-controller",
+		Owner:    naming.ControllerPGAdmin,
 		Recorder: mgr.GetEventRecorderFor(naming.ControllerPGAdmin),
 	}
 
@@ -347,10 +347,8 @@ func addControllersToManager(mgr runtime.Manager, log logging.Logger, reg regist
 	}
 
 	crunchyBridgeClusterReconciler := &crunchybridgecluster.CrunchyBridgeClusterReconciler{
-		Client: mgr.GetClient(),
-		Owner:  "crunchybridgecluster-controller",
-		// TODO(crunchybridgecluster): recorder?
-		// Recorder: mgr.GetEventRecorderFor(naming...),
+		Client:    mgr.GetClient(),
+		Owner:     naming.ControllerCrunchyBridgeCluster,
 		NewClient: constructor,
 	}
 

--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -250,6 +250,7 @@ func main() {
 
 	// add all PostgreSQL Operator controllers to the runtime manager
 	addControllersToManager(manager, log, registrar)
+	must(standalone_pgadmin.ManagedReconciler(manager))
 
 	if features.Enabled(feature.BridgeIdentifiers) {
 		url := os.Getenv("PGO_BRIDGE_URL")
@@ -326,17 +327,6 @@ func addControllersToManager(mgr runtime.Manager, log logging.Logger, reg regist
 
 	if err := upgradeReconciler.SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create PGUpgrade controller")
-		os.Exit(1)
-	}
-
-	pgAdminReconciler := &standalone_pgadmin.PGAdminReconciler{
-		Client:   mgr.GetClient(),
-		Owner:    naming.ControllerPGAdmin,
-		Recorder: mgr.GetEventRecorderFor(naming.ControllerPGAdmin),
-	}
-
-	if err := pgAdminReconciler.SetupWithManager(mgr); err != nil {
-		log.Error(err, "unable to create PGAdmin controller")
 		os.Exit(1)
 	}
 

--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -257,6 +257,7 @@ func main() {
 
 	// add all PostgreSQL Operator controllers to the runtime manager
 	addControllersToManager(manager, log, registrar)
+	must(pgupgrade.ManagedReconciler(manager, registrar))
 	must(standalone_pgadmin.ManagedReconciler(manager))
 	must(crunchybridgecluster.ManagedReconciler(manager, func() bridge.ClientInterface {
 		return bridgeClient()
@@ -318,18 +319,6 @@ func addControllersToManager(mgr runtime.Manager, log logging.Logger, reg regist
 
 	if err := pgReconciler.SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create PostgresCluster controller")
-		os.Exit(1)
-	}
-
-	upgradeReconciler := &pgupgrade.PGUpgradeReconciler{
-		Client:       mgr.GetClient(),
-		Owner:        naming.ControllerPGUpgrade,
-		Recorder:     mgr.GetEventRecorderFor(naming.ControllerPGUpgrade),
-		Registration: reg,
-	}
-
-	if err := upgradeReconciler.SetupWithManager(mgr); err != nil {
-		log.Error(err, "unable to create PGUpgrade controller")
 		os.Exit(1)
 	}
 }

--- a/internal/bridge/crunchybridgecluster/apply.go
+++ b/internal/bridge/crunchybridgecluster/apply.go
@@ -11,23 +11,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// patch sends patch to object's endpoint in the Kubernetes API and updates
-// object with any returned content. The fieldManager is set to r.Owner, but
-// can be overridden in options.
-// - https://docs.k8s.io/reference/using-api/server-side-apply/#managers
-//
-// NOTE: This function is duplicated from a version in the postgrescluster package
-func (r *CrunchyBridgeClusterReconciler) patch(
-	ctx context.Context, object client.Object,
-	patch client.Patch, options ...client.PatchOption,
-) error {
-	options = append([]client.PatchOption{r.Owner}, options...)
-	return r.Patch(ctx, object, patch, options...)
-}
-
 // apply sends an apply patch to object's endpoint in the Kubernetes API and
-// updates object with any returned content. The fieldManager is set to
-// r.Owner and the force parameter is true.
+// updates object with any returned content. The fieldManager is set by
+// r.Writer and the force parameter is true.
 // - https://docs.k8s.io/reference/using-api/server-side-apply/#managers
 // - https://docs.k8s.io/reference/using-api/server-side-apply/#conflicts
 //
@@ -40,7 +26,7 @@ func (r *CrunchyBridgeClusterReconciler) apply(ctx context.Context, object clien
 
 	// Send the apply-patch with force=true.
 	if err == nil {
-		err = r.patch(ctx, object, apply, client.ForceOwnership)
+		err = r.Writer.Patch(ctx, object, apply, client.ForceOwnership)
 	}
 
 	return err

--- a/internal/bridge/crunchybridgecluster/delete.go
+++ b/internal/bridge/crunchybridgecluster/delete.go
@@ -31,7 +31,7 @@ func (r *CrunchyBridgeClusterReconciler) handleDelete(
 	if crunchybridgecluster.DeletionTimestamp.IsZero() {
 		if !controllerutil.ContainsFinalizer(crunchybridgecluster, finalizer) {
 			controllerutil.AddFinalizer(crunchybridgecluster, finalizer)
-			if err := r.Update(ctx, crunchybridgecluster); err != nil {
+			if err := r.Writer.Update(ctx, crunchybridgecluster); err != nil {
 				return nil, err
 			}
 		}
@@ -57,7 +57,7 @@ func (r *CrunchyBridgeClusterReconciler) handleDelete(
 				log.Info("cluster deleted", "clusterName", crunchybridgecluster.Spec.ClusterName)
 
 				controllerutil.RemoveFinalizer(crunchybridgecluster, finalizer)
-				if err := r.Update(ctx, crunchybridgecluster); err != nil {
+				if err := r.Writer.Update(ctx, crunchybridgecluster); err != nil {
 					return &ctrl.Result{}, err
 				}
 			}

--- a/internal/bridge/crunchybridgecluster/delete_test.go
+++ b/internal/bridge/crunchybridgecluster/delete_test.go
@@ -32,8 +32,7 @@ func TestHandleDeleteCluster(t *testing.T) {
 	secondClusterInBridge.ID = "2345"
 
 	reconciler := &CrunchyBridgeClusterReconciler{
-		Client: tClient,
-		Owner:  "crunchybridgecluster-controller",
+		Writer: client.WithFieldOwner(tClient, t.Name()),
 	}
 	testBridgeClient := &TestBridgeClient{
 		ApiKey:   "9012",

--- a/internal/bridge/crunchybridgecluster/postgres.go
+++ b/internal/bridge/crunchybridgecluster/postgres.go
@@ -92,7 +92,7 @@ func (r *CrunchyBridgeClusterReconciler) reconcilePostgresRoleSecrets(
 	// Make sure that this cluster's role secret names are not being used by any other
 	// secrets in the namespace
 	allSecretsInNamespace := &corev1.SecretList{}
-	err := errors.WithStack(r.List(ctx, allSecretsInNamespace, client.InNamespace(cluster.Namespace)))
+	err := errors.WithStack(r.Reader.List(ctx, allSecretsInNamespace, client.InNamespace(cluster.Namespace)))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -115,7 +115,7 @@ func (r *CrunchyBridgeClusterReconciler) reconcilePostgresRoleSecrets(
 	selector, err := naming.AsSelector(naming.CrunchyBridgeClusterPostgresRoles(cluster.Name))
 	if err == nil {
 		err = errors.WithStack(
-			r.List(ctx, secrets,
+			r.Reader.List(ctx, secrets,
 				client.InNamespace(cluster.Namespace),
 				client.MatchingLabelsSelector{Selector: selector},
 			))

--- a/internal/bridge/crunchybridgecluster/postgres_test.go
+++ b/internal/bridge/crunchybridgecluster/postgres_test.go
@@ -20,16 +20,10 @@ import (
 )
 
 func TestGeneratePostgresRoleSecret(t *testing.T) {
-	tClient := setupKubernetes(t)
-	require.ParallelCapacity(t, 0)
-
-	reconciler := &CrunchyBridgeClusterReconciler{
-		Client: tClient,
-		Owner:  "crunchybridgecluster-controller",
-	}
+	reconciler := &CrunchyBridgeClusterReconciler{}
 
 	cluster := testCluster()
-	cluster.Namespace = setupNamespace(t, tClient).Name
+	cluster.Namespace = "asdf"
 
 	spec := &v1beta1.CrunchyBridgeClusterRoleSpec{
 		Name:       "application",
@@ -77,8 +71,8 @@ func TestReconcilePostgresRoleSecrets(t *testing.T) {
 	ns := setupNamespace(t, tClient).Name
 
 	reconciler := &CrunchyBridgeClusterReconciler{
-		Client: tClient,
-		Owner:  "crunchybridgecluster-controller",
+		Reader: tClient,
+		Writer: client.WithFieldOwner(tClient, t.Name()),
 	}
 
 	t.Run("DuplicateSecretNameInSpec", func(t *testing.T) {

--- a/internal/bridge/crunchybridgecluster/watches.go
+++ b/internal/bridge/crunchybridgecluster/watches.go
@@ -26,7 +26,7 @@ func (r *CrunchyBridgeClusterReconciler) findCrunchyBridgeClustersForSecret(
 	// namespace, we can configure the [manager.Manager] field indexer and pass a
 	// [fields.Selector] here.
 	// - https://book.kubebuilder.io/reference/watching-resources/externally-managed.html
-	if err := r.List(ctx, &clusters, &client.ListOptions{
+	if err := r.Reader.List(ctx, &clusters, &client.ListOptions{
 		Namespace: secret.Namespace,
 	}); err == nil {
 		for i := range clusters.Items {

--- a/internal/bridge/crunchybridgecluster/watches_test.go
+++ b/internal/bridge/crunchybridgecluster/watches_test.go
@@ -21,7 +21,7 @@ func TestFindCrunchyBridgeClustersForSecret(t *testing.T) {
 	require.ParallelCapacity(t, 0)
 
 	ns := setupNamespace(t, tClient)
-	reconciler := &CrunchyBridgeClusterReconciler{Client: tClient}
+	reconciler := &CrunchyBridgeClusterReconciler{Reader: tClient}
 
 	secret := &corev1.Secret{}
 	secret.Namespace = ns.Name

--- a/internal/controller/pgupgrade/apply.go
+++ b/internal/controller/pgupgrade/apply.go
@@ -11,21 +11,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// patch sends patch to object's endpoint in the Kubernetes API and updates
-// object with any returned content. The fieldManager is set to r.Owner, but
-// can be overridden in options.
-// - https://docs.k8s.io/reference/using-api/server-side-apply/#managers
-func (r *PGUpgradeReconciler) patch(
-	ctx context.Context, object client.Object,
-	patch client.Patch, options ...client.PatchOption,
-) error {
-	options = append([]client.PatchOption{r.Owner}, options...)
-	return r.Client.Patch(ctx, object, patch, options...)
-}
-
 // apply sends an apply patch to object's endpoint in the Kubernetes API and
-// updates object with any returned content. The fieldManager is set to
-// r.Owner and the force parameter is true.
+// updates object with any returned content. The fieldManager is set by
+// r.Writer and the force parameter is true.
 // - https://docs.k8s.io/reference/using-api/server-side-apply/#managers
 // - https://docs.k8s.io/reference/using-api/server-side-apply/#conflicts
 func (r *PGUpgradeReconciler) apply(ctx context.Context, object client.Object) error {
@@ -36,7 +24,7 @@ func (r *PGUpgradeReconciler) apply(ctx context.Context, object client.Object) e
 
 	// Send the apply-patch with force=true.
 	if err == nil {
-		err = r.patch(ctx, object, apply, client.ForceOwnership)
+		err = r.Writer.Patch(ctx, object, apply, client.ForceOwnership)
 	}
 
 	return err

--- a/internal/controller/pgupgrade/utils.go
+++ b/internal/controller/pgupgrade/utils.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/crunchydata/postgres-operator/internal/controller/runtime"
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
@@ -29,7 +30,7 @@ func (r *PGUpgradeReconciler) setControllerReference(
 	owner *v1beta1.PGUpgrade, controlled client.Object,
 ) {
 	if metav1.GetControllerOf(controlled) != nil {
-		panic(controllerutil.SetControllerReference(owner, controlled, r.Client.Scheme()))
+		panic(controllerutil.SetControllerReference(owner, controlled, runtime.Scheme))
 	}
 
 	controlled.SetOwnerReferences(append(

--- a/internal/controller/pgupgrade/world.go
+++ b/internal/controller/pgupgrade/world.go
@@ -39,7 +39,7 @@ func (r *PGUpgradeReconciler) observeWorld(
 
 	cluster := v1beta1.NewPostgresCluster()
 	err := errors.WithStack(
-		r.Client.Get(ctx, client.ObjectKey{
+		r.Reader.Get(ctx, client.ObjectKey{
 			Namespace: upgrade.Namespace,
 			Name:      upgrade.Spec.PostgresClusterName,
 		}, cluster))
@@ -48,7 +48,7 @@ func (r *PGUpgradeReconciler) observeWorld(
 	if err == nil {
 		var endpoints corev1.EndpointsList
 		err = errors.WithStack(
-			r.Client.List(ctx, &endpoints,
+			r.Reader.List(ctx, &endpoints,
 				client.InNamespace(upgrade.Namespace),
 				client.MatchingLabelsSelector{Selector: selectCluster},
 			))
@@ -58,7 +58,7 @@ func (r *PGUpgradeReconciler) observeWorld(
 	if err == nil {
 		var jobs batchv1.JobList
 		err = errors.WithStack(
-			r.Client.List(ctx, &jobs,
+			r.Reader.List(ctx, &jobs,
 				client.InNamespace(upgrade.Namespace),
 				client.MatchingLabelsSelector{Selector: selectCluster},
 			))
@@ -70,7 +70,7 @@ func (r *PGUpgradeReconciler) observeWorld(
 	if err == nil {
 		var statefulsets appsv1.StatefulSetList
 		err = errors.WithStack(
-			r.Client.List(ctx, &statefulsets,
+			r.Reader.List(ctx, &statefulsets,
 				client.InNamespace(upgrade.Namespace),
 				client.MatchingLabelsSelector{Selector: selectCluster},
 			))

--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/crunchydata/postgres-operator/internal/initialize"
 	"github.com/crunchydata/postgres-operator/internal/kubernetes"
 	"github.com/crunchydata/postgres-operator/internal/logging"
+	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/pki"
 	"github.com/crunchydata/postgres-operator/internal/postgres"
 	"github.com/crunchydata/postgres-operator/internal/registration"
@@ -40,10 +41,7 @@ import (
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
-const (
-	// ControllerName is the name of the PostgresCluster controller
-	ControllerName = "postgrescluster-controller"
-)
+const controllerName = naming.ControllerPostgresCluster
 
 // Reconciler holds resources for the PostgresCluster reconciler
 type Reconciler struct {

--- a/internal/controller/postgrescluster/controller_ref_manager.go
+++ b/internal/controller/postgrescluster/controller_ref_manager.go
@@ -41,7 +41,7 @@ func (r *Reconciler) adoptObject(ctx context.Context, postgresCluster *v1beta1.P
 
 	return r.Client.Patch(ctx, obj, client.RawPatch(types.StrategicMergePatchType,
 		patchBytes), &client.PatchOptions{
-		FieldManager: ControllerName,
+		FieldManager: controllerName,
 	})
 }
 

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -179,8 +179,8 @@ func TestReconcilePGBackRest(t *testing.T) {
 	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Owner:    ControllerName,
+			Recorder: mgr.GetEventRecorderFor(controllerName),
+			Owner:    controllerName,
 		}
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
@@ -778,8 +778,8 @@ func TestReconcileStanzaCreate(t *testing.T) {
 	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Owner:    ControllerName,
+			Recorder: mgr.GetEventRecorderFor(controllerName),
+			Owner:    controllerName,
 		}
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
@@ -1060,8 +1060,8 @@ func TestReconcileManualBackup(t *testing.T) {
 	_, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Owner:    ControllerName,
+			Recorder: mgr.GetEventRecorderFor(controllerName),
+			Owner:    controllerName,
 		}
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
@@ -1804,8 +1804,8 @@ func TestReconcilePostgresClusterDataSource(t *testing.T) {
 	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   tClient,
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Owner:    ControllerName,
+			Recorder: mgr.GetEventRecorderFor(controllerName),
+			Owner:    controllerName,
 		}
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
@@ -2183,8 +2183,8 @@ func TestReconcileCloudBasedDataSource(t *testing.T) {
 	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   tClient,
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Owner:    ControllerName,
+			Recorder: mgr.GetEventRecorderFor(controllerName),
+			Owner:    controllerName,
 		}
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
@@ -2608,7 +2608,7 @@ func TestGenerateBackupJobIntent(t *testing.T) {
 
 	r := &Reconciler{
 		Client: cc,
-		Owner:  ControllerName,
+		Owner:  controllerName,
 	}
 
 	ctx := context.Background()
@@ -3904,8 +3904,8 @@ func TestReconcileScheduledBackups(t *testing.T) {
 	_, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Owner:    ControllerName,
+			Recorder: mgr.GetEventRecorderFor(controllerName),
+			Owner:    controllerName,
 		}
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })
@@ -4240,8 +4240,8 @@ func TestBackupsEnabled(t *testing.T) {
 	ctx, cancel := setupManager(t, cfg, func(mgr manager.Manager) {
 		r = &Reconciler{
 			Client:   mgr.GetClient(),
-			Recorder: mgr.GetEventRecorderFor(ControllerName),
-			Owner:    ControllerName,
+			Recorder: mgr.GetEventRecorderFor(controllerName),
+			Owner:    controllerName,
 		}
 	})
 	t.Cleanup(func() { teardownManager(cancel, t) })

--- a/internal/controller/postgrescluster/pki_test.go
+++ b/internal/controller/postgrescluster/pki_test.go
@@ -43,7 +43,7 @@ func TestReconcileCerts(t *testing.T) {
 
 	r := &Reconciler{
 		Client: tClient,
-		Owner:  ControllerName,
+		Owner:  controllerName,
 	}
 
 	// set up cluster1

--- a/internal/controller/standalone_pgadmin/apply.go
+++ b/internal/controller/standalone_pgadmin/apply.go
@@ -11,23 +11,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// patch sends patch to object's endpoint in the Kubernetes API and updates
-// object with any returned content. The fieldManager is set to r.Owner, but
-// can be overridden in options.
-// - https://docs.k8s.io/reference/using-api/server-side-apply/#managers
-//
-// TODO(tjmoore4): This function is duplicated from a version that takes a PostgresCluster object.
-func (r *PGAdminReconciler) patch(
-	ctx context.Context, object client.Object,
-	patch client.Patch, options ...client.PatchOption,
-) error {
-	options = append([]client.PatchOption{r.Owner}, options...)
-	return r.Patch(ctx, object, patch, options...)
-}
-
 // apply sends an apply patch to object's endpoint in the Kubernetes API and
-// updates object with any returned content. The fieldManager is set to
-// r.Owner and the force parameter is true.
+// updates object with any returned content. The fieldManager is set by
+// r.Writer and the force parameter is true.
 // - https://docs.k8s.io/reference/using-api/server-side-apply/#managers
 // - https://docs.k8s.io/reference/using-api/server-side-apply/#conflicts
 //
@@ -40,7 +26,7 @@ func (r *PGAdminReconciler) apply(ctx context.Context, object client.Object) err
 
 	// Send the apply-patch with force=true.
 	if err == nil {
-		err = r.patch(ctx, object, apply, client.ForceOwnership)
+		err = r.Writer.Patch(ctx, object, apply, client.ForceOwnership)
 	}
 
 	return err

--- a/internal/controller/standalone_pgadmin/controller_test.go
+++ b/internal/controller/standalone_pgadmin/controller_test.go
@@ -24,7 +24,7 @@ func TestDeleteControlled(t *testing.T) {
 	require.ParallelCapacity(t, 1)
 
 	ns := setupNamespace(t, cc)
-	reconciler := PGAdminReconciler{Client: cc}
+	reconciler := PGAdminReconciler{Writer: cc}
 
 	pgadmin := new(v1beta1.PGAdmin)
 	pgadmin.Namespace = ns.Name

--- a/internal/controller/standalone_pgadmin/related.go
+++ b/internal/controller/standalone_pgadmin/related.go
@@ -30,7 +30,7 @@ func (r *PGAdminReconciler) findPGAdminsForPostgresCluster(
 	// namespace, we can configure the [manager.Manager] field indexer and pass a
 	// [fields.Selector] here.
 	// - https://book.kubebuilder.io/reference/watching-resources/externally-managed.html
-	if r.List(ctx, &pgadmins, &client.ListOptions{
+	if r.Reader.List(ctx, &pgadmins, &client.ListOptions{
 		Namespace: cluster.GetNamespace(),
 	}) == nil {
 		for i := range pgadmins.Items {
@@ -64,7 +64,7 @@ func (r *PGAdminReconciler) findPGAdminsForSecret(
 	// namespace, we can configure the [manager.Manager] field indexer and pass a
 	// [fields.Selector] here.
 	// - https://book.kubebuilder.io/reference/watching-resources/externally-managed.html
-	if err := r.List(ctx, &pgadmins, &client.ListOptions{
+	if err := r.Reader.List(ctx, &pgadmins, &client.ListOptions{
 		Namespace: secret.Namespace,
 	}); err == nil {
 		for i := range pgadmins.Items {
@@ -93,7 +93,7 @@ func (r *PGAdminReconciler) getClustersForPGAdmin(
 	for _, serverGroup := range pgAdmin.Spec.ServerGroups {
 		var cluster v1beta1.PostgresCluster
 		if serverGroup.PostgresClusterName != "" {
-			err = r.Get(ctx, client.ObjectKey{
+			err = r.Reader.Get(ctx, client.ObjectKey{
 				Name:      serverGroup.PostgresClusterName,
 				Namespace: pgAdmin.GetNamespace(),
 			}, &cluster)
@@ -104,7 +104,7 @@ func (r *PGAdminReconciler) getClustersForPGAdmin(
 		}
 		if selector, err = naming.AsSelector(serverGroup.PostgresClusterSelector); err == nil {
 			var list v1beta1.PostgresClusterList
-			err = r.List(ctx, &list,
+			err = r.Reader.List(ctx, &list,
 				client.InNamespace(pgAdmin.Namespace),
 				client.MatchingLabelsSelector{Selector: selector},
 			)

--- a/internal/controller/standalone_pgadmin/related_test.go
+++ b/internal/controller/standalone_pgadmin/related_test.go
@@ -22,7 +22,7 @@ func TestFindPGAdminsForSecret(t *testing.T) {
 	require.ParallelCapacity(t, 0)
 
 	ns := setupNamespace(t, tClient)
-	reconciler := &PGAdminReconciler{Client: tClient}
+	reconciler := &PGAdminReconciler{Reader: tClient}
 
 	secret1 := &corev1.Secret{}
 	secret1.Namespace = ns.Name

--- a/internal/controller/standalone_pgadmin/service.go
+++ b/internal/controller/standalone_pgadmin/service.go
@@ -36,7 +36,7 @@ func (r *PGAdminReconciler) reconcilePGAdminService(
 	// need to delete any existing service(s). At the start of every reconcile
 	// get all services that match the current pgAdmin labels.
 	services := corev1.ServiceList{}
-	if err := r.List(ctx, &services,
+	if err := r.Reader.List(ctx, &services,
 		client.InNamespace(pgadmin.Namespace),
 		client.MatchingLabels{
 			naming.LabelStandalonePGAdmin: pgadmin.Name,
@@ -62,7 +62,7 @@ func (r *PGAdminReconciler) reconcilePGAdminService(
 	if pgadmin.Spec.ServiceName != "" {
 		// Look for an existing service with name ServiceName in the namespace
 		existingService := &corev1.Service{}
-		err := r.Get(ctx, types.NamespacedName{
+		err := r.Reader.Get(ctx, types.NamespacedName{
 			Name:      pgadmin.Spec.ServiceName,
 			Namespace: pgadmin.GetNamespace(),
 		}, existingService)

--- a/internal/controller/standalone_pgadmin/statefulset.go
+++ b/internal/controller/standalone_pgadmin/statefulset.go
@@ -34,7 +34,7 @@ func (r *PGAdminReconciler) reconcilePGAdminStatefulSet(
 	// When we delete the StatefulSet, we will leave its Pods in place. They will be claimed by
 	// the StatefulSet that gets created in the next reconcile.
 	existing := &appsv1.StatefulSet{}
-	if err := errors.WithStack(r.Get(ctx, client.ObjectKeyFromObject(sts), existing)); err != nil {
+	if err := errors.WithStack(r.Reader.Get(ctx, client.ObjectKeyFromObject(sts), existing)); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
@@ -47,7 +47,7 @@ func (r *PGAdminReconciler) reconcilePGAdminStatefulSet(
 			exactly := client.Preconditions{UID: &uid, ResourceVersion: &version}
 			propagate := client.PropagationPolicy(metav1.DeletePropagationOrphan)
 
-			return errors.WithStack(client.IgnoreNotFound(r.Delete(ctx, existing, exactly, propagate)))
+			return errors.WithStack(client.IgnoreNotFound(r.Writer.Delete(ctx, existing, exactly, propagate)))
 		}
 	}
 

--- a/internal/controller/standalone_pgadmin/statefulset_test.go
+++ b/internal/controller/standalone_pgadmin/statefulset_test.go
@@ -27,8 +27,8 @@ func TestReconcilePGAdminStatefulSet(t *testing.T) {
 	require.ParallelCapacity(t, 1)
 
 	reconciler := &PGAdminReconciler{
-		Client: cc,
-		Owner:  client.FieldOwner(t.Name()),
+		Reader: cc,
+		Writer: client.WithFieldOwner(cc, t.Name()),
 	}
 
 	ns := setupNamespace(t, cc)

--- a/internal/controller/standalone_pgadmin/users.go
+++ b/internal/controller/standalone_pgadmin/users.go
@@ -53,7 +53,7 @@ func (r *PGAdminReconciler) reconcilePGAdminUsers(ctx context.Context, pgadmin *
 	pod := &corev1.Pod{ObjectMeta: naming.StandalonePGAdmin(pgadmin)}
 	pod.Name += "-0"
 
-	err := errors.WithStack(r.Get(ctx, client.ObjectKeyFromObject(pod), pod))
+	err := errors.WithStack(r.Reader.Get(ctx, client.ObjectKeyFromObject(pod), pod))
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
@@ -136,7 +136,7 @@ func (r *PGAdminReconciler) writePGAdminUsers(ctx context.Context, pgadmin *v1be
 
 	existingUserSecret := &corev1.Secret{ObjectMeta: naming.StandalonePGAdmin(pgadmin)}
 	err := errors.WithStack(
-		r.Get(ctx, client.ObjectKeyFromObject(existingUserSecret), existingUserSecret))
+		r.Reader.Get(ctx, client.ObjectKeyFromObject(existingUserSecret), existingUserSecret))
 	if client.IgnoreNotFound(err) != nil {
 		return err
 	}
@@ -186,7 +186,7 @@ cd $PGADMIN_DIR
 			Name:      user.PasswordRef.Name,
 		}}
 		err := errors.WithStack(
-			r.Get(ctx, client.ObjectKeyFromObject(userPasswordSecret), userPasswordSecret))
+			r.Reader.Get(ctx, client.ObjectKeyFromObject(userPasswordSecret), userPasswordSecret))
 		if err != nil {
 			log.Error(err, "Could not get user password secret")
 			continue

--- a/internal/controller/standalone_pgadmin/volume_test.go
+++ b/internal/controller/standalone_pgadmin/volume_test.go
@@ -30,8 +30,7 @@ func TestReconcilePGAdminDataVolume(t *testing.T) {
 	require.ParallelCapacity(t, 1)
 
 	reconciler := &PGAdminReconciler{
-		Client: cc,
-		Owner:  client.FieldOwner(t.Name()),
+		Writer: client.WithFieldOwner(cc, t.Name()),
 	}
 
 	ns := setupNamespace(t, cc)

--- a/internal/naming/controllers.go
+++ b/internal/naming/controllers.go
@@ -5,6 +5,9 @@
 package naming
 
 const (
-	ControllerBridge  = "bridge-controller"
-	ControllerPGAdmin = "pgadmin-controller"
+	ControllerBridge               = "bridge-controller"
+	ControllerCrunchyBridgeCluster = "crunchybridgecluster-controller"
+	ControllerPGAdmin              = "pgadmin-controller"
+	ControllerPGUpgrade            = "pgupgrade-controller"
+	ControllerPostgresCluster      = "postgrescluster-controller"
 )

--- a/internal/upgradecheck/header.go
+++ b/internal/upgradecheck/header.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/crunchydata/postgres-operator/internal/controller/postgrescluster"
 	"github.com/crunchydata/postgres-operator/internal/feature"
 	"github.com/crunchydata/postgres-operator/internal/kubernetes"
 	"github.com/crunchydata/postgres-operator/internal/logging"
@@ -128,7 +127,7 @@ func manageUpgradeCheckConfigMap(ctx context.Context, crClient crclient.Client,
 		}
 	}
 
-	err = applyConfigMap(ctx, crClient, cm, postgrescluster.ControllerName)
+	err = applyConfigMap(ctx, crClient, cm, naming.ControllerPostgresCluster)
 	if err != nil {
 		log.V(1).Info("upgrade check issue: could not apply configmap",
 			"response", err.Error())


### PR DESCRIPTION
This separates the `client.Client` interface in our controllers into three: `Reader`, `Writer`, and `StatusWriter`. The idea is to add a _little_ friction when a Client to a test, so we're more intentional about separating reads from writes. During this refactor, I found a number of tests that didn't need Kubernetes at all. This exercise has increased the amount of code covered by `make check`.

This refactor is one step toward my goal of a single, shared SSA Apply function.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
 - [x] Other
