### PR TITLE
Allow quotes in license extraction

### DIFF
--- a/hack/extract-licenses.go
+++ b/hack/extract-licenses.go
@@ -208,10 +208,12 @@ func identifyModules(ctx context.Context, executables ...string) []string {
 		os.Exit(cmd.ProcessState.ExitCode())
 	}
 
-	// Parse the tab-separated table without checking row lengths.
+	// Parse the tab-separated table without checking row lengths
+	// and without enforcing strict quote mark rules.
 	reader := csv.NewReader(&stdout)
 	reader.Comma = '\t'
 	reader.FieldsPerRecord = -1
+	reader.LazyQuotes = true
 
 	lines, _ := reader.ReadAll()
 	result := make([]string, 0, len(lines))


### PR DESCRIPTION
**What is the current behavior (link to any open issues here)?**

Some non-Crunchy Go binaries may have quotes in the build data, e.g., `ldflag` settings, which interfere with getting the licenses from the binary.

**What is the new behavior (if this is a feature change)?**

Setting `LazyQuotes` means we won't error on those quotes, but continue with parsing the dep and build fields.
