### PR TITLE
Set data directory group permissions during bootstrap

### DIFF
--- a/internal/patroni/config.go
+++ b/internal/patroni/config.go
@@ -552,6 +552,11 @@ func instanceYAML(
 		} else {
 
 			initdb := []string{
+				// Pod "securityContext.fsGroup" ensures processes and filesystems agree on a GID.
+				// Group access ensures processes can access data regardless of their UID.
+				// NOTE: The "--allow-group-access" option was introduced in PostgreSQL v11.
+				"allow-group-access",
+
 				// Enable checksums on data pages to help detect corruption of
 				// storage that would otherwise be silent. This also enables
 				// "wal_log_hints" which is a prerequisite for using `pg_rewind`.
@@ -568,7 +573,7 @@ func instanceYAML(
 				"data-checksums",
 				"encoding=UTF8",
 
-				// NOTE(cbandy): The "--waldir" option was introduced in PostgreSQL v10.
+				// NOTE: The "--waldir" option was introduced in PostgreSQL v10.
 				"waldir=" + postgres.WALDirectory(cluster, instance),
 			}
 

--- a/internal/patroni/config_test.go
+++ b/internal/patroni/config_test.go
@@ -685,6 +685,7 @@ func TestInstanceYAML(t *testing.T) {
 # Your changes will not be saved.
 bootstrap:
   initdb:
+  - allow-group-access
   - data-checksums
   - encoding=UTF8
   - waldir=/pgdata/pg12_wal
@@ -708,6 +709,7 @@ tags: {}
 # Your changes will not be saved.
 bootstrap:
   initdb:
+  - allow-group-access
   - data-checksums
   - encoding=UTF8
   - waldir=/pgdata/pg12_wal
@@ -747,6 +749,7 @@ tags: {}
 # Your changes will not be saved.
 bootstrap:
   initdb:
+  - allow-group-access
   - data-checksums
   - encoding=UTF8
   - waldir=/pgdata/pg12_wal


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix

**What is the current behavior (link to any open issues here)?**

Immediately after bootstrap, the data directory lacks group permissions when the storage provider ignores fsGroup. These are usually local-only providers for minkube and similar.

**What is the new behavior (if this is a feature change)?**

Bootstrap includes group permissions on development storage.

**Other Information**:

One workaround is to restart the pod. The startup container resets group permissions correctly.

Issue: PGO-300
See: c7842e7a2723044ccce5d5643dc1f66f6007a081