### PR TITLE
Another test helper for metav1.Status.Details

### DIFF
--- a/internal/testing/require/errors.go
+++ b/internal/testing/require/errors.go
@@ -16,12 +16,23 @@ import (
 // StatusError returns the [metav1.Status] within err's tree.
 // It calls t.Fatal when err is nil or there is no status.
 func StatusError(t testing.TB, err error) metav1.Status {
-	status, ok := err.(apierrors.APIStatus)
+	t.Helper()
 
+	status, ok := err.(apierrors.APIStatus)
 	assert.Assert(t, ok || errors.As(err, &status),
 		"%T does not implement %T", err, status)
 
 	return status.Status()
+}
+
+// StatusErrorDetails returns the details of [metav1.Status] within err's tree.
+// It calls t.Fatal when err is nil, there is no status, or its Details field is nil.
+func StatusErrorDetails(t testing.TB, err error) metav1.StatusDetails {
+	t.Helper()
+
+	status := StatusError(t, err)
+	assert.Assert(t, status.Details != nil)
+	return *status.Details
 }
 
 // Value returns v or panics when err is not nil.

--- a/internal/testing/validation/pgadmin_test.go
+++ b/internal/testing/validation/pgadmin_test.go
@@ -47,15 +47,14 @@ func TestPGAdminDataVolume(t *testing.T) {
 		assert.ErrorContains(t, err, "dataVolumeClaimSpec")
 		assert.ErrorContains(t, err, "Required")
 
-		status := require.StatusError(t, err)
-		assert.Assert(t, status.Details != nil)
-		assert.Assert(t, cmp.Len(status.Details.Causes, 2))
+		details := require.StatusErrorDetails(t, err)
+		assert.Assert(t, cmp.Len(details.Causes, 2))
 
-		assert.Equal(t, status.Details.Causes[0].Field, "spec.dataVolumeClaimSpec")
-		assert.Assert(t, cmp.Contains(status.Details.Causes[0].Message, "Required"))
+		assert.Equal(t, details.Causes[0].Field, "spec.dataVolumeClaimSpec")
+		assert.Assert(t, cmp.Contains(details.Causes[0].Message, "Required"))
 
-		assert.Equal(t, string(status.Details.Causes[1].Type), "FieldValueInvalid")
-		assert.Assert(t, cmp.Contains(status.Details.Causes[1].Message, "rules were not checked"))
+		assert.Equal(t, string(details.Causes[1].Type), "FieldValueInvalid")
+		assert.Assert(t, cmp.Contains(details.Causes[1].Message, "rules were not checked"))
 	})
 
 	t.Run("AccessModes", func(t *testing.T) {
@@ -150,11 +149,10 @@ func TestPGAdminInstrumentation(t *testing.T) {
 					assert.ErrorContains(t, err, "minRecords")
 					assert.ErrorContains(t, err, "maxDelay")
 
-					status := require.StatusError(t, err)
-					assert.Assert(t, status.Details != nil)
-					assert.Assert(t, cmp.Len(status.Details.Causes, 1))
+					details := require.StatusErrorDetails(t, err)
+					assert.Assert(t, cmp.Len(details.Causes, 1))
 
-					for _, cause := range status.Details.Causes {
+					for _, cause := range details.Causes {
 						assert.Equal(t, cause.Field, "spec.instrumentation.logs.batches")
 						assert.Assert(t, cmp.Contains(cause.Message, "disable batching"))
 						assert.Assert(t, cmp.Contains(cause.Message, "minRecords and maxDelay must be zero"))
@@ -176,11 +174,10 @@ func TestPGAdminInstrumentation(t *testing.T) {
 			assert.ErrorContains(t, err, "maxDelay")
 			assert.ErrorContains(t, err, "5m")
 
-			status := require.StatusError(t, err)
-			assert.Assert(t, status.Details != nil)
-			assert.Assert(t, cmp.Len(status.Details.Causes, 1))
+			details := require.StatusErrorDetails(t, err)
+			assert.Assert(t, cmp.Len(details.Causes, 1))
 
-			for _, cause := range status.Details.Causes {
+			for _, cause := range details.Causes {
 				assert.Equal(t, cause.Field, "spec.instrumentation.logs.batches.maxDelay")
 			}
 		})
@@ -200,11 +197,10 @@ func TestPGAdminInstrumentation(t *testing.T) {
 			assert.ErrorContains(t, err, "maxRecords")
 			assert.ErrorContains(t, err, "greater than or equal to 1")
 
-			status := require.StatusError(t, err)
-			assert.Assert(t, status.Details != nil)
-			assert.Assert(t, cmp.Len(status.Details.Causes, 2))
+			details := require.StatusErrorDetails(t, err)
+			assert.Assert(t, cmp.Len(details.Causes, 2))
 
-			for _, cause := range status.Details.Causes {
+			for _, cause := range details.Causes {
 				switch cause.Field {
 				case "spec.instrumentation.logs.batches.maxRecords":
 					assert.Assert(t, cmp.Contains(cause.Message, "0"))
@@ -233,11 +229,10 @@ func TestPGAdminInstrumentation(t *testing.T) {
 					assert.ErrorContains(t, err, "minRecords")
 					assert.ErrorContains(t, err, "maxRecords")
 
-					status := require.StatusError(t, err)
-					assert.Assert(t, status.Details != nil)
-					assert.Assert(t, cmp.Len(status.Details.Causes, 1))
+					details := require.StatusErrorDetails(t, err)
+					assert.Assert(t, cmp.Len(details.Causes, 1))
 
-					for _, cause := range status.Details.Causes {
+					for _, cause := range details.Causes {
 						assert.Equal(t, cause.Field, "spec.instrumentation.logs.batches")
 						assert.Assert(t, cmp.Contains(cause.Message, "minRecords cannot be larger than maxRecords"))
 					}
@@ -260,11 +255,10 @@ func TestPGAdminInstrumentation(t *testing.T) {
 		assert.ErrorContains(t, err, "hour|day|week")
 		assert.ErrorContains(t, err, "one hour")
 
-		status := require.StatusError(t, err)
-		assert.Assert(t, status.Details != nil)
-		assert.Assert(t, cmp.Len(status.Details.Causes, 2))
+		details := require.StatusErrorDetails(t, err)
+		assert.Assert(t, cmp.Len(details.Causes, 2))
 
-		for _, cause := range status.Details.Causes {
+		for _, cause := range details.Causes {
 			assert.Equal(t, cause.Field, "spec.instrumentation.logs.retentionPeriod")
 		}
 

--- a/internal/testing/validation/postgrescluster/postgres_authentication_test.go
+++ b/internal/testing/validation/postgrescluster/postgres_authentication_test.go
@@ -99,11 +99,10 @@ func testPostgresAuthenticationCommon(t *testing.T, cc client.Client, base unstr
 		err := cc.Create(ctx, cluster, client.DryRunAll)
 		assert.Assert(t, apierrors.IsInvalid(err))
 
-		status := require.StatusError(t, err)
-		assert.Assert(t, status.Details != nil)
-		assert.Assert(t, cmp.Len(status.Details.Causes, 2))
+		details := require.StatusErrorDetails(t, err)
+		assert.Assert(t, cmp.Len(details.Causes, 2))
 
-		for i, cause := range status.Details.Causes {
+		for i, cause := range details.Causes {
 			assert.Equal(t, cause.Field, fmt.Sprintf("spec.authentication.rules[%d]", i))
 			assert.Assert(t, cmp.Contains(cause.Message, "cannot be combined"))
 		}
@@ -122,11 +121,10 @@ func testPostgresAuthenticationCommon(t *testing.T, cc client.Client, base unstr
 		err := cc.Create(ctx, cluster, client.DryRunAll)
 		assert.Assert(t, apierrors.IsInvalid(err))
 
-		status := require.StatusError(t, err)
-		assert.Assert(t, status.Details != nil)
-		assert.Assert(t, cmp.Len(status.Details.Causes, 3))
+		details := require.StatusErrorDetails(t, err)
+		assert.Assert(t, cmp.Len(details.Causes, 3))
 
-		for i, cause := range status.Details.Causes {
+		for i, cause := range details.Causes {
 			assert.Equal(t, cause.Field, fmt.Sprintf("spec.authentication.rules[%d].hba", i))
 			assert.Assert(t, cmp.Contains(cause.Message, "cannot include"))
 		}
@@ -145,11 +143,10 @@ func testPostgresAuthenticationCommon(t *testing.T, cc client.Client, base unstr
 		err := cc.Create(ctx, cluster, client.DryRunAll)
 		assert.Assert(t, apierrors.IsInvalid(err))
 
-		status := require.StatusError(t, err)
-		assert.Assert(t, status.Details != nil)
-		assert.Assert(t, cmp.Len(status.Details.Causes, 3))
+		details := require.StatusErrorDetails(t, err)
+		assert.Assert(t, cmp.Len(details.Causes, 3))
 
-		for i, cause := range status.Details.Causes {
+		for i, cause := range details.Causes {
 			assert.Equal(t, cause.Field, fmt.Sprintf("spec.authentication.rules[%d].method", i))
 			assert.Assert(t, cmp.Contains(cause.Message, "unsafe"))
 		}
@@ -169,11 +166,10 @@ func testPostgresAuthenticationCommon(t *testing.T, cc client.Client, base unstr
 			err := cc.Create(ctx, cluster, client.DryRunAll)
 			assert.Assert(t, apierrors.IsInvalid(err))
 
-			status := require.StatusError(t, err)
-			assert.Assert(t, status.Details != nil)
-			assert.Assert(t, cmp.Len(status.Details.Causes, 3))
+			details := require.StatusErrorDetails(t, err)
+			assert.Assert(t, cmp.Len(details.Causes, 3))
 
-			for i, cause := range status.Details.Causes {
+			for i, cause := range details.Causes {
 				assert.Equal(t, cause.Field, fmt.Sprintf("spec.authentication.rules[%d]", i), "%#v", cause)
 				assert.Assert(t, cmp.Contains(cause.Message, `"ldap" method requires`))
 			}
@@ -205,11 +201,10 @@ func testPostgresAuthenticationCommon(t *testing.T, cc client.Client, base unstr
 			err := cc.Create(ctx, cluster, client.DryRunAll)
 			assert.Assert(t, apierrors.IsInvalid(err))
 
-			status := require.StatusError(t, err)
-			assert.Assert(t, status.Details != nil)
-			assert.Assert(t, cmp.Len(status.Details.Causes, 2))
+			details := require.StatusErrorDetails(t, err)
+			assert.Assert(t, cmp.Len(details.Causes, 2))
 
-			for i, cause := range status.Details.Causes {
+			for i, cause := range details.Causes {
 				assert.Equal(t, cause.Field, fmt.Sprintf("spec.authentication.rules[%d]", i), "%#v", cause)
 				assert.Assert(t, cmp.Regexp(`cannot use .+? options with .+? options`, cause.Message))
 			}
@@ -246,11 +241,10 @@ func testPostgresAuthenticationCommon(t *testing.T, cc client.Client, base unstr
 			err := cc.Create(ctx, cluster, client.DryRunAll)
 			assert.Assert(t, apierrors.IsInvalid(err))
 
-			status := require.StatusError(t, err)
-			assert.Assert(t, status.Details != nil)
-			assert.Assert(t, cmp.Len(status.Details.Causes, 5))
+			details := require.StatusErrorDetails(t, err)
+			assert.Assert(t, cmp.Len(details.Causes, 5))
 
-			for i, cause := range status.Details.Causes {
+			for i, cause := range details.Causes {
 				assert.Equal(t, cause.Field, fmt.Sprintf("spec.authentication.rules[%d]", i), "%#v", cause)
 				assert.Assert(t, cmp.Contains(cause.Message, `"radius" method requires`))
 			}

--- a/internal/testing/validation/postgrescluster/postgres_config_test.go
+++ b/internal/testing/validation/postgrescluster/postgres_config_test.go
@@ -131,13 +131,12 @@ func testPostgresConfigParametersCommon(t *testing.T, cc client.Client, base uns
 				err := cc.Create(ctx, cluster, client.DryRunAll)
 				assert.Assert(t, apierrors.IsInvalid(err))
 
-				status := require.StatusError(t, err)
-				assert.Assert(t, status.Details != nil)
-				assert.Assert(t, cmp.Len(status.Details.Causes, 1))
+				details := require.StatusErrorDetails(t, err)
+				assert.Assert(t, cmp.Len(details.Causes, 1))
 
 				// TODO(k8s-1.30) TODO(validation): Move the parameter name from the message to the field path.
-				assert.Equal(t, status.Details.Causes[0].Field, "spec.config.parameters")
-				assert.Assert(t, cmp.Contains(status.Details.Causes[0].Message, tt.key))
+				assert.Equal(t, details.Causes[0].Field, "spec.config.parameters")
+				assert.Assert(t, cmp.Contains(details.Causes[0].Message, tt.key))
 			})
 		}
 	})
@@ -180,14 +179,13 @@ func testPostgresConfigParametersCommon(t *testing.T, cc client.Client, base uns
 				} else {
 					assert.Assert(t, apierrors.IsInvalid(err))
 
-					status := require.StatusError(t, err)
-					assert.Assert(t, status.Details != nil)
-					assert.Assert(t, cmp.Len(status.Details.Causes, 1))
+					details := require.StatusErrorDetails(t, err)
+					assert.Assert(t, cmp.Len(details.Causes, 1))
 
 					// TODO(k8s-1.30) TODO(validation): Move the parameter name from the message to the field path.
-					assert.Equal(t, status.Details.Causes[0].Field, "spec.config.parameters")
-					assert.Assert(t, cmp.Contains(status.Details.Causes[0].Message, tt.key))
-					assert.Assert(t, cmp.Contains(status.Details.Causes[0].Message, tt.message))
+					assert.Equal(t, details.Causes[0].Field, "spec.config.parameters")
+					assert.Assert(t, cmp.Contains(details.Causes[0].Message, tt.key))
+					assert.Assert(t, cmp.Contains(details.Causes[0].Message, tt.message))
 				}
 			})
 		}
@@ -256,11 +254,10 @@ func testPostgresConfigParametersCommon(t *testing.T, cc client.Client, base uns
 			assert.Assert(t, apierrors.IsInvalid(err))
 			assert.ErrorContains(t, err, `"replica" or higher`)
 
-			status := require.StatusError(t, err)
-			assert.Assert(t, status.Details != nil)
-			assert.Assert(t, cmp.Len(status.Details.Causes, 1))
-			assert.Equal(t, status.Details.Causes[0].Field, "spec.config.parameters")
-			assert.Assert(t, cmp.Contains(status.Details.Causes[0].Message, "wal_level"))
+			details := require.StatusErrorDetails(t, err)
+			assert.Assert(t, cmp.Len(details.Causes, 1))
+			assert.Equal(t, details.Causes[0].Field, "spec.config.parameters")
+			assert.Assert(t, cmp.Contains(details.Causes[0].Message, "wal_level"))
 		})
 	})
 

--- a/internal/testing/validation/postgrescluster/postgres_users_test.go
+++ b/internal/testing/validation/postgrescluster/postgres_users_test.go
@@ -103,11 +103,10 @@ func testPostgresUserOptionsCommon(t *testing.T, cc client.Client, base unstruct
 		assert.Assert(t, apierrors.IsInvalid(err))
 		assert.ErrorContains(t, err, "cannot contain comments")
 
-		status := require.StatusError(t, err)
-		assert.Assert(t, status.Details != nil)
-		assert.Assert(t, cmp.Len(status.Details.Causes, 3))
+		details := require.StatusErrorDetails(t, err)
+		assert.Assert(t, cmp.Len(details.Causes, 3))
 
-		for i, cause := range status.Details.Causes {
+		for i, cause := range details.Causes {
 			assert.Equal(t, cause.Field, fmt.Sprintf("spec.users[%d].options", i))
 			assert.Assert(t, cmp.Contains(cause.Message, "cannot contain comments"))
 		}
@@ -126,11 +125,10 @@ func testPostgresUserOptionsCommon(t *testing.T, cc client.Client, base unstruct
 		assert.Assert(t, apierrors.IsInvalid(err))
 		assert.ErrorContains(t, err, "cannot assign password")
 
-		status := require.StatusError(t, err)
-		assert.Assert(t, status.Details != nil)
-		assert.Assert(t, cmp.Len(status.Details.Causes, 2))
+		details := require.StatusErrorDetails(t, err)
+		assert.Assert(t, cmp.Len(details.Causes, 2))
 
-		for i, cause := range status.Details.Causes {
+		for i, cause := range details.Causes {
 			assert.Equal(t, cause.Field, fmt.Sprintf("spec.users[%d].options", i))
 			assert.Assert(t, cmp.Contains(cause.Message, "cannot assign password"))
 		}
@@ -148,10 +146,9 @@ func testPostgresUserOptionsCommon(t *testing.T, cc client.Client, base unstruct
 		assert.Assert(t, apierrors.IsInvalid(err))
 		assert.ErrorContains(t, err, "should match")
 
-		status := require.StatusError(t, err)
-		assert.Assert(t, status.Details != nil)
-		assert.Assert(t, cmp.Len(status.Details.Causes, 1))
-		assert.Equal(t, status.Details.Causes[0].Field, "spec.users[0].options")
+		details := require.StatusErrorDetails(t, err)
+		assert.Assert(t, cmp.Len(details.Causes, 1))
+		assert.Equal(t, details.Causes[0].Field, "spec.users[0].options")
 	})
 
 	t.Run("Valid", func(t *testing.T) {


### PR DESCRIPTION
Every call to "require.StatusError" was followed by reaching into its Details field. This eliminates the check for nil that entailed.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement