### PR TITLE
Limit the number of allowed instances sets in v1

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -11683,6 +11683,7 @@ spec:
                   required:
                   - dataVolumeClaimSpec
                   type: object
+                maxItems: 16
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -18412,7 +18413,9 @@ spec:
             - fieldPath: .config.parameters.log_directory
               message: all instances need an additional volume to log in "/volumes"
               rule: self.?config.parameters.log_directory.optMap(v, type(v) != string
-                || !v.startsWith("/volumes") || self.instances.all(i, i.?volumes.additional.hasValue())).orValue(true)
+                || !v.startsWith("/volumes") || self.instances.all(i, i.?volumes.additional.hasValue()
+                && i.volumes.additional.exists(volume, v.startsWith("/volumes/" +
+                volume.name)))).orValue(true)
           status:
             description: PostgresClusterStatus defines the observed state of PostgresCluster
             properties:

--- a/internal/testing/validation/postgrescluster/postgres_config_test.go
+++ b/internal/testing/validation/postgrescluster/postgres_config_test.go
@@ -226,25 +226,31 @@ func TestPostgresConfigParametersV1(t *testing.T) {
 					message: `"/pgwal/logs/postgres"`,
 				},
 
-				// Directories inside /volumes are acceptable, but every instance set needs additional volumes.
-				//
-				// TODO(validation): This could be more precise and check the directory name of each additional
-				// volume, but Kubernetes 1.33 incorrectly estimates the cost of volume.name:
-				// https://github.com/kubernetes-sigs/controller-tools/pull/1270#issuecomment-3272211184
+				// Directories inside /volumes are acceptable, but every instance set needs the correct additional volume.
 				{
-					name:  "two instance sets and two additional volumes",
-					value: "/volumes/anything",
+					name:  "two instance sets and two correct additional volumes",
+					value: "/volumes/yep",
 					instances: `[
-						{ name: one, dataVolumeClaimSpec: ` + volume + `, volumes: { additional: [{ name: dir, claimName: a }] } },
-						{ name: two, dataVolumeClaimSpec: ` + volume + `, volumes: { additional: [{ name: dir, claimName: b }] } },
+						{ name: one, dataVolumeClaimSpec: ` + volume + `, volumes: { additional: [{ name: yep, claimName: a }] } },
+						{ name: two, dataVolumeClaimSpec: ` + volume + `, volumes: { additional: [{ name: yep, claimName: b }] } },
 					]`,
 					valid: true,
 				},
 				{
-					name:  "two instance sets and one additional volume",
-					value: "/volumes/anything",
+					name:  "two instance sets and one correct additional volume",
+					value: "/volumes/yep",
 					instances: `[
-						{ name: one, dataVolumeClaimSpec: ` + volume + `, volumes: { additional: [{ name: dir, claimName: a }] } },
+						{ name: one, dataVolumeClaimSpec: ` + volume + `, volumes: { additional: [{ name: yep, claimName: a }] } },
+						{ name: two, dataVolumeClaimSpec: ` + volume + `, volumes: { additional: [{ name: diff, claimName: b }] } },
+					]`,
+					valid:   false,
+					message: `all instances need an additional volume`,
+				},
+				{
+					name:  "two instance sets and one additional volume",
+					value: "/volumes/yep",
+					instances: `[
+						{ name: one, dataVolumeClaimSpec: ` + volume + `, volumes: { additional: [{ name: yep, claimName: a }] } },
 						{ name: two, dataVolumeClaimSpec: ` + volume + ` },
 					]`,
 					valid:   false,
@@ -252,7 +258,7 @@ func TestPostgresConfigParametersV1(t *testing.T) {
 				},
 				{
 					name:  "two instance sets and no additional volumes",
-					value: "/volumes/anything",
+					value: "/volumes/yep",
 					instances: `[
 						{ name: one, dataVolumeClaimSpec: ` + volume + ` },
 						{ name: two, dataVolumeClaimSpec: ` + volume + ` },


### PR DESCRIPTION
This allows CEL rules inside instance sets to fit within the cost budget. Without it, Kubernetes estimates that rules may execute over the maximum size of a request.

The cost of the affected rule changes from ~700k to ~9k.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other
