### PR TITLE
Add a Make target that runs crd-schema-checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ CONTROLLER ?= $(GO) tool sigs.k8s.io/controller-tools/cmd/controller-gen
 # Run tests using the latest tools.
 CHAINSAW ?= $(GO) run github.com/kyverno/chainsaw@latest
 CHAINSAW_TEST ?= $(CHAINSAW) test
+CRD_CHECKER ?= $(GO) run github.com/openshift/crd-schema-checker/cmd/crd-schema-checker@latest
 ENVTEST ?= $(GO) run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 KUTTL ?= $(GO) run github.com/kudobuilder/kuttl/cmd/kubectl-kuttl@latest
 KUTTL_TEST ?= $(KUTTL) test
@@ -147,6 +148,12 @@ check: ## Run basic go tests with coverage output
 check: get-pgmonitor
 	QUERIES_CONFIG_DIR="$(CURDIR)/${QUERIES_CONFIG_DIR}" $(GO_TEST) -cover ./...
 
+# Informational only; no criteria to enforce at this time.
+.PHONY: check-crd
+check-crd:
+	$(foreach CRD, $(wildcard config/crd/bases/*.yaml), \
+		$(CRD_CHECKER) check-manifests --new-crd-filename '$(CRD)' 2>&1 | awk -f hack/check-manifests.awk $(newline))
+
 # Available versions: curl -s 'https://storage.googleapis.com/kubebuilder-tools/' | grep -o '<Key>[^<]*</Key>'
 # - KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT=true
 .PHONY: check-envtest
@@ -253,3 +260,9 @@ generate-rbac: ## Generate RBAC
 		) rbac:roleName='postgres-operator' $(\
 		) paths='./cmd/...' paths='./internal/...' $(\
 		) output:dir='config/rbac' # {directory}/role.yaml
+
+# https://www.gnu.org/software/make/manual/make.html#Multi_002dLine
+define newline
+
+
+endef

--- a/hack/check-manifests.awk
+++ b/hack/check-manifests.awk
@@ -1,0 +1,26 @@
+# Copyright 2025 Crunchy Data Solutions, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+## TODO: Exit successfully only when there are no errors.
+#/^ERROR:/ { rc = 1 }
+#END { exit rc }
+
+# Shorten these frequent messages about validation rules.
+/The maximum allowable value is 10000000[.]/ {
+	sub(/ The maximum allowable value is 10000000./, "")
+	sub(/ allowed budget/, "&, 10M")
+}
+
+# These are informational, but "MustNot" sounds like something is wrong.
+/^info: "MustNotExceedCostBudget"/ {
+	sub(/"MustNotExceedCostBudget"/, "\"CostBudget\"")
+}
+
+# Color errors and warnings when attached to a terminal.
+ENVIRON["MAKE_TERMOUT"] != "" {
+	sub(/^ERROR:/, "\033[0;31m&\033[0m")
+	sub(/^Warning:/, "\033[1;33m&\033[0m")
+}
+
+{ print }


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

---

This tool helped me understand the cost of CEL validation rules as I was writing them. ~~The second and third commits are optional; I followed some of the recommendations emitted by the tool.~~ Edit: Removed these commits.

The output for PGUpgrades looks similar to:

```
go run github.com/openshift/crd-schema-checker/cmd/crd-schema-checker@latest check-manifests --disabled-validators 'NoBools,NoMaps' --new-crd-filename 'config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml' 2>&1 | awk -f hack/check-manifests.awk                                                                                                                          
ERROR: "ListsMustHaveSSATags": crd/pgupgrades.postgres-operator.crunchydata.com version/v1beta1 field/^.spec.imagePullSecrets must set x-kubernetes-list-type                                 
info: "CostBudget": ^.spec: Field has a maximum cardinality of 1.                                                                                                                             
info: "CostBudget": ^.spec: Rule 0 raw cost is 5. Estimated total cost of 5. Rule is 0.00% of allowed budget, 10M.                                                                            
info: "CostBudget": ^.spec: Field has a maximum cardinality of 1.                                                                                                                             
info: "CostBudget": ^.spec: Rule 1 raw cost is 19. Estimated total cost of 19. Rule is 0.00% of allowed budget, 10M.                                                                          
info: "CostBudget": ^.spec: Field has a maximum cardinality of 1.                                                                                                                             
info: "CostBudget": ^.spec: Rule 2 raw cost is 20. Estimated total cost of 20. Rule is 0.00% of allowed budget, 10M.
exit status 1
```
