### PR TITLE
Fix missing error handling in WriteUsersInPostgreSQL

### DIFF
--- a/internal/postgres/users.go
+++ b/internal/postgres/users.go
@@ -169,7 +169,7 @@ SELECT pg_catalog.format('GRANT ALL PRIVILEGES ON DATABASE %I TO %I',
 	// The operator will attempt to write schemas for the users in the spec if
 	// 	* the feature gate is enabled and
 	// 	* the cluster is annotated.
-	if feature.Enabled(ctx, feature.AutoCreateUserSchema) {
+	if feature.Enabled(ctx, feature.AutoCreateUserSchema) && err == nil {
 		autoCreateUserSchemaAnnotationValue, annotationExists := cluster.Annotations[naming.AutoCreateUserSchemaAnnotation]
 		if annotationExists && strings.EqualFold(autoCreateUserSchemaAnnotationValue, "true") {
 			log.V(1).Info("Writing schemas for users.")


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other

**Other Information**:
It seems that the error returned by stdout, stderr, err := exec.Exec(...) could be overwritten by err = WriteUsersSchemasInPostgreSQL(ctx, exec, users), so this patch addresses that issue.