### PR TITLE
Prepare image file permissions in the build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,15 @@ COPY hack/tools/queries /opt/crunchy/conf
 
 WORKDIR /usr/src/app
 COPY . .
-ENV GOCACHE=/var/cache/go
 
-# Build the operator and assemble the licenses
-RUN --mount=type=cache,target=/var/cache/go go build ./cmd/postgres-operator
-RUN go run ./hack/extract-licenses.go licenses postgres-operator 
+ENV GOCACHE=/var/cache/go
+ENV GOMODCACHE=/var/cache/gomod
+RUN --mount=type=cache,target=/var/cache \
+<<-SHELL
+set -e
+go build ./cmd/postgres-operator
+go run ./hack/extract-licenses.go licenses postgres-operator
+SHELL
 
 FROM docker.io/library/debian:bookworm
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix

**What is the current behavior (link to any open issues here)?**

Some files and directories were not readable by the image user. Doing `ls` would fail:

```
$ podman run --rm --entrypoint=bash localhost/postgres-operator -c 'shopt -s globstar && ls -ldh /licenses/** /opt/crunchy/**'

ls: cannot access '/licenses/cel.dev/expr@v0.24.0': Permission denied
ls: cannot access '/licenses/github.com/antlr4-go': Permission denied
…
ls: cannot access '/opt/crunchy/conf/pg11/queries_general.yml': Permission denied
ls: cannot access '/opt/crunchy/conf/pg11/queries_pg_stat_statements.yml': Permission denied
…
drwxr-xr-x. 13 root root 4.0K Oct  2 23:00 /licenses/
-r--r--r--.  1 root root  11K Sep 30 18:54 /licenses/LICENSE.txt
dr--r--r--.  3 root root   26 Oct  2 23:00 /licenses/cel.dev
dr--r--r--. 37 root root 4.0K Oct  2 23:00 /licenses/github.com
dr--r--r--.  7 root root   78 Oct  2 23:00 /licenses/go.opentelemetry.io
dr--r--r--.  3 root root   30 Oct  2 23:00 /licenses/go.uber.org
dr--r--r--.  3 root root   18 Oct  2 23:00 /licenses/go.yaml.in
dr--r--r--.  3 root root   15 Oct  2 23:00 /licenses/golang.org
dr--r--r--.  3 root root   23 Oct  2 23:00 /licenses/gomodules.xyz
dr--r--r--.  5 root root   66 Oct  2 23:00 /licenses/google.golang.org
dr--r--r--.  5 root root   64 Oct  2 23:00 /licenses/gopkg.in
dr--r--r--. 11 root root 4.0K Oct  2 23:00 /licenses/k8s.io
dr--r--r--.  8 root root  189 Oct  2 23:00 /licenses/sigs.k8s.io
drwxr-xr-x.  3 root root   18 Oct  2 23:00 /opt/crunchy/
drwxr-xr-x.  9 root root 4.0K Oct  2 23:00 /opt/crunchy/conf
dr--r--r--.  2 root root   88 Jul 28 16:14 /opt/crunchy/conf/pg11
dr--r--r--.  2 root root  137 Jul 28 16:14 /opt/crunchy/conf/pg12
dr--r--r--.  2 root root  137 Jul 28 16:14 /opt/crunchy/conf/pg13
dr--r--r--.  2 root root  137 Jul 28 16:14 /opt/crunchy/conf/pg14
dr--r--r--.  2 root root  137 Jul 28 16:14 /opt/crunchy/conf/pg15
dr--r--r--.  2 root root  137 Jul 28 16:14 /opt/crunchy/conf/pg16
dr--r--r--.  2 root root  137 Jul 28 16:14 /opt/crunchy/conf/pg17
-r--r--r--.  1 root root 8.7K Oct  2 23:00 /opt/crunchy/conf/queries_backrest.yml
-r--r--r--.  1 root root  950 Oct  2 23:00 /opt/crunchy/conf/queries_bloat.yml
-r--r--r--.  1 root root  15K Oct  2 23:00 /opt/crunchy/conf/queries_global.yml
-r--r--r--.  1 root root  495 Oct  2 23:00 /opt/crunchy/conf/queries_global_dbsize.yml
-r--r--r--.  1 root root  433 Oct  2 23:00 /opt/crunchy/conf/queries_global_matview.yml
-r--r--r--.  1 root root 7.6K Oct  2 23:00 /opt/crunchy/conf/queries_nodemx.yml
-r--r--r--.  1 root root 2.9K Oct  2 23:00 /opt/crunchy/conf/queries_per_db.yml
-r--r--r--.  1 root root 2.8K Oct  2 23:00 /opt/crunchy/conf/queries_per_db_matview.yml
-r--r--r--.  1 root root 4.6K Oct  2 23:00 /opt/crunchy/conf/queries_pgbouncer.yml
-r--r--r--.  1 root root 5.2K Oct  2 23:00 /opt/crunchy/conf/setup_metric_views.sql
```

**What is the new behavior (if this is a feature change)?**

No errors from `ls`. The same command above returns:

```
drwxr-xr-x. 13 root root 4.0K Oct  2 23:22 /licenses/
-r--r--r--.  1 root root  11K Sep 30 18:54 /licenses/LICENSE.txt
dr-xr-xr-x.  3 root root   26 Oct  2 23:22 /licenses/cel.dev
dr-xr-xr-x.  2 root root   21 Oct  2 23:22 /licenses/cel.dev/expr@v0.24.0
-r--r--r--.  1 root root  12K Oct  2 23:22 /licenses/cel.dev/expr@v0.24.0/LICENSE
…
drwxr-xr-x.  3 root root   18 Oct  2 23:22 /opt/crunchy/
drwxr-xr-x.  9 root root 4.0K Oct  2 23:22 /opt/crunchy/conf
dr-xr-xr-x.  2 root root   88 Jul 28 16:14 /opt/crunchy/conf/pg11
-r--r--r--.  1 root root 2.2K Oct  2 23:22 /opt/crunchy/conf/pg11/queries_general.yml
-r--r--r--.  1 root root 4.3K Oct  2 23:22 /opt/crunchy/conf/pg11/queries_pg_stat_statements.yml
-r--r--r--.  1 root root  15K Oct  2 23:22 /opt/crunchy/conf/pg11/setup.sql
dr-xr-xr-x.  2 root root  137 Jul 28 16:14 /opt/crunchy/conf/pg12
-r--r--r--.  1 root root 2.8K Oct  2 23:22 /opt/crunchy/conf/pg12/queries_general.yml
-r--r--r--.  1 root root 4.3K Oct  2 23:22 /opt/crunchy/conf/pg12/queries_pg_stat_statements.yml
-r--r--r--.  1 root root  431 Oct  2 23:22 /opt/crunchy/conf/pg12/queries_pg_stat_statements_reset_info.yml
-r--r--r--.  1 root root  16K Oct  2 23:22 /opt/crunchy/conf/pg12/setup.sql
…
```