### PR TITLE
ci: revert e2e Go pin to stable now that chainsaw/kuttl support Go 1.26

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
-        with: { go-version: '1.25.x' } # TODO: revert to stable when chainsaw supports Go 1.26 (missing testDeps.ModulePath)
+        with: { go-version: stable }
 
       - name: Start k3s
         uses: ./.github/actions/k3d
@@ -142,7 +142,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
-        with: { go-version: '1.25.x' } # TODO: revert to stable when kuttl supports Go 1.26 (missing testDeps.ModulePath)
+        with: { go-version: stable }
 
       - name: Start k3s
         uses: ./.github/actions/k3d


### PR DESCRIPTION
## Summary
The `e2e-k3d-chainsaw` and `e2e-k3d-kuttl` jobs were pinned to Go 1.25.x with a TODO noting that chainsaw/kuttl were missing `testDeps.ModulePath` (added in Go 1.26). Both upstreams have since shipped releases that **require** `go >= 1.26.0`:
- `github.com/kudobuilder/kuttl@v0.26.0` -> `go 1.26.0`
- `github.com/kyverno/chainsaw` (main)   -> `go 1.26.0`
`actions/setup-go@v6` sets `GOTOOLCHAIN=local` when an explicit version is requested, so a 1.25 runner cannot auto-upgrade to build them.

