### PR TITLE
Set fsGroup on pgBouncer pods

### DIFF
--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -462,7 +462,13 @@ func (r *Reconciler) generatePGBouncerDeployment(
 	// Do not add environment variables describing services in this namespace.
 	deploy.Spec.Template.Spec.EnableServiceLinks = initialize.Bool(false)
 
-	deploy.Spec.Template.Spec.SecurityContext = initialize.PodSecurityContext()
+	fsGroup := 2
+	if initialize.FromPointer(cluster.Spec.OpenShift) {
+		fsGroup = 0
+	}
+	deploy.Spec.Template.Spec.SecurityContext = util.PodSecurityContext(int64(fsGroup),
+		cluster.Spec.SupplementalGroups,
+	)
 
 	// set the image pull secrets, if any exist
 	deploy.Spec.Template.Spec.ImagePullSecrets = cluster.Spec.ImagePullSecrets

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -478,6 +478,7 @@ containers: null
 enableServiceLinks: false
 restartPolicy: Always
 securityContext:
+  fsGroup: 2
   fsGroupChangePolicy: OnRootMismatch
 shareProcessNamespace: true
 topologySpreadConstraints:

--- a/internal/util/pod_security.go
+++ b/internal/util/pod_security.go
@@ -1,0 +1,40 @@
+// Copyright 2017 - 2025 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/crunchydata/postgres-operator/internal/initialize"
+)
+
+// PodSecurityContext returns a v1.PodSecurityContext for cluster that can write
+// to PersistentVolumes.
+// This func sets the supplmental groups and fsGgroup if present.
+// fsGroup should not be present in OpenShift environments
+func PodSecurityContext(fsgroup int64, supplementalGroups []int64) *corev1.PodSecurityContext {
+	psc := initialize.PodSecurityContext()
+
+	// Use the specified supplementary groups except for root. The CRD has
+	// similar validation, but we should never emit a PodSpec with that group.
+	// - https://docs.k8s.io/concepts/security/pod-security-standards/
+	for i := range supplementalGroups {
+		if gid := supplementalGroups[i]; gid > 0 {
+			psc.SupplementalGroups = append(psc.SupplementalGroups, gid)
+		}
+	}
+
+	// OpenShift assigns a filesystem group based on a SecurityContextConstraint.
+	// Otherwise, set a filesystem group so PostgreSQL can write to files
+	// regardless of the UID or GID of a container.
+	// - https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids
+	// - https://docs.k8s.io/tasks/configure-pod-container/security-context/
+	// - https://docs.openshift.com/container-platform/4.8/authentication/managing-security-context-constraints.html
+	if fsgroup > 0 {
+		psc.FSGroup = initialize.Int64(fsgroup)
+	}
+
+	return psc
+}

--- a/internal/util/pod_security_test.go
+++ b/internal/util/pod_security_test.go
@@ -1,0 +1,52 @@
+// Copyright 2017 - 2025 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/crunchydata/postgres-operator/internal/testing/cmp"
+)
+
+func TestPodSecurityContext(t *testing.T) {
+	t.Run("Non-Openshift", func(t *testing.T) {
+		assert.Assert(t, cmp.MarshalMatches(PodSecurityContext(2, []int64{}), `
+fsGroup: 2
+fsGroupChangePolicy: OnRootMismatch
+	`))
+
+		supplementalGroups := []int64{3, 4}
+		assert.Assert(t, cmp.MarshalMatches(PodSecurityContext(26, supplementalGroups), `
+fsGroup: 26
+fsGroupChangePolicy: OnRootMismatch
+supplementalGroups:
+- 3
+- 4
+	`))
+	})
+
+	t.Run("OpenShift", func(t *testing.T) {
+		assert.Assert(t, cmp.MarshalMatches(PodSecurityContext(0, []int64{}),
+			`fsGroupChangePolicy: OnRootMismatch`))
+
+		supplementalGroups := []int64{3, 4}
+		assert.Assert(t, cmp.MarshalMatches(PodSecurityContext(0, supplementalGroups), `
+fsGroupChangePolicy: OnRootMismatch
+supplementalGroups:
+- 3
+- 4
+	`))
+	})
+
+	t.Run("NoRootGID", func(t *testing.T) {
+		supplementalGroups := []int64{999, 0, 100, 0}
+		assert.DeepEqual(t, []int64{999, 100}, PodSecurityContext(2, supplementalGroups).SupplementalGroups)
+
+		supplementalGroups = []int64{0}
+		assert.Assert(t, PodSecurityContext(2, supplementalGroups).SupplementalGroups == nil)
+	})
+}


### PR DESCRIPTION
When we looked into logging validation, we found that pgBouncer wasn't being created with an fsGroup setting. This PR updates that.

**Checklist:**
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [x] Other


**What is the current behavior (link to any open issues here)?**

pgBouncer wasn't getting fsGroup set as part of the security context. We'll need this for some volume mounting.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

fsGroup set

**Other Information**:
Issues: [PGO-2565]