### PR TITLE
bump trivy to v0.70.0 and setup-trivy to v0.2.6 to fix REL_5_8 CI

### DIFF
--- a/.github/actions/trivy/action.yaml
+++ b/.github/actions/trivy/action.yaml
@@ -39,7 +39,7 @@ inputs:
       The value "skip" fetches no Trivy data at all.
 
   setup:
-    default: v0.65.0,cache
+    default: v0.70.0,cache
     description: >-
       How to install Trivy; one or more of version, none, or cache.
       The value "none" does not install Trivy at all.
@@ -84,7 +84,7 @@ runs:
     # Install Trivy as requested.
     # NOTE: `setup-trivy` can download a "latest" version but cannot cache it.
     - if: ${{ ! contains(fromJSON(steps.parsed.outputs.setup), 'none') }}
-      uses: aquasecurity/setup-trivy@v0.2.5
+      uses: aquasecurity/setup-trivy@v0.2.6
       with:
         cache: ${{ contains(fromJSON(steps.parsed.outputs.setup), 'cache') }}
         version: ${{ steps.parsed.outputs.version }}


### PR DESCRIPTION
## Summary

Two related Aqua Security artifacts were removed/GC'd, breaking the `cache`, `licenses`, `secrets`, and `vulnerabilities` jobs on every PR and push to `REL_5_8`:

1. **Trivy binary `v0.65.0`** — Aqua GC's old GitHub release artifacts, so `setup-trivy` can no longer download it.
2. **`aquasecurity/setup-trivy@v0.2.5`** action wrapper — the v0.2.5 tag was itself removed from the marketplace. The runner now reports:


This PR bumps both:

| | From | To | Why |
|---|---|---|---|
| Trivy binary | `v0.65.0` | `v0.70.0` | Same fix already on `main` |
| `aquasecurity/setup-trivy` action | `v0.2.5` | `v0.2.6` | Latest available tag |

Both changes touch a single file: `.github/actions/trivy/action.yaml`.

## Supersedes

This supersedes #4465 (which only does the action wrapper bump and is currently blocked by stale-base lint failures). After this lands, #4465 can be closed.

