### PR TITLE
Handle user-set pgBouncer logfile for OTEL, mkdir

### DIFF
--- a/internal/collector/pgbouncer_test.go
+++ b/internal/collector/pgbouncer_test.go
@@ -11,6 +11,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/crunchydata/postgres-operator/internal/feature"
+	"github.com/crunchydata/postgres-operator/internal/naming"
 	"github.com/crunchydata/postgres-operator/internal/testing/require"
 	"github.com/crunchydata/postgres-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
@@ -28,7 +29,7 @@ func TestEnablePgBouncerLogging(t *testing.T) {
 		require.UnmarshalInto(t, &cluster.Spec, `{
 			instrumentation: {}
 		}`)
-		EnablePgBouncerLogging(ctx, cluster, config)
+		EnablePgBouncerLogging(ctx, cluster, config, naming.PGBouncerFullLogPath)
 
 		result, err := config.ToYAML()
 		assert.NilError(t, err)
@@ -127,7 +128,7 @@ service:
 		cluster := new(v1beta1.PostgresCluster)
 		cluster.Spec.Instrumentation = testInstrumentationSpec()
 
-		EnablePgBouncerLogging(ctx, cluster, config)
+		EnablePgBouncerLogging(ctx, cluster, config, naming.PGBouncerFullLogPath)
 
 		result, err := config.ToYAML()
 		assert.NilError(t, err)

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -506,8 +506,8 @@ func (r *Reconciler) generatePGBouncerDeployment(
 	AddTMPEmptyDir(&deploy.Spec.Template)
 
 	// mount additional volumes to the pgbouncer containers
-	if err == nil && cluster.Spec.Proxy.PGBouncer.Volumes != nil && len(cluster.Spec.Proxy.PGBouncer.Volumes.Additional) > 0 {
-		missingContainers := util.AddAdditionalVolumesAndMounts(&deploy.Spec.Template.Spec, cluster.Spec.Proxy.PGBouncer.Volumes.Additional)
+	if volumes := cluster.Spec.Proxy.PGBouncer.Volumes; err == nil && volumes != nil && len(volumes.Additional) > 0 {
+		missingContainers := util.AddAdditionalVolumesAndMounts(&deploy.Spec.Template.Spec, volumes.Additional)
 
 		if len(missingContainers) > 0 {
 			r.Recorder.Eventf(cluster, corev1.EventTypeWarning, "SpecifiedContainerNotFound",

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -382,7 +382,7 @@ func TestGeneratePGBouncerDeployment(t *testing.T) {
 			cluster := cluster.DeepCopy()
 			cluster.Spec.Proxy = spec
 
-			deploy, specified, err := reconciler.generatePGBouncerDeployment(ctx, cluster, nil, nil, nil)
+			deploy, specified, err := reconciler.generatePGBouncerDeployment(ctx, cluster, nil, nil, nil, "")
 			assert.NilError(t, err)
 			assert.Assert(t, !specified)
 
@@ -415,7 +415,7 @@ namespace: ns3
 		}
 
 		deploy, specified, err := reconciler.generatePGBouncerDeployment(
-			ctx, cluster, primary, configmap, secret)
+			ctx, cluster, primary, configmap, secret, "")
 		assert.NilError(t, err)
 		assert.Assert(t, specified)
 
@@ -456,7 +456,7 @@ namespace: ns3
 
 	t.Run("PodSpec", func(t *testing.T) {
 		deploy, specified, err := reconciler.generatePGBouncerDeployment(
-			ctx, cluster, primary, configmap, secret)
+			ctx, cluster, primary, configmap, secret, "")
 		assert.NilError(t, err)
 		assert.Assert(t, specified)
 
@@ -503,7 +503,7 @@ topologySpreadConstraints:
 			cluster.Spec.DisableDefaultPodScheduling = initialize.Bool(true)
 
 			deploy, specified, err := reconciler.generatePGBouncerDeployment(
-				ctx, cluster, primary, configmap, secret)
+				ctx, cluster, primary, configmap, secret, "")
 			assert.NilError(t, err)
 			assert.Assert(t, specified)
 
@@ -521,7 +521,7 @@ topologySpreadConstraints:
 		}
 
 		deploy, specified, err := reconciler.generatePGBouncerDeployment(
-			ctx, cluster, primary, configmap, secret)
+			ctx, cluster, primary, configmap, secret, "")
 
 		assert.NilError(t, err)
 		assert.Assert(t, specified)


### PR DESCRIPTION
pgBouncer allows users to set the log destination; when OTEL is enabled, we assume that destination is the default that we set. This PR patches that hole by setting OTEL to use the either the default or the user-set log destination.

This PR also handles creating the destination dir for the logfile.

This is a preliminary step on the way to validating the log config in v1.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [X] Other


**What is the current behavior (link to any open issues here)?**

Our pgBouncer OTEL settings assume a user hasn't set the logfile config, and won't work right if they do.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This updates OTEL with what the user sets.

**Other Information**:
Issues: [PGO-2565]