### PR TITLE
OTel kuttl test fix: add bad psql command to force an error and ensur…

### DIFF
--- a/testing/kuttl/e2e/otel-logging-and-metrics/22-assert-instance.yaml
+++ b/testing/kuttl/e2e/otel-logging-and-metrics/22-assert-instance.yaml
@@ -4,6 +4,8 @@ commands:
 # First, check that all containers in the instance pod are ready.
 # Then, grab the collector metrics output and check that a postgres 
 # metric is present, as well as a patroni metric.
+# Then use psql to run a bad command in the database to get an error
+# and ensure that there is a postgres log to capture.
 # Then, check the collector logs for patroni, and postgres logs.
 # Finally, ensure the monitoring user exists and is configured.
 - script: |
@@ -34,6 +36,8 @@ commands:
       retry "patroni metric not found"
       exit 1
     }
+
+    kubectl exec "${pod}" -n "${NAMESPACE}" -- psql -c "SHOW DOES_NOT_EXIST;" 2>/dev/null || true
 
     logs=$(kubectl logs "${pod}" --namespace "${NAMESPACE}" -c collector | grep InstrumentationScope)
     { contains "${logs}" 'InstrumentationScope patroni'; } || {


### PR DESCRIPTION
…e there will be a postgres log to capture.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

OTel kuttl test is failing because when backups are disabled, postgres has no logs to capture.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

For the part of the test where backups are disabled, we use psql to run a bad command on the database, ensuring there is a log for OTel to capture.

**Other Information**:
