### PR TITLE
Installer updates for the August 2026 6.0.3 release

### DIFF
--- a/config/components/images-by-tag/kustomization.yaml
+++ b/config/components/images-by-tag/kustomization.yaml
@@ -2,58 +2,58 @@ kind: Component
 images:
 - name: image-pgadmin
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4
-  newTag: ubi9-9.15-2621
+  newTag: ubi9-9.17-2633
 - name: image-pgbackrest
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest
-  newTag: ubi9-2.58.0-2621
+  newTag: ubi9-2.59.0-2633
 - name: image-pgbouncer
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer
-  newTag: ubi9-1.25-2621
+  newTag: ubi9-1.25-2633
 - name: image-postgres-exporter
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter
-  newTag: ubi9-0.18.1-2621
+  newTag: ubi9-0.19.1-2633
 - name: image-postgres-operator-6.0
   newName: registry.developers.crunchydata.com/crunchydata/postgres-operator
-  newTag: ubi9-6.0.2-0
+  newTag: ubi9-6.0.3-0
 - name: image-postgres-operator-5.8
   newName: registry.developers.crunchydata.com/crunchydata/postgres-operator
-  newTag: ubi9-5.8.8-0
+  newTag: ubi9-5.8.9-0
 - name: image-crunchy-postgres-15
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres
-  newTag: ubi9-15.18-2621
+  newTag: ubi9-15.19-2633
 - name: image-crunchy-postgres-16
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres
-  newTag: ubi9-16.14-2621
+  newTag: ubi9-16.15-2633
 - name: image-crunchy-postgres-17
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres
-  newTag: ubi9-17.10-2621
+  newTag: ubi9-17.11-2633
 - name: image-crunchy-postgres-18
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres
-  newTag: ubi9-18.4-2621
+  newTag: ubi9-18.6-2633
 - name: image-crunchy-upgrade
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-upgrade
-  newTag: ubi9-18.4-2621
+  newTag: ubi9-18.6-2633
 - name: image-crunchy-postgres-15-gis-3.3
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis
-  newTag: ubi9-15.18-3.3-2621
+  newTag: ubi9-15.19-3.3-2633
 - name: image-crunchy-postgres-15-gis-3.4
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis
-  newTag: ubi9-15.18-3.4-2621
+  newTag: ubi9-15.19-3.4-2633
 - name: image-crunchy-postgres-16-gis-3.3
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis
-  newTag: ubi9-16.14-3.3-2621
+  newTag: ubi9-16.15-3.3-2633
 - name: image-crunchy-postgres-16-gis-3.4
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis
-  newTag: ubi9-16.14-3.4-2621
+  newTag: ubi9-16.15-3.4-2633
 - name: image-crunchy-postgres-17-gis-3.4
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis
-  newTag: ubi9-17.10-3.4-2621
+  newTag: ubi9-17.11-3.4-2633
 - name: image-crunchy-postgres-17-gis-3.5
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis
-  newTag: ubi9-17.10-3.5-2621
+  newTag: ubi9-17.11-3.5-2633
 - name: image-crunchy-postgres-17-gis-3.6
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis
-  newTag: ubi9-17.10-3.6-2621
+  newTag: ubi9-17.11-3.6-2633
 - name: image-crunchy-postgres-18-gis-3.6
   newName: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis
-  newTag: ubi9-18.4-3.6-2621
+  newTag: ubi9-18.6-3.6-2633

--- a/config/crd/bases/postgres-operator.crunchydata.com_pgadmins.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_pgadmins.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: pgadmins.postgres-operator.crunchydata.com
   labels:
-    app.kubernetes.io/version: 6.0.2
+    app.kubernetes.io/version: 6.0.3
 spec:
   group: postgres-operator.crunchydata.com
   names:

--- a/config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: pgupgrades.postgres-operator.crunchydata.com
   labels:
-    app.kubernetes.io/version: 6.0.2
+    app.kubernetes.io/version: 6.0.3
 spec:
   group: postgres-operator.crunchydata.com
   names:

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: postgresclusters.postgres-operator.crunchydata.com
   labels:
-    app.kubernetes.io/version: 6.0.2
+    app.kubernetes.io/version: 6.0.3
 spec:
   group: postgres-operator.crunchydata.com
   names:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -7,7 +7,7 @@ labels:
   includeTemplates: true
   pairs:
     app.kubernetes.io/name: pgo
-    app.kubernetes.io/version: 6.0.2
+    app.kubernetes.io/version: 6.0.3
 - includeSelectors: true
   includeTemplates: true
   pairs:

--- a/config/rbac/cluster/kustomization.yaml
+++ b/config/rbac/cluster/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
-- role_binding.yaml
 - role.yaml
+- role_binding.yaml
 - service_account.yaml

--- a/config/singlenamespace/kustomization.yaml
+++ b/config/singlenamespace/kustomization.yaml
@@ -7,7 +7,7 @@ labels:
   includeTemplates: true
   pairs:
     app.kubernetes.io/name: pgo
-    app.kubernetes.io/version: 6.0.2
+    app.kubernetes.io/version: 6.0.3
 - includeSelectors: true
   includeTemplates: true
   pairs:


### PR DESCRIPTION
Regenerated from operator-installers with
release-artifacts/prerelease/developer/release-manifest-ubi9.yaml and copied into config/ via `make publish-public-installers`.

Image tags moved from calver 2621 -> 2633 with the following version bumps (mirrors versioning.yaml):

* postgres-operator 6.0: 6.0.2-0 -> 6.0.3-0
* postgres-operator 5.8: 5.8.8-0 -> 5.8.9-0
* crunchy-pgadmin4: ubi9-9.15 -> ubi9-9.17
* crunchy-pgbackrest: ubi9-2.58.0 -> ubi9-2.59.0
* crunchy-postgres-exporter: ubi9-0.18.1 -> ubi9-0.19.1
* crunchy-postgres 15/16/17/18: 15.18/16.14/17.10/18.4 ->
  15.19/16.15/17.11/18.6 (and matching -gis variants)
* crunchy-pgbouncer: ubi9-1.25 (unchanged upstream, calver-only bump)

app.kubernetes.io/version bumped 6.0.2 -> 6.0.3 in config/default/kustomization.yaml, config/singlenamespace/kustomization.yaml, and the three CRD label sets (pgadmins, pgupgrades, postgresclusters).

config/rbac/cluster/kustomization.yaml resource list reordered alphabetically by the installer generator (role.yaml before role_binding.yaml); functionally equivalent.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
