### PR TITLE
Allow indented YAML in tests

### DIFF
--- a/internal/testing/cmp/cmp_test.go
+++ b/internal/testing/cmp/cmp_test.go
@@ -1,0 +1,66 @@
+// Copyright 2021 - 2025 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmp
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestDedentLines(t *testing.T) {
+	for _, tc := range []struct {
+		width    int
+		input    string
+		expected string
+	}{
+		// empty stays that way
+		{width: 0, input: "", expected: ""},
+		{width: 1, input: "", expected: ""},
+		{width: 2, input: "", expected: ""},
+
+		// adds a missing newline
+		{input: "\n", expected: "\n"},
+		{input: "x", expected: "x\n"},
+		{input: "x\n", expected: "x\n"},
+		{input: "x\n\n", expected: "x\n\n"},
+
+		// width does not affect whats removed
+		{width: 2, input: "x", expected: "x\n"},
+		{width: 2, input: "\tx", expected: "x\n"},
+		{width: 2, input: " x", expected: "x\n"},
+		{width: 2, input: "  x", expected: "x\n"},
+		{width: 2, input: "   x", expected: "x\n"},
+
+		// positive width changes tabs to spaces
+		{width: 0, input: "\t\t~\n\t~\n", expected: "\t~\n~\n"},
+		{width: 1, input: "\t\t~\n\t~\n", expected: " ~\n~\n"},
+		{width: 2, input: "\t\t~\n\t~\n", expected: "  ~\n~\n"},
+
+		// width does not affect spaces
+		{width: 0, input: "  ~\n ~\n", expected: " ~\n~\n"},
+		{width: 1, input: "  ~\n ~\n", expected: " ~\n~\n"},
+		{width: 2, input: "  ~\n ~\n", expected: " ~\n~\n"},
+
+		// smallest indent can be anywhere
+		{input: " ~\n  ~\n  ~\n", expected: "~\n ~\n ~\n"},
+		{input: "  ~\n ~\n  ~\n", expected: " ~\n~\n ~\n"},
+		{input: "  ~\n  ~\n ~\n", expected: " ~\n ~\n~\n"},
+
+		// entirely whitespace becomes newline
+		{input: " ", expected: "\n"},
+		{input: "  ", expected: "\n"},
+		{input: "\t", expected: "\n"},
+		{input: "\t\t", expected: "\n"},
+
+		// blank lines preserved
+		{input: " ~\n\n ~\n", expected: "~\n\n~\n"},
+	} {
+		t.Run(fmt.Sprintf("%v:%#v", tc.width, tc.input), func(t *testing.T) {
+			assert.DeepEqual(t, dedentLines(tc.input, tc.width), tc.expected)
+		})
+	}
+}

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/cmp_test.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/cmp_test.go
@@ -1,0 +1,23 @@
+// Copyright 2021 - 2025 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1_test
+
+import (
+	"bytes"
+
+	"gotest.tools/v3/assert/cmp"
+	"sigs.k8s.io/yaml"
+)
+
+// MarshalsTo converts x to YAML and compares that to y.
+func MarshalsTo[T []byte | string](x any, y T) cmp.Comparison {
+	b, err := yaml.Marshal(x)
+	if err != nil {
+		return func() cmp.Result { return cmp.ResultFromError(err) }
+	}
+	return cmp.DeepEqual(string(b), string(
+		append(bytes.TrimLeft(bytes.TrimRight([]byte(y), "\t\n"), "\n"), '\n'),
+	))
+}

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/cmp_test.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/cmp_test.go
@@ -5,8 +5,12 @@
 package v1beta1_test
 
 import (
-	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
 
+	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 	"sigs.k8s.io/yaml"
 )
@@ -17,7 +21,116 @@ func MarshalsTo[T []byte | string](x any, y T) cmp.Comparison {
 	if err != nil {
 		return func() cmp.Result { return cmp.ResultFromError(err) }
 	}
-	return cmp.DeepEqual(string(b), string(
-		append(bytes.TrimLeft(bytes.TrimRight([]byte(y), "\t\n"), "\n"), '\n'),
+	return cmp.DeepEqual(string(b), dedentLines(
+		strings.TrimLeft(strings.TrimRight(string(y), "\t\n"), "\n"), 2,
 	))
+}
+
+var leadingTabs = regexp.MustCompile(`^\t+`)
+
+// dedentLines finds the shortest leading whitespace of every line in data and then removes it from every line.
+// When tabWidth is positive, leading tabs are converted to spaces first.
+func dedentLines(data string, tabWidth int) string {
+	if len(data) < 1 {
+		return ""
+	}
+
+	var lines = make([]string, 0, 20)
+	var lowest, highest string
+
+	for line := range strings.Lines(data) {
+		tabs := leadingTabs.FindString(line)
+
+		// Replace any leading tabs with spaces when tabWidth is positive.
+		// NOTE: [strings.Repeat] has a fast-path for spaces.
+		if need := tabWidth * len(tabs); need > 0 {
+			line = strings.Repeat(" ", need) + line[len(tabs):]
+		}
+
+		switch {
+		case lowest == "", highest == "":
+			lowest, highest = line, line
+
+		case len(strings.TrimSpace(line)) > 0:
+			lowest = min(lowest, line)
+			highest = max(highest, line)
+		}
+
+		lines = append(lines, line)
+	}
+
+	// This treats one tab the same as one space.
+	// That is, it expects all lines to be indented using spaces or using tabs; not both.
+	if width := func() int {
+		for i := range lowest {
+			if (lowest[i] != ' ' && lowest[i] != '\t') || lowest[i] != highest[i] {
+				return i
+			}
+		}
+		return len(lowest)
+	}(); width > 0 {
+		for i := range lines {
+			if len(lines[i]) > width {
+				lines[i] = lines[i][width:]
+			} else {
+				lines[i] = "\n"
+			}
+		}
+	}
+
+	return strings.TrimSuffix(strings.Join(lines, ""), "\n") + "\n"
+}
+
+func TestDedentLines(t *testing.T) {
+	for _, tc := range []struct {
+		width    int
+		input    string
+		expected string
+	}{
+		// empty stays that way
+		{width: 0, input: "", expected: ""},
+		{width: 1, input: "", expected: ""},
+		{width: 2, input: "", expected: ""},
+
+		// adds a missing newline
+		{input: "\n", expected: "\n"},
+		{input: "x", expected: "x\n"},
+		{input: "x\n", expected: "x\n"},
+		{input: "x\n\n", expected: "x\n\n"},
+
+		// width does not affect whats removed
+		{width: 2, input: "x", expected: "x\n"},
+		{width: 2, input: "\tx", expected: "x\n"},
+		{width: 2, input: " x", expected: "x\n"},
+		{width: 2, input: "  x", expected: "x\n"},
+		{width: 2, input: "   x", expected: "x\n"},
+
+		// positive width changes tabs to spaces
+		{width: 0, input: "\t\t~\n\t~\n", expected: "\t~\n~\n"},
+		{width: 1, input: "\t\t~\n\t~\n", expected: " ~\n~\n"},
+		{width: 2, input: "\t\t~\n\t~\n", expected: "  ~\n~\n"},
+
+		// width does not affect spaces
+		{width: 0, input: "  ~\n ~\n", expected: " ~\n~\n"},
+		{width: 1, input: "  ~\n ~\n", expected: " ~\n~\n"},
+		{width: 2, input: "  ~\n ~\n", expected: " ~\n~\n"},
+
+		// smallest indent can be anywhere
+		{input: " ~\n  ~\n  ~\n", expected: "~\n ~\n ~\n"},
+		{input: "  ~\n ~\n  ~\n", expected: " ~\n~\n ~\n"},
+		{input: "  ~\n  ~\n ~\n", expected: " ~\n ~\n~\n"},
+
+		// entirely whitespace becomes newline
+		{input: " ", expected: "\n"},
+		{input: "  ", expected: "\n"},
+		{input: "\t", expected: "\n"},
+		{input: "\t\t", expected: "\n"},
+
+		// blank lines preserved
+		{input: " ~\n\n ~\n", expected: "~\n\n~\n"},
+	} {
+		t.Run(fmt.Sprintf("%v:%#v", tc.width, tc.input), func(t *testing.T) {
+			assert.DeepEqual(t, dedentLines(tc.input, tc.width), tc.expected)
+		})
+	}
 }

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/config_types_test.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/config_types_test.go
@@ -19,10 +19,10 @@ func TestOptionalConfigMapKeyRefAsProjection(t *testing.T) {
 
 		out := in.AsProjection("three")
 		assert.Assert(t, MarshalsTo(out, `
-items:
-- key: two
-  path: three
-name: one
+			items:
+			- key: two
+				path: three
+			name: one
 		`))
 	})
 
@@ -33,11 +33,11 @@ name: one
 
 		out := in.AsProjection("three")
 		assert.Assert(t, MarshalsTo(out, `
-items:
-- key: two
-  path: three
-name: one
-optional: true
+			items:
+			- key: two
+				path: three
+			name: one
+			optional: true
 		`))
 	})
 
@@ -48,11 +48,11 @@ optional: true
 
 		out := in.AsProjection("three")
 		assert.Assert(t, MarshalsTo(out, `
-items:
-- key: two
-  path: three
-name: one
-optional: false
+			items:
+			- key: two
+				path: three
+			name: one
+			optional: false
 		`))
 	})
 }
@@ -62,10 +62,10 @@ func TestConfigMapKeyRefAsProjection(t *testing.T) {
 	out := in.AsProjection("some-path")
 
 	assert.Assert(t, MarshalsTo(out, `
-items:
-- key: foobar
-  path: some-path
-name: asdf
+		items:
+		- key: foobar
+			path: some-path
+		name: asdf
 	`))
 }
 
@@ -76,10 +76,10 @@ func TestOptionalSecretKeyRefAsProjection(t *testing.T) {
 
 		out := in.AsProjection("three")
 		assert.Assert(t, MarshalsTo(out, `
-items:
-- key: two
-  path: three
-name: one
+			items:
+			- key: two
+				path: three
+			name: one
 		`))
 	})
 
@@ -90,11 +90,11 @@ name: one
 
 		out := in.AsProjection("three")
 		assert.Assert(t, MarshalsTo(out, `
-items:
-- key: two
-  path: three
-name: one
-optional: true
+			items:
+			- key: two
+				path: three
+			name: one
+			optional: true
 		`))
 	})
 
@@ -105,11 +105,11 @@ optional: true
 
 		out := in.AsProjection("three")
 		assert.Assert(t, MarshalsTo(out, `
-items:
-- key: two
-  path: three
-name: one
-optional: false
+			items:
+			- key: two
+				path: three
+			name: one
+			optional: false
 		`))
 	})
 }
@@ -119,9 +119,9 @@ func TestSecretKeyRefAsProjection(t *testing.T) {
 	out := in.AsProjection("some-path")
 
 	assert.Assert(t, MarshalsTo(out, `
-items:
-- key: foobar
-  path: some-path
-name: asdf
+		items:
+		- key: foobar
+			path: some-path
+		name: asdf
 	`))
 }

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/config_types_test.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/config_types_test.go
@@ -5,11 +5,9 @@
 package v1beta1_test
 
 import (
-	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
-	"sigs.k8s.io/yaml"
 
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
@@ -20,14 +18,12 @@ func TestOptionalConfigMapKeyRefAsProjection(t *testing.T) {
 		in.Name, in.Key = "one", "two"
 
 		out := in.AsProjection("three")
-		b, err := yaml.Marshal(out)
-		assert.NilError(t, err)
-		assert.DeepEqual(t, string(b), strings.TrimSpace(`
+		assert.Assert(t, MarshalsTo(out, `
 items:
 - key: two
   path: three
 name: one
-		`)+"\n")
+		`))
 	})
 
 	t.Run("True", func(t *testing.T) {
@@ -36,15 +32,13 @@ name: one
 		in.Name, in.Key = "one", "two"
 
 		out := in.AsProjection("three")
-		b, err := yaml.Marshal(out)
-		assert.NilError(t, err)
-		assert.DeepEqual(t, string(b), strings.TrimSpace(`
+		assert.Assert(t, MarshalsTo(out, `
 items:
 - key: two
   path: three
 name: one
 optional: true
-		`)+"\n")
+		`))
 	})
 
 	t.Run("False", func(t *testing.T) {
@@ -53,15 +47,13 @@ optional: true
 		in.Name, in.Key = "one", "two"
 
 		out := in.AsProjection("three")
-		b, err := yaml.Marshal(out)
-		assert.NilError(t, err)
-		assert.DeepEqual(t, string(b), strings.TrimSpace(`
+		assert.Assert(t, MarshalsTo(out, `
 items:
 - key: two
   path: three
 name: one
 optional: false
-		`)+"\n")
+		`))
 	})
 }
 
@@ -69,14 +61,12 @@ func TestConfigMapKeyRefAsProjection(t *testing.T) {
 	in := v1beta1.ConfigMapKeyRef{Name: "asdf", Key: "foobar"}
 	out := in.AsProjection("some-path")
 
-	b, err := yaml.Marshal(out)
-	assert.NilError(t, err)
-	assert.DeepEqual(t, string(b), strings.TrimSpace(`
+	assert.Assert(t, MarshalsTo(out, `
 items:
 - key: foobar
   path: some-path
 name: asdf
-	`)+"\n")
+	`))
 }
 
 func TestOptionalSecretKeyRefAsProjection(t *testing.T) {
@@ -85,14 +75,12 @@ func TestOptionalSecretKeyRefAsProjection(t *testing.T) {
 		in.Name, in.Key = "one", "two"
 
 		out := in.AsProjection("three")
-		b, err := yaml.Marshal(out)
-		assert.NilError(t, err)
-		assert.DeepEqual(t, string(b), strings.TrimSpace(`
+		assert.Assert(t, MarshalsTo(out, `
 items:
 - key: two
   path: three
 name: one
-		`)+"\n")
+		`))
 	})
 
 	t.Run("True", func(t *testing.T) {
@@ -101,15 +89,13 @@ name: one
 		in.Name, in.Key = "one", "two"
 
 		out := in.AsProjection("three")
-		b, err := yaml.Marshal(out)
-		assert.NilError(t, err)
-		assert.DeepEqual(t, string(b), strings.TrimSpace(`
+		assert.Assert(t, MarshalsTo(out, `
 items:
 - key: two
   path: three
 name: one
 optional: true
-		`)+"\n")
+		`))
 	})
 
 	t.Run("False", func(t *testing.T) {
@@ -118,15 +104,13 @@ optional: true
 		in.Name, in.Key = "one", "two"
 
 		out := in.AsProjection("three")
-		b, err := yaml.Marshal(out)
-		assert.NilError(t, err)
-		assert.DeepEqual(t, string(b), strings.TrimSpace(`
+		assert.Assert(t, MarshalsTo(out, `
 items:
 - key: two
   path: three
 name: one
 optional: false
-		`)+"\n")
+		`))
 	})
 }
 
@@ -134,12 +118,10 @@ func TestSecretKeyRefAsProjection(t *testing.T) {
 	in := v1beta1.SecretKeyRef{Name: "asdf", Key: "foobar"}
 	out := in.AsProjection("some-path")
 
-	b, err := yaml.Marshal(out)
-	assert.NilError(t, err)
-	assert.DeepEqual(t, string(b), strings.TrimSpace(`
+	assert.Assert(t, MarshalsTo(out, `
 items:
 - key: foobar
   path: some-path
 name: asdf
-	`)+"\n")
+	`))
 }


### PR DESCRIPTION
We use YAML literals to assert the contents of complex Kubernetes DTOs, but it is time-consuming to align those literals correctly with spaces. This PR adds logic to test helpers that allows us to indent YAML and indent it with tabs.

Rather than import any internal packages in pkg/apis, I copied one test helper there.

Existing tests continue to work because their YAML is already standard and valid. I did, however, convert the YAML in `config_types_test.go` to confirm that the helper works and that tab indentation is still readable.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Testing enhancement
