### PR TITLE
Clear volume auto-grow statuses when limit not set

### DIFF
--- a/internal/controller/postgrescluster/autogrow_test.go
+++ b/internal/controller/postgrescluster/autogrow_test.go
@@ -291,74 +291,69 @@ func TestLimitIsSet(t *testing.T) {
 		tcName       string
 		Voltype      string
 		instanceName string
-		expected     *bool
+		expected     bool
 	}{{
 		tcName:       "PGDATA Limit is set for defined volume",
 		Voltype:      "pgData",
 		instanceName: "red",
-		expected:     initialize.Pointer(true),
+		expected:     true,
 	}, {
 		tcName:       "PGDATA Limit is not set for defined volume",
 		Voltype:      "pgData",
 		instanceName: "blue",
-		expected:     initialize.Pointer(false),
+		expected:     false,
 	}, {
 		tcName:       "PGDATA Check volume for non-existent instance",
 		Voltype:      "pgData",
 		instanceName: "orange",
-		expected:     nil,
+		expected:     false,
 	}, {
 		tcName:       "PGWAL Limit is set for defined volume",
 		Voltype:      "pgWAL",
 		instanceName: "red",
-		expected:     initialize.Pointer(true),
+		expected:     true,
 	}, {
 		tcName:       "PGWAL WAL volume defined but limit is not set",
 		Voltype:      "pgWAL",
 		instanceName: "green",
-		expected:     initialize.Pointer(false),
+		expected:     false,
 	}, {
 		tcName:       "PGWAL Instance has no pg_wal volume defined",
 		Voltype:      "pgWAL",
 		instanceName: "blue",
-		expected:     nil,
+		expected:     false,
 	}, {
 		tcName:       "PGWAL Check volume for non-existent instance",
 		Voltype:      "pgWAL",
 		instanceName: "orange",
-		expected:     nil,
+		expected:     false,
 	}, {
 		tcName:       "REPO Limit set for defined volume",
 		Voltype:      "repo1",
 		instanceName: "",
-		expected:     initialize.Pointer(true),
+		expected:     true,
 	}, {
 		tcName:       "REPO Limit is not set for defined volume",
 		Voltype:      "repo2",
 		instanceName: "",
-		expected:     initialize.Pointer(false),
+		expected:     false,
 	}, {
 		tcName:       "REPO volume not defined for repo",
 		Voltype:      "repo3",
 		instanceName: "",
-		expected:     nil,
+		expected:     false,
 	}, {
 		tcName:       "REPO Check volume for non-existent repo",
 		Voltype:      "repo4",
 		instanceName: "",
-		expected:     nil,
+		expected:     false,
 	}}
 
 	for _, tc := range testCases {
 		t.Run(tc.tcName, func(t *testing.T) {
 
 			limitSet := limitIsSet(&cluster, tc.Voltype, tc.instanceName)
-			if tc.expected == nil {
-				assert.Assert(t, limitSet == nil)
-			} else {
-				assert.Assert(t, limitSet != nil)
-				assert.Check(t, *limitSet == *tc.expected)
-			}
+			assert.Check(t, limitSet == tc.expected)
 		})
 	}
 }

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -373,7 +373,8 @@ func (r *Reconciler) observeInstances(
 		// checked to ensure that the value from the annotations can be parsed to a valid
 		// value. Otherwise the previous value, if available, will be used. If a limit is
 		// not defined for the given volume and an empty string has been returned, nothing
-		// will be stored in the status.
+		// will be stored in the status. In the event that the value is empty, any existing
+		// request value will be removed.
 		if autogrow {
 			for _, instance := range observed.bySet[name] {
 				if pgDataRequest := r.storeDesiredRequest(
@@ -382,6 +383,8 @@ func (r *Reconciler) observeInstances(
 					previousPGDataDesiredRequests[instance.Name],
 				); pgDataRequest != "" {
 					status.DesiredPGDataVolume[instance.Name] = pgDataRequest
+				} else {
+					delete(status.DesiredPGDataVolume, instance.Name)
 				}
 
 				if pgWALRequest := r.storeDesiredRequest(
@@ -390,6 +393,8 @@ func (r *Reconciler) observeInstances(
 					previousPGWALDesiredRequests[instance.Name],
 				); pgWALRequest != "" {
 					status.DesiredPGWALVolume[instance.Name] = pgWALRequest
+				} else {
+					delete(status.DesiredPGWALVolume, instance.Name)
 				}
 			}
 		}


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
Clears any existing volume auto-grow statuses when the limit is not currently set.


**Other Information**:
Issue: PGO-2654