### PR TITLE
Filter out metrics that we care about using grep

### DIFF
--- a/testing/kuttl/e2e/otel-logging-and-metrics/05-assert-pgbouncer.yaml
+++ b/testing/kuttl/e2e/otel-logging-and-metrics/05-assert-pgbouncer.yaml
@@ -21,7 +21,7 @@ commands:
     }
 
     scrape_metrics=$(kubectl exec "${pod}" -c collector -n "${NAMESPACE}" -- \
-      curl --insecure --silent http://localhost:9187/metrics)
+      curl --insecure --silent http://localhost:9187/metrics | grep 'ccp_pgbouncer_clients_wait_seconds')
     { contains "${scrape_metrics}" 'ccp_pgbouncer_clients_wait_seconds'; } || {
       retry "pgbouncer metric not found"
       exit 1

--- a/testing/kuttl/e2e/otel-logging-and-metrics/06-assert-instance.yaml
+++ b/testing/kuttl/e2e/otel-logging-and-metrics/06-assert-instance.yaml
@@ -38,7 +38,10 @@ commands:
     }
 
     scrape_metrics=$(kubectl exec "${pod}" -c collector -n "${NAMESPACE}" -- \
-      curl --insecure --silent http://localhost:9187/metrics)
+      curl --insecure --silent http://localhost:9187/metrics | grep \
+        -e 'ccp_connection_stats_active' \
+        -e 'patroni_postgres_running' \
+        -e 'ccp_database_size_bytes')
     { contains "${scrape_metrics}" 'ccp_connection_stats_active'; } || {
       retry "5 second metric not found"
       exit 1

--- a/testing/kuttl/e2e/otel-logging-and-metrics/12-assert-per-db-queries.yaml
+++ b/testing/kuttl/e2e/otel-logging-and-metrics/12-assert-per-db-queries.yaml
@@ -21,7 +21,7 @@ commands:
     }
 
     scrape_metrics=$(kubectl exec "${pod}" -c collector -n "${NAMESPACE}" -- \
-      curl --insecure --silent http://localhost:9187/metrics)
+      curl --insecure --silent http://localhost:9187/metrics | grep 'ccp_table_size_bytes')
     { contains "${scrape_metrics}" 'ccp_table_size_bytes{dbname="pikachu"'; } || {
       retry "ccp_table_size_bytes not found for pikachu"
       exit 1

--- a/testing/kuttl/e2e/otel-logging-and-metrics/14-assert-per-db-queries-for-multiple-targets.yaml
+++ b/testing/kuttl/e2e/otel-logging-and-metrics/14-assert-per-db-queries-for-multiple-targets.yaml
@@ -21,7 +21,7 @@ commands:
     }
 
     scrape_metrics=$(kubectl exec "${pod}" -c collector -n "${NAMESPACE}" -- \
-      curl --insecure --silent http://localhost:9187/metrics)
+      curl --insecure --silent http://localhost:9187/metrics | grep 'ccp_table_size_bytes')
     { contains "${scrape_metrics}" 'ccp_table_size_bytes{dbname="pikachu"'; } || {
       retry "ccp_table_size_bytes not found for pikachu"
       exit 1

--- a/testing/kuttl/e2e/otel-logging-and-metrics/18-assert-custom-queries-per-db.yaml
+++ b/testing/kuttl/e2e/otel-logging-and-metrics/18-assert-custom-queries-per-db.yaml
@@ -23,7 +23,7 @@ commands:
     }
 
     scrape_metrics=$(kubectl exec "${pod}" -c collector -n "${NAMESPACE}" -- \
-      curl --insecure --silent http://localhost:9187/metrics)
+      curl --insecure --silent http://localhost:9187/metrics | grep 'ccp_table_size_bytes')
     { contains "${scrape_metrics}" 'ccp_table_size_bytes_1{dbname="pikachu"'; } || {
       retry "custom metric not found for pikachu db"
       exit 1

--- a/testing/kuttl/e2e/otel-logging-and-metrics/22-assert-instance.yaml
+++ b/testing/kuttl/e2e/otel-logging-and-metrics/22-assert-instance.yaml
@@ -23,7 +23,9 @@ commands:
     }
 
     scrape_metrics=$(kubectl exec "${pod}" -c collector -n "${NAMESPACE}" -- \
-      curl --insecure --silent http://localhost:9187/metrics)
+      curl --insecure --silent http://localhost:9187/metrics | grep \
+        -e 'ccp_connection_stats_active' \
+        -e 'patroni_postgres_running')
     { contains "${scrape_metrics}" 'ccp_connection_stats_active'; } || {
       retry "5 second metric not found"
       exit 1


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

The `otel-logging-and-metrics` can fail due to what appears to be too much output when we scrape metrics in certain place.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

We adjust the test so that we `grep` the output of the scrape metrics `curl` before we use regex to search for the existence of certain metrics.

**Other Information**:
