### PR TITLE
Volume autogrow status updates

### DIFF
--- a/internal/controller/postgrescluster/autogrow.go
+++ b/internal/controller/postgrescluster/autogrow.go
@@ -62,6 +62,11 @@ func (r *Reconciler) storeDesiredRequest(
 		return ""
 	}
 
+	// if the volume exists but the limit is not set, do not return the new value
+	if !*limitSet {
+		return desiredRequestBackup
+	}
+
 	if *limitSet && current.Value() > previous.Value() {
 		r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "VolumeAutoGrow",
 			"%s volume expansion to %v requested for %s/%s.",

--- a/internal/controller/postgrescluster/autogrow_test.go
+++ b/internal/controller/postgrescluster/autogrow_test.go
@@ -113,7 +113,7 @@ func TestStoreDesiredRequest(t *testing.T) {
 	}, {
 		tcName:  "PGData-NoLimitNoEvent",
 		Voltype: "pgData", host: "blue",
-		desiredRequest: "1Gi", desiredRequestBackup: "", expectedValue: "1Gi",
+		desiredRequest: "1Gi", desiredRequestBackup: "", expectedValue: "",
 		expectedNumEvents: 0, expectedNumLogs: 0,
 	}, {
 		tcName:  "PGData-BadBackupRequest",
@@ -142,7 +142,7 @@ func TestStoreDesiredRequest(t *testing.T) {
 	}, {
 		tcName:  "PGWAL-NoLimitNoEvent",
 		Voltype: "pgWAL", host: "blue",
-		desiredRequest: "1Gi", desiredRequestBackup: "", expectedValue: "1Gi",
+		desiredRequest: "1Gi", desiredRequestBackup: "", expectedValue: "",
 		expectedNumEvents: 0, expectedNumLogs: 0,
 	}, {
 		tcName:  "PGWAL-NoVolumeDefined",
@@ -176,7 +176,7 @@ func TestStoreDesiredRequest(t *testing.T) {
 	}, {
 		tcName:  "Repo-NoLimitNoEvent",
 		Voltype: "repo2", host: "repo-host",
-		desiredRequest: "1Gi", desiredRequestBackup: "", expectedValue: "1Gi",
+		desiredRequest: "1Gi", desiredRequestBackup: "", expectedValue: "",
 		expectedNumEvents: 0, expectedNumLogs: 0,
 	}, {
 		tcName:  "Repo-NoRepoDefined",

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -370,14 +370,26 @@ func (r *Reconciler) observeInstances(
 		// If autogrow is enabled, determine the desired volume size for each instance
 		// now that all the pod annotations have been collected. This final value will be
 		// checked to ensure that the value from the annotations can be parsed to a valid
-		// value. Otherwise the previous value, if available, will be used.
+		// value. Otherwise the previous value, if available, will be used. If a limit is
+		// not defined for the given volume and an empty string has been returned, nothing
+		// will be stored in the status.
 		if autogrow {
 			for _, instance := range observed.bySet[name] {
-				status.DesiredPGDataVolume[instance.Name] = r.storeDesiredRequest(ctx, cluster, "pgData",
-					name, status.DesiredPGDataVolume[instance.Name], previousPGDataDesiredRequests[instance.Name])
+				if pgDataRequest := r.storeDesiredRequest(
+					ctx, cluster, "pgData", name,
+					status.DesiredPGDataVolume[instance.Name],
+					previousPGDataDesiredRequests[instance.Name],
+				); pgDataRequest != "" {
+					status.DesiredPGDataVolume[instance.Name] = pgDataRequest
+				}
 
-				status.DesiredPGWALVolume[instance.Name] = r.storeDesiredRequest(ctx, cluster, "pgWAL",
-					name, status.DesiredPGWALVolume[instance.Name], previousPGWALDesiredRequests[instance.Name])
+				if pgWALRequest := r.storeDesiredRequest(
+					ctx, cluster, "pgWAL", name,
+					status.DesiredPGWALVolume[instance.Name],
+					previousPGWALDesiredRequests[instance.Name],
+				); pgWALRequest != "" {
+					status.DesiredPGWALVolume[instance.Name] = pgWALRequest
+				}
 			}
 		}
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- Only store pgData and pgWAL request values when autogrow is enabled

  The desiredPGDataVolume and desiredPGWALVolume status values should
  only be stored when a volume auto-grow event is imminent. This update
  adjusts the behavior so that this pattern is followed.

  Existing values will remain in place as needed if/when a Limit is
  removed.


**Other Information**:
Issue: PGO-1428