### PR TITLE
Suppress successful autogrow PATCH response logs

### DIFF
--- a/internal/controller/postgrescluster/instance_test.go
+++ b/internal/controller/postgrescluster/instance_test.go
@@ -582,7 +582,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
         fi
         newSizeMi="${newSize}Mi"
         d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
-        curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
+        curl --silent --show-error --output /dev/null --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
       fi
     }
 
@@ -760,7 +760,7 @@ func TestAddPGBackRestToInstancePodSpec(t *testing.T) {
         fi
         newSizeMi="${newSize}Mi"
         d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
-        curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
+        curl --silent --show-error --output /dev/null --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
       fi
     }
 

--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -652,7 +652,7 @@ manageAutogrowAnnotation() {
     fi
     newSizeMi="${newSize}Mi"
     d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
-    curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
+    curl --silent --show-error --output /dev/null --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
   fi
 }
 

--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -729,6 +729,8 @@ func TestReloadCommand(t *testing.T) {
 	assert.Assert(t, cmp.Contains(command[3], "manageAutogrowAnnotation \"repo2\" \"20\" \"2048\""))
 	assert.Assert(t, cmp.Contains(command[3], "manageAutogrowAnnotation \"repo3\" \"30\" \"3072\""))
 	assert.Assert(t, cmp.Contains(command[3], "manageAutogrowAnnotation \"repo4\" \"40\" \"4096\""))
+	assert.Assert(t, cmp.Contains(command[3], "curl --silent --show-error --output /dev/null"),
+		"expected successful autogrow annotation responses to be omitted from logs")
 
 }
 

--- a/internal/pgbackrest/reconcile_test.go
+++ b/internal/pgbackrest/reconcile_test.go
@@ -770,7 +770,7 @@ func TestAddServerToInstancePod(t *testing.T) {
         fi
         newSizeMi="${newSize}Mi"
         d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
-        curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
+        curl --silent --show-error --output /dev/null --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
       fi
     }
 
@@ -960,7 +960,7 @@ func TestAddServerToInstancePod(t *testing.T) {
         fi
         newSizeMi="${newSize}Mi"
         d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
-        curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
+        curl --silent --show-error --output /dev/null --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
       fi
     }
 
@@ -1139,7 +1139,7 @@ func TestAddServerToRepoPod(t *testing.T) {
         fi
         newSizeMi="${newSize}Mi"
         d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
-        curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
+        curl --silent --show-error --output /dev/null --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
       fi
     }
 

--- a/internal/postgres/config.go
+++ b/internal/postgres/config.go
@@ -356,7 +356,7 @@ manageAutogrowAnnotation() {
     fi
     newSizeMi="${newSize}Mi"
     d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
-    curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
+    curl --silent --show-error --output /dev/null --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
   fi
 }
 

--- a/internal/postgres/config_test.go
+++ b/internal/postgres/config_test.go
@@ -652,5 +652,7 @@ func TestReloadCommand(t *testing.T) {
 
 	assert.Assert(t, cmp.Contains(command[3], "manageAutogrowAnnotation \"pgdata\" \"10\" \"1024\""))
 	assert.Assert(t, cmp.Contains(command[3], "manageAutogrowAnnotation \"pgwal\" \"20\" \"2048\""))
+	assert.Assert(t, cmp.Contains(command[3], "curl --silent --show-error --output /dev/null"),
+		"expected successful autogrow annotation responses to be omitted from logs")
 
 }

--- a/internal/postgres/reconcile_test.go
+++ b/internal/postgres/reconcile_test.go
@@ -206,7 +206,7 @@ containers:
         fi
         newSizeMi="${newSize}Mi"
         d='[{"op": "add", "path": "/metadata/annotations/suggested-'"${volume}"'-pvc-size", "value": "'"${newSizeMi}"'"}]'
-        curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
+        curl --silent --show-error --output /dev/null --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -XPATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}?fieldManager=kubectl-annotate" -H "Content-Type: application/json-patch+json" --data "${d}"
       fi
     }
 


### PR DESCRIPTION
**Checklist:**

 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [x] Have you added automated tests?



**Type of Changes:**

 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

In some autogrow scenarios, `replication-cert-copy` can generate a large amount of sidecar log output while a volume remains above the configured usage threshold. This was already raised in CrunchyData/postgres-operator#4391.

In the reported environment, two replicas generated roughly 2 GiB of logs per day while the volume remained above the autogrow threshold.

The generated `replication-cert-copy` script checks volume usage every five seconds and PATCHes the Pod annotation when autogrow should be triggered. A successful Pod PATCH returns the updated Pod JSON, and `curl` writes that response body to stdout by default. While expansion is pending or blocked, that full JSON response **is logged repeatedly**.

While checking the reported path, I found the same successful-response logging pattern in the pgBackRest autogrow script, so this change updates both autogrow PATCH paths.


**What is the new behavior (if this is a feature change)?**

Successful autogrow PATCH response bodies are discarded with `--output /dev/null`. Curl progress output is suppressed with `--silent`, while curl error output is preserved with `--show-error`.

Autogrow behavior is unchanged: annotations are still patched, and operator events/status/PVC state remain the source of autogrow diagnostics.

This intentionally does not change the repeated PATCH behavior or autogrow decision logic. It only prevents successful Kubernetes API response bodies from being emitted to sidecar stdout.

No user-facing documentation was added because this removes unintended successful response output without changing user-facing configuration or behavior.

 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:

Tested with:

```sh
go test ./internal/postgres -run 'TestReloadCommand|TestInstancePod'
go test ./internal/pgbackrest -run 'TestReloadCommand|TestReconcile'
go test ./internal/postgres ./internal/pgbackrest
go test ./internal/controller/postgrescluster -run 'TestAddPGBackRestToInstancePodSpec|TestGenerateInstanceStatefulSetIntent'
```

These tests cover the generated sidecar command strings, shellcheck validation for the generated scripts, and the affected golden Pod/StatefulSet output. That is the relevant validation for this change because the PR changes the generated `curl` invocation only; it does not change autogrow sizing or reconciliation logic.
