### PR TITLE
fix: propagate pgbackrest info failures

### DIFF
--- a/components/image-postgres/bin/pgbackrest-info.sh
+++ b/components/image-postgres/bin/pgbackrest-info.sh
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+set -e
+
 printf '|'
 pgbackrest info --output=json --log-level-console=info --log-level-stderr=warn
 echo

--- a/components/image-postgres/bin/pgbackrest-info_test.go
+++ b/components/image-postgres/bin/pgbackrest-info_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Crunchy Data Solutions, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bin_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestPgBackRestInfoScript(t *testing.T) {
+	const script = "pgbackrest-info.sh"
+
+	t.Run("Failure", func(t *testing.T) {
+		dir := t.TempDir()
+		pgbackrest := filepath.Join(dir, "pgbackrest")
+		assert.NilError(t, os.WriteFile(pgbackrest, []byte("#!/bin/sh\nexit 42\n"), 0o600))
+		assert.NilError(t, os.Chmod(pgbackrest, 0o700))
+
+		cmd := exec.CommandContext(t.Context(), "bash", script)
+		cmd.Env = append(os.Environ(), "PATH="+dir)
+
+		output, err := cmd.CombinedOutput()
+		assert.ErrorContains(t, err, "exit status 42")
+		assert.Equal(t, string(output), "|")
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		dir := t.TempDir()
+		pgbackrest := filepath.Join(dir, "pgbackrest")
+		assert.NilError(t, os.WriteFile(pgbackrest, []byte("#!/bin/sh\nprintf '[{}]'\n"), 0o600))
+		assert.NilError(t, os.Chmod(pgbackrest, 0o700))
+
+		cmd := exec.CommandContext(t.Context(), "bash", script)
+		cmd.Env = append(os.Environ(), "PATH="+dir)
+
+		output, err := cmd.CombinedOutput()
+		assert.NilError(t, err)
+		assert.Equal(t, string(output), "|[{}]\n")
+	})
+}


### PR DESCRIPTION
Small fix for `pgbackrest_info.sh`.

Right now the script prints `|`, runs `pgbackrest info`, then always reaches `echo`. So if `pgbackrest` exits non-zero, the helper can still look green. sneaky little footgun.

Repro:

```sh
printf '#!/bin/sh\nexit 42\n' > /tmp/pgbackrest
chmod +x /tmp/pgbackrest
PATH=/tmp /bin/bash components/image-postgres/bin/pgbackrest-info.sh
```

Before: exits `0`.
After: exits `42`.

This is reachable in real clusters: `pgbackrest info` can fail from config/stanza issues, repo storage or network errors, missing binaries in a bad image, or an OOM/signal. No cloud quota edge-case needed here.

Tested:

```sh
go test ./components/... -count=1
```

Related: #3293
