### PR TITLE
Backpatch: Pin go version to 1.25 for kuttl github action tests (until kuttl sup…

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
-        with: { go-version: stable }
+        with: { go-version: '1.25.x' } # TODO: revert to stable when kuttl supports Go 1.26 (missing testDeps.ModulePath)
 
       - name: Start k3s
         uses: ./.github/actions/k3d


### PR DESCRIPTION
…ports go 1.26).