### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ deploy-dev: createnamespaces
 
 .PHONY: build
 build: ## Build a postgres-operator image
+build: get-pgmonitor
 	$(BUILDAH) build --tag localhost/postgres-operator \
 		--label org.opencontainers.image.authors='Crunchy Data' \
 		--label org.opencontainers.image.description='Crunchy PostgreSQL Operator' \


### PR DESCRIPTION
Our Dockerfile expects to find the pgmonitor queries so we should run get-pgmonitor as part of the build target
