### PR TITLE
Change Reconciler implementations to ObjectReconciler

### DIFF
--- a/internal/controller/postgrescluster/cluster_test.go
+++ b/internal/controller/postgrescluster/cluster_test.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crunchydata/postgres-operator/internal/controller/runtime"
 	"github.com/crunchydata/postgres-operator/internal/feature"
@@ -100,9 +99,7 @@ func TestCustomLabels(t *testing.T) {
 		})
 
 		// Reconcile the cluster
-		result, err := reconciler.Reconcile(ctx, reconcile.Request{
-			NamespacedName: client.ObjectKeyFromObject(cluster),
-		})
+		result, err := reconciler.Reconcile(ctx, cluster)
 		assert.NilError(t, err)
 		assert.Assert(t, result.Requeue == false)
 	}
@@ -339,9 +336,7 @@ func TestCustomAnnotations(t *testing.T) {
 		})
 
 		// Reconcile the cluster
-		result, err := reconciler.Reconcile(ctx, reconcile.Request{
-			NamespacedName: client.ObjectKeyFromObject(cluster),
-		})
+		result, err := reconciler.Reconcile(ctx, cluster)
 		assert.NilError(t, err)
 		assert.Assert(t, result.Requeue == false)
 	}

--- a/internal/controller/postgrescluster/controller_test.go
+++ b/internal/controller/postgrescluster/controller_test.go
@@ -166,9 +166,7 @@ var _ = Describe("PostgresCluster Reconciler", func() {
 	reconcile := func(cluster *v1beta1.PostgresCluster) reconcile.Result {
 		ctx := context.Background()
 
-		result, err := test.Reconciler.Reconcile(ctx,
-			reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cluster)},
-		)
+		result, err := test.Reconciler.Reconcile(ctx, cluster)
 		Expect(err).ToNot(HaveOccurred(), func() string {
 			var t interface{ StackTrace() errors.StackTrace }
 			if errors.As(err, &t) {

--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/crunchydata/postgres-operator/internal/collector"
 	"github.com/crunchydata/postgres-operator/internal/controller/runtime"
@@ -1233,9 +1232,7 @@ func TestDeleteInstance(t *testing.T) {
 
 	// Reconcile the entire cluster so that we don't have to create all the
 	// resources needed to reconcile a single instance (cm,secrets,svc, etc.)
-	result, err := reconciler.Reconcile(ctx, reconcile.Request{
-		NamespacedName: client.ObjectKeyFromObject(cluster),
-	})
+	result, err := reconciler.Reconcile(ctx, cluster)
 	assert.NilError(t, err)
 	assert.Assert(t, result.Requeue == false)
 


### PR DESCRIPTION
Each implementation was doing the first fetch of its main object a bit differently. The controller-runtime module can do this since v0.17.0 and Go generics.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Other
