### PR TITLE
Automatically set an exact maxLength on enum fields in CRDs

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_crunchybridgeclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_crunchybridgeclusters.yaml
@@ -90,7 +90,7 @@ spec:
                 - aws
                 - azure
                 - gcp
-                maxLength: 10
+                maxLength: 5
                 type: string
                 x-kubernetes-validations:
                 - message: immutable
@@ -199,6 +199,7 @@ spec:
                       - "True"
                       - "False"
                       - Unknown
+                      maxLength: 7
                       type: string
                     type:
                       description: type of condition in CamelCase or in foo.example.com/CamelCase.

--- a/config/crd/bases/postgres-operator.crunchydata.com_pgadmins.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_pgadmins.yaml
@@ -1610,7 +1610,7 @@ spec:
                 - Always
                 - Never
                 - IfNotPresent
-                maxLength: 15
+                maxLength: 12
                 type: string
               imagePullSecrets:
                 description: |-
@@ -2579,7 +2579,7 @@ spec:
                       enum:
                       - Administrator
                       - User
-                      maxLength: 15
+                      maxLength: 13
                       type: string
                     username:
                       description: |-
@@ -2694,6 +2694,7 @@ spec:
                       - "True"
                       - "False"
                       - Unknown
+                      maxLength: 7
                       type: string
                     type:
                       description: type of condition in CamelCase or in foo.example.com/CamelCase.

--- a/config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml
@@ -971,7 +971,7 @@ spec:
                 - Always
                 - Never
                 - IfNotPresent
-                maxLength: 15
+                maxLength: 12
                 type: string
               imagePullSecrets:
                 description: |-
@@ -1133,7 +1133,7 @@ spec:
                 - Copy
                 - CopyFileRange
                 - Link
-                maxLength: 15
+                maxLength: 13
                 type: string
             required:
             - fromPostgresVersion
@@ -1195,6 +1195,7 @@ spec:
                       - "True"
                       - "False"
                       - Unknown
+                      maxLength: 7
                       type: string
                     type:
                       description: type of condition in CamelCase or in foo.example.com/CamelCase.

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -8074,7 +8074,7 @@ spec:
                 - Always
                 - Never
                 - IfNotPresent
-                maxLength: 15
+                maxLength: 12
                 type: string
               imagePullSecrets:
                 description: |-
@@ -12956,7 +12956,7 @@ spec:
                         - INFO
                         - DEBUG
                         - NOTSET
-                        maxLength: 10
+                        maxLength: 8
                         type: string
                       storageLimit:
                         description: |-
@@ -13001,7 +13001,7 @@ spec:
                         enum:
                         - Switchover
                         - Failover
-                        maxLength: 15
+                        maxLength: 10
                         type: string
                     required:
                     - enabled
@@ -15915,14 +15915,14 @@ spec:
                             enum:
                             - Cluster
                             - Local
-                            maxLength: 10
+                            maxLength: 7
                             type: string
                           internalTrafficPolicy:
                             description: 'More info: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-policies'
                             enum:
                             - Cluster
                             - Local
-                            maxLength: 10
+                            maxLength: 7
                             type: string
                           ipFamilies:
                             items:
@@ -15932,6 +15932,7 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
+                              maxLength: 4
                               type: string
                             type: array
                           ipFamilyPolicy:
@@ -15940,6 +15941,7 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
+                            maxLength: 16
                             type: string
                           metadata:
                             description: Metadata contains metadata for custom resources
@@ -15968,7 +15970,7 @@ spec:
                             - ClusterIP
                             - NodePort
                             - LoadBalancer
-                            maxLength: 15
+                            maxLength: 12
                             type: string
                         type: object
                       sidecars:
@@ -16322,14 +16324,14 @@ spec:
                     enum:
                     - Cluster
                     - Local
-                    maxLength: 10
+                    maxLength: 7
                     type: string
                   internalTrafficPolicy:
                     description: 'More info: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-policies'
                     enum:
                     - Cluster
                     - Local
-                    maxLength: 10
+                    maxLength: 7
                     type: string
                   ipFamilies:
                     items:
@@ -16339,6 +16341,7 @@ spec:
                       enum:
                       - IPv4
                       - IPv6
+                      maxLength: 4
                       type: string
                     type: array
                   ipFamilyPolicy:
@@ -16347,6 +16350,7 @@ spec:
                     - SingleStack
                     - PreferDualStack
                     - RequireDualStack
+                    maxLength: 16
                     type: string
                   metadata:
                     description: Metadata contains metadata for custom resources
@@ -16375,7 +16379,7 @@ spec:
                     - ClusterIP
                     - NodePort
                     - LoadBalancer
-                    maxLength: 15
+                    maxLength: 12
                     type: string
                 type: object
               service:
@@ -16387,14 +16391,14 @@ spec:
                     enum:
                     - Cluster
                     - Local
-                    maxLength: 10
+                    maxLength: 7
                     type: string
                   internalTrafficPolicy:
                     description: 'More info: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-policies'
                     enum:
                     - Cluster
                     - Local
-                    maxLength: 10
+                    maxLength: 7
                     type: string
                   ipFamilies:
                     items:
@@ -16404,6 +16408,7 @@ spec:
                       enum:
                       - IPv4
                       - IPv6
+                      maxLength: 4
                       type: string
                     type: array
                   ipFamilyPolicy:
@@ -16412,6 +16417,7 @@ spec:
                     - SingleStack
                     - PreferDualStack
                     - RequireDualStack
+                    maxLength: 16
                     type: string
                   metadata:
                     description: Metadata contains metadata for custom resources
@@ -16440,7 +16446,7 @@ spec:
                     - ClusterIP
                     - NodePort
                     - LoadBalancer
-                    maxLength: 15
+                    maxLength: 12
                     type: string
                 type: object
               shutdown:
@@ -18086,14 +18092,14 @@ spec:
                             enum:
                             - Cluster
                             - Local
-                            maxLength: 10
+                            maxLength: 7
                             type: string
                           internalTrafficPolicy:
                             description: 'More info: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-policies'
                             enum:
                             - Cluster
                             - Local
-                            maxLength: 10
+                            maxLength: 7
                             type: string
                           ipFamilies:
                             items:
@@ -18103,6 +18109,7 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
+                              maxLength: 4
                               type: string
                             type: array
                           ipFamilyPolicy:
@@ -18111,6 +18118,7 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
+                            maxLength: 16
                             type: string
                           metadata:
                             description: Metadata contains metadata for custom resources
@@ -18139,7 +18147,7 @@ spec:
                             - ClusterIP
                             - NodePort
                             - LoadBalancer
-                            maxLength: 15
+                            maxLength: 12
                             type: string
                         type: object
                       tolerations:
@@ -18422,7 +18430,7 @@ spec:
                           enum:
                           - ASCII
                           - AlphaNumeric
-                          maxLength: 15
+                          maxLength: 12
                           type: string
                       required:
                       - type
@@ -18511,6 +18519,7 @@ spec:
                       - "True"
                       - "False"
                       - Unknown
+                      maxLength: 7
                       type: string
                     type:
                       description: type of condition in CamelCase or in foo.example.com/CamelCase.
@@ -26898,7 +26907,7 @@ spec:
                 - Always
                 - Never
                 - IfNotPresent
-                maxLength: 15
+                maxLength: 12
                 type: string
               imagePullSecrets:
                 description: |-
@@ -31779,7 +31788,7 @@ spec:
                         - INFO
                         - DEBUG
                         - NOTSET
-                        maxLength: 10
+                        maxLength: 8
                         type: string
                       storageLimit:
                         description: |-
@@ -31824,7 +31833,7 @@ spec:
                         enum:
                         - Switchover
                         - Failover
-                        maxLength: 15
+                        maxLength: 10
                         type: string
                     required:
                     - enabled
@@ -34738,14 +34747,14 @@ spec:
                             enum:
                             - Cluster
                             - Local
-                            maxLength: 10
+                            maxLength: 7
                             type: string
                           internalTrafficPolicy:
                             description: 'More info: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-policies'
                             enum:
                             - Cluster
                             - Local
-                            maxLength: 10
+                            maxLength: 7
                             type: string
                           ipFamilies:
                             items:
@@ -34755,6 +34764,7 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
+                              maxLength: 4
                               type: string
                             type: array
                           ipFamilyPolicy:
@@ -34763,6 +34773,7 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
+                            maxLength: 16
                             type: string
                           metadata:
                             description: Metadata contains metadata for custom resources
@@ -34791,7 +34802,7 @@ spec:
                             - ClusterIP
                             - NodePort
                             - LoadBalancer
-                            maxLength: 15
+                            maxLength: 12
                             type: string
                         type: object
                       sidecars:
@@ -35139,14 +35150,14 @@ spec:
                     enum:
                     - Cluster
                     - Local
-                    maxLength: 10
+                    maxLength: 7
                     type: string
                   internalTrafficPolicy:
                     description: 'More info: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-policies'
                     enum:
                     - Cluster
                     - Local
-                    maxLength: 10
+                    maxLength: 7
                     type: string
                   ipFamilies:
                     items:
@@ -35156,6 +35167,7 @@ spec:
                       enum:
                       - IPv4
                       - IPv6
+                      maxLength: 4
                       type: string
                     type: array
                   ipFamilyPolicy:
@@ -35164,6 +35176,7 @@ spec:
                     - SingleStack
                     - PreferDualStack
                     - RequireDualStack
+                    maxLength: 16
                     type: string
                   metadata:
                     description: Metadata contains metadata for custom resources
@@ -35192,7 +35205,7 @@ spec:
                     - ClusterIP
                     - NodePort
                     - LoadBalancer
-                    maxLength: 15
+                    maxLength: 12
                     type: string
                 type: object
               service:
@@ -35204,14 +35217,14 @@ spec:
                     enum:
                     - Cluster
                     - Local
-                    maxLength: 10
+                    maxLength: 7
                     type: string
                   internalTrafficPolicy:
                     description: 'More info: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-policies'
                     enum:
                     - Cluster
                     - Local
-                    maxLength: 10
+                    maxLength: 7
                     type: string
                   ipFamilies:
                     items:
@@ -35221,6 +35234,7 @@ spec:
                       enum:
                       - IPv4
                       - IPv6
+                      maxLength: 4
                       type: string
                     type: array
                   ipFamilyPolicy:
@@ -35229,6 +35243,7 @@ spec:
                     - SingleStack
                     - PreferDualStack
                     - RequireDualStack
+                    maxLength: 16
                     type: string
                   metadata:
                     description: Metadata contains metadata for custom resources
@@ -35257,7 +35272,7 @@ spec:
                     - ClusterIP
                     - NodePort
                     - LoadBalancer
-                    maxLength: 15
+                    maxLength: 12
                     type: string
                 type: object
               shutdown:
@@ -36903,14 +36918,14 @@ spec:
                             enum:
                             - Cluster
                             - Local
-                            maxLength: 10
+                            maxLength: 7
                             type: string
                           internalTrafficPolicy:
                             description: 'More info: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-policies'
                             enum:
                             - Cluster
                             - Local
-                            maxLength: 10
+                            maxLength: 7
                             type: string
                           ipFamilies:
                             items:
@@ -36920,6 +36935,7 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
+                              maxLength: 4
                               type: string
                             type: array
                           ipFamilyPolicy:
@@ -36928,6 +36944,7 @@ spec:
                             - SingleStack
                             - PreferDualStack
                             - RequireDualStack
+                            maxLength: 16
                             type: string
                           metadata:
                             description: Metadata contains metadata for custom resources
@@ -36956,7 +36973,7 @@ spec:
                             - ClusterIP
                             - NodePort
                             - LoadBalancer
-                            maxLength: 15
+                            maxLength: 12
                             type: string
                         type: object
                       tolerations:
@@ -37236,7 +37253,7 @@ spec:
                           enum:
                           - ASCII
                           - AlphaNumeric
-                          maxLength: 15
+                          maxLength: 12
                           type: string
                       required:
                       - type
@@ -37302,6 +37319,7 @@ spec:
                       - "True"
                       - "False"
                       - Unknown
+                      maxLength: 7
                       type: string
                     type:
                       description: type of condition in CamelCase or in foo.example.com/CamelCase.

--- a/pkg/apis/postgres-operator.crunchydata.com/v1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1/postgrescluster_types.go
@@ -94,11 +94,6 @@ type PostgresClusterSpec struct {
 	// pull (download) container images.
 	// More info: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 	// ---
-	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=15
-	// +kubebuilder:validation:Type=string
-	//
 	// +kubebuilder:validation:Enum={Always,Never,IfNotPresent}
 	// +optional
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/crunchy_bridgecluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/crunchy_bridgecluster_types.go
@@ -52,10 +52,6 @@ type CrunchyBridgeClusterSpec struct {
 	// The cloud provider where the cluster is located.
 	// Currently Bridge offers aws, azure, and gcp only
 	// ---
-	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=10
-	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum={aws,azure,gcp}
 	// +kubebuilder:validation:XValidation:rule=`self == oldSelf`,message="immutable"

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/patroni_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/patroni_types.go
@@ -68,10 +68,6 @@ type PatroniLogConfig struct {
 	// The Patroni log level.
 	// More info: https://docs.python.org/3/library/logging.html#levels
 	// ---
-	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=10
-	//
 	// +default="INFO"
 	// +kubebuilder:validation:Enum={CRITICAL,ERROR,WARNING,INFO,DEBUG,NOTSET}
 	// +optional
@@ -96,10 +92,6 @@ type PatroniSwitchover struct {
 	// factors. A TargetInstance must be specified to failover.
 	// NOTE: The Failover type is reserved as the "last resort" case.
 	// ---
-	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=15
-	//
 	// +kubebuilder:validation:Enum={Switchover,Failover}
 	// +kubebuilder:default:=Switchover
 	// +optional

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgupgrade_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgupgrade_types.go
@@ -29,11 +29,6 @@ type PGUpgradeSpec struct {
 	// pull (download) container images.
 	// More info: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 	// ---
-	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=15
-	// +kubebuilder:validation:Type=string
-	//
 	// +kubebuilder:validation:Enum={Always,Never,IfNotPresent}
 	// +optional
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
@@ -109,10 +104,6 @@ type PGUpgradeSettings struct {
 	// - Copy and Link forever:  https://git.postgresql.org/gitweb/?p=postgresql.git;f=src/bin/pg_upgrade/pg_upgrade.h;hb=REL_10_0#l232
 	// - Clone since 12:         https://git.postgresql.org/gitweb/?p=postgresql.git;f=src/bin/pg_upgrade/pg_upgrade.h;hb=REL_12_0#l232
 	// - CopyFileRange since 17: https://git.postgresql.org/gitweb/?p=postgresql.git;f=src/bin/pg_upgrade/pg_upgrade.h;hb=REL_17_0#l251
-	//
-	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=15
 	//
 	// +kubebuilder:validation:Enum={Clone,Copy,CopyFileRange,Link}
 	// +optional

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgres_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgres_types.go
@@ -175,10 +175,6 @@ type PostgresPasswordSpec struct {
 	// "ASCII" passwords contain letters, numbers, and symbols from the US-ASCII character set.
 	// "AlphaNumeric" passwords contain letters and numbers from the US-ASCII character set.
 	// ---
-	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=15
-	//
 	// +kubebuilder:default=ASCII
 	// +kubebuilder:validation:Enum={ASCII,AlphaNumeric}
 	// +required

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/postgrescluster_types.go
@@ -81,11 +81,6 @@ type PostgresClusterSpec struct {
 	// pull (download) container images.
 	// More info: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 	// ---
-	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=15
-	// +kubebuilder:validation:Type=string
-	//
 	// +kubebuilder:validation:Enum={Always,Never,IfNotPresent}
 	// +optional
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/shared_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/shared_types.go
@@ -244,10 +244,6 @@ type ServiceSpec struct {
 
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 	// ---
-	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=15
-	//
 	// +optional
 	// +kubebuilder:default=ClusterIP
 	// +kubebuilder:validation:Enum={ClusterIP,NodePort,LoadBalancer}
@@ -265,11 +261,6 @@ type ServiceSpec struct {
 
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-policies
 	// ---
-	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=10
-	// +kubebuilder:validation:Type=string
-	//
 	// +optional
 	// +kubebuilder:validation:Enum={Cluster,Local}
 	InternalTrafficPolicy *corev1.ServiceInternalTrafficPolicy `json:"internalTrafficPolicy,omitempty"`
@@ -277,10 +268,6 @@ type ServiceSpec struct {
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-policies
 	// ---
 	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=10
-	// +kubebuilder:validation:Type=string
-	//
 	// +optional
 	// +kubebuilder:validation:Enum={Cluster,Local}
 	ExternalTrafficPolicy *corev1.ServiceExternalTrafficPolicy `json:"externalTrafficPolicy,omitempty"`

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/standalone_pgadmin_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/standalone_pgadmin_types.go
@@ -105,11 +105,6 @@ type PGAdminSpec struct {
 	// pull (download) container images.
 	// More info: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 	// ---
-	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=15
-	// +kubebuilder:validation:Type=string
-	//
 	// +kubebuilder:validation:Enum={Always,Never,IfNotPresent}
 	// +optional
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
@@ -207,10 +202,6 @@ type PGAdminUser struct {
 	// Role determines whether the user has admin privileges or not.
 	// Defaults to User. Valid options are Administrator and User.
 	// ---
-	// Kubernetes assumes the evaluation cost of an enum value is very large.
-	// TODO(k8s-1.29): Drop MaxLength after Kubernetes 1.29; https://issue.k8s.io/119511
-	// +kubebuilder:validation:MaxLength=15
-	//
 	// +kubebuilder:validation:Enum={Administrator,User}
 	// +optional
 	Role string `json:"role,omitempty"`


### PR DESCRIPTION
This automates what a CRD author would do anytime they add or change an enum field. See:
- https://github.com/CrunchyData/postgres-operator/pull/4048

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other
