### PR TITLE
Ensure root CA certificate secret inherits cluster metadata

### DIFF
--- a/internal/controller/postgrescluster/helpers_test.go
+++ b/internal/controller/postgrescluster/helpers_test.go
@@ -117,7 +117,11 @@ func testCluster() *v1beta1.PostgresCluster {
 		},
 		Spec: v1beta1.PostgresClusterSpec{
 			PostgresVersion: 13,
-			Image:           CrunchyPostgresHAImage,
+			Metadata: &v1beta1.Metadata{
+				Labels:      map[string]string{"env-label": "test-label-value"},
+				Annotations: map[string]string{"env-annotation": "test-annotation-value"},
+			},
+			Image: CrunchyPostgresHAImage,
 			ImagePullSecrets: []corev1.LocalObjectReference{{
 				Name: "myImagePullSecret"},
 			},

--- a/internal/controller/postgrescluster/pki.go
+++ b/internal/controller/postgrescluster/pki.go
@@ -64,6 +64,8 @@ func (r *Reconciler) reconcileRootCertificate(
 	intent.Namespace, intent.Name = cluster.Namespace, naming.RootCertSecret
 	intent.Data = make(map[string][]byte)
 	intent.OwnerReferences = existing.OwnerReferences
+	intent.Annotations = naming.Merge(cluster.Spec.Metadata.GetAnnotationsOrNil())
+	intent.Labels = naming.Merge(cluster.Spec.Metadata.GetLabelsOrNil())
 
 	// A root secret is scoped to the namespace where postgrescluster(s)
 	// are deployed. For operator deployments with postgresclusters in more than

--- a/internal/controller/postgrescluster/pki_test.go
+++ b/internal/controller/postgrescluster/pki_test.go
@@ -137,6 +137,26 @@ func TestReconcileCerts(t *testing.T) {
 			assert.DeepEqual(t, *fromSecret, initialRoot.Certificate)
 		})
 
+		t.Run("check root CA secret labels", func(t *testing.T) {
+			err := tClient.Get(ctx, client.ObjectKeyFromObject(rootSecret), rootSecret)
+			assert.NilError(t, err)
+
+			assert.Check(t, len(rootSecret.Labels) == 1, "root CA secret labels not set")
+
+			expectedLabel := map[string]string{"env-label": "test-label-value"}
+			assert.DeepEqual(t, rootSecret.Labels, expectedLabel)
+		})
+
+		t.Run("check root CA secret annotations", func(t *testing.T) {
+			err := tClient.Get(ctx, client.ObjectKeyFromObject(rootSecret), rootSecret)
+			assert.NilError(t, err)
+
+			assert.Check(t, len(rootSecret.Annotations) == 1, "root CA secret annotations not set")
+
+			expectedAnnotation := map[string]string{"env-annotation": "test-annotation-value"}
+			assert.DeepEqual(t, rootSecret.Annotations, expectedAnnotation)
+		})
+
 		t.Run("root certificate changes", func(t *testing.T) {
 			// force the generation of a new root cert
 			// create an empty secret and apply the change


### PR DESCRIPTION
Add support for propagating PostgresCluster metadata (labels and annotations) to the root CA certificate secret. This allows users to apply custom labels and annotations defined in the cluster spec to the shared root certificate secret.

Changes:
- Updated reconcileRootCertificate to merge cluster metadata into the root certificate secret's labels and annotations
- Updated testCluster helper to include metadata for testing purposes
- Added tests to verify labels and annotations are properly set on the root CA secret

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

#4324


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Ensures that the cluster spec.metadata fields are applied to the PGO

**Other Information**:
