### PR TITLE
Separate postgrescluster.Reconciler client concerns

### DIFF
--- a/internal/controller/postgrescluster/apply.go
+++ b/internal/controller/postgrescluster/apply.go
@@ -16,8 +16,8 @@ import (
 )
 
 // apply sends an apply patch to object's endpoint in the Kubernetes API and
-// updates object with any returned content. The fieldManager is set to
-// r.Owner and the force parameter is true.
+// updates object with any returned content. The fieldManager is set by
+// r.Writer and the force parameter is true.
 // - https://docs.k8s.io/reference/using-api/server-side-apply/#managers
 // - https://docs.k8s.io/reference/using-api/server-side-apply/#conflicts
 func (r *Reconciler) apply(ctx context.Context, object client.Object) error {
@@ -32,7 +32,7 @@ func (r *Reconciler) apply(ctx context.Context, object client.Object) error {
 
 	// Send the apply-patch with force=true.
 	if err == nil {
-		err = r.patch(ctx, object, apply, client.ForceOwnership)
+		err = r.Writer.Patch(ctx, object, apply, client.ForceOwnership)
 	}
 
 	// Some fields cannot be server-side applied correctly. When their outcome
@@ -44,7 +44,7 @@ func (r *Reconciler) apply(ctx context.Context, object client.Object) error {
 
 	// Send the json-patch when necessary.
 	if err == nil && !patch.IsEmpty() {
-		err = r.patch(ctx, object, patch)
+		err = r.Writer.Patch(ctx, object, patch)
 	}
 	return err
 }

--- a/internal/controller/postgrescluster/cluster_test.go
+++ b/internal/controller/postgrescluster/cluster_test.go
@@ -82,19 +82,20 @@ func TestCustomLabels(t *testing.T) {
 	require.ParallelCapacity(t, 2)
 
 	reconciler := &Reconciler{
-		Client:   cc,
-		Owner:    client.FieldOwner(t.Name()),
-		Recorder: new(record.FakeRecorder),
+		Reader:       cc,
+		Recorder:     new(record.FakeRecorder),
+		StatusWriter: client.WithFieldOwner(cc, t.Name()).Status(),
+		Writer:       client.WithFieldOwner(cc, t.Name()),
 	}
 
 	ns := setupNamespace(t, cc)
 
 	reconcileTestCluster := func(cluster *v1beta1.PostgresCluster) {
-		assert.NilError(t, reconciler.Client.Create(ctx, cluster))
+		assert.NilError(t, cc.Create(ctx, cluster))
 		t.Cleanup(func() {
 			// Remove finalizers, if any, so the namespace can terminate.
 			assert.Check(t, client.IgnoreNotFound(
-				reconciler.Client.Patch(ctx, cluster, client.RawPatch(
+				cc.Patch(ctx, cluster, client.RawPatch(
 					client.Merge.Type(), []byte(`{"metadata":{"finalizers":[]}}`)))))
 		})
 
@@ -168,7 +169,7 @@ func TestCustomLabels(t *testing.T) {
 		for _, gvk := range gvks {
 			uList := &unstructured.UnstructuredList{}
 			uList.SetGroupVersionKind(gvk)
-			assert.NilError(t, reconciler.Client.List(ctx, uList,
+			assert.NilError(t, cc.List(ctx, uList,
 				client.InNamespace(cluster.Namespace),
 				client.MatchingLabelsSelector{Selector: selector}))
 
@@ -216,7 +217,7 @@ func TestCustomLabels(t *testing.T) {
 				for _, gvk := range gvks {
 					uList := &unstructured.UnstructuredList{}
 					uList.SetGroupVersionKind(gvk)
-					assert.NilError(t, reconciler.Client.List(ctx, uList,
+					assert.NilError(t, cc.List(ctx, uList,
 						client.InNamespace(cluster.Namespace),
 						client.MatchingLabelsSelector{Selector: selector}))
 
@@ -263,7 +264,7 @@ func TestCustomLabels(t *testing.T) {
 		for _, gvk := range gvks {
 			uList := &unstructured.UnstructuredList{}
 			uList.SetGroupVersionKind(gvk)
-			assert.NilError(t, reconciler.Client.List(ctx, uList,
+			assert.NilError(t, cc.List(ctx, uList,
 				client.InNamespace(cluster.Namespace),
 				client.MatchingLabelsSelector{Selector: selector}))
 
@@ -298,7 +299,7 @@ func TestCustomLabels(t *testing.T) {
 		for _, gvk := range gvks {
 			uList := &unstructured.UnstructuredList{}
 			uList.SetGroupVersionKind(gvk)
-			assert.NilError(t, reconciler.Client.List(ctx, uList,
+			assert.NilError(t, cc.List(ctx, uList,
 				client.InNamespace(cluster.Namespace),
 				client.MatchingLabelsSelector{Selector: selector}))
 
@@ -320,19 +321,20 @@ func TestCustomAnnotations(t *testing.T) {
 	require.ParallelCapacity(t, 2)
 
 	reconciler := &Reconciler{
-		Client:   cc,
-		Owner:    client.FieldOwner(t.Name()),
-		Recorder: new(record.FakeRecorder),
+		Reader:       cc,
+		Recorder:     new(record.FakeRecorder),
+		StatusWriter: client.WithFieldOwner(cc, t.Name()).Status(),
+		Writer:       client.WithFieldOwner(cc, t.Name()),
 	}
 
 	ns := setupNamespace(t, cc)
 
 	reconcileTestCluster := func(cluster *v1beta1.PostgresCluster) {
-		assert.NilError(t, reconciler.Client.Create(ctx, cluster))
+		assert.NilError(t, cc.Create(ctx, cluster))
 		t.Cleanup(func() {
 			// Remove finalizers, if any, so the namespace can terminate.
 			assert.Check(t, client.IgnoreNotFound(
-				reconciler.Client.Patch(ctx, cluster, client.RawPatch(
+				cc.Patch(ctx, cluster, client.RawPatch(
 					client.Merge.Type(), []byte(`{"metadata":{"finalizers":[]}}`)))))
 		})
 
@@ -407,7 +409,7 @@ func TestCustomAnnotations(t *testing.T) {
 		for _, gvk := range gvks {
 			uList := &unstructured.UnstructuredList{}
 			uList.SetGroupVersionKind(gvk)
-			assert.NilError(t, reconciler.Client.List(ctx, uList,
+			assert.NilError(t, cc.List(ctx, uList,
 				client.InNamespace(cluster.Namespace),
 				client.MatchingLabelsSelector{Selector: selector}))
 
@@ -455,7 +457,7 @@ func TestCustomAnnotations(t *testing.T) {
 				for _, gvk := range gvks {
 					uList := &unstructured.UnstructuredList{}
 					uList.SetGroupVersionKind(gvk)
-					assert.NilError(t, reconciler.Client.List(ctx, uList,
+					assert.NilError(t, cc.List(ctx, uList,
 						client.InNamespace(cluster.Namespace),
 						client.MatchingLabelsSelector{Selector: selector}))
 
@@ -502,7 +504,7 @@ func TestCustomAnnotations(t *testing.T) {
 		for _, gvk := range gvks {
 			uList := &unstructured.UnstructuredList{}
 			uList.SetGroupVersionKind(gvk)
-			assert.NilError(t, reconciler.Client.List(ctx, uList,
+			assert.NilError(t, cc.List(ctx, uList,
 				client.InNamespace(cluster.Namespace),
 				client.MatchingLabelsSelector{Selector: selector}))
 
@@ -537,7 +539,7 @@ func TestCustomAnnotations(t *testing.T) {
 		for _, gvk := range gvks {
 			uList := &unstructured.UnstructuredList{}
 			uList.SetGroupVersionKind(gvk)
-			assert.NilError(t, reconciler.Client.List(ctx, uList,
+			assert.NilError(t, cc.List(ctx, uList,
 				client.InNamespace(cluster.Namespace),
 				client.MatchingLabelsSelector{Selector: selector}))
 
@@ -554,10 +556,7 @@ func TestCustomAnnotations(t *testing.T) {
 }
 
 func TestGenerateClusterPrimaryService(t *testing.T) {
-	_, cc := setupKubernetes(t)
-	require.ParallelCapacity(t, 0)
-
-	reconciler := &Reconciler{Client: cc}
+	reconciler := &Reconciler{}
 
 	cluster := &v1beta1.PostgresCluster{}
 	cluster.Namespace = "ns2"
@@ -658,7 +657,7 @@ func TestReconcileClusterPrimaryService(t *testing.T) {
 	_, cc := setupKubernetes(t)
 	require.ParallelCapacity(t, 1)
 
-	reconciler := &Reconciler{Client: cc, Owner: client.FieldOwner(t.Name())}
+	reconciler := &Reconciler{Writer: client.WithFieldOwner(cc, t.Name())}
 
 	cluster := testCluster()
 	cluster.Namespace = setupNamespace(t, cc).Name
@@ -676,10 +675,7 @@ func TestReconcileClusterPrimaryService(t *testing.T) {
 }
 
 func TestGenerateClusterReplicaServiceIntent(t *testing.T) {
-	_, cc := setupKubernetes(t)
-	require.ParallelCapacity(t, 0)
-
-	reconciler := &Reconciler{Client: cc}
+	reconciler := &Reconciler{}
 
 	cluster := &v1beta1.PostgresCluster{}
 	cluster.Namespace = "ns1"

--- a/internal/controller/postgrescluster/controller_ref_manager_test.go
+++ b/internal/controller/postgrescluster/controller_ref_manager_test.go
@@ -22,7 +22,10 @@ func TestManageControllerRefs(t *testing.T) {
 	require.ParallelCapacity(t, 1)
 
 	ctx := context.Background()
-	r := &Reconciler{Client: tClient}
+	r := &Reconciler{
+		Reader: tClient,
+		Writer: client.WithFieldOwner(tClient, t.Name()),
+	}
 	clusterName := "hippo"
 
 	cluster := testCluster()
@@ -59,7 +62,7 @@ func TestManageControllerRefs(t *testing.T) {
 		obj.Name = "adopt"
 		obj.Labels = map[string]string{naming.LabelCluster: clusterName}
 
-		if err := r.Client.Create(ctx, obj); err != nil {
+		if err := tClient.Create(ctx, obj); err != nil {
 			t.Error(err)
 		}
 
@@ -100,7 +103,7 @@ func TestManageControllerRefs(t *testing.T) {
 			BlockOwnerDeletion: &isTrue,
 		})
 
-		if err := r.Client.Create(ctx, obj); err != nil {
+		if err := tClient.Create(ctx, obj); err != nil {
 			t.Error(err)
 		}
 
@@ -123,7 +126,7 @@ func TestManageControllerRefs(t *testing.T) {
 		obj.Name = "ignore-no-labels-refs"
 		obj.Labels = map[string]string{"ignore-label": "ignore-value"}
 
-		if err := r.Client.Create(ctx, obj); err != nil {
+		if err := tClient.Create(ctx, obj); err != nil {
 			t.Error(err)
 		}
 
@@ -146,7 +149,7 @@ func TestManageControllerRefs(t *testing.T) {
 		obj.Name = "ignore-no-postgrescluster"
 		obj.Labels = map[string]string{naming.LabelCluster: "nonexistent"}
 
-		if err := r.Client.Create(ctx, obj); err != nil {
+		if err := tClient.Create(ctx, obj); err != nil {
 			t.Error(err)
 		}
 

--- a/internal/controller/postgrescluster/delete.go
+++ b/internal/controller/postgrescluster/delete.go
@@ -58,7 +58,7 @@ func (r *Reconciler) handleDelete(
 		// Make another copy so that Patch doesn't write back to cluster.
 		intent := before.DeepCopy()
 		intent.Finalizers = append(intent.Finalizers, naming.Finalizer)
-		err := errors.WithStack(r.patch(ctx, intent,
+		err := errors.WithStack(r.Writer.Patch(ctx, intent,
 			client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})))
 
 		// The caller can do what they like or requeue upon error.
@@ -96,7 +96,7 @@ func (r *Reconciler) handleDelete(
 	// Make another copy so that Patch doesn't write back to cluster.
 	intent := before.DeepCopy()
 	intent.Finalizers = finalizers.Delete(naming.Finalizer).List()
-	err := errors.WithStack(r.patch(ctx, intent,
+	err := errors.WithStack(r.Writer.Patch(ctx, intent,
 		client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})))
 
 	// The caller should wait for further events or requeue upon error.

--- a/internal/controller/postgrescluster/patroni.go
+++ b/internal/controller/postgrescluster/patroni.go
@@ -37,7 +37,7 @@ func (r *Reconciler) deletePatroniArtifacts(
 	selector, err := naming.AsSelector(naming.ClusterPatronis(cluster))
 	if err == nil {
 		err = errors.WithStack(
-			r.Client.DeleteAllOf(ctx, &corev1.Endpoints{},
+			r.Writer.DeleteAllOf(ctx, &corev1.Endpoints{},
 				client.InNamespace(cluster.Namespace),
 				client.MatchingLabelsSelector{Selector: selector},
 			))
@@ -324,7 +324,7 @@ func (r *Reconciler) reconcilePatroniStatus(
 
 	dcs := &corev1.Endpoints{ObjectMeta: naming.PatroniDistributedConfiguration(cluster)}
 	err := errors.WithStack(client.IgnoreNotFound(
-		r.Client.Get(ctx, client.ObjectKeyFromObject(dcs), dcs)))
+		r.Reader.Get(ctx, client.ObjectKeyFromObject(dcs), dcs)))
 
 	if err == nil {
 		if dcs.Annotations["initialize"] != "" {
@@ -362,14 +362,14 @@ func (r *Reconciler) reconcileReplicationSecret(
 			Name:      cluster.Spec.CustomReplicationClientTLSSecret.Name,
 			Namespace: cluster.Namespace,
 		}}
-		err := errors.WithStack(r.Client.Get(ctx,
+		err := errors.WithStack(r.Reader.Get(ctx,
 			client.ObjectKeyFromObject(custom), custom))
 		return custom, err
 	}
 
 	existing := &corev1.Secret{ObjectMeta: naming.ReplicationClientCertSecret(cluster)}
 	err := errors.WithStack(client.IgnoreNotFound(
-		r.Client.Get(ctx, client.ObjectKeyFromObject(existing), existing)))
+		r.Reader.Get(ctx, client.ObjectKeyFromObject(existing), existing)))
 
 	leaf := &pki.LeafCertificate{}
 	commonName := postgres.ReplicationUser

--- a/internal/controller/postgrescluster/pgadmin.go
+++ b/internal/controller/postgrescluster/pgadmin.go
@@ -96,7 +96,7 @@ func (r *Reconciler) reconcilePGAdminConfigMap(
 		// pgAdmin is disabled; delete the ConfigMap if it exists. Check the
 		// client cache first using Get.
 		key := client.ObjectKeyFromObject(configmap)
-		err := errors.WithStack(r.Client.Get(ctx, key, configmap))
+		err := errors.WithStack(r.Reader.Get(ctx, key, configmap))
 		if err == nil {
 			err = errors.WithStack(r.deleteControlled(ctx, cluster, configmap))
 		}
@@ -212,7 +212,7 @@ func (r *Reconciler) reconcilePGAdminService(
 		// pgAdmin is disabled; delete the Service if it exists. Check the client
 		// cache first using Get.
 		key := client.ObjectKeyFromObject(service)
-		err := errors.WithStack(r.Client.Get(ctx, key, service))
+		err := errors.WithStack(r.Reader.Get(ctx, key, service))
 		if err == nil {
 			err = errors.WithStack(r.deleteControlled(ctx, cluster, service))
 		}
@@ -240,7 +240,7 @@ func (r *Reconciler) reconcilePGAdminStatefulSet(
 		// pgAdmin is disabled; delete the Deployment if it exists. Check the
 		// client cache first using Get.
 		key := client.ObjectKeyFromObject(sts)
-		err := errors.WithStack(r.Client.Get(ctx, key, sts))
+		err := errors.WithStack(r.Reader.Get(ctx, key, sts))
 		if err == nil {
 			err = errors.WithStack(r.deleteControlled(ctx, cluster, sts))
 		}
@@ -333,7 +333,7 @@ func (r *Reconciler) reconcilePGAdminStatefulSet(
 	// When we delete the StatefulSet, we will leave its Pods in place. They will be claimed by
 	// the StatefulSet that gets created in the next reconcile.
 	existing := &appsv1.StatefulSet{}
-	if err := errors.WithStack(r.Client.Get(ctx, client.ObjectKeyFromObject(sts), existing)); err != nil {
+	if err := errors.WithStack(r.Reader.Get(ctx, client.ObjectKeyFromObject(sts), existing)); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
@@ -346,7 +346,7 @@ func (r *Reconciler) reconcilePGAdminStatefulSet(
 			exactly := client.Preconditions{UID: &uid, ResourceVersion: &version}
 			propagate := client.PropagationPolicy(metav1.DeletePropagationOrphan)
 
-			return errors.WithStack(client.IgnoreNotFound(r.Client.Delete(ctx, existing, exactly, propagate)))
+			return errors.WithStack(client.IgnoreNotFound(r.Writer.Delete(ctx, existing, exactly, propagate)))
 		}
 	}
 
@@ -391,7 +391,7 @@ func (r *Reconciler) reconcilePGAdminDataVolume(
 		// pgAdmin is disabled; delete the PVC if it exists. Check the client
 		// cache first using Get.
 		key := client.ObjectKeyFromObject(pvc)
-		err := errors.WithStack(r.Client.Get(ctx, key, pvc))
+		err := errors.WithStack(r.Reader.Get(ctx, key, pvc))
 		if err == nil {
 			err = errors.WithStack(r.deleteControlled(ctx, cluster, pvc))
 		}
@@ -439,7 +439,7 @@ func (r *Reconciler) reconcilePGAdminUsers(
 	pod := &corev1.Pod{ObjectMeta: naming.ClusterPGAdmin(cluster)}
 	pod.Name += "-0"
 
-	err := errors.WithStack(r.Client.Get(ctx, client.ObjectKeyFromObject(pod), pod))
+	err := errors.WithStack(r.Reader.Get(ctx, client.ObjectKeyFromObject(pod), pod))
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -97,7 +97,7 @@ func (r *Reconciler) reconcilePGBouncerConfigMap(
 		// PgBouncer is disabled; delete the ConfigMap if it exists. Check the
 		// client cache first using Get.
 		key := client.ObjectKeyFromObject(configmap)
-		err := errors.WithStack(r.Client.Get(ctx, key, configmap))
+		err := errors.WithStack(r.Reader.Get(ctx, key, configmap))
 		if err == nil {
 			err = errors.WithStack(r.deleteControlled(ctx, cluster, configmap))
 		}
@@ -230,7 +230,7 @@ func (r *Reconciler) reconcilePGBouncerSecret(
 ) (*corev1.Secret, error) {
 	existing := &corev1.Secret{ObjectMeta: naming.ClusterPGBouncer(cluster)}
 	err := errors.WithStack(
-		r.Client.Get(ctx, client.ObjectKeyFromObject(existing), existing))
+		r.Reader.Get(ctx, client.ObjectKeyFromObject(existing), existing))
 	if client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (r *Reconciler) reconcilePGBouncerService(
 		// PgBouncer is disabled; delete the Service if it exists. Check the client
 		// cache first using Get.
 		key := client.ObjectKeyFromObject(service)
-		err := errors.WithStack(r.Client.Get(ctx, key, service))
+		err := errors.WithStack(r.Reader.Get(ctx, key, service))
 		if err == nil {
 			err = errors.WithStack(r.deleteControlled(ctx, cluster, service))
 		}
@@ -565,7 +565,7 @@ func (r *Reconciler) reconcilePGBouncerDeployment(
 		// PgBouncer is disabled; delete the Deployment if it exists. Check the
 		// client cache first using Get.
 		key := client.ObjectKeyFromObject(deploy)
-		err := errors.WithStack(r.Client.Get(ctx, key, deploy))
+		err := errors.WithStack(r.Reader.Get(ctx, key, deploy))
 		if err == nil {
 			err = errors.WithStack(r.deleteControlled(ctx, cluster, deploy))
 		}
@@ -590,7 +590,7 @@ func (r *Reconciler) reconcilePGBouncerPodDisruptionBudget(
 ) error {
 	deleteExistingPDB := func(cluster *v1beta1.PostgresCluster) error {
 		existing := &policyv1.PodDisruptionBudget{ObjectMeta: naming.ClusterPGBouncer(cluster)}
-		err := errors.WithStack(r.Client.Get(ctx, client.ObjectKeyFromObject(existing), existing))
+		err := errors.WithStack(r.Reader.Get(ctx, client.ObjectKeyFromObject(existing), existing))
 		if err == nil {
 			err = errors.WithStack(r.deleteControlled(ctx, cluster, existing))
 		}

--- a/internal/controller/postgrescluster/pgmonitor.go
+++ b/internal/controller/postgrescluster/pgmonitor.go
@@ -153,7 +153,7 @@ func (r *Reconciler) reconcileMonitoringSecret(
 
 	existing := &corev1.Secret{ObjectMeta: naming.MonitoringUserSecret(cluster)}
 	err := errors.WithStack(
-		r.Client.Get(ctx, client.ObjectKeyFromObject(existing), existing))
+		r.Reader.Get(ctx, client.ObjectKeyFromObject(existing), existing))
 	if client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
@@ -380,7 +380,7 @@ func (r *Reconciler) reconcileExporterWebConfig(ctx context.Context,
 	}
 
 	existing := &corev1.ConfigMap{ObjectMeta: naming.ExporterWebConfigMap(cluster)}
-	err := errors.WithStack(r.Client.Get(ctx, client.ObjectKeyFromObject(existing), existing))
+	err := errors.WithStack(r.Reader.Get(ctx, client.ObjectKeyFromObject(existing), existing))
 	if client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
@@ -439,7 +439,7 @@ func (r *Reconciler) reconcileExporterQueriesConfig(ctx context.Context,
 	cluster *v1beta1.PostgresCluster) (*corev1.ConfigMap, error) {
 
 	existing := &corev1.ConfigMap{ObjectMeta: naming.ExporterQueriesConfigMap(cluster)}
-	err := errors.WithStack(r.Client.Get(ctx, client.ObjectKeyFromObject(existing), existing))
+	err := errors.WithStack(r.Reader.Get(ctx, client.ObjectKeyFromObject(existing), existing))
 	if client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}

--- a/internal/controller/postgrescluster/pgmonitor_test.go
+++ b/internal/controller/postgrescluster/pgmonitor_test.go
@@ -702,7 +702,10 @@ func TestReconcileMonitoringSecret(t *testing.T) {
 	_, cc := setupKubernetes(t)
 	require.ParallelCapacity(t, 0)
 
-	reconciler := &Reconciler{Client: cc, Owner: client.FieldOwner(t.Name())}
+	reconciler := &Reconciler{
+		Reader: cc,
+		Writer: client.WithFieldOwner(cc, t.Name()),
+	}
 
 	cluster := testCluster()
 	cluster.Default()
@@ -776,7 +779,10 @@ func TestReconcileExporterQueriesConfig(t *testing.T) {
 	_, cc := setupKubernetes(t)
 	require.ParallelCapacity(t, 0)
 
-	reconciler := &Reconciler{Client: cc, Owner: client.FieldOwner(t.Name())}
+	reconciler := &Reconciler{
+		Reader: cc,
+		Writer: client.WithFieldOwner(cc, t.Name()),
+	}
 
 	cluster := testCluster()
 	cluster.Default()

--- a/internal/controller/postgrescluster/pki.go
+++ b/internal/controller/postgrescluster/pki.go
@@ -42,7 +42,7 @@ func (r *Reconciler) reconcileRootCertificate(
 	existing := &corev1.Secret{}
 	existing.Namespace, existing.Name = cluster.Namespace, naming.RootCertSecret
 	err := errors.WithStack(client.IgnoreNotFound(
-		r.Client.Get(ctx, client.ObjectKeyFromObject(existing), existing)))
+		r.Reader.Get(ctx, client.ObjectKeyFromObject(existing), existing)))
 
 	root := &pki.RootCertificateAuthority{}
 
@@ -120,7 +120,7 @@ func (r *Reconciler) reconcileClusterCertificate(
 
 	existing := &corev1.Secret{ObjectMeta: naming.PostgresTLSSecret(cluster)}
 	err := errors.WithStack(client.IgnoreNotFound(
-		r.Client.Get(ctx, client.ObjectKeyFromObject(existing), existing)))
+		r.Reader.Get(ctx, client.ObjectKeyFromObject(existing), existing)))
 
 	leaf := &pki.LeafCertificate{}
 	dnsNames := append(naming.ServiceDNSNames(ctx, primaryService), naming.ServiceDNSNames(ctx, replicaService)...)

--- a/internal/controller/postgrescluster/pki_test.go
+++ b/internal/controller/postgrescluster/pki_test.go
@@ -42,8 +42,8 @@ func TestReconcileCerts(t *testing.T) {
 	namespace := setupNamespace(t, tClient).Name
 
 	r := &Reconciler{
-		Client: tClient,
-		Owner:  controllerName,
+		Reader: tClient,
+		Writer: client.WithFieldOwner(tClient, controllerName),
 	}
 
 	// set up cluster1

--- a/internal/controller/postgrescluster/pod_disruption_budget_test.go
+++ b/internal/controller/postgrescluster/pod_disruption_budget_test.go
@@ -13,14 +13,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/crunchydata/postgres-operator/internal/initialize"
-	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
 func TestGeneratePodDisruptionBudget(t *testing.T) {
-	_, cc := setupKubernetes(t)
-	r := &Reconciler{Client: cc}
-	require.ParallelCapacity(t, 0)
+	r := &Reconciler{}
 
 	var (
 		minAvailable *intstr.IntOrString

--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -542,7 +542,7 @@ func (r *Reconciler) reconcilePostgresUserSecrets(
 	selector, err := naming.AsSelector(naming.ClusterPostgresUsers(cluster.Name))
 	if err == nil {
 		err = errors.WithStack(
-			r.Client.List(ctx, secrets,
+			r.Reader.List(ctx, secrets,
 				client.InNamespace(cluster.Namespace),
 				client.MatchingLabelsSelector{Selector: selector},
 			))
@@ -898,7 +898,7 @@ func (r *Reconciler) reconcilePostgresWALVolume(
 		// No WAL volume is specified; delete the PVC safely if it exists. Check
 		// the client cache first using Get.
 		key := client.ObjectKeyFromObject(pvc)
-		err := errors.WithStack(r.Client.Get(ctx, key, pvc))
+		err := errors.WithStack(r.Reader.Get(ctx, key, pvc))
 		if err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
@@ -1003,7 +1003,7 @@ func (r *Reconciler) reconcileDatabaseInitSQL(ctx context.Context,
 				Namespace: cluster.Namespace,
 			},
 		}
-		err := r.Client.Get(ctx, client.ObjectKeyFromObject(cm), cm)
+		err := r.Reader.Get(ctx, client.ObjectKeyFromObject(cm), cm)
 		if err != nil {
 			return "", err
 		}

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -375,7 +375,10 @@ func TestReconcileConfigureExistingPVCs(t *testing.T) {
 	_, tClient := setupKubernetes(t)
 	require.ParallelCapacity(t, 1)
 
-	r := &Reconciler{Client: tClient, Owner: client.FieldOwner(t.Name())}
+	r := &Reconciler{
+		Reader: tClient,
+		Writer: client.WithFieldOwner(tClient, t.Name()),
+	}
 
 	ns := setupNamespace(t, tClient)
 	cluster := &v1beta1.PostgresCluster{
@@ -637,7 +640,10 @@ func TestReconcileMoveDirectories(t *testing.T) {
 	_, tClient := setupKubernetes(t)
 	require.ParallelCapacity(t, 1)
 
-	r := &Reconciler{Client: tClient, Owner: client.FieldOwner(t.Name())}
+	r := &Reconciler{
+		Reader: tClient,
+		Writer: client.WithFieldOwner(tClient, t.Name()),
+	}
 
 	ns := setupNamespace(t, tClient)
 	cluster := &v1beta1.PostgresCluster{
@@ -732,7 +738,7 @@ func TestReconcileMoveDirectories(t *testing.T) {
 	assert.Assert(t, returnEarly)
 
 	moveJobs := &batchv1.JobList{}
-	err = r.Client.List(ctx, moveJobs, &client.ListOptions{
+	err = tClient.List(ctx, moveJobs, &client.ListOptions{
 		Namespace:     cluster.Namespace,
 		LabelSelector: naming.DirectoryMoveJobLabels(cluster.Name).AsSelector(),
 	})


### PR DESCRIPTION
This is the same idea as #4253, but for the PostgresCluster controller: it separates the `client.Client` interface into three. Similarly, this increases the amount of code covered by `make check`.

This refactor is another step toward my goal of a single, shared SSA Apply function.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
 - [x] Other

Wait for these and rebase after:
- [x] https://github.com/CrunchyData/postgres-operator/pull/4263
- [x] https://github.com/CrunchyData/postgres-operator/pull/4280
- [x] https://github.com/CrunchyData/postgres-operator/pull/4281
- [x] https://github.com/CrunchyData/postgres-operator/pull/4282