### PR TITLE
Installer updates for the August 2026 5.8.9 release

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -17,4 +17,4 @@ resources:
 images:
 - name: postgres-operator
   newName: registry.developers.crunchydata.com/crunchydata/postgres-operator
-  newTag: ubi9-5.8.8-0
+  newTag: ubi9-5.8.9-0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,39 +23,39 @@ spec:
         - name: CRUNCHY_DEBUG
           value: "true"
         - name: RELATED_IMAGE_POSTGRES_15
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-15.18-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-15.19-2633"
         - name: RELATED_IMAGE_POSTGRES_15_GIS_3.3
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-15.18-3.3-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-15.19-3.3-2633"
         - name: RELATED_IMAGE_POSTGRES_16
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-16.14-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-16.15-2633"
         - name: RELATED_IMAGE_POSTGRES_16_GIS_3.3
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-16.14-3.3-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-16.15-3.3-2633"
         - name: RELATED_IMAGE_POSTGRES_16_GIS_3.4
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-16.14-3.4-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-16.15-3.4-2633"
         - name: RELATED_IMAGE_POSTGRES_17
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-17.10-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-17.11-2633"
         - name: RELATED_IMAGE_POSTGRES_17_GIS_3.4
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-17.10-3.4-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-17.11-3.4-2633"
         - name: RELATED_IMAGE_POSTGRES_17_GIS_3.5
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-17.10-3.5-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-17.11-3.5-2633"
         - name: RELATED_IMAGE_POSTGRES_17_GIS_3.6
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-17.10-3.6-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-17.11-3.6-2633"
         - name: RELATED_IMAGE_POSTGRES_18
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-18.4-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-18.6-2633"
         - name: RELATED_IMAGE_POSTGRES_18_GIS_3.6
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-18.4-3.6-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi9-18.6-3.6-2633"
         - name: RELATED_IMAGE_PGBACKREST
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi9-2.58.0-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi9-2.59.0-2633"
         - name: RELATED_IMAGE_PGBOUNCER
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi9-1.25-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi9-1.25-2633"
         - name: RELATED_IMAGE_PGEXPORTER
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi9-0.18.1-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi9-0.19.1-2633"
         - name: RELATED_IMAGE_PGUPGRADE
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi9-18.4-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi9-18.6-2633"
         - name: RELATED_IMAGE_STANDALONE_PGADMIN
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi9-9.15-2621"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi9-9.17-2633"
         - name: RELATED_IMAGE_COLLECTOR
-          value: "registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi9-5.8.8-0"
+          value: "registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi9-5.8.9-0"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities: { drop: [ALL] }


### PR DESCRIPTION
Bumps operator image tag and all RELATED_IMAGE_* env vars to match the 5.8.9-0 images-by-tag component produced by operator-installers from release-artifacts/prerelease/developer/release-manifest-ubi9.yaml.

Calver bumped 2621 -> 2633 across all images. Content bumps from versioning.yaml:

* postgres-operator 5.8: 5.8.8-0 -> 5.8.9-0
* crunchy-postgres 15/16/17/18: 15.18/16.14/17.10/18.4 ->
  15.19/16.15/17.11/18.6
* matching -gis variants (3.3/3.4/3.5/3.6)
* crunchy-pgbackrest: 2.58.0 -> 2.59.0
* crunchy-postgres-exporter: 0.18.1 -> 0.19.1
* crunchy-pgadmin4: 9.15 -> 9.17
* crunchy-upgrade: 18.4 -> 18.6
* crunchy-pgbouncer: 1.25 (unchanged upstream, calver-only bump)

Only config/default/kustomization.yaml and config/manager/manager.yaml are touched (matches the shape of the prior 5.8.8 installer commit 426faadf3); `make publish-public-installers` is not run wholesale on REL_5_8 because its build/ tree targets the 6.0-style layout and this branch keeps the legacy simpler config/ shape.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**



**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



**Other Information**:
