### PR TITLE
ci: revert e2e-k3d-kuttl Go pin to stable on REL_5_8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
-        with: { go-version: '1.25.x' } # TODO: revert to stable when kuttl supports Go 1.26 (missing testDeps.ModulePath)
+        with: { go-version: stable }
 
       - name: Start k3s
         uses: ./.github/actions/k3d


### PR DESCRIPTION

The `e2e-k3d-kuttl` job on `REL_5_8` is pinned to `go-version: '1.25.x'` with a TODO about `kuttl` not yet supporting Go 1.26. Combined with `GOTOOLCHAIN=local`, this prevents Go from auto-upgrading when building `kuttl@latest` (`v0.26.0`), which requires Go >= 1.26 (`testDeps.ModulePath`).
This is the cause of the persistent `e2e-k3d-kuttl (v1.30)` and `e2e-k3d-kuttl (v1.34)` failures on every recent PR targeting `REL_5_8`.
Mirrors PR #4488 (which fixed the same issue on `main`) by switching the job back to `go-version: stable`.

