### PR TITLE
Fix failing envtest

### DIFF
--- a/internal/controller/postgrescluster/apply_test.go
+++ b/internal/controller/postgrescluster/apply_test.go
@@ -151,6 +151,7 @@ func TestServerSideApply(t *testing.T) {
 				MatchLabels: map[string]string{"select": name},
 			}
 			sts.Spec.Template.Labels = map[string]string{"select": name}
+			sts.Spec.Template.Spec.Containers = []corev1.Container{{Name: "test", Image: "test"}}
 			return &sts
 		}
 

--- a/internal/controller/postgrescluster/controller_ref_manager_test.go
+++ b/internal/controller/postgrescluster/controller_ref_manager_test.go
@@ -46,6 +46,9 @@ func TestManageControllerRefs(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"label1": "val1"},
 				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test", Image: "test"}},
+				},
 			},
 		},
 	}

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -1707,7 +1707,9 @@ func TestGetPGBackRestResources(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: naming.PGBackRestDedicatedLabels(clusterName),
 						},
-						Spec: corev1.PodSpec{},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "test", Image: "test"}},
+						},
 					},
 				},
 			},
@@ -1745,7 +1747,9 @@ func TestGetPGBackRestResources(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: naming.PGBackRestDedicatedLabels(clusterName),
 						},
-						Spec: corev1.PodSpec{},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "test", Image: "test"}},
+						},
 					},
 				},
 			},
@@ -1781,7 +1785,9 @@ func TestGetPGBackRestResources(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: naming.PGBackRestDedicatedLabels(clusterName),
 						},
-						Spec: corev1.PodSpec{},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "test", Image: "test"}},
+						},
 					},
 				},
 			},

--- a/internal/controller/standalone_pgadmin/statefulset_test.go
+++ b/internal/controller/standalone_pgadmin/statefulset_test.go
@@ -37,6 +37,7 @@ func TestReconcilePGAdminStatefulSet(t *testing.T) {
 	pgadmin := new(v1beta1.PGAdmin)
 	pgadmin.Name = "test-standalone-pgadmin"
 	pgadmin.Namespace = ns.Name
+	pgadmin.Spec.Image = initialize.String("test")
 	require.UnmarshalInto(t, &pgadmin.Spec, `{
 		dataVolumeClaimSpec: {
 			accessModes: [ReadWriteOnce],
@@ -113,6 +114,7 @@ terminationGracePeriodSeconds: 30
 		// add pod level customizations
 		custompgadmin.Name = "custom-pgadmin"
 		custompgadmin.Namespace = ns.Name
+		custompgadmin.Spec.Image = initialize.String("test")
 		require.UnmarshalInto(t, &custompgadmin.Spec, `{
 			dataVolumeClaimSpec: {
 				accessModes: [ReadWriteOnce],
@@ -231,7 +233,7 @@ tolerations:
 		// add pod level customizations
 		custompgadmin.Name = "custom-volumes"
 		custompgadmin.Namespace = ns.Name
-
+		custompgadmin.Spec.Image = initialize.String("test")
 		require.UnmarshalInto(t, &custompgadmin.Spec, `{
 			dataVolumeClaimSpec: {
 				accessModes: [ReadWriteOnce],


### PR DESCRIPTION
**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other

**What is the current behavior (link to any open issues here)?**

Since the introduction of k8s 1.34 as the envtest latest, some of our tests were failing due to missing elements of the statefulset spec (mostly). 

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This PR fixes those tests by adding those elements.

**Other Information**:
Issues: [PGO-2648]