### PR TITLE
chore(deps): bump Go to 1.26.6 on REL_5_8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/crunchydata/postgres-operator
 
 // If this is changing when you don't want it to, see hack/go-get.sh
-go 1.26.3
+go 1.26.6
 
 require (
 	github.com/go-logr/logr v1.4.4


### PR DESCRIPTION
Match the main-branch Go toolchain bump (see #4541) for the August 2026 release. Directive-only change; `go mod tidy` is a no-op past line 4 and produces no go.sum churn.

Local `go build ./...` on macOS hits a pre-existing pg_query_go/v5 cgo `strchrnul` collision with the current macOS SDK; the same error reproduces on unmodified REL_5_8 at go 1.26.3, so it is unrelated to this bump. Linux CI (which is where PGO is built for release) compiles cleanly.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
