### PR TITLE
Adjust pgAdmin version comparision logic

### DIFF
--- a/internal/controller/standalone_pgadmin/users.go
+++ b/internal/controller/standalone_pgadmin/users.go
@@ -179,11 +179,19 @@ cd $PGADMIN_DIR
 	}
 
 	var olderThan9_3 bool
-	versionFloat, err := strconv.ParseFloat(pgadmin.Status.MinorVersion, 64)
-	if err != nil {
-		return err
+
+	// Validate the pgAdmin minor version is in the format "X.Y"
+	parts := strings.Split(pgadmin.Status.MinorVersion, ".")
+	if len(parts) != 2 {
+		return errors.New("invalid pgAdmin minor version: " + pgadmin.Status.MinorVersion)
 	}
-	if versionFloat < 9.3 {
+
+	// Parse the major and minor versions
+	major, _ := strconv.Atoi(parts[0])
+	minor, _ := strconv.Atoi(parts[1])
+
+	// Check if the pgAdmin version is older than 9.3
+	if major < 9 || (major == 9 && minor < 3) {
 		olderThan9_3 = true
 	}
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
Now that the current version of pgAdmin is greater than 9.9, the version comparison logic has to be updated to properly compare the values (i.e. we can no longer use a simple x < y to compare floats).


**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This update makes the necessary adjustments so our code works as expected for newer versions of pgAdmin.


**Other Information**:
Issue: PGO-2838