### PR TITLE
fix(kuttl): align standalone pgAdmin user-management asserts with python3.12

### DIFF
--- a/internal/controller/standalone_pgadmin/config.go
+++ b/internal/controller/standalone_pgadmin/config.go
@@ -15,5 +15,5 @@ const (
 	pgAdminPort = 5050
 
 	// Directory for pgAdmin in container
-	pgAdminDir = "/usr/local/lib/python3.11/site-packages/pgadmin4"
+	pgAdminDir = "/usr/local/lib/python3.12/site-packages/pgadmin4"
 )

--- a/internal/controller/standalone_pgadmin/pod_test.go
+++ b/internal/controller/standalone_pgadmin/pod_test.go
@@ -45,7 +45,7 @@ containers:
   - |-
     monitor() {
     export PGADMIN_SETUP_PASSWORD="$(date +%s | sha256sum | base64 | head -c 32)"
-    PGADMIN_DIR=/usr/local/lib/python3.11/site-packages/pgadmin4
+    PGADMIN_DIR=/usr/local/lib/python3.12/site-packages/pgadmin4
     APP_RELEASE=$(cd $PGADMIN_DIR && python3 -c "import config; print(config.APP_RELEASE)")
 
     echo "Running pgAdmin4 Setup"
@@ -246,7 +246,7 @@ containers:
   - |-
     monitor() {
     export PGADMIN_SETUP_PASSWORD="$(date +%s | sha256sum | base64 | head -c 32)"
-    PGADMIN_DIR=/usr/local/lib/python3.11/site-packages/pgadmin4
+    PGADMIN_DIR=/usr/local/lib/python3.12/site-packages/pgadmin4
     APP_RELEASE=$(cd $PGADMIN_DIR && python3 -c "import config; print(config.APP_RELEASE)")
 
     echo "Running pgAdmin4 Setup"

--- a/testing/kuttl/e2e/standalone-pgadmin-user-management/01-assert.yaml
+++ b/testing/kuttl/e2e/standalone-pgadmin-user-management/01-assert.yaml
@@ -6,8 +6,8 @@ commands:
     pod_name=$(kubectl get pod -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
     secret_name=$(kubectl get secret -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
 
-    # /usr/local/lib/python3.11/site-packages/pgadmin4 allows for various Python versions to be referenced in testing
-    users_in_pgadmin=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py get-users --json")
+    # /usr/local/lib/python3.12/site-packages/pgadmin4 allows for various Python versions to be referenced in testing
+    users_in_pgadmin=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.12/site-packages/pgadmin4/setup.py get-users --json")
     
     bob_role=$(printf '%s\n' $users_in_pgadmin | jq -r '.[] | select(.username=="bob@example.com") | .role')
     dave_role=$(printf '%s\n' $users_in_pgadmin | jq -r '.[] | select(.username=="dave@example.com") | .role')

--- a/testing/kuttl/e2e/standalone-pgadmin-user-management/03-assert.yaml
+++ b/testing/kuttl/e2e/standalone-pgadmin-user-management/03-assert.yaml
@@ -6,8 +6,8 @@ commands:
     pod_name=$(kubectl get pod -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
     secret_name=$(kubectl get secret -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
 
-    # /usr/local/lib/python3.11/site-packages/pgadmin4 allows for various Python versions to be referenced in testing
-    users_in_pgadmin=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py get-users --json")
+    # /usr/local/lib/python3.12/site-packages/pgadmin4 allows for various Python versions to be referenced in testing
+    users_in_pgadmin=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.12/site-packages/pgadmin4/setup.py get-users --json")
     
     bob_role=$(printf '%s\n' $users_in_pgadmin | jq -r '.[] | select(.username=="bob@example.com") | .role')
     dave_role=$(printf '%s\n' $users_in_pgadmin | jq -r '.[] | select(.username=="dave@example.com") | .role')

--- a/testing/kuttl/e2e/standalone-pgadmin-user-management/05-assert.yaml
+++ b/testing/kuttl/e2e/standalone-pgadmin-user-management/05-assert.yaml
@@ -6,8 +6,8 @@ commands:
     pod_name=$(kubectl get pod -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
     secret_name=$(kubectl get secret -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
 
-    # /usr/local/lib/python3.11/site-packages/pgadmin4 allows for various Python versions to be referenced in testing
-    users_in_pgadmin=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py get-users --json")
+    # /usr/local/lib/python3.12/site-packages/pgadmin4 allows for various Python versions to be referenced in testing
+    users_in_pgadmin=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.12/site-packages/pgadmin4/setup.py get-users --json")
     
     bob_role=$(printf '%s\n' $users_in_pgadmin | jq -r '.[] | select(.username=="bob@example.com") | .role')
     dave_role=$(printf '%s\n' $users_in_pgadmin | jq -r '.[] | select(.username=="dave@example.com") | .role')

--- a/testing/kuttl/e2e/standalone-pgadmin-user-management/07-assert.yaml
+++ b/testing/kuttl/e2e/standalone-pgadmin-user-management/07-assert.yaml
@@ -6,8 +6,8 @@ commands:
     pod_name=$(kubectl get pod -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
     secret_name=$(kubectl get secret -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/pgadmin=pgadmin -o name)
 
-    # /usr/local/lib/python3.11/site-packages/pgadmin4 allows for various Python versions to be referenced in testing
-    users_in_pgadmin=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.11/site-packages/pgadmin4/setup.py get-users --json")
+    # /usr/local/lib/python3.12/site-packages/pgadmin4 allows for various Python versions to be referenced in testing
+    users_in_pgadmin=$(kubectl exec -n "${NAMESPACE}" "${pod_name}" -- bash -c "python3 /usr/local/lib/python3.12/site-packages/pgadmin4/setup.py get-users --json")
     
     bob_role=$(printf '%s\n' $users_in_pgadmin | jq -r '.[] | select(.username=="bob@example.com") | .role')
     dave_role=$(printf '%s\n' $users_in_pgadmin | jq -r '.[] | select(.username=="dave@example.com") | .role')


### PR DESCRIPTION
The four standalone-pgadmin-user-management assert scripts still exec setup.py out of /usr/local/lib/python3.11/site-packages/pgadmin4, which fails against the python3.12-built pgAdmin image now shipped for 5.8. Bump the path to /usr/local/lib/python3.12/site-packages/pgadmin4 in {01,03,05,07}-assert.yaml.


